### PR TITLE
feat: bind gestures to components

### DIFF
--- a/packages/components/src/components/iot-connector/iot-connector.spec.ts
+++ b/packages/components/src/components/iot-connector/iot-connector.spec.ts
@@ -101,3 +101,15 @@ it('updates with new query', async () => {
     ],
   });
 });
+
+//TODO: Backfill these tests.
+// Onboard cypress and try the component test runner https://www.cypress.io/blog/2021/04/06/introducing-the-cypress-component-test-runner/
+describe('handles gestures', () => {
+  it('panning', () => {
+    //TODO: Make sure data is requested for new viewport range when panning back in time
+  });
+
+  it('zooming', () => {
+    //TODO: Make sure correct resolution is displayed for selected viewport range based on resolution mapping
+  });
+});

--- a/packages/components/src/components/iot-connector/iot-connector.tsx
+++ b/packages/components/src/components/iot-connector/iot-connector.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, State, Watch } from '@stencil/core';
+import { Component, Listen, Prop, State, Watch } from '@stencil/core';
 import { DataStream } from '@synchro-charts/core';
 import isEqual from 'lodash.isequal';
 import {
@@ -60,6 +60,18 @@ export class IotConnector {
       this.update({
         query: this.query,
         request: this.request,
+      });
+    }
+  }
+
+  @Listen('dateRangeChange')
+  private handleDateRangeChange({ detail: [start, end, lastUpdatedBy] }: { detail: [Date, Date, string | undefined] }) {
+    if (this.update != null) {
+      this.update({
+        request: {
+          ...this.request,
+          viewport: {start, end, lastUpdatedBy}
+        },
       });
     }
   }


### PR DESCRIPTION
## Overview
Bind gestures to components. Now data will be requested for the selected viewport when panning or zooming out and correct resolution will be determined for viewport range when zooming.

![gestures](https://user-images.githubusercontent.com/6397726/148981282-c0c80749-36ce-4e10-ab85-696fa8a43784.gif)

## Tests
It does not make much sense to write unit tests for this, since they would basically just check that when we dispatch a custom event `dateRangeChange` with certain details - start, end, lastUpdatedBy -`subscribeToDataStreams` `update` callback gets called with the updated `viewport` in the `request` object. Instead we should backfill with integration tests for  more "customer centric" tests once we onboard to cypress.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
