### PR TITLE
Resource Explorer - Selection event listener

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -56,6 +56,7 @@ export namespace Components {
         "filterEnabled": boolean;
         "filterTexts"?: FilterTexts;
         "loadingText"?: string;
+        "onSelectionChange": (event: NonCancelableCustomEvent<TableProps.SelectionChangeDetail<unknown>>) => void;
         "paginationEnabled": boolean;
         "query": ResourceExplorerQuery;
         "selectionType"?: TableProps.SelectionType;
@@ -123,6 +124,7 @@ export namespace Components {
         "filterEnabled": boolean;
         "filterTexts"?: FilterTexts;
         "loadingText"?: string;
+        "onSelectionChange": (event: NonCancelableCustomEvent<TableProps.SelectionChangeDetail<unknown>>) => void;
         "paginationEnabled": boolean;
         "query": SiteWiseAssetTreeQuery;
         "selectionType"?: TableProps.SelectionType;
@@ -300,6 +302,7 @@ declare namespace LocalJSX {
         "filterEnabled"?: boolean;
         "filterTexts"?: FilterTexts;
         "loadingText"?: string;
+        "onSelectionChange"?: (event: NonCancelableCustomEvent<TableProps.SelectionChangeDetail<unknown>>) => void;
         "paginationEnabled"?: boolean;
         "query"?: ResourceExplorerQuery;
         "selectionType"?: TableProps.SelectionType;
@@ -367,6 +370,7 @@ declare namespace LocalJSX {
         "filterEnabled"?: boolean;
         "filterTexts"?: FilterTexts;
         "loadingText"?: string;
+        "onSelectionChange"?: (event: NonCancelableCustomEvent<TableProps.SelectionChangeDetail<unknown>>) => void;
         "paginationEnabled"?: boolean;
         "query"?: SiteWiseAssetTreeQuery;
         "selectionType"?: TableProps.SelectionType;

--- a/packages/components/src/components/iot-resource-explorer/iot-resource-explorer.tsx
+++ b/packages/components/src/components/iot-resource-explorer/iot-resource-explorer.tsx
@@ -5,6 +5,7 @@ import { EmptyStateProps } from '@iot-app-kit/related-table';
 import { isSiteWiseQuery } from './utils';
 import { TableProps } from '@awsui/components-react/table';
 import { ResourceExplorerQuery, FilterTexts } from './types';
+import { NonCancelableCustomEvent } from '@awsui/components-react';
 
 @Component({
   tag: 'iot-resource-explorer',
@@ -21,6 +22,8 @@ export class IotResourceExplorer {
   @Prop() sortingEnabled: boolean = true;
   @Prop() paginationEnabled: boolean = true;
   @Prop() wrapLines: boolean = false;
+
+  @Prop() onSelectionChange: (event: NonCancelableCustomEvent<TableProps.SelectionChangeDetail<unknown>>) => void;
 
   siteWiseColumnDefinitions: ColumnDefinition<SitewiseAssetResource>[] = [
     {
@@ -63,6 +66,7 @@ export class IotResourceExplorer {
           sortingEnabled={this.sortingEnabled}
           paginationEnabled={this.paginationEnabled}
           wrapLines={this.wrapLines}
+          onSelectionChange={this.onSelectionChange}
         ></sitewise-resource-explorer>
       );
     }

--- a/packages/components/src/components/iot-resource-explorer/sitewise-resource-explorer.tsx
+++ b/packages/components/src/components/iot-resource-explorer/sitewise-resource-explorer.tsx
@@ -12,6 +12,7 @@ import { EmptyStateProps, ITreeNode, UseTreeCollection } from '@iot-app-kit/rela
 import { parseSitewiseAssetTree } from './utils';
 import { TableProps } from '@awsui/components-react/table';
 import { FilterTexts, ColumnDefinition } from './types';
+import { NonCancelableCustomEvent } from '@awsui/components-react';
 
 @Component({
   tag: 'sitewise-resource-explorer',
@@ -28,7 +29,8 @@ export class SitewiseResourceExplorer {
   @Prop() paginationEnabled: boolean;
   @Prop() wrapLines: boolean;
 
-  @State() selectItems: unknown[] = [];
+  @Prop() onSelectionChange: (event: NonCancelableCustomEvent<TableProps.SelectionChangeDetail<unknown>>) => void;
+
   @State() items: SitewiseAssetResource[] = [];
 
   defaults = {
@@ -97,9 +99,7 @@ export class SitewiseResourceExplorer {
         loadingText={this.loadingText || this.defaults.loadingText}
         filterPlaceholder={filtering?.placeholder}
         onExpandChildren={this.expandNode}
-        onSelectionChange={(event) => {
-          this.selectItems = event.detail.selectedItems;
-        }}
+        onSelectionChange={this.onSelectionChange}
         empty={this.empty || this.defaults.empty}
         sortingDisabled={!this.sortingEnabled}
         wrapLines={this.wrapLines}


### PR DESCRIPTION
## Overview
Adds callback to Selection Change event on the Resource Explorer component. In that way customers can listen for selected items and act on it.

## Tests
- `yarn fix && yarn test`
- Manual testing by running stencil locally.
- Unit tests: https://github.com/awslabs/iot-app-kit/runs/4861542562?check_suite_focus=true

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
