### PR TITLE
Fix setTimeout error

### DIFF
--- a/packages/core/src/asset-modules/sitewise/requestProcessorWorkerGroup.spec.ts
+++ b/packages/core/src/asset-modules/sitewise/requestProcessorWorkerGroup.spec.ts
@@ -227,7 +227,7 @@ it('producers can run a finalizer when the last subscriber unsubscribes', (done)
         timeoutID = setInterval(function incrementer() {
           counter++;
           subscriber.next(counter);
-          if (counter == 5) {
+          if (counter === 5) {
             unsubscribe();
           }
         }, 5);


### PR DESCRIPTION
## Overview
Replaces a setTimeout with a call from inside the interval loop. Its not a real use-case but its not likely to break now wither.

## Tests
ran UTs

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
