### PR TITLE
Fix credentials import statement

### DIFF
--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -1,5 +1,5 @@
 import { Config } from '@stencil/core';
-import { accessKeyId, secretAccessKey, sessionToken } from './creds.json';
+import { credentials } from './creds.json';
 import replace from '@rollup/plugin-replace';
 
 export const config: Config = {
@@ -27,9 +27,9 @@ export const config: Config = {
     // NOTE: Prefer to use npm package https://www.npmjs.com/package/rollup-plugin-dotenv and have it
     // read directly from a .env file, but unable to get `rollup-plugin-dotenv` working. more investigation required.
     replace({
-      'process.env.AWS_ACCESS_KEY_ID': JSON.stringify(accessKeyId),
-      'process.env.AWS_SECRET_ACCESS_KEY': JSON.stringify(secretAccessKey),
-      'process.env.AWS_SESSION_TOKEN': JSON.stringify(sessionToken),
+      'process.env.AWS_ACCESS_KEY_ID': JSON.stringify(credentials.accessKeyId),
+      'process.env.AWS_SECRET_ACCESS_KEY': JSON.stringify(credentials.secretAccessKey),
+      'process.env.AWS_SESSION_TOKEN': JSON.stringify(credentials.sessionToken),
     }),
   ],
 };


### PR DESCRIPTION
*Description of changes:* The default credentials block has the 3 keys we need in credentials object.

*Test Output:*
```
lerna success run Ran npm script 'test' in 2 packages in 31.2s:
lerna success - @iot-app-kit/components
lerna success - @iot-app-kit/core
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
