### PR TITLE
feat: api simplification of requestSettings

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { AnyDataStreamQuery, AssetSummaryQuery, AssetTreeSubscription, DataModule, Request, RequestConfig, SiteWiseAssetTreeQuery } from "@iot-app-kit/core";
+import { AnyDataStreamQuery, AssetSummaryQuery, AssetTreeSubscription, DataModule, SiteWiseAssetTreeQuery, TimeSeriesDataRequest, TimeSeriesDataRequestSettings } from "@iot-app-kit/core";
 import { DataStream, MinimalViewPortConfig } from "@synchro-charts/core";
 import { TableProps } from "@awsui/components-react/table";
 import { EmptyStateProps, ITreeNode, UseTreeCollection } from "@iot-app-kit/related-table";
@@ -23,7 +23,7 @@ export namespace Components {
         "appKit": DataModule;
         "isEditing": boolean | undefined;
         "query": AnyDataStreamQuery;
-        "requestConfig": RequestConfig | undefined;
+        "settings": TimeSeriesDataRequestSettings | undefined;
         "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
@@ -31,13 +31,13 @@ export namespace Components {
         "appKit": DataModule;
         "query": AnyDataStreamQuery;
         "renderFunc": ({ dataStreams }: { dataStreams: DataStream[] }) => unknown;
-        "requestInfo": Request;
+        "request": TimeSeriesDataRequest;
     }
     interface IotKpi {
         "appKit": DataModule;
         "isEditing": boolean | undefined;
         "query": AnyDataStreamQuery;
-        "requestConfig": RequestConfig | undefined;
+        "settings": TimeSeriesDataRequestSettings | undefined;
         "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
@@ -45,7 +45,7 @@ export namespace Components {
         "appKit": DataModule;
         "isEditing": boolean | undefined;
         "query": AnyDataStreamQuery;
-        "requestConfig": RequestConfig | undefined;
+        "settings": TimeSeriesDataRequestSettings | undefined;
         "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
@@ -53,7 +53,7 @@ export namespace Components {
         "appKit": DataModule;
         "isEditing": boolean | undefined;
         "query": AnyDataStreamQuery;
-        "requestConfig": RequestConfig | undefined;
+        "settings": TimeSeriesDataRequestSettings | undefined;
         "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
@@ -61,7 +61,7 @@ export namespace Components {
         "appKit": DataModule;
         "isEditing": boolean | undefined;
         "query": AnyDataStreamQuery;
-        "requestConfig": RequestConfig | undefined;
+        "settings": TimeSeriesDataRequestSettings | undefined;
         "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
@@ -69,14 +69,14 @@ export namespace Components {
         "appKit": DataModule;
         "isEditing": boolean | undefined;
         "query": AnyDataStreamQuery;
-        "requestConfig": RequestConfig | undefined;
+        "settings": TimeSeriesDataRequestSettings | undefined;
         "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface IotTable {
         "appKit": DataModule;
         "query": AnyDataStreamQuery;
-        "requestConfig": RequestConfig | undefined;
+        "settings": TimeSeriesDataRequestSettings | undefined;
         "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
@@ -242,7 +242,7 @@ declare namespace LocalJSX {
         "appKit"?: DataModule;
         "isEditing"?: boolean | undefined;
         "query"?: AnyDataStreamQuery;
-        "requestConfig"?: RequestConfig | undefined;
+        "settings"?: TimeSeriesDataRequestSettings | undefined;
         "viewport"?: MinimalViewPortConfig;
         "widgetId"?: string;
     }
@@ -250,13 +250,13 @@ declare namespace LocalJSX {
         "appKit"?: DataModule;
         "query"?: AnyDataStreamQuery;
         "renderFunc"?: ({ dataStreams }: { dataStreams: DataStream[] }) => unknown;
-        "requestInfo"?: Request;
+        "request"?: TimeSeriesDataRequest;
     }
     interface IotKpi {
         "appKit"?: DataModule;
         "isEditing"?: boolean | undefined;
         "query"?: AnyDataStreamQuery;
-        "requestConfig"?: RequestConfig | undefined;
+        "settings"?: TimeSeriesDataRequestSettings | undefined;
         "viewport"?: MinimalViewPortConfig;
         "widgetId"?: string;
     }
@@ -264,7 +264,7 @@ declare namespace LocalJSX {
         "appKit"?: DataModule;
         "isEditing"?: boolean | undefined;
         "query"?: AnyDataStreamQuery;
-        "requestConfig"?: RequestConfig | undefined;
+        "settings"?: TimeSeriesDataRequestSettings | undefined;
         "viewport"?: MinimalViewPortConfig;
         "widgetId"?: string;
     }
@@ -272,7 +272,7 @@ declare namespace LocalJSX {
         "appKit"?: DataModule;
         "isEditing"?: boolean | undefined;
         "query"?: AnyDataStreamQuery;
-        "requestConfig"?: RequestConfig | undefined;
+        "settings"?: TimeSeriesDataRequestSettings | undefined;
         "viewport"?: MinimalViewPortConfig;
         "widgetId"?: string;
     }
@@ -280,7 +280,7 @@ declare namespace LocalJSX {
         "appKit"?: DataModule;
         "isEditing"?: boolean | undefined;
         "query"?: AnyDataStreamQuery;
-        "requestConfig"?: RequestConfig | undefined;
+        "settings"?: TimeSeriesDataRequestSettings | undefined;
         "viewport"?: MinimalViewPortConfig;
         "widgetId"?: string;
     }
@@ -288,14 +288,14 @@ declare namespace LocalJSX {
         "appKit"?: DataModule;
         "isEditing"?: boolean | undefined;
         "query"?: AnyDataStreamQuery;
-        "requestConfig"?: RequestConfig | undefined;
+        "settings"?: TimeSeriesDataRequestSettings | undefined;
         "viewport"?: MinimalViewPortConfig;
         "widgetId"?: string;
     }
     interface IotTable {
         "appKit"?: DataModule;
         "query"?: AnyDataStreamQuery;
-        "requestConfig"?: RequestConfig | undefined;
+        "settings"?: TimeSeriesDataRequestSettings | undefined;
         "viewport"?: MinimalViewPortConfig;
         "widgetId"?: string;
     }

--- a/packages/components/src/components/iot-bar-chart/iot-bar-chart.tsx
+++ b/packages/components/src/components/iot-bar-chart/iot-bar-chart.tsx
@@ -1,6 +1,6 @@
 import { Component, Prop, h } from '@stencil/core';
 import { MinimalViewPortConfig } from '@synchro-charts/core';
-import { AnyDataStreamQuery, DataModule, Request, RequestConfig } from '@iot-app-kit/core';
+import { AnyDataStreamQuery, DataModule, TimeSeriesDataRequestSettings } from '@iot-app-kit/core';
 
 const DEFAULT_VIEWPORT = { duration: 10 * 1000 * 60 };
 
@@ -19,27 +19,29 @@ export class IotBarChart {
 
   @Prop() isEditing: boolean | undefined;
 
-  @Prop() requestConfig: RequestConfig | undefined
+  @Prop() settings: TimeSeriesDataRequestSettings | undefined;
 
-  requestInfo(): Request {
+  getSettings(): TimeSeriesDataRequestSettings {
     return {
-      viewport: this.viewport,
-      onlyFetchLatestValue: false,
-      requestConfig: this.requestConfig,
+      ...this.settings,
+      fetchFromStartToEnd: true,
     };
   }
 
   render() {
-    const requestInfo = this.requestInfo();
+    const settings = this.getSettings();
     return (
       <iot-connector
         appKit={this.appKit}
         query={this.query}
-        requestInfo={requestInfo}
+        request={{
+          settings,
+          viewport: this.viewport,
+        }}
         renderFunc={({ dataStreams }) => (
           <sc-bar-chart
             dataStreams={dataStreams}
-            viewport={requestInfo.viewport}
+            viewport={this.viewport}
             isEditing={this.isEditing}
             widgetId={this.widgetId}
           />

--- a/packages/components/src/components/iot-connector/iot-connector.spec.ts
+++ b/packages/components/src/components/iot-connector/iot-connector.spec.ts
@@ -31,7 +31,7 @@ const connectorSpecPage = async (propOverrides: Partial<Components.IotConnector>
       source: 'test-mock',
       assets: [],
     } as SiteWiseDataStreamQuery, // static casting because of legacy sw
-    requestInfo: { viewport, onlyFetchLatestValue: true },
+    request: { viewport, settings: { fetchMostRecentBeforeEnd: true } },
     ...propOverrides,
   };
   update(connector, props);

--- a/packages/components/src/components/iot-connector/iot-connector.tsx
+++ b/packages/components/src/components/iot-connector/iot-connector.tsx
@@ -1,7 +1,13 @@
 import { Component, Prop, State, Watch } from '@stencil/core';
 import { DataStream } from '@synchro-charts/core';
 import isEqual from 'lodash.isequal';
-import { Request, AnyDataStreamQuery, SubscriptionUpdate, subscribeToDataStreams, DataModule } from '@iot-app-kit/core';
+import {
+  AnyDataStreamQuery,
+  SubscriptionUpdate,
+  subscribeToDataStreams,
+  DataModule,
+  TimeSeriesDataRequest,
+} from '@iot-app-kit/core';
 
 @Component({
   tag: 'iot-connector',
@@ -12,7 +18,7 @@ export class IotConnector {
 
   @Prop() query: AnyDataStreamQuery;
 
-  @Prop() requestInfo: Request;
+  @Prop() request: TimeSeriesDataRequest;
 
   @Prop() renderFunc: ({ dataStreams }: { dataStreams: DataStream[] }) => unknown;
 
@@ -28,7 +34,7 @@ export class IotConnector {
       this.appKit,
       {
         query: this.query,
-        requestInfo: this.requestInfo,
+        request: this.request,
       },
       (dataStreams: DataStream[]) => {
         this.dataStreams = dataStreams;
@@ -47,13 +53,13 @@ export class IotConnector {
   /**
    * Sync subscription to change in queried data
    */
-  @Watch('requestInfo')
+  @Watch('request')
   @Watch('query')
   onUpdateProp(newProp: unknown, oldProp: unknown) {
     if (!isEqual(newProp, oldProp) && this.update != null) {
       this.update({
         query: this.query,
-        requestInfo: this.requestInfo,
+        request: this.request,
       });
     }
   }

--- a/packages/components/src/components/iot-kpi/iot-kpi.tsx
+++ b/packages/components/src/components/iot-kpi/iot-kpi.tsx
@@ -1,6 +1,6 @@
 import { Component, Prop, h } from '@stencil/core';
 import { MinimalViewPortConfig } from '@synchro-charts/core';
-import { AnyDataStreamQuery, DataModule, RequestConfig } from '@iot-app-kit/core';
+import { AnyDataStreamQuery, DataModule, TimeSeriesDataRequestSettings } from '@iot-app-kit/core';
 
 const DEFAULT_VIEWPORT = { duration: 10 * 1000 };
 
@@ -19,27 +19,29 @@ export class IotKpi {
 
   @Prop() isEditing: boolean | undefined;
 
-  @Prop() requestConfig: RequestConfig | undefined
+  @Prop() settings: TimeSeriesDataRequestSettings | undefined;
 
-  requestInfo() {
+  getSettings(): TimeSeriesDataRequestSettings {
     return {
-      viewport: this.viewport,
-      onlyFetchLatestValue: true,
-      requestConfig: this.requestConfig,
+      ...this.settings,
+      fetchMostRecentBeforeEnd: true,
     };
   }
 
   render() {
-    const requestInfo = this.requestInfo();
+    const settings = this.getSettings();
     return (
       <iot-connector
         appKit={this.appKit}
         query={this.query}
-        requestInfo={requestInfo}
+        request={{
+          settings,
+          viewport: this.viewport,
+        }}
         renderFunc={({ dataStreams }) => (
           <sc-kpi
             dataStreams={dataStreams}
-            viewport={requestInfo.viewport}
+            viewport={this.viewport}
             isEditing={this.isEditing}
             widgetId={this.widgetId}
           />

--- a/packages/components/src/components/iot-line-chart/iot-line-chart.tsx
+++ b/packages/components/src/components/iot-line-chart/iot-line-chart.tsx
@@ -1,6 +1,6 @@
 import { Component, Prop, h } from '@stencil/core';
 import { MinimalViewPortConfig } from '@synchro-charts/core';
-import { AnyDataStreamQuery, DataModule, Request, RequestConfig } from '@iot-app-kit/core';
+import { AnyDataStreamQuery, DataModule, TimeSeriesDataRequestSettings } from '@iot-app-kit/core';
 
 const DEFAULT_VIEWPORT = { duration: 10 * 1000 * 60 };
 
@@ -19,27 +19,31 @@ export class IotLineChart {
 
   @Prop() isEditing: boolean | undefined;
 
-  @Prop() requestConfig: RequestConfig | undefined
+  @Prop() settings: TimeSeriesDataRequestSettings | undefined;
 
-  requestInfo(): Request {
+  getSettings(): TimeSeriesDataRequestSettings {
     return {
-      viewport: this.viewport,
-      onlyFetchLatestValue: false,
-      requestConfig: this.requestConfig,
+      ...this.settings,
+      fetchFromStartToEnd: true,
+      // Required to be able to draw line from last point visible, to first point before the viewport.
+      fetchMostRecentBeforeStart: true,
     };
   }
 
   render() {
-    const requestInfo = this.requestInfo();
+    const settings = this.getSettings();
     return (
       <iot-connector
         appKit={this.appKit}
         query={this.query}
-        requestInfo={requestInfo}
+        request={{
+          settings,
+          viewport: this.viewport,
+        }}
         renderFunc={({ dataStreams }) => (
           <sc-line-chart
             dataStreams={dataStreams}
-            viewport={requestInfo.viewport}
+            viewport={this.viewport}
             isEditing={this.isEditing}
             widgetId={this.widgetId}
           />

--- a/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.tsx
+++ b/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.tsx
@@ -1,6 +1,6 @@
 import { Component, Prop, h } from '@stencil/core';
 import { MinimalViewPortConfig } from '@synchro-charts/core';
-import { AnyDataStreamQuery, DataModule, Request, RequestConfig } from '@iot-app-kit/core';
+import { AnyDataStreamQuery, DataModule, TimeSeriesDataRequestSettings } from '@iot-app-kit/core';
 
 const DEFAULT_VIEWPORT = { duration: 10 * 1000 * 60 };
 
@@ -19,27 +19,29 @@ export class IotScatterChart {
 
   @Prop() isEditing: boolean | undefined;
 
-  @Prop() requestConfig: RequestConfig | undefined
+  @Prop() settings: TimeSeriesDataRequestSettings | undefined;
 
-  requestInfo(): Request {
+  getSettings(): TimeSeriesDataRequestSettings {
     return {
-      viewport: this.viewport,
-      onlyFetchLatestValue: false,
-      requestConfig: this.requestConfig,
+      ...this.settings,
+      fetchFromStartToEnd: true,
     };
   }
 
   render() {
-    const requestInfo = this.requestInfo();
+    const settings = this.getSettings();
     return (
       <iot-connector
         appKit={this.appKit}
         query={this.query}
-        requestInfo={requestInfo}
+        request={{
+          settings,
+          viewport: this.viewport,
+        }}
         renderFunc={({ dataStreams }) => (
           <sc-scatter-chart
             dataStreams={dataStreams}
-            viewport={requestInfo.viewport}
+            viewport={this.viewport}
             isEditing={this.isEditing}
             widgetId={this.widgetId}
           />

--- a/packages/components/src/components/iot-status-grid/iot-status-grid.tsx
+++ b/packages/components/src/components/iot-status-grid/iot-status-grid.tsx
@@ -1,6 +1,6 @@
 import { Component, Prop, h } from '@stencil/core';
 import { MinimalViewPortConfig } from '@synchro-charts/core';
-import { AnyDataStreamQuery, DataModule, Request, RequestConfig } from '@iot-app-kit/core';
+import { AnyDataStreamQuery, DataModule, TimeSeriesDataRequestSettings } from '@iot-app-kit/core';
 
 const DEFAULT_VIEWPORT = { duration: 10 * 1000 * 60 };
 
@@ -19,27 +19,29 @@ export class IotStatusGrid {
 
   @Prop() isEditing: boolean | undefined;
 
-  @Prop() requestConfig: RequestConfig | undefined
+  @Prop() settings: TimeSeriesDataRequestSettings | undefined;
 
-  requestInfo(): Request {
+  getSettings(): TimeSeriesDataRequestSettings {
     return {
-      viewport: this.viewport,
-      onlyFetchLatestValue: true,
-      requestConfig: this.requestConfig,
+      ...this.settings,
+      fetchMostRecentBeforeEnd: true,
     };
   }
 
   render() {
-    const requestInfo = this.requestInfo();
+    const settings = this.getSettings();
     return (
       <iot-connector
         appKit={this.appKit}
         query={this.query}
-        requestInfo={requestInfo}
+        request={{
+          settings,
+          viewport: this.viewport,
+        }}
         renderFunc={({ dataStreams }) => (
           <sc-status-grid
             dataStreams={dataStreams}
-            viewport={requestInfo.viewport}
+            viewport={this.viewport}
             isEditing={this.isEditing}
             widgetId={this.widgetId}
           />

--- a/packages/components/src/components/iot-status-timeline/iot-status-timeline.tsx
+++ b/packages/components/src/components/iot-status-timeline/iot-status-timeline.tsx
@@ -1,6 +1,6 @@
 import { Component, Prop, h } from '@stencil/core';
 import { MinimalViewPortConfig } from '@synchro-charts/core';
-import { AnyDataStreamQuery, DataModule, Request, RequestConfig } from '@iot-app-kit/core';
+import { AnyDataStreamQuery, DataModule, TimeSeriesDataRequestSettings } from '@iot-app-kit/core';
 
 const DEFAULT_VIEWPORT = { duration: 10 * 1000 * 60 };
 
@@ -19,27 +19,30 @@ export class IotStatusTimeline {
 
   @Prop() isEditing: boolean | undefined;
 
-  @Prop() requestConfig: RequestConfig | undefined
+  @Prop() settings: TimeSeriesDataRequestSettings | undefined;
 
-  requestInfo(): Request {
+  getSettings(): TimeSeriesDataRequestSettings {
     return {
-      viewport: this.viewport,
-      onlyFetchLatestValue: false,
-      requestConfig: this.requestConfig,
+      ...this.settings,
+      fetchMostRecentBeforeStart: true,
+      fetchFromStartToEnd: true,
     };
   }
 
   render() {
-    const requestInfo = this.requestInfo();
+    const settings = this.getSettings();
     return (
       <iot-connector
         appKit={this.appKit}
         query={this.query}
-        requestInfo={requestInfo}
+        request={{
+          settings,
+          viewport: this.viewport,
+        }}
         renderFunc={({ dataStreams }) => (
           <sc-status-timeline
             dataStreams={dataStreams}
-            viewport={requestInfo.viewport}
+            viewport={this.viewport}
             isEditing={this.isEditing}
             widgetId={this.widgetId}
           />

--- a/packages/components/src/components/iot-table/iot-table.tsx
+++ b/packages/components/src/components/iot-table/iot-table.tsx
@@ -1,6 +1,6 @@
 import { Component, Prop, h } from '@stencil/core';
 import { MinimalViewPortConfig } from '@synchro-charts/core';
-import { AnyDataStreamQuery, DataModule, Request, RequestConfig } from '@iot-app-kit/core';
+import { AnyDataStreamQuery, DataModule, TimeSeriesDataRequestSettings } from '@iot-app-kit/core';
 
 const DEFAULT_VIEWPORT = { duration: 10 * 1000 * 60 };
 
@@ -17,25 +17,27 @@ export class IotTable {
 
   @Prop() widgetId: string;
 
-  @Prop() requestConfig: RequestConfig | undefined
+  @Prop() settings: TimeSeriesDataRequestSettings | undefined;
 
-  requestInfo(): Request {
+  getSettings(): TimeSeriesDataRequestSettings {
     return {
-      viewport: this.viewport,
-      onlyFetchLatestValue: true,
-      requestConfig: this.requestConfig,
+      ...this.settings,
+      fetchMostRecentBeforeEnd: true,
     };
   }
 
   render() {
-    const requestInfo = this.requestInfo();
+    const settings = this.getSettings();
     return (
       <iot-connector
         appKit={this.appKit}
         query={this.query}
-        requestInfo={requestInfo}
+        request={{
+          viewport: this.viewport,
+          settings,
+        }}
         renderFunc={({ dataStreams }) => (
-          <sc-table dataStreams={dataStreams} viewport={requestInfo.viewport} widgetId={this.widgetId} />
+          <sc-table dataStreams={dataStreams} viewport={this.viewport} widgetId={this.widgetId} />
         )}
       />
     );

--- a/packages/components/src/testing/createMockSource.ts
+++ b/packages/components/src/testing/createMockSource.ts
@@ -11,7 +11,7 @@ const dataStreamIds = (query: SiteWiseDataStreamQuery) =>
 export const createMockSource = (dataStreams: DataStream[]): DataSource => ({
   name: 'test-mock',
   initiateRequest: ({ onSuccess }: DataSourceRequest<AnyDataStreamQuery>) => onSuccess(dataStreams),
-  getRequestsFromQuery: ({ query, requestInfo }) =>
+  getRequestsFromQuery: ({ query }) =>
     dataStreams
       .filter(({ id }) => dataStreamIds(query).includes(id))
       .map(({ data, aggregates, ...dataStreamInfo }) => dataStreamInfo),

--- a/packages/components/src/testing/testing-ground/siteWiseQueries.ts
+++ b/packages/components/src/testing/testing-ground/siteWiseQueries.ts
@@ -33,13 +33,15 @@ const AGGREGATED_DATA_PROPERTY_2 = '11d2599a-2547-451d-ab79-a47f878dbbe3';
 
 export const AGGREGATED_DATA_QUERY = {
   source: 'site-wise',
-  assets: [{
-    assetId: AGGREGATED_DATA_ASSET,
-    properties: [
-      { propertyId: AGGREGATED_DATA_PROPERTY },
-      { propertyId: AGGREGATED_DATA_PROPERTY_2, resolution: '1m' }
-    ]
-  }],
+  assets: [
+    {
+      assetId: AGGREGATED_DATA_ASSET,
+      properties: [
+        { propertyId: AGGREGATED_DATA_PROPERTY },
+        { propertyId: AGGREGATED_DATA_PROPERTY_2, resolution: '1m' },
+      ],
+    },
+  ],
 };
 
 // From demo turbine asset, found at https://p-rlvy2rj8.app.iotsitewise.aws/

--- a/packages/components/src/testing/testing-ground/testing-ground.tsx
+++ b/packages/components/src/testing/testing-ground/testing-ground.tsx
@@ -17,7 +17,7 @@ const THREE_MINUTES = 1000 * 60 * 3;
 
 const DEFAULT_RESOLUTION_MAPPING = {
   [THREE_MINUTES]: '1m',
-}
+};
 
 @Component({
   tag: 'testing-ground',
@@ -35,20 +35,20 @@ export class TestingGround {
   private changeResolution = (ev: Event) => {
     const resolution = (ev.target as HTMLSelectElement)?.value;
 
-    if (resolution === 'auto'){
+    if (resolution === 'auto') {
       this.resolution = DEFAULT_RESOLUTION_MAPPING;
     } else if (resolution === '0') {
       this.resolution = {};
     } else {
       this.resolution = resolution;
     }
-  }
+  };
 
   private changeDuration = (ev: Event) => {
     const duration = `${(ev.target as HTMLSelectElement)?.value}m`;
 
     this.viewport = { duration };
-  }
+  };
 
   render() {
     return (
@@ -106,22 +106,28 @@ export class TestingGround {
             />
           </div>
         </div>
-        resolution: <select onChange={this.changeResolution}>
+        resolution:{' '}
+        <select onChange={this.changeResolution}>
           <option value={'0'}>raw</option>
           <option value={'1m'}>1m</option>
-          <option selected value={'auto'}>auto</option>
+          <option selected value={'auto'}>
+            auto
+          </option>
         </select>
-        viewport: <select onChange={this.changeDuration}>
+        viewport:{' '}
+        <select onChange={this.changeDuration}>
           <option value={'1'}>1 minute</option>
           <option value={'3'}>3 minutes</option>
-          <option selected value={'5'}>5 minutes</option>
+          <option selected value={'5'}>
+            5 minutes
+          </option>
         </select>
         <div style={{ width: '400px', height: '500px' }}>
           <iot-line-chart
             appKit={this.dataModule}
             query={AGGREGATED_DATA_QUERY}
-            viewport={this.viewport}
-            requestConfig={{ resolution: this.resolution, fetchAggregatedData: true }}
+            viewport={VIEWPORT}
+            settings={{ resolution: this.resolution }}
           />
         </div>
         <iot-asset-details query={ASSET_DETAILS_QUERY} />

--- a/packages/core/src/asset-modules/mocks.spec.ts
+++ b/packages/core/src/asset-modules/mocks.spec.ts
@@ -1,14 +1,16 @@
 import {
-  AssetHierarchyQuery, assetHierarchyQueryKey,
+  AssetHierarchyQuery,
+  assetHierarchyQueryKey,
   AssetModelQuery,
   AssetPropertyValueQuery,
   AssetSummaryQuery,
   HierarchyAssetSummaryList,
   isAssetHierarchyQuery,
   isAssetModelQuery,
-  isAssetPropertyValueQuery, isAssetSummaryQuery,
+  isAssetPropertyValueQuery,
+  isAssetSummaryQuery,
   SiteWiseAssetModuleInterface,
-  SiteWiseAssetSessionInterface
+  SiteWiseAssetSessionInterface,
 } from './sitewise/types';
 import { AssetState, DescribeAssetModelResponse, DescribeAssetResponse, Quality } from '@aws-sdk/client-iotsitewise';
 import { Observable, Subscription } from 'rxjs';
@@ -91,22 +93,24 @@ export class MockSiteWiseAssetsReplayData {
   public assets: Map<string, AssetSummary> = new Map<string, AssetSummary>();
 
   public addAssetModels(newModels: DescribeAssetModelResponse[]) {
-    newModels.forEach(model => this.models.set(model.assetModelId as string, model));
+    newModels.forEach((model) => this.models.set(model.assetModelId as string, model));
   }
 
   public addAssetSummaries(newAssetSummaries: AssetSummary[]) {
-    newAssetSummaries.forEach(summary => this.assets.set(summary.id as string, summary));
+    newAssetSummaries.forEach((summary) => this.assets.set(summary.id as string, summary));
   }
 
-  public addAssetPropertyValues(propertyValue: {assetId: string, propertyId: string, value: AssetPropertyValue}) {
+  public addAssetPropertyValues(propertyValue: { assetId: string; propertyId: string; value: AssetPropertyValue }) {
     this.properties.set(propertyValue.assetId + ':' + propertyValue.propertyId, propertyValue.value);
   }
 
-  public addHierarchyAssetSummaryList(query: AssetHierarchyQuery, newHierarchyAssetSummaryList: HierarchyAssetSummaryList) {
+  public addHierarchyAssetSummaryList(
+    query: AssetHierarchyQuery,
+    newHierarchyAssetSummaryList: HierarchyAssetSummaryList
+  ) {
     this.hierarchies.set(assetHierarchyQueryKey(query), newHierarchyAssetSummaryList);
   }
 }
-
 
 export class MockSiteWiseAssetSession implements SiteWiseAssetSessionInterface {
   private readonly replayData: MockSiteWiseAssetsReplayData;
@@ -119,11 +123,14 @@ export class MockSiteWiseAssetSession implements SiteWiseAssetSessionInterface {
   addRequest(query: AssetPropertyValueQuery, observer: (assetPropertyValue: AssetPropertyValue) => void): Subscription;
   addRequest(query: AssetHierarchyQuery, observer: (assetSummary: HierarchyAssetSummaryList) => void): Subscription;
   addRequest(query: AssetSummaryQuery, observer: (assetSummary: AssetSummary) => void): Subscription;
-  addRequest(query: AssetModelQuery | AssetPropertyValueQuery | AssetHierarchyQuery | AssetSummaryQuery,
-             observer: ((assetModel: DescribeAssetModelResponse) => void)
-               | ((assetPropertyValue: AssetPropertyValue) => void)
-               | ((assetSummary: HierarchyAssetSummaryList) => void)
-               | ((assetSummary: AssetSummary) => void)): Subscription {
+  addRequest(
+    query: AssetModelQuery | AssetPropertyValueQuery | AssetHierarchyQuery | AssetSummaryQuery,
+    observer:
+      | ((assetModel: DescribeAssetModelResponse) => void)
+      | ((assetPropertyValue: AssetPropertyValue) => void)
+      | ((assetSummary: HierarchyAssetSummaryList) => void)
+      | ((assetSummary: AssetSummary) => void)
+  ): Subscription {
     let observable: Observable<any>;
     if (isAssetModelQuery(query)) {
       observable = new Observable<DescribeAssetModelResponse>((observer) => {
@@ -148,8 +155,7 @@ export class MockSiteWiseAssetSession implements SiteWiseAssetSessionInterface {
     return observable.subscribe(observer);
   }
 
-  close(): void {
-  }
+  close(): void {}
 }
 
 export class MockSiteWiseAssetModule implements SiteWiseAssetModuleInterface {
@@ -164,4 +170,6 @@ export class MockSiteWiseAssetModule implements SiteWiseAssetModuleInterface {
   }
 }
 
-it('no-op', () => { expect(true).toBeTruthy()});
+it('no-op', () => {
+  expect(true).toBeTruthy();
+});

--- a/packages/core/src/asset-modules/sitewise-asset-tree/assetTreeModule.spec.ts
+++ b/packages/core/src/asset-modules/sitewise-asset-tree/assetTreeModule.spec.ts
@@ -4,24 +4,20 @@ import { HIERARCHY_ROOT_ID, HierarchyAssetSummaryList, LoadingStateEnum } from '
 
 it('initializes', () => {
   expect(
-    () =>
-      new SiteWiseAssetTreeModule(new MockSiteWiseAssetModule(new MockSiteWiseAssetsReplayData()))
+    () => new SiteWiseAssetTreeModule(new MockSiteWiseAssetModule(new MockSiteWiseAssetsReplayData()))
   ).not.toThrowError();
 });
 
 it('returns a session', () => {
   let replayData = new MockSiteWiseAssetsReplayData();
-  let testData:HierarchyAssetSummaryList = {
+  let testData: HierarchyAssetSummaryList = {
     assetHierarchyId: HIERARCHY_ROOT_ID,
     assets: [sampleAssetSummary],
-    loadingState: LoadingStateEnum.LOADED
-  }
-  replayData.addHierarchyAssetSummaryList({assetHierarchyId: HIERARCHY_ROOT_ID}, testData);
+    loadingState: LoadingStateEnum.LOADED,
+  };
+  replayData.addHierarchyAssetSummaryList({ assetHierarchyId: HIERARCHY_ROOT_ID }, testData);
   replayData.addAssetSummaries([sampleAssetSummary]);
-  expect(
-    () =>
-      new SiteWiseAssetTreeModule(new MockSiteWiseAssetModule(replayData))
-        .startSession({rootAssetId: undefined})
+  expect(() =>
+    new SiteWiseAssetTreeModule(new MockSiteWiseAssetModule(replayData)).startSession({ rootAssetId: undefined })
   ).not.toBeUndefined();
 });
-

--- a/packages/core/src/asset-modules/sitewise-asset-tree/assetTreeSession.spec.ts
+++ b/packages/core/src/asset-modules/sitewise-asset-tree/assetTreeSession.spec.ts
@@ -17,37 +17,36 @@ import {
 
 it('initializes', () => {
   let replayData = new MockSiteWiseAssetsReplayData();
-  let testData:HierarchyAssetSummaryList = {
+  let testData: HierarchyAssetSummaryList = {
     assetHierarchyId: HIERARCHY_ROOT_ID,
     assets: [sampleAssetSummary],
-    loadingState: LoadingStateEnum.LOADED
-  }
-  replayData.addHierarchyAssetSummaryList({assetHierarchyId: HIERARCHY_ROOT_ID}, testData);
+    loadingState: LoadingStateEnum.LOADED,
+  };
+  replayData.addHierarchyAssetSummaryList({ assetHierarchyId: HIERARCHY_ROOT_ID }, testData);
   replayData.addAssetSummaries([sampleAssetSummary]);
   expect(
-    () =>
-      new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData),
-        {rootAssetId: ''})
+    () => new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData), { rootAssetId: '' })
   ).not.toThrowError();
 });
 
 describe('root loading functionality', () => {
   let replayData = new MockSiteWiseAssetsReplayData();
   let rootAsset: AssetSummary = { ...sampleAssetSummary };
-  rootAsset.hierarchies = [{id: 'bananas1234', name: 'bananas'}];
+  rootAsset.hierarchies = [{ id: 'bananas1234', name: 'bananas' }];
 
   let rootHierarchy: HierarchyAssetSummaryList = {
     assetHierarchyId: HIERARCHY_ROOT_ID,
     assets: [rootAsset],
-    loadingState: LoadingStateEnum.NOT_LOADED
-  }
-  replayData.addHierarchyAssetSummaryList({assetHierarchyId: HIERARCHY_ROOT_ID}, rootHierarchy);
+    loadingState: LoadingStateEnum.NOT_LOADED,
+  };
+  replayData.addHierarchyAssetSummaryList({ assetHierarchyId: HIERARCHY_ROOT_ID }, rootHierarchy);
   replayData.addAssetSummaries([rootAsset]);
 
-  it('When you subscribe the root is returned', done => {
-    const session:SiteWiseAssetTreeSession =  new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData),
-      {rootAssetId: ''});
-    session.subscribe(treeRoot => {
+  it('When you subscribe the root is returned', (done) => {
+    const session: SiteWiseAssetTreeSession = new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData), {
+      rootAssetId: '',
+    });
+    session.subscribe((treeRoot) => {
       if (!treeRoot || treeRoot.length == 0) {
         return;
       }
@@ -55,13 +54,17 @@ describe('root loading functionality', () => {
       expect(treeRoot[0]?.asset).toEqual(rootAsset);
       expect(treeRoot[0]?.hierarchies.size).toEqual(1);
       expect(treeRoot[0]?.hierarchies.get('bananas1234')?.isExpanded).toBeFalse();
-      expect(treeRoot[0]?.hierarchies.get('bananas1234')).toEqual({children: [], id: "bananas1234",
-        isExpanded: false, loadingState: LoadingStateEnum.NOT_LOADED, name: "bananas"});
+      expect(treeRoot[0]?.hierarchies.get('bananas1234')).toEqual({
+        children: [],
+        id: 'bananas1234',
+        isExpanded: false,
+        loadingState: LoadingStateEnum.NOT_LOADED,
+        name: 'bananas',
+      });
 
-      expect(treeRoot[0]?.properties).toBeEmpty()
+      expect(treeRoot[0]?.properties).toBeEmpty();
       done();
     });
-
   });
 });
 
@@ -71,20 +74,20 @@ describe('branch loading functionality', () => {
   replayData.addAssetSummaries([rootAsset]);
   // This time the asset has no hierarchis and the loading will stop at just the asset
 
-  it('When you subscribe the asset is returned', done => {
-    const session:SiteWiseAssetTreeSession =  new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData),
-      {rootAssetId: rootAsset.id});
-    session.subscribe(treeRoot => {
+  it('When you subscribe the asset is returned', (done) => {
+    const session: SiteWiseAssetTreeSession = new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData), {
+      rootAssetId: rootAsset.id,
+    });
+    session.subscribe((treeRoot) => {
       if (!treeRoot || treeRoot.length == 0) {
         return;
       }
       expect(treeRoot.length).toEqual(1);
       expect(treeRoot[0]?.asset).toEqual(rootAsset);
       expect(treeRoot[0]?.hierarchies.size).toEqual(0);
-      expect(treeRoot[0]?.properties).toBeEmpty()
+      expect(treeRoot[0]?.properties).toBeEmpty();
       done();
     });
-
   });
 });
 
@@ -95,16 +98,18 @@ describe('model loading', () => {
   let rootHierarchy: HierarchyAssetSummaryList = {
     assetHierarchyId: HIERARCHY_ROOT_ID,
     assets: [rootAsset],
-    loadingState: LoadingStateEnum.NOT_LOADED
-  }
-  replayData.addHierarchyAssetSummaryList({assetHierarchyId: HIERARCHY_ROOT_ID}, rootHierarchy);
+    loadingState: LoadingStateEnum.NOT_LOADED,
+  };
+  replayData.addHierarchyAssetSummaryList({ assetHierarchyId: HIERARCHY_ROOT_ID }, rootHierarchy);
   replayData.addAssetSummaries([rootAsset]);
   replayData.addAssetModels([sampleAssetModel]);
 
-  it('When you request the model you get the model', done => {
-    const session:SiteWiseAssetTreeSession =  new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData),
-      {rootAssetId: '', withModels: true});
-    session.subscribe(treeRoot => {
+  it('When you request the model you get the model', (done) => {
+    const session: SiteWiseAssetTreeSession = new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData), {
+      rootAssetId: '',
+      withModels: true,
+    });
+    session.subscribe((treeRoot) => {
       if (!treeRoot || treeRoot.length == 0) {
         return;
       }
@@ -112,10 +117,9 @@ describe('model loading', () => {
       expect(treeRoot[0]?.asset).toEqual(rootAsset);
       expect(treeRoot[0]?.model).toEqual(sampleAssetModel);
 
-      expect(treeRoot[0]?.properties).toBeEmpty()
+      expect(treeRoot[0]?.properties).toBeEmpty();
       done();
     });
-
   });
 });
 
@@ -126,9 +130,9 @@ describe('asset property loading', () => {
   let rootHierarchy: HierarchyAssetSummaryList = {
     assetHierarchyId: HIERARCHY_ROOT_ID,
     assets: [rootAsset],
-    loadingState: LoadingStateEnum.NOT_LOADED
-  }
-  replayData.addHierarchyAssetSummaryList({assetHierarchyId: HIERARCHY_ROOT_ID}, rootHierarchy);
+    loadingState: LoadingStateEnum.NOT_LOADED,
+  };
+  replayData.addHierarchyAssetSummaryList({ assetHierarchyId: HIERARCHY_ROOT_ID }, rootHierarchy);
   replayData.addAssetSummaries([rootAsset]);
   const modelWithProperties: DescribeAssetModelResponse = { ...sampleAssetModel };
   const sampleProperty: AssetModelProperty = {
@@ -137,9 +141,9 @@ describe('asset property loading', () => {
     name: 'modelNumber',
     type: {
       attribute: {
-        defaultValue: 'Model No. 1234'
-      }
-    }
+        defaultValue: 'Model No. 1234',
+      },
+    },
   };
   const propertyNotInModel: AssetModelProperty = {
     dataType: PropertyDataType.STRING,
@@ -147,9 +151,9 @@ describe('asset property loading', () => {
     name: 'propertyNotInModel',
     type: {
       attribute: {
-        defaultValue: 'Bogons'
-      }
-    }
+        defaultValue: 'Bogons',
+      },
+    },
   };
   modelWithProperties.assetModelProperties = [sampleProperty];
   replayData.addAssetModels([modelWithProperties]);
@@ -163,19 +167,22 @@ describe('asset property loading', () => {
     value: expectedPropertyValue,
   });
   const badPropertyValue: AssetPropertyValue = {
-    value: { stringValue: "This should never get loaded" },
+    value: { stringValue: 'This should never get loaded' },
     timestamp: { timeInSeconds: 12345, offsetInNanos: 0 },
-  }
+  };
   replayData.addAssetPropertyValues({
     assetId: rootAsset.id as string,
     propertyId: propertyNotInModel.id as string,
-    value: badPropertyValue
+    value: badPropertyValue,
   });
 
-  it('When you request a property and it exists it is attached to the asset node', done => {
-    const session:SiteWiseAssetTreeSession =  new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData),
-      {rootAssetId: '', withModels: true, propertyIds: ['propertyNotInModel.id.1234', 'modelNumber.id.1234']});
-    session.subscribe(treeRoot => {
+  it('When you request a property and it exists it is attached to the asset node', (done) => {
+    const session: SiteWiseAssetTreeSession = new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData), {
+      rootAssetId: '',
+      withModels: true,
+      propertyIds: ['propertyNotInModel.id.1234', 'modelNumber.id.1234'],
+    });
+    session.subscribe((treeRoot) => {
       if (!treeRoot || treeRoot.length == 0) {
         return;
       }
@@ -192,7 +199,7 @@ describe('asset property loading', () => {
 describe('expand functionality', () => {
   let replayData = new MockSiteWiseAssetsReplayData();
   let rootAsset: AssetSummary = { ...sampleAssetSummary };
-  rootAsset.hierarchies = [{id: 'bananas1234', name: 'bananas'}];
+  rootAsset.hierarchies = [{ id: 'bananas1234', name: 'bananas' }];
   let bananaOne: AssetSummary = { ...sampleAssetSummary };
   bananaOne.id = bananaOne.name = 'bananaOne';
   let bananaTwo: AssetSummary = { ...sampleAssetSummary };
@@ -201,25 +208,25 @@ describe('expand functionality', () => {
   let rootHierarchy: HierarchyAssetSummaryList = {
     assetHierarchyId: HIERARCHY_ROOT_ID,
     assets: [rootAsset],
-    loadingState: LoadingStateEnum.NOT_LOADED
-  }
-  replayData.addHierarchyAssetSummaryList({assetHierarchyId: HIERARCHY_ROOT_ID}, rootHierarchy);
+    loadingState: LoadingStateEnum.NOT_LOADED,
+  };
+  replayData.addHierarchyAssetSummaryList({ assetHierarchyId: HIERARCHY_ROOT_ID }, rootHierarchy);
 
   let bananaHierarchy: HierarchyAssetSummaryList = {
     assetHierarchyId: 'bananas1234',
     assets: [bananaOne, bananaTwo],
-    loadingState: LoadingStateEnum.NOT_LOADED
-  }
-  replayData.addHierarchyAssetSummaryList({assetId: rootAsset.id, assetHierarchyId: 'bananas1234'},
-    bananaHierarchy);
+    loadingState: LoadingStateEnum.NOT_LOADED,
+  };
+  replayData.addHierarchyAssetSummaryList({ assetId: rootAsset.id, assetHierarchyId: 'bananas1234' }, bananaHierarchy);
 
   replayData.addAssetSummaries([rootAsset, bananaOne, bananaTwo]);
 
-  it('Expands a hierarchy when requested', done => {
-    const session: SiteWiseAssetTreeSession =  new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData),
-      {rootAssetId: ''});
+  it('Expands a hierarchy when requested', (done) => {
+    const session: SiteWiseAssetTreeSession = new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData), {
+      rootAssetId: '',
+    });
     session.expand(new BranchReference(rootAsset.id, 'bananas1234'));
-    session.subscribe(treeRoot => {
+    session.subscribe((treeRoot) => {
       if (treeRoot.length == 0) {
         return;
       }
@@ -237,11 +244,12 @@ describe('expand functionality', () => {
     });
   });
 
-  it('Collapses and expanded hierarchy', done => {
-    const session: SiteWiseAssetTreeSession =  new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData),
-      {rootAssetId: ''});
+  it('Collapses and expanded hierarchy', (done) => {
+    const session: SiteWiseAssetTreeSession = new SiteWiseAssetTreeSession(new MockSiteWiseAssetSession(replayData), {
+      rootAssetId: '',
+    });
     session.collapse(new BranchReference(rootAsset.id, 'bananas1234'));
-    session.subscribe(treeRoot => {
+    session.subscribe((treeRoot) => {
       if (treeRoot.length == 0) {
         return;
       }

--- a/packages/core/src/asset-modules/sitewise-asset-tree/types.ts
+++ b/packages/core/src/asset-modules/sitewise-asset-tree/types.ts
@@ -3,31 +3,31 @@ import { Subscription } from 'rxjs';
 import { LoadingStateEnum } from '../sitewise/types';
 
 export type SiteWiseAssetTreeNode = {
-  asset: AssetSummary,
-  model?: DescribeAssetModelResponse,
-  properties: Map<string, AssetPropertyValue>,
-  hierarchies: Map<string, HierarchyGroup>,
+  asset: AssetSummary;
+  model?: DescribeAssetModelResponse;
+  properties: Map<string, AssetPropertyValue>;
+  hierarchies: Map<string, HierarchyGroup>;
 };
 
 export type HierarchyGroup = {
-  id: string,
-  name: string | undefined,
-  isExpanded: boolean,
-  loadingState: LoadingStateEnum,
-  children: SiteWiseAssetTreeNode[],
-}
+  id: string;
+  name: string | undefined;
+  isExpanded: boolean;
+  loadingState: LoadingStateEnum;
+  children: SiteWiseAssetTreeNode[];
+};
 
 export type SiteWiseAssetTreeQuery = {
-  rootAssetId: string | undefined
-  withModels?: boolean,
-  propertyIds?: string[]
-}
+  rootAssetId: string | undefined;
+  withModels?: boolean;
+  propertyIds?: string[];
+};
 
 export type AssetTreeSubscription = {
-  unsubscribe: () => void,
-  expand: (branchRef: BranchReference) => void,
-  collapse: (branchRef: BranchReference) => void
-}
+  unsubscribe: () => void;
+  expand: (branchRef: BranchReference) => void;
+  collapse: (branchRef: BranchReference) => void;
+};
 
 export class BranchReference {
   public readonly assetId: string | undefined;

--- a/packages/core/src/asset-modules/sitewise/cache.spec.ts
+++ b/packages/core/src/asset-modules/sitewise/cache.spec.ts
@@ -3,13 +3,13 @@ import { LoadingStateEnum } from './types';
 import {
   ASSET_ID,
   ASSET_MODEL_ID,
-  ASSET_PROPERTY_ID, HIERARCHY_ID,
+  ASSET_PROPERTY_ID,
+  HIERARCHY_ID,
   sampleAssetDescription,
   sampleAssetModel,
-  sampleAssetSummary, samplePropertyValue
+  sampleAssetSummary,
+  samplePropertyValue,
 } from '../mocks.spec';
-
-
 
 describe('cacheAssetSummary', () => {
   const cache: SiteWiseAssetCache = new SiteWiseAssetCache();
@@ -67,22 +67,28 @@ describe('cacheAssetHierarchy', () => {
 
   it('returns the cached hierarchy when one is stored', () => {
     cache.appendHierarchyResults(HIERARCHY_ID, [sampleAssetSummary], LoadingStateEnum.LOADING, 'next1');
-    expect(cache.getHierarchy(HIERARCHY_ID)).toEqual({assetIds: [ASSET_ID],
+    expect(cache.getHierarchy(HIERARCHY_ID)).toEqual({
+      assetIds: [ASSET_ID],
       loadingStage: LoadingStateEnum.LOADING,
-      paginationToken: 'next1'});
+      paginationToken: 'next1',
+    });
   });
 
   it('returns the combined records when a new one is appended', () => {
     cache.appendHierarchyResults(HIERARCHY_ID, [sampleAssetSummary], LoadingStateEnum.PAUSED, 'next2');
-    expect(cache.getHierarchy(HIERARCHY_ID)).toEqual({assetIds: [ASSET_ID, ASSET_ID],
+    expect(cache.getHierarchy(HIERARCHY_ID)).toEqual({
+      assetIds: [ASSET_ID, ASSET_ID],
       loadingStage: LoadingStateEnum.PAUSED,
-      paginationToken: 'next2'});
+      paginationToken: 'next2',
+    });
   });
 
   it('returns the updated loading state for a hierarchy when it is changed', () => {
     cache.setHierarchyLoadingState(HIERARCHY_ID, LoadingStateEnum.LOADED);
-    expect(cache.getHierarchy(HIERARCHY_ID)).toEqual({assetIds: [ASSET_ID, ASSET_ID],
+    expect(cache.getHierarchy(HIERARCHY_ID)).toEqual({
+      assetIds: [ASSET_ID, ASSET_ID],
       loadingStage: LoadingStateEnum.LOADED,
-      paginationToken: 'next2'});
+      paginationToken: 'next2',
+    });
   });
 });

--- a/packages/core/src/asset-modules/sitewise/cache.ts
+++ b/packages/core/src/asset-modules/sitewise/cache.ts
@@ -47,7 +47,9 @@ export class SiteWiseAssetCache {
     }
   }
 
-  public storeAssetSummaries<Type extends DescribeAssetResponse>(assetSummaryList: DescribeAssetResponse[] | AssociatedAssetsSummary[]): void {
+  public storeAssetSummaries<Type extends DescribeAssetResponse>(
+    assetSummaryList: DescribeAssetResponse[] | AssociatedAssetsSummary[]
+  ): void {
     assetSummaryList.forEach((summary) => {
       this.storeAssetSummary(summary as AssetSummary);
     });
@@ -79,8 +81,8 @@ export class SiteWiseAssetCache {
     return {
       assetIds: [],
       loadingStage: LoadingStateEnum.NOT_LOADED,
-      paginationToken: undefined
-    }
+      paginationToken: undefined,
+    };
   }
 
   private setupHierarchyCache(hierarchyId: string): CachedAssetSummaryBlock {
@@ -92,8 +94,12 @@ export class SiteWiseAssetCache {
     return storedHierarchy;
   }
 
-  public appendHierarchyResults(hierarchyId: string, assetSummaries: AssetSummary[] | AssociatedAssetsSummary[] | undefined,
-                                loadingState: LoadingStateEnum, paginationToken: string | undefined) {
+  public appendHierarchyResults(
+    hierarchyId: string,
+    assetSummaries: AssetSummary[] | AssociatedAssetsSummary[] | undefined,
+    loadingState: LoadingStateEnum,
+    paginationToken: string | undefined
+  ) {
     let storedHierarchy: CachedAssetSummaryBlock = this.setupHierarchyCache(hierarchyId);
 
     storedHierarchy.loadingStage = loadingState;
@@ -101,7 +107,7 @@ export class SiteWiseAssetCache {
     if (!assetSummaries) {
       return;
     }
-    assetSummaries.forEach(assetSummary => {
+    assetSummaries.forEach((assetSummary) => {
       if (assetSummary.id != undefined) {
         this.storeAssetSummary(assetSummary);
         storedHierarchy.assetIds.push(assetSummary.id);

--- a/packages/core/src/asset-modules/sitewise/requestProcessor.spec.ts
+++ b/packages/core/src/asset-modules/sitewise/requestProcessor.spec.ts
@@ -4,8 +4,6 @@ import { SiteWiseAssetCache } from './cache';
 
 it('initializes', () => {
   expect(
-    () =>
-        new RequestProcessor(new IoTSiteWiseClient({ region: 'us-east' }), new SiteWiseAssetCache())
+    () => new RequestProcessor(new IoTSiteWiseClient({ region: 'us-east' }), new SiteWiseAssetCache())
   ).not.toThrowError();
 });
-

--- a/packages/core/src/asset-modules/sitewise/requestProcessorWorkerGroup.ts
+++ b/packages/core/src/asset-modules/sitewise/requestProcessorWorkerGroup.ts
@@ -8,9 +8,11 @@ export class RequestProcessorWorkerGroup<TQuery extends AssetQuery, TResult> {
   private readonly queryToKey: (query: TQuery) => string;
   private readonly startValue: (query: TQuery) => TResult;
 
-  constructor(workerFactory: (query: TQuery) => Observable<TResult>,
-              queryToKey: (query: TQuery) => string,
-              startValue: (query: TQuery) => TResult) {
+  constructor(
+    workerFactory: (query: TQuery) => Observable<TResult>,
+    queryToKey: (query: TQuery) => string,
+    startValue: (query: TQuery) => TResult
+  ) {
     this.workerFactory = workerFactory;
     this.queryToKey = queryToKey;
     this.startValue = startValue;

--- a/packages/core/src/asset-modules/sitewise/session.ts
+++ b/packages/core/src/asset-modules/sitewise/session.ts
@@ -4,11 +4,13 @@ import {
   AssetModelQuery,
   AssetPropertyValueQuery,
   AssetQuery,
-  AssetSummaryQuery, HierarchyAssetSummaryList,
+  AssetSummaryQuery,
+  HierarchyAssetSummaryList,
   isAssetHierarchyQuery,
   isAssetModelQuery,
   isAssetPropertyValueQuery,
-  isAssetSummaryQuery, SiteWiseAssetSessionInterface,
+  isAssetSummaryQuery,
+  SiteWiseAssetSessionInterface,
 } from './types';
 import { AssetSummary, DescribeAssetModelResponse } from '@aws-sdk/client-iotsitewise/dist-types';
 import { RequestProcessor } from './requestProcessor';
@@ -24,13 +26,15 @@ export class SiteWiseAssetSession implements SiteWiseAssetSessionInterface {
     this.processor = processor;
   }
 
-
   public addRequest(query: AssetModelQuery, observer: (assetModel: DescribeAssetModelResponse) => void): Subscription;
   public addRequest(
     query: AssetPropertyValueQuery,
     observer: (assetPropertyValue: AssetPropertyValue) => void
   ): Subscription;
-  public addRequest(query: AssetHierarchyQuery, observer: (assetSummary: HierarchyAssetSummaryList) => void): Subscription;
+  public addRequest(
+    query: AssetHierarchyQuery,
+    observer: (assetSummary: HierarchyAssetSummaryList) => void
+  ): Subscription;
   public addRequest(query: AssetSummaryQuery, observer: (assetSummary: AssetSummary) => void): Subscription;
   public addRequest<Result>(query: AssetQuery, observerAny: (consumedType: Result) => void): Subscription {
     let observable: Observable<any>;

--- a/packages/core/src/asset-modules/sitewise/types.ts
+++ b/packages/core/src/asset-modules/sitewise/types.ts
@@ -32,7 +32,7 @@ export type AssetHierarchyQuery = AssetQuery & {
 };
 
 export function assetHierarchyQueryKey(query: AssetHierarchyQuery): string {
-  return (query.assetId ? (query.assetId + ":") : '') + query.assetHierarchyId;
+  return (query.assetId ? query.assetId + ':' : '') + query.assetHierarchyId;
 }
 export const isAssetHierarchyQuery = (query: AssetQuery): query is AssetHierarchyQuery =>
   (query as AssetHierarchyQuery).assetHierarchyId != undefined;
@@ -47,30 +47,27 @@ export enum LoadingStateEnum {
 export const HIERARCHY_ROOT_ID = 'HIERARCHY_ROOT_ID';
 
 export type CachedAssetSummaryBlock = {
-  assetIds: string[],
-  loadingStage: LoadingStateEnum,
-  paginationToken: string | undefined
-}
+  assetIds: string[];
+  loadingStage: LoadingStateEnum;
+  paginationToken: string | undefined;
+};
 
 export type HierarchyAssetSummaryList = {
-  assetHierarchyId: string,
-  assets: AssetSummary[],
-  loadingState: LoadingStateEnum,
-}
+  assetHierarchyId: string;
+  assets: AssetSummary[];
+  loadingState: LoadingStateEnum;
+};
 
 export interface SiteWiseAssetModuleInterface {
-  startSession(): SiteWiseAssetSessionInterface
+  startSession(): SiteWiseAssetSessionInterface;
 }
 
 export interface SiteWiseAssetSessionInterface {
   addRequest(query: AssetModelQuery, observer: (assetModel: DescribeAssetModelResponse) => void): Subscription;
-  addRequest(
-    query: AssetPropertyValueQuery,
-    observer: (assetPropertyValue: AssetPropertyValue) => void
-  ): Subscription;
+  addRequest(query: AssetPropertyValueQuery, observer: (assetPropertyValue: AssetPropertyValue) => void): Subscription;
   addRequest(query: AssetHierarchyQuery, observer: (assetSummary: HierarchyAssetSummaryList) => void): Subscription;
   addRequest(query: AssetSummaryQuery, observer: (assetSummary: AssetSummary) => void): Subscription;
   // addRequest<Result>(query: AssetQuery, observerAny: (consumedType: Result) => void): Subscription;
 
-  close(): void
+  close(): void;
 }

--- a/packages/core/src/data-module/data-cache/caching/caching.ts
+++ b/packages/core/src/data-module/data-cache/caching/caching.ts
@@ -11,7 +11,7 @@ import {
 
 import { CacheSettings, DataStreamsStore, DataStreamStore, TTLDurationMapping } from '../types';
 import { getExpiredCacheIntervals } from './expiredCacheIntervals';
-import { RequestConfig } from '../requestTypes';
+import { TimeSeriesDataRequestSettings } from '../requestTypes';
 import { pointBisector } from '../../../common/dataFilters';
 
 export const unexpiredCacheIntervals = (
@@ -197,7 +197,7 @@ export const checkCacheForRecentPoint = ({
 
 // Validates request config to see if we need to make a fetch Request
 // This will expand in future to accomodate more requestConfig variants
-export const validateRequestConfig = (requestConfig: RequestConfig | undefined) => {
+export const validateRequestConfig = (requestConfig: TimeSeriesDataRequestSettings | undefined) => {
   if (requestConfig) {
     return requestConfig.fetchMostRecentBeforeStart;
   }

--- a/packages/core/src/data-module/data-cache/dataCacheWrapped.spec.ts
+++ b/packages/core/src/data-module/data-cache/dataCacheWrapped.spec.ts
@@ -101,7 +101,9 @@ describe('actions', () => {
   it('onSuccess works', () => {
     const dataCache = new DataCache();
 
-    dataCache.onSuccess({ onlyFetchLatestValue: false, viewport: { duration: SECOND_IN_MS } })([DATA_STREAM]);
+    dataCache.onSuccess({ settings: { fetchFromStartToEnd: true }, viewport: { duration: SECOND_IN_MS } })([
+      DATA_STREAM,
+    ]);
     const state = dataCache.getState() as any;
 
     expect(state[DATA_STREAM.id][DATA_STREAM.resolution]).toBeDefined();

--- a/packages/core/src/data-module/data-cache/dataCacheWrapped.ts
+++ b/packages/core/src/data-module/data-cache/dataCacheWrapped.ts
@@ -2,7 +2,7 @@ import { Store } from 'redux';
 import { DataStream, Resolution } from '@synchro-charts/core';
 import { DataStreamsStore } from './types';
 import { configureStore } from './createStore';
-import { Request } from './requestTypes';
+import { TimeSeriesDataRequest } from './requestTypes';
 import { onErrorAction, onRequestAction, onSuccessAction } from './dataActions';
 import { viewportEndDate, viewportStartDate } from '../../common/viewport';
 import { getDataStreamStore } from './getDataStreamStore';
@@ -93,7 +93,7 @@ export class DataCache {
    * coordinating the dispatching of the action throughout the file.
    */
 
-  public onSuccess = (queryConfig: Request) => (dataStreams: DataStream[]): void => {
+  public onSuccess = (queryConfig: TimeSeriesDataRequest) => (dataStreams: DataStream[]): void => {
     const queryStart: Date = viewportStartDate(queryConfig.viewport);
     const queryEnd: Date = viewportEndDate(queryConfig.viewport);
 

--- a/packages/core/src/data-module/data-cache/requestTypes.ts
+++ b/packages/core/src/data-module/data-cache/requestTypes.ts
@@ -9,17 +9,32 @@ export type Viewport =
 /**
  * Request Information utilized by consumers of the widgets to connect the `data-provider` to their data source.
  */
-export type Request = {
+export type TimeSeriesDataRequest = {
   viewport: MinimalViewPortConfig;
-  // when this is true, we only require the latest value to be returned when in a live view, and will return most recent when in a historical view.
-  onlyFetchLatestValue: boolean;
-  // how long before waiting to check if another request should be initiated, in ms
-  refreshRate?: number;
-  requestConfig?: RequestConfig;
+  settings?: TimeSeriesDataRequestSettings;
 };
 
+export type ResolutionConfig = ResolutionMapping | string;
+
+export interface TimeSeriesDataRequestSettings {
+  // Higher buffer will lead to more off-viewport data to be requested.
+  requestBuffer?: number;
+
+  // refresh rate in milliseconds
+  refreshRate?: number;
+
+  resolution?: ResolutionConfig;
+
+  fetchAggregatedData?: boolean;
+
+  // Specify what data intervals to request given a viewport
+  fetchFromStartToEnd?: boolean;
+  fetchMostRecentBeforeStart?: boolean;
+  fetchMostRecentBeforeEnd?: boolean;
+}
+
 export type OnRequestData = (opts: {
-  request: Request;
+  request: TimeSeriesDataRequest;
   resolution: number; // milliseconds, 0 for raw data
   onError: (id: DataStreamId, resolution: Resolution, error: string) => void;
   onSuccess: (id: DataStreamId, data: DataStream, first: Date, last: Date) => void;
@@ -29,12 +44,3 @@ export type OnRequestData = (opts: {
 export type ResolutionMapping = {
   [viewportDuration: number]: number | string;
 };
-
-export type ResolutionConfig = ResolutionMapping | string;
-
-export interface RequestConfig {
-  fetchMostRecentBeforeStart?: boolean;
-  requestBuffer?: number;
-  fetchAggregatedData?: boolean;
-  resolution?: ResolutionConfig;
-}

--- a/packages/core/src/data-module/data-source-store/dataSourceStore.spec.ts
+++ b/packages/core/src/data-module/data-source-store/dataSourceStore.spec.ts
@@ -16,10 +16,10 @@ it('initiate a request on a registered data source', () => {
 
   const query = { source: 'custom' };
 
-  const requestInfo = { viewport: { start: new Date(), end: new Date() }, onlyFetchLatestValue: false };
+  const request = { viewport: { start: new Date(), end: new Date() }, settings: { fetchFromStartToEnd: true } };
   dataSourceStore.initiateRequest(
     {
-      requestInfo,
+      request,
       query,
       onSuccess: () => {},
       onError: () => {},
@@ -29,7 +29,7 @@ it('initiate a request on a registered data source', () => {
 
   expect(customSource.initiateRequest).toBeCalledWith(
     {
-      requestInfo,
+      request,
       query,
       onSuccess: expect.toBeFunction(),
       onError: expect.toBeFunction(),
@@ -41,11 +41,11 @@ it('initiate a request on a registered data source', () => {
 it('throws error when attempting to initiate a request to a non-existent data source', () => {
   const dataSourceStore = new DataSourceStore();
 
-  const requestInfo = { viewport: { start: new Date(), end: new Date() }, onlyFetchLatestValue: false };
+  const request = { viewport: { start: new Date(), end: new Date() }, settings: { fetchFromStartToEnd: true } };
   expect(() =>
     dataSourceStore.initiateRequest(
       {
-        requestInfo,
+        request,
         query: { source: 'some-name' },
         onSuccess: () => {},
         onError: () => {},

--- a/packages/core/src/data-module/data-source-store/dataSourceStore.ts
+++ b/packages/core/src/data-module/data-source-store/dataSourceStore.ts
@@ -6,8 +6,7 @@ import {
   RequestInformation,
   RequestInformationAndRange,
 } from '../types.d';
-import { Request } from '../data-cache/requestTypes';
-
+import { TimeSeriesDataRequest } from '../data-cache/requestTypes';
 
 /**
  * Manages the collection of registered data sources, as well as delegating requests to the correct data-source.
@@ -28,9 +27,15 @@ export default class DataSourceStore {
     return this.dataSources[source];
   };
 
-  public getRequestsFromQuery = <Query extends DataStreamQuery>({ query, requestInfo }: { query: Query, requestInfo: Request }): RequestInformation[] => {
+  public getRequestsFromQuery = <Query extends DataStreamQuery>({
+    query,
+    request,
+  }: {
+    query: Query;
+    request: TimeSeriesDataRequest;
+  }): RequestInformation[] => {
     const dataSource = this.getDataSource(query.source);
-    return dataSource.getRequestsFromQuery({ query, requestInfo });
+    return dataSource.getRequestsFromQuery({ query, request });
   };
 
   public initiateRequest = <Query extends DataStreamQuery>(

--- a/packages/core/src/data-module/index.ts
+++ b/packages/core/src/data-module/index.ts
@@ -16,9 +16,6 @@ export const registerDataSource: RegisterDataSource = (dataModule, ...inputs) =>
 export const subscribeToDataStreams: SubscribeToDataStreams = (dataModule, ...inputs) =>
   dataModule.subscribeToDataStreams(...inputs);
 
-export const subscribeToDataStreamsFrom: SubscribeToDataStreamsFrom = (dataModule, ...inputs) =>
-  dataModule.subscribeToDataStreamsFrom(...inputs);
-
 /**
  * Initialize IoT App Kit
  *

--- a/packages/core/src/data-module/subscription-store/subscriptionStore.spec.ts
+++ b/packages/core/src/data-module/subscription-store/subscriptionStore.spec.ts
@@ -22,7 +22,13 @@ const createSubscriptionStore = () => {
 const MOCK_SUBSCRIPTION: Subscription<SiteWiseDataStreamQuery> = {
   emit: () => {},
   query: { source: SITEWISE_DATA_SOURCE, assets: [] },
-  requestInfo: { viewport: { start: new Date(2000, 0, 0), end: new Date() }, onlyFetchLatestValue: false },
+  request: {
+    viewport: { start: new Date(2000, 0, 0), end: new Date() },
+    settings: {
+      fetchFromStartToEnd: true,
+      fetchMostRecentBeforeStart: true,
+    },
+  },
   fulfill: () => {},
 };
 

--- a/packages/core/src/data-module/subscription-store/subscriptionStore.ts
+++ b/packages/core/src/data-module/subscription-store/subscriptionStore.ts
@@ -15,7 +15,7 @@ export default class SubscriptionStore {
   private dataCache: DataCache;
   private unsubscribeMap: { [subscriberId: string]: Function } = {};
   private scheduler: RequestScheduler = new RequestScheduler();
-  private subscriptions: { [subscriptionId: string]: Subscription<AnyDataStreamQuery> } = {};
+  private subscriptions: { [subscriptionId: string]: Subscription } = {};
 
   constructor({ dataSourceStore, dataCache }: { dataSourceStore: DataSourceStore; dataCache: DataCache }) {
     this.dataCache = dataCache;
@@ -30,21 +30,21 @@ export default class SubscriptionStore {
       if ('query' in subscription) {
         subscription.fulfill();
 
-        if ('duration' in subscription.requestInfo.viewport) {
+        if ('duration' in subscription.request.viewport) {
           /** has a duration, so periodically request for data */
           this.scheduler.create({
             id: subscriptionId,
             cb: () => subscription.fulfill(),
-            duration: parseDuration((subscription.requestInfo.viewport as MinimalLiveViewport).duration),
-            refreshRate: subscription.requestInfo.refreshRate,
+            duration: parseDuration((subscription.request.viewport as MinimalLiveViewport).duration),
+            refreshRate: subscription.request.settings?.refreshRate,
           });
         }
 
-        const { query, requestInfo } = subscription;
+        const { query, request } = subscription;
 
         // Subscribe to changes from the data cache
         const unsubscribe = this.dataCache.subscribe(
-          this.dataSourceStore.getRequestsFromQuery({ query, requestInfo }),
+          this.dataSourceStore.getRequestsFromQuery({ query, request }),
           subscription.emit
         );
 

--- a/packages/core/src/data-module/types.d.ts
+++ b/packages/core/src/data-module/types.d.ts
@@ -1,5 +1,5 @@
 import { DataStream, DataStreamId, Resolution } from '@synchro-charts/core';
-import { Request } from './data-cache/requestTypes';
+import { TimeSeriesDataRequest } from './data-cache/requestTypes';
 
 export type RequestInformation = { id: DataStreamId; resolution: Resolution };
 export type RequestInformationAndRange = RequestInformation & { start: Date; end: Date };
@@ -10,35 +10,29 @@ export type DataSource<Query extends DataStreamQuery = AnyDataStreamQuery> = {
   // An identifier for the name of the source, i.e. 'site-wise', 'roci', etc..
   name: DataSourceName; // this is unique
   initiateRequest: (request: DataSourceRequest<Query>, requestInformations: RequestInformationAndRange[]) => void;
-  getRequestsFromQuery: ({ query, requestInfo}: { query: Query, requestInfo: Request }) => RequestInformation[];
+  getRequestsFromQuery: ({
+    query,
+    requestInfo,
+  }: {
+    query: Query;
+    request: TimeSeriesDataRequest;
+  }) => RequestInformation[];
 };
 
 export type DataStreamCallback = (dataStreams: DataStream[]) => void;
 
-export type QuerySubscription<Query extends DataStreamQuery> =
-  | {
-      query: Query;
-      requestInfo: Request;
-      emit: DataStreamCallback;
-      // Initiate requests for the subscription
-      fulfill: () => void;
-    }
-  | {
-      emit: DataStreamCallback;
-      source: string;
-    };
-
-export type SourceSubscription = {
+export type QuerySubscription<Query extends DataStreamQuery> = {
+  query: Query;
+  request: TimeSeriesDataRequest;
   emit: DataStreamCallback;
-  source: string;
+  // Initiate requests for the subscription
+  fulfill: () => void;
 };
 
-export type Subscription<Query extends DataStreamQuery = AnyDataStreamQuery> =
-  | QuerySubscription<Query>
-  | SourceSubscription;
+export type Subscription<Query extends DataStreamQuery = AnyDataStreamQuery> = QuerySubscription<Query>;
 
 export type DataModuleSubscription<Query extends DataStreamQuery> = {
-  requestInfo: Request;
+  request: TimeSeriesDataRequest;
   query: Query;
 };
 
@@ -53,7 +47,7 @@ export type ErrorCallback = ({ id, resolution, error }) => void;
 export type SubscriptionUpdate<Query extends DataStreamQuery> = Partial<Omit<Subscription<Query>, 'emit'>>;
 
 export type DataSourceRequest<Query extends DataStreamQuery> = {
-  requestInfo: Request;
+  request: TimeSeriesDataRequest;
   query: Query;
   onSuccess: DataStreamCallback;
   onError: ErrorCallback;
@@ -95,13 +89,6 @@ export type SubscribeToDataStreamsFrom = (
   unsubscribe: () => void;
 };
 
-type SubscribeToDataStreamsFromPrivate = (
-  source: string,
-  emit: DataStreamCallback
-) => {
-  unsubscribe: () => void;
-};
-
 /**
  * Register custom data source to the data module.
  */
@@ -116,5 +103,4 @@ export type RegisterDataSource = <Query extends DataStreamQuery>(
 export interface DataModule {
   registerDataSource: RegisterDataSourcePrivate;
   subscribeToDataStreams: SubscribeToDataStreamsPrivate;
-  subscribeToDataStreamsFrom: SubscribeToDataStreamsFromPrivate;
 }

--- a/packages/core/src/data-sources/site-wise-legacy/data-source.ts
+++ b/packages/core/src/data-sources/site-wise-legacy/data-source.ts
@@ -14,12 +14,12 @@ export const createSiteWiseLegacyDataSource = (
   name: 'site-wise',
   getRequestsFromQuery: ({ query: { dataStreamInfos } }): RequestInformation[] =>
     dataStreamInfos.map(({ id, resolution }) => ({ id, resolution })),
-  initiateRequest: ({ query, requestInfo, onSuccess }, requestInformations) => {
+  initiateRequest: ({ query, request, onSuccess }, requestInformations) => {
     query.dataStreamInfos
       .filter((dataStreamInfo) => requestInformations.some((r) => r.id === dataStreamInfo.id))
       .forEach((info) => {
         onRequestData({
-          request: requestInfo,
+          request,
           resolution: info.resolution,
           onError: () => {},
           onSuccess: (id: DataStreamId, data: DataStream) => {

--- a/packages/core/src/data-sources/site-wise/client/client.spec.ts
+++ b/packages/core/src/data-sources/site-wise/client/client.spec.ts
@@ -188,14 +188,16 @@ describe('getAggregatedPropertyDataPoints', () => {
     const endDate = new Date(2001, 0, 0);
     const aggregateTypes = [AggregateType.AVERAGE];
 
-    await expect(async () => { await client.getAggregatedPropertyDataPoints({
-      query,
-      onSuccess,
-      onError,
-      start: startDate,
-      end: endDate,
-      aggregateTypes,
-    })}).rejects.toThrowError();
+    await expect(async () => {
+      await client.getAggregatedPropertyDataPoints({
+        query,
+        onSuccess,
+        onError,
+        start: startDate,
+        end: endDate,
+        aggregateTypes,
+      });
+    }).rejects.toThrowError();
   });
 
   it('returns data point on success', async () => {

--- a/packages/core/src/data-sources/site-wise/client/getAggregatedPropertyDataPoints.ts
+++ b/packages/core/src/data-sources/site-wise/client/getAggregatedPropertyDataPoints.ts
@@ -58,12 +58,14 @@ const getAggregatedPropertyDataPointsForProperty = ({
           .map((assetPropertyValue) => aggregateToDataPoint(assetPropertyValue))
           .filter(isDefined);
 
-        onSuccess([dataStreamFromSiteWise({
-          assetId,
-          propertyId,
-          dataPoints,
-          resolution: RESOLUTION_TO_MS_MAPPING[resolution]
-        })]);
+        onSuccess([
+          dataStreamFromSiteWise({
+            assetId,
+            propertyId,
+            dataPoints,
+            resolution: RESOLUTION_TO_MS_MAPPING[resolution],
+          }),
+        ]);
       }
 
       if (nextToken) {
@@ -112,26 +114,25 @@ export const getAggregatedPropertyDataPoints = async ({
   const requests = query.assets
     .map(({ assetId, properties }) =>
       properties.map(({ propertyId, resolution: propertyResolution }) => {
-          const resolutionOverride = propertyResolution || resolution;
+        const resolutionOverride = propertyResolution || resolution;
 
-          if (resolutionOverride == null) {
-            throw new Error('Resolution must be either specified in requestConfig or query');
-          }
-
-          return getAggregatedPropertyDataPointsForProperty({
-            client,
-            assetId,
-            propertyId,
-            start,
-            end,
-            resolution: resolutionOverride,
-            aggregateTypes,
-            maxResults,
-            onSuccess,
-            onError,
-          })
+        if (resolutionOverride == null) {
+          throw new Error('Resolution must be either specified in requestConfig or query');
         }
-      )
+
+        return getAggregatedPropertyDataPointsForProperty({
+          client,
+          assetId,
+          propertyId,
+          start,
+          end,
+          resolution: resolutionOverride,
+          aggregateTypes,
+          maxResults,
+          onSuccess,
+          onError,
+        });
+      })
     )
     .flat();
 

--- a/packages/core/src/data-sources/site-wise/client/getHistoricalPropertyDataPoints.ts
+++ b/packages/core/src/data-sources/site-wise/client/getHistoricalPropertyDataPoints.ts
@@ -103,5 +103,9 @@ export const getHistoricalPropertyDataPoints = async ({
     )
     .flat();
 
-  await Promise.all(requests);
+  try {
+    await Promise.all(requests);
+  } catch (err) {
+    // NOOP
+  }
 };

--- a/packages/core/src/data-sources/site-wise/client/getLatestPropertyDataPoint.ts
+++ b/packages/core/src/data-sources/site-wise/client/getLatestPropertyDataPoint.ts
@@ -18,7 +18,7 @@ export const getLatestPropertyDataPoint = async ({
   client: IoTSiteWiseClient;
 }): Promise<void> => {
   const requests = assets
-    .map(({ assetId,properties }) =>
+    .map(({ assetId, properties }) =>
       properties.map(({ propertyId }) => {
         return client
           .send(new GetAssetPropertyValueCommand({ assetId, propertyId }))

--- a/packages/core/src/data-sources/site-wise/dataStreamFromSiteWise.ts
+++ b/packages/core/src/data-sources/site-wise/dataStreamFromSiteWise.ts
@@ -14,18 +14,18 @@ export const dataStreamFromSiteWise = ({
   resolution?: number;
 }): DataStream => {
   const dataStream: DataStream = {
-    name: toDataStreamId({assetId, propertyId}),
-    id: toDataStreamId({assetId, propertyId}),
+    name: toDataStreamId({ assetId, propertyId }),
+    id: toDataStreamId({ assetId, propertyId }),
     data: dataPoints || [],
     resolution,
     // TODO: Better support for various data types, will need to utilize associated asset information to infer.
     dataType: DataType.NUMBER,
-  }
+  };
 
   if (resolution) {
     dataStream.aggregates = {
-      [resolution]: dataPoints || []
-    }
+      [resolution]: dataPoints || [],
+    };
   }
 
   return dataStream;

--- a/packages/core/src/data-sources/site-wise/types.d.ts
+++ b/packages/core/src/data-sources/site-wise/types.d.ts
@@ -11,13 +11,13 @@ export type AssetId = string;
 export type PropertyAlias = string;
 
 export type PropertyQuery = {
-  propertyId: string,
-  resolution?: string
-}
+  propertyId: string;
+  resolution?: string;
+};
 
 export type AssetQuery = {
   assetId: AssetId;
-  properties: PropertyQuery[]
+  properties: PropertyQuery[];
 };
 
 type SiteWiseAssetDataStreamQuery = DataStreamQuery & {

--- a/packages/core/src/data-sources/site-wise/util/resolution.ts
+++ b/packages/core/src/data-sources/site-wise/util/resolution.ts
@@ -3,12 +3,12 @@ import { MINUTE_IN_MS, HOUR_IN_MS, DAY_IN_MS } from '../../../common/time';
 export enum SupportedResolutions {
   ONE_MINUTE = '1m',
   ONE_HOUR = '1h',
-  ONE_DAY = '1d'
+  ONE_DAY = '1d',
 }
 
 export const RESOLUTION_TO_MS_MAPPING: { [key: string]: number } = {
   '0': 0,
   [SupportedResolutions.ONE_MINUTE]: MINUTE_IN_MS,
   [SupportedResolutions.ONE_HOUR]: HOUR_IN_MS,
-  [SupportedResolutions.ONE_DAY]: DAY_IN_MS
-}
+  [SupportedResolutions.ONE_DAY]: DAY_IN_MS,
+};


### PR DESCRIPTION
## Overview
API work on core

Utilize the originally planned API structure, with settings such as `fetchFromStartToEnd`, `fetchMostRecentBeforeEnd`, `fetchMostRecentBeforeStart`, etc.,

- run yarn run fix on root, which effected some files which were not properly formatted
- Alter API to remove the concept of a requestConfig in favor for settings
- 
## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
