### PR TITLE
Fix: Swapped ternary statement terms

### DIFF
--- a/packages/core/src/asset-modules/sitewise/types.ts
+++ b/packages/core/src/asset-modules/sitewise/types.ts
@@ -32,7 +32,7 @@ export type AssetHierarchyQuery = AssetQuery & {
 };
 
 export function assetHierarchyQueryKey(query: AssetHierarchyQuery): string {
-  return (query.assetId ? '' : (query.assetId + ":")) + query.assetHierarchyId;
+  return (query.assetId ? (query.assetId + ":") : '') + query.assetHierarchyId;
 }
 export const isAssetHierarchyQuery = (query: AssetQuery): query is AssetHierarchyQuery =>
   (query as AssetHierarchyQuery).assetHierarchyId != undefined;


### PR DESCRIPTION
## Overview
This statement was backwards, causing caching keys to collide when they shouldn't have.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
