### PR TITLE
feat: query provider pt. 1 -  core interfaces, implementations, and TimeSeriesData support

### DIFF
--- a/packages/components/src/components/iot-connector/iot-connector.tsx
+++ b/packages/components/src/components/iot-connector/iot-connector.tsx
@@ -38,7 +38,7 @@ export class IotConnector {
         queries: this.queries,
         request: this.request,
       },
-      (dataStreams: DataStream[]) => {
+      ({ dataStreams }) => {
         this.dataStreams = bindStylesToDataStreams({ dataStreams, styleSettings: this.styleSettings });
       }
     );

--- a/packages/core/src/app-kit-component-session.ts
+++ b/packages/core/src/app-kit-component-session.ts
@@ -1,0 +1,39 @@
+import { SiteWiseAssetModule } from '.';
+import { IotAppKitDataModule } from './data-module/IotAppKitDataModule';
+import { IoTAppKitComponentSession, DataModuleSession } from './interface.d';
+
+/**
+ * Component session to manage component data module sessions.
+ * Contains a reference to sitewise data modules
+ */
+export class AppKitComponentSession implements IoTAppKitComponentSession {
+  public componentId: string;
+
+  public siteWiseTimeSeriesModule: IotAppKitDataModule;
+
+  public siteWiseAssetModule: SiteWiseAssetModule;
+
+  private sessions: DataModuleSession[] = [];
+
+  constructor({
+    componentId,
+    siteWiseTimeSeriesModule,
+    siteWiseAssetModule,
+  }: {
+    componentId: string;
+    siteWiseTimeSeriesModule: IotAppKitDataModule;
+    siteWiseAssetModule: SiteWiseAssetModule;
+  }) {
+    this.componentId = componentId;
+    this.siteWiseTimeSeriesModule = siteWiseTimeSeriesModule;
+    this.siteWiseAssetModule = siteWiseAssetModule;
+  }
+
+  attachDataModuleSession(session: DataModuleSession): void {
+    this.sessions.push(session);
+  }
+
+  close(): void {
+    this.sessions.forEach((session) => session.close());
+  }
+}

--- a/packages/core/src/data-module/IotAppKitDataModule.ts
+++ b/packages/core/src/data-module/IotAppKitDataModule.ts
@@ -3,13 +3,13 @@ import SubscriptionStore from './subscription-store/subscriptionStore';
 import {
   DataModule,
   DataModuleSubscription,
-  DataStreamCallback,
   DataStreamQuery,
   RequestInformation,
   RequestInformationAndRange,
   Subscription,
   SubscriptionUpdate,
 } from './types.d';
+import { TimeSeriesData } from '../interface';
 import { DataStreamsStore, CacheSettings } from './data-cache/types';
 import DataSourceStore from './data-source-store/dataSourceStore';
 import { SubscriptionResponse } from '../iotsitewise/time-series-data/types.d';
@@ -136,7 +136,7 @@ export class IotAppKitDataModule implements DataModule {
 
   public subscribeToDataStreams = <Query extends DataStreamQuery>(
     { queries, request }: DataModuleSubscription<Query>,
-    callback: DataStreamCallback
+    callback: (data: TimeSeriesData) => void
   ): SubscriptionResponse<Query> => {
     const subscriptionId = v4();
 

--- a/packages/core/src/data-module/subscription-store/subscriptionStore.ts
+++ b/packages/core/src/data-module/subscription-store/subscriptionStore.ts
@@ -69,7 +69,7 @@ export default class SubscriptionStore {
         // Subscribe to changes from the data cache
         const unsubscribe = this.dataCache.subscribe(
           this.dataSourceStore.getRequestsFromQueries({ queries, request }),
-          subscription.emit
+          (dataStreams) => subscription.emit({ dataStreams, viewport: subscription.request.viewport })
         );
 
         this.unsubscribeMap[subscriptionId] = () => {

--- a/packages/core/src/data-module/types.d.ts
+++ b/packages/core/src/data-module/types.d.ts
@@ -15,6 +15,7 @@ import {
 import { RefId } from '../iotsitewise/time-series-data/types';
 import { CacheSettings } from './data-cache/types';
 import { DataPoint, StreamAssociation } from '@synchro-charts/core/dist/types/utils/dataTypes';
+import { TimeSeriesData } from '../interface';
 
 export type RequestInformation = {
   id: DataStreamId;
@@ -68,7 +69,7 @@ export type DataStreamCallback = (dataStreams: DataStream[]) => void;
 export type QuerySubscription<Query extends DataStreamQuery> = {
   queries: Query[];
   request: TimeSeriesDataRequest;
-  emit: DataStreamCallback;
+  emit: (data: TimeSeriesData) => void;
   // Initiate requests for the subscription
   fulfill: () => void;
 };
@@ -107,7 +108,7 @@ export type DataSourceRequest<Query extends DataStreamQuery> = {
 export type SubscribeToDataStreams = <Query extends DataStreamQuery>(
   dataModule: DataModule,
   { queries, requestInfo }: DataModuleSubscription<Query>,
-  callback: DataStreamCallback
+  callback: (data: TimeSeriesData) => void
 ) => {
   unsubscribe: () => void;
   update: (subscriptionUpdate: SubscriptionUpdate<Query>) => void;
@@ -115,7 +116,7 @@ export type SubscribeToDataStreams = <Query extends DataStreamQuery>(
 
 type SubscribeToDataStreamsPrivate = <Query extends DataStreamQuery>(
   { queries, requestInfo }: DataModuleSubscription<Query>,
-  callback: DataStreamCallback
+  callback: (data: TimeSeriesData) => void
 ) => {
   unsubscribe: () => void;
   update: (subscriptionUpdate: SubscriptionUpdate<Query>) => void;
@@ -129,14 +130,14 @@ type SubscribeToDataStreamsPrivate = <Query extends DataStreamQuery>(
 export type SubscribeToDataStreamsFrom = (
   dataModule: DataModule,
   source: string,
-  emit: DataStreamCallback
+  emit: (data: TimeSeriesData) => void
 ) => {
   unsubscribe: () => void;
 };
 
 type SubscribeToDataStreamsFromPrivate = (
   source: string,
-  emit: DataStreamCallback
+  emit: (data: TimeSeriesData) => void
 ) => {
   unsubscribe: () => void;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,6 @@ export * from './data-module/index';
 export * from './asset-modules/index';
 export * from './iotAppKit';
 export * from './common/tests/util';
+export * from './module-namespace';
+export * from './query-namespace';
+export * from './iotsitewise/time-series-data/provider';

--- a/packages/core/src/iotAppKit.ts
+++ b/packages/core/src/iotAppKit.ts
@@ -3,7 +3,7 @@ import { sitewiseSdk } from './iotsitewise/time-series-data/sitewise-sdk';
 import { SiteWiseAssetDataSource } from './data-module/types';
 import { createSiteWiseAssetDataSource } from './iotsitewise/time-series-data/asset-data-source';
 import { SiteWiseAssetModule } from './asset-modules';
-import { IoTAppKitSession, IoTAppKitInitInputs } from './interface.d';
+import { IoTAppKitInitInputs, IoTAppKitSession } from './interface.d';
 import { createDataSource } from './iotsitewise/time-series-data';
 import { subscribeToTimeSeriesData } from './iotsitewise/time-series-data/coordinator';
 import { subscribeToAssetTree } from './asset-modules/coordinator';
@@ -15,7 +15,7 @@ import { subscribeToAssetTree } from './asset-modules/coordinator';
  * @param awsRegion - Region for AWS based data sources to point towards, i.e. us-east-1
  */
 export const initialize = (input: IoTAppKitInitInputs) => {
-  const dataModule = new IotAppKitDataModule();
+  const siteWiseTimeSeriesModule = new IotAppKitDataModule();
   const siteWiseSdk =
     'iotSiteWiseClient' in input ? input.iotSiteWiseClient : sitewiseSdk(input.awsCredentials, input.awsRegion);
 
@@ -25,16 +25,16 @@ export const initialize = (input: IoTAppKitInitInputs) => {
 
   if (input.registerDataSources !== false) {
     /** Automatically registered data sources */
-    dataModule.registerDataSource(createDataSource(siteWiseSdk));
+    siteWiseTimeSeriesModule.registerDataSource(createDataSource(siteWiseSdk));
   }
 
   return {
     session: (): IoTAppKitSession => ({
-      subscribeToTimeSeriesData: subscribeToTimeSeriesData(dataModule, siteWiseAssetModuleSession),
+      subscribeToTimeSeriesData: subscribeToTimeSeriesData(siteWiseTimeSeriesModule, siteWiseAssetModuleSession),
       iotsitewise: {
         subscribeToAssetTree: subscribeToAssetTree(siteWiseAssetModuleSession),
       },
-      registerDataSource: dataModule.registerDataSource,
+      registerDataSource: siteWiseTimeSeriesModule.registerDataSource,
     }),
   };
 };

--- a/packages/core/src/iotsitewise/time-series-data/data-source.spec.ts
+++ b/packages/core/src/iotsitewise/time-series-data/data-source.spec.ts
@@ -346,7 +346,7 @@ describe('e2e through data-module', () => {
 
       dataModule.registerDataSource(dataSource);
 
-      const dataStreamCallback = jest.fn();
+      const timeSeriesCallback = jest.fn();
       const assetId = 'asset-id';
       const propertyId = 'property-id';
 
@@ -360,20 +360,24 @@ describe('e2e through data-module', () => {
           ],
           request: HISTORICAL_REQUEST,
         },
-        dataStreamCallback
+        timeSeriesCallback
       );
 
       await flushPromises();
 
-      expect(dataStreamCallback).toBeCalledTimes(2);
-      expect(dataStreamCallback).toHaveBeenLastCalledWith([
+      expect(timeSeriesCallback).toBeCalledTimes(2);
+      expect(timeSeriesCallback).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          id: toDataStreamId({ assetId, propertyId }),
-          error: ERR_MESSAGE,
-          isLoading: false,
-          isRefreshing: false,
-        }),
-      ]);
+          dataStreams: [
+            expect.objectContaining({
+              id: toDataStreamId({ assetId, propertyId }),
+              error: ERR_MESSAGE,
+              isLoading: false,
+              isRefreshing: false,
+            }),
+          ],
+        })
+      );
     });
   });
 
@@ -389,7 +393,7 @@ describe('e2e through data-module', () => {
 
       dataModule.registerDataSource(dataSource);
 
-      const dataStreamCallback = jest.fn();
+      const timeSeriesCallback = jest.fn();
       const assetId = 'asset-id';
       const propertyId = 'property-id';
 
@@ -406,20 +410,24 @@ describe('e2e through data-module', () => {
             settings: { fetchMostRecentBeforeEnd: true },
           },
         },
-        dataStreamCallback
+        timeSeriesCallback
       );
 
       await flushPromises();
 
-      expect(dataStreamCallback).toBeCalledTimes(2);
-      expect(dataStreamCallback).toHaveBeenLastCalledWith([
+      expect(timeSeriesCallback).toBeCalledTimes(2);
+      expect(timeSeriesCallback).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          id: toDataStreamId({ assetId, propertyId }),
-          error: ERR_MESSAGE,
-          isLoading: false,
-          isRefreshing: false,
-        }),
-      ]);
+          dataStreams: [
+            expect.objectContaining({
+              id: toDataStreamId({ assetId, propertyId }),
+              error: ERR_MESSAGE,
+              isLoading: false,
+              isRefreshing: false,
+            }),
+          ],
+        })
+      );
     });
   });
 });

--- a/packages/core/src/iotsitewise/time-series-data/provider.spec.ts
+++ b/packages/core/src/iotsitewise/time-series-data/provider.spec.ts
@@ -1,0 +1,112 @@
+import { SiteWiseTimeSeriesDataProvider } from './provider';
+import { createMockSiteWiseSDK, SiteWiseAssetModule } from '../..';
+import { IotAppKitDataModule } from '../../data-module/IotAppKitDataModule';
+import { createSiteWiseAssetDataSource } from './asset-data-source';
+import { DESCRIBE_ASSET_RESPONSE } from '../../testing/__mocks__/assetSummary';
+import { AppKitComponentSession } from '../../app-kit-component-session';
+import { DATA_STREAM } from '../../testing/__mocks__/mockWidgetProperties';
+import { SiteWiseDataStreamQuery } from './types';
+import { DataSource, DataStream } from '../../interface';
+import { MINUTE_IN_MS } from '../../common/time';
+
+const createMockSource = (dataStreams: DataStream[]): DataSource<SiteWiseDataStreamQuery> => ({
+  name: 'site-wise',
+  initiateRequest: jest.fn(({ onSuccess }: any) => onSuccess(dataStreams)),
+  getRequestsFromQuery: () => dataStreams.map((dataStream) => ({ id: dataStream.id, resolution: 0 })),
+});
+
+const timeSeriesModule = new IotAppKitDataModule();
+const dataSource = createMockSource([DATA_STREAM]);
+timeSeriesModule.registerDataSource(dataSource);
+
+const assetModule = new SiteWiseAssetModule(
+  createSiteWiseAssetDataSource(
+    createMockSiteWiseSDK({
+      describeAsset: () => Promise.resolve(DESCRIBE_ASSET_RESPONSE),
+    })
+  )
+);
+
+const componentSession = new AppKitComponentSession({
+  componentId: 'componentId',
+  siteWiseAssetModule: assetModule,
+  siteWiseTimeSeriesModule: timeSeriesModule,
+});
+
+beforeAll(() => {
+  jest.useFakeTimers('modern');
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+it('subscribes, updates, and unsubscribes to time series data by delegating to underlying data modules', () => {
+  const START_1 = new Date(2020, 0, 0);
+  const END_1 = new Date();
+
+  const refreshRate = MINUTE_IN_MS;
+
+  const provider = new SiteWiseTimeSeriesDataProvider(componentSession, {
+    queries: [{ source: 'site-wise', assets: [] }],
+    request: {
+      viewport: { start: START_1, end: END_1 },
+      settings: { fetchFromStartToEnd: true, refreshRate },
+    },
+  });
+
+  const timeSeriesCallback = jest.fn();
+
+  // subscribe
+  provider.subscribe(timeSeriesCallback);
+
+  expect(timeSeriesCallback).toBeCalledWith({
+    dataStreams: [
+      expect.objectContaining({
+        id: DATA_STREAM.id,
+      }),
+    ],
+    viewport: {
+      start: START_1,
+      end: END_1,
+    },
+  });
+
+  const START_2 = new Date(2019, 0, 0);
+  const END_2 = new Date();
+
+  timeSeriesCallback.mockClear();
+
+  // update
+  provider.updateSubscription({
+    request: { viewport: { start: START_2, end: END_2 } },
+  });
+
+  expect(timeSeriesCallback).toBeCalledWith({
+    dataStreams: [
+      expect.objectContaining({
+        id: DATA_STREAM.id,
+      }),
+    ],
+    viewport: {
+      start: START_2,
+      end: END_2,
+    },
+  });
+
+  timeSeriesCallback.mockClear();
+
+  // check that subscription refreshes
+  jest.advanceTimersByTime(refreshRate);
+
+  expect(timeSeriesCallback).toHaveBeenCalled();
+
+  timeSeriesCallback.mockClear();
+
+  // unsubscribe
+  provider.unsubscribe();
+
+  jest.advanceTimersByTime(refreshRate);
+
+  expect(timeSeriesCallback).not.toHaveBeenCalled();
+});

--- a/packages/core/src/iotsitewise/time-series-data/provider.ts
+++ b/packages/core/src/iotsitewise/time-series-data/provider.ts
@@ -1,0 +1,46 @@
+import { MinimalViewPortConfig } from '@synchro-charts/core';
+import { Provider, IoTAppKitComponentSession } from '../../interface';
+import { AnyDataStreamQuery, DataModuleSubscription, SubscriptionUpdate } from '../../data-module/types';
+import { datamodule } from '../..';
+import { subscribeToTimeSeriesData } from './coordinator';
+import { TimeSeriesData } from './types';
+
+/**
+ * Provider for SiteWise time series data
+ */
+export class SiteWiseTimeSeriesDataProvider implements Provider<TimeSeriesData> {
+  private session: IoTAppKitComponentSession;
+
+  private input: DataModuleSubscription<AnyDataStreamQuery>;
+
+  private update: (subscriptionUpdate: SubscriptionUpdate<AnyDataStreamQuery>) => void;
+
+  constructor(session: IoTAppKitComponentSession, input: DataModuleSubscription<AnyDataStreamQuery>) {
+    this.session = session;
+    this.input = input;
+  }
+
+  subscribe(callback: (data: TimeSeriesData) => void) {
+    const { session } = this;
+
+    const { update, unsubscribe } = subscribeToTimeSeriesData(
+      datamodule.iotsitewise.timeSeriesDataSession(session),
+      datamodule.iotsitewise.assetDataSession(session)
+    )(this.input, callback);
+
+    this.update = update;
+
+    /** @todo move into datamodule namespace when sessions are supported on time series module */
+    this.session.attachDataModuleSession({
+      close: unsubscribe,
+    });
+  }
+
+  updateSubscription(subscriptionUpdate: SubscriptionUpdate<AnyDataStreamQuery>) {
+    this.update(subscriptionUpdate);
+  }
+
+  unsubscribe() {
+    this.session.close();
+  }
+}

--- a/packages/core/src/iotsitewise/time-series-data/types.d.ts
+++ b/packages/core/src/iotsitewise/time-series-data/types.d.ts
@@ -1,5 +1,7 @@
+import { MinimalViewPortConfig } from '@synchro-charts/core';
 import { CacheSettings } from '../../data-module/data-cache/types';
 import { DataStreamQuery, SubscriptionUpdate } from '../../data-module/types';
+import { DataStream } from '../../interface';
 
 /**
  * Learn more about AWS IoT SiteWise assets at https://docs.aws.amazon.com/iot-sitewise/latest/userguide/industrial-asset-models.html
@@ -47,4 +49,9 @@ export type SubscriptionResponse<Query extends DataStreamQuery> = {
 
   /** Update the subscription. This will immediately evaluate if a new query must be requested */
   update: (subscriptionUpdate: SubscriptionUpdate<Query>) => void;
+};
+
+export type TimeSeriesData = {
+  dataStreams: DataStream[];
+  viewport: MinimalViewPortConfig;
 };

--- a/packages/core/src/module-namespace.ts
+++ b/packages/core/src/module-namespace.ts
@@ -1,0 +1,19 @@
+import { IoTAppKitComponentSession } from './interface';
+import { DataModule } from './data-module/types';
+import { SiteWiseAssetSession } from '.';
+import { AppKitComponentSession } from './app-kit-component-session';
+
+/**
+ * Extensible datamodule namespace exposing module sessions.
+ */
+export namespace datamodule.iotsitewise {
+  export function timeSeriesDataSession(session: IoTAppKitComponentSession): DataModule {
+    return (session as AppKitComponentSession).siteWiseTimeSeriesModule; // casting to hide modules from public interface
+  }
+
+  export function assetDataSession(session: IoTAppKitComponentSession): SiteWiseAssetSession {
+    const assetSession = (session as AppKitComponentSession).siteWiseAssetModule.startSession();
+    session.attachDataModuleSession(assetSession);
+    return assetSession;
+  }
+}

--- a/packages/core/src/query-namespace.ts
+++ b/packages/core/src/query-namespace.ts
@@ -1,0 +1,24 @@
+import { IoTAppKitComponentSession, TimeSeriesDataRequestSettings, TimeSeriesQuery } from './interface';
+import { AnyDataStreamQuery, DataModuleSubscription } from './data-module/types';
+import { SiteWiseTimeSeriesDataProvider } from './iotsitewise/time-series-data/provider';
+
+/**
+ * Extensible query namespace exposing methods that return Query<Provider> implementations
+ */
+export namespace query.iotsitewise {
+  export const timeSeriesData = (
+    input: DataModuleSubscription<AnyDataStreamQuery>
+  ): TimeSeriesQuery<SiteWiseTimeSeriesDataProvider> => ({
+    build: (session: IoTAppKitComponentSession, params?: TimeSeriesDataRequestSettings) =>
+      new SiteWiseTimeSeriesDataProvider(session, {
+        ...input,
+        request: {
+          ...input.request,
+          settings: {
+            ...(params || {}),
+            ...input.request.settings,
+          },
+        },
+      }),
+  });
+}


### PR DESCRIPTION
## Overview

1. Updated data module to be more like a "time series" module. It now emits TimeSeriesData which includes both DataStream and Viewport.

2. Added core functionality for query provider design

- AppKitComponentSession - component-scoped session that handles sessions and eventually metrics
- IoTAppKit - to be exported in place of IoTAppKitSession in part 2 component PR
- SiteWiseTimeSeriesDataProvider - Provider for SiteWise time series data that wraps our existing time series data module
- query namespace - extensible namespace for defining Query implementations to be used as input to app kit components
- datamodule namespace - extensible namespace for accessing datamodule sessions

## Tests
https://github.com/boweihan/iot-app-kit/runs/5120234660?check_suite_focus=true

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
