### PR TITLE
feat: refresh static charts until data is no longer expire-able

### DIFF
--- a/packages/core/src/data-module/IotAppKitDataModule.ts
+++ b/packages/core/src/data-module/IotAppKitDataModule.ts
@@ -50,11 +50,15 @@ export class IotAppKitDataModule implements DataModule {
     const { initialDataCache, cacheSettings } = configuration;
 
     this.dataCache = new DataCache(initialDataCache);
-    this.subscriptions = new SubscriptionStore({ dataSourceStore: this.dataSourceStore, dataCache: this.dataCache });
     this.cacheSettings = {
       ...DEFAULT_CACHE_SETTINGS,
       ...cacheSettings,
     };
+    this.subscriptions = new SubscriptionStore({
+      dataSourceStore: this.dataSourceStore,
+      dataCache: this.dataCache,
+      cacheSettings: this.cacheSettings,
+    });
   }
 
   public registerDataSource = this.dataSourceStore.registerDataSource;
@@ -172,6 +176,7 @@ export class IotAppKitDataModule implements DataModule {
     const subscription = this.subscriptions.getSubscription(subscriptionId);
 
     const updatedSubscription = Object.assign({}, subscription, subscriptionUpdate) as Subscription;
+
     if ('query' in updatedSubscription) {
       this.subscriptions.updateSubscription(subscriptionId, {
         ...updatedSubscription,

--- a/packages/core/src/data-module/subscription-store/subscriptionStore.spec.ts
+++ b/packages/core/src/data-module/subscription-store/subscriptionStore.spec.ts
@@ -4,6 +4,7 @@ import { DataCache } from '../data-cache/dataCacheWrapped';
 import DataSourceStore from '../data-source-store/dataSourceStore';
 import { SiteWiseDataStreamQuery } from '../../data-sources/site-wise/types';
 import { SITEWISE_DATA_SOURCE } from '../../data-sources';
+import { DEFAULT_CACHE_SETTINGS } from '../IotAppKitDataModule';
 
 const createSubscriptionStore = () => {
   const store = new DataSourceStore();
@@ -16,6 +17,7 @@ const createSubscriptionStore = () => {
   return new SubscriptionStore({
     dataCache: new DataCache(),
     dataSourceStore: store,
+    cacheSettings: DEFAULT_CACHE_SETTINGS,
   });
 };
 


### PR DESCRIPTION
## Overview
Visualizations with static viewports (those with a fixed start and end date) do not schedule data refreshes via the `requestScheduler` - thus a static chart could possibly be displaying out-of-date or incomplete data.

This change schedules data refreshes for visualizations with static viewports. Static viewports will be refreshed until the data is no longer expire-able (timestamps of any data point < current timestamp - largest TTL duration). `refreshRate` can be used to control the refresh rate of static visualizations.


## Tests
[[Include a link to the passing GitHub action running the test suite here.]](https://github.com/boweihan/iot-app-kit/runs/4806766393?check_suite_focus=true)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
