### PR TITLE
feat: adjust component interface to accept viewport, settings, and queries as top level props

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -5,12 +5,12 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { AssetSummaryQuery, AssetTreeSubscription, IoTAppKit, Provider, SiteWiseAssetTreeQuery, SiteWiseTimeSeriesDataProvider, StyleSettingsMap, TimeSeriesData, TimeSeriesQuery } from "@iot-app-kit/core";
+import { AssetSummaryQuery, AssetTreeSubscription, IoTAppKit, Provider, SiteWiseAssetTreeQuery, SiteWiseTimeSeriesDataProvider, StyleSettingsMap, TimeSeriesData, TimeSeriesDataRequestSettings, TimeSeriesQuery } from "@iot-app-kit/core";
+import { MinimalViewPortConfig } from "@synchro-charts/core";
 import { ColumnDefinition, FilterTexts, ResourceExplorerQuery, SitewiseAssetResource } from "./components/iot-resource-explorer/types";
 import { TableProps } from "@awsui/components-react/table";
 import { EmptyStateProps, ITreeNode, UseTreeCollection } from "@iot-app-kit/related-table";
 import { NonCancelableCustomEvent } from "@awsui/components-react";
-import { MinimalViewPortConfig } from "@synchro-charts/core";
 export namespace Components {
     interface IotAssetDetails {
         "query": AssetSummaryQuery;
@@ -22,22 +22,28 @@ export namespace Components {
     interface IotBarChart {
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
-        "query": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings": TimeSeriesDataRequestSettings;
         "styleSettings": StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface IotKpi {
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
-        "query": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings": TimeSeriesDataRequestSettings;
         "styleSettings": StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface IotLineChart {
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
-        "query": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings": TimeSeriesDataRequestSettings;
         "styleSettings": StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface IotResourceExplorer {
@@ -59,28 +65,36 @@ export namespace Components {
     interface IotScatterChart {
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
-        "query": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings": TimeSeriesDataRequestSettings;
         "styleSettings": StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface IotStatusGrid {
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
-        "query": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings": TimeSeriesDataRequestSettings;
         "styleSettings": StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface IotStatusTimeline {
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
-        "query": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings": TimeSeriesDataRequestSettings;
         "styleSettings": StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface IotTable {
         "appKit": IoTAppKit;
-        "query": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings": TimeSeriesDataRequestSettings;
         "styleSettings": StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId": string;
     }
     interface IotTestRoutes {
@@ -260,24 +274,30 @@ declare namespace LocalJSX {
         "subscription"?: AssetTreeSubscription;
     }
     interface IotBarChart {
-        "appKit"?: IoTAppKit;
+        "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
-        "query"?: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings"?: TimeSeriesDataRequestSettings;
         "styleSettings"?: StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId"?: string;
     }
     interface IotKpi {
-        "appKit"?: IoTAppKit;
+        "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
-        "query"?: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings"?: TimeSeriesDataRequestSettings;
         "styleSettings"?: StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId"?: string;
     }
     interface IotLineChart {
-        "appKit"?: IoTAppKit;
+        "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
-        "query"?: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings"?: TimeSeriesDataRequestSettings;
         "styleSettings"?: StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId"?: string;
     }
     interface IotResourceExplorer {
@@ -297,30 +317,38 @@ declare namespace LocalJSX {
     interface IotResourceExplorerDemo {
     }
     interface IotScatterChart {
-        "appKit"?: IoTAppKit;
+        "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
-        "query"?: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings"?: TimeSeriesDataRequestSettings;
         "styleSettings"?: StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId"?: string;
     }
     interface IotStatusGrid {
-        "appKit"?: IoTAppKit;
+        "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
-        "query"?: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings"?: TimeSeriesDataRequestSettings;
         "styleSettings"?: StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId"?: string;
     }
     interface IotStatusTimeline {
-        "appKit"?: IoTAppKit;
+        "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
-        "query"?: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings"?: TimeSeriesDataRequestSettings;
         "styleSettings"?: StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId"?: string;
     }
     interface IotTable {
-        "appKit"?: IoTAppKit;
-        "query"?: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+        "appKit": IoTAppKit;
+        "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+        "settings"?: TimeSeriesDataRequestSettings;
         "styleSettings"?: StyleSettingsMap | undefined;
+        "viewport": MinimalViewPortConfig;
         "widgetId"?: string;
     }
     interface IotTestRoutes {

--- a/packages/components/src/components/iot-bar-chart/iot-bar-chart.spec.ts
+++ b/packages/components/src/components/iot-bar-chart/iot-bar-chart.spec.ts
@@ -31,17 +31,12 @@ const barChartSpecPage = async (propOverrides: Partial<Components.IotBarChart> =
     appKit,
     widgetId: 'test-bar-chart-widget',
     isEditing: false,
-    query: query.iotsitewise.timeSeriesData({
-      queries: [
-        {
-          source: 'test-mock',
-          assets: [{ assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] }],
-        } as SiteWiseDataStreamQuery,
-      ],
-      request: {
-        viewport,
-      },
-    }),
+    viewport,
+    queries: [
+      query.iotsitewise.timeSeriesData([
+        { assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] },
+      ]),
+    ],
     ...propOverrides,
   };
   update(barChart, props);

--- a/packages/components/src/components/iot-bar-chart/iot-bar-chart.tsx
+++ b/packages/components/src/components/iot-bar-chart/iot-bar-chart.tsx
@@ -1,11 +1,12 @@
 import { Component, Prop, h, Listen, State, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream } from '@synchro-charts/core';
+import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   TimeSeriesDataRequestSettings,
   StyleSettingsMap,
   SiteWiseTimeSeriesDataProvider,
   IoTAppKit,
   TimeSeriesQuery,
+  composeSiteWiseProviders,
 } from '@iot-app-kit/core';
 
 @Component({
@@ -13,9 +14,13 @@ import {
   shadow: false,
 })
 export class IotBarChart {
-  @Prop() appKit: IoTAppKit;
+  @Prop() appKit!: IoTAppKit;
 
-  @Prop() query: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+  @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+
+  @Prop() viewport!: MinimalViewPortConfig;
+
+  @Prop() settings: TimeSeriesDataRequestSettings = {};
 
   @Prop() widgetId: string;
 
@@ -29,13 +34,29 @@ export class IotBarChart {
     fetchFromStartToEnd: true,
   };
 
-  componentWillLoad() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  buildProvider() {
+    this.provider = composeSiteWiseProviders(
+      this.queries.map((query) =>
+        query.build(this.appKit.session(this.widgetId), {
+          viewport: this.viewport,
+          settings: {
+            ...this.defaultSettings,
+            ...this.settings,
+          },
+        })
+      )
+    );
   }
 
-  @Watch('query')
-  private onQueryUpdate() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  componentWillLoad() {
+    this.buildProvider();
+  }
+
+  @Watch('queries')
+  @Watch('settings')
+  @Watch('viewport')
+  private onPropUpdate() {
+    this.buildProvider();
   }
 
   @Listen('dateRangeChange')

--- a/packages/components/src/components/iot-kpi/iot-kpi.spec.ts
+++ b/packages/components/src/components/iot-kpi/iot-kpi.spec.ts
@@ -31,17 +31,12 @@ const kpiSpecPage = async (propOverrides: Partial<Components.IotKpi> = {}) => {
     appKit,
     widgetId: 'test-kpi-widget',
     isEditing: false,
-    query: query.iotsitewise.timeSeriesData({
-      queries: [
-        {
-          source: 'test-mock',
-          assets: [{ assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] }],
-        } as SiteWiseDataStreamQuery,
-      ],
-      request: {
-        viewport,
-      },
-    }),
+    viewport,
+    queries: [
+      query.iotsitewise.timeSeriesData([
+        { assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] },
+      ]),
+    ],
     ...propOverrides,
   };
   update(kpi, props);

--- a/packages/components/src/components/iot-kpi/iot-kpi.tsx
+++ b/packages/components/src/components/iot-kpi/iot-kpi.tsx
@@ -1,11 +1,12 @@
 import { Component, Prop, h, State, Listen, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream } from '@synchro-charts/core';
+import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   StyleSettingsMap,
   SiteWiseTimeSeriesDataProvider,
   IoTAppKit,
   TimeSeriesQuery,
   TimeSeriesDataRequestSettings,
+  composeSiteWiseProviders,
 } from '@iot-app-kit/core';
 
 @Component({
@@ -13,9 +14,13 @@ import {
   shadow: false,
 })
 export class IotKpi {
-  @Prop() appKit: IoTAppKit;
+  @Prop() appKit!: IoTAppKit;
 
-  @Prop() query: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+  @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+
+  @Prop() viewport!: MinimalViewPortConfig;
+
+  @Prop() settings: TimeSeriesDataRequestSettings = {};
 
   @Prop() widgetId: string;
 
@@ -29,13 +34,29 @@ export class IotKpi {
     fetchMostRecentBeforeEnd: true,
   };
 
-  componentWillLoad() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  buildProvider() {
+    this.provider = composeSiteWiseProviders(
+      this.queries.map((query) =>
+        query.build(this.appKit.session(this.widgetId), {
+          viewport: this.viewport,
+          settings: {
+            ...this.defaultSettings,
+            ...this.settings,
+          },
+        })
+      )
+    );
   }
 
-  @Watch('query')
-  private onQueryUpdate() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  componentWillLoad() {
+    this.buildProvider();
+  }
+
+  @Watch('queries')
+  @Watch('settings')
+  @Watch('viewport')
+  private onPropUpdate() {
+    this.buildProvider();
   }
 
   @Listen('dateRangeChange')

--- a/packages/components/src/components/iot-line-chart/iot-line-chart.spec.ts
+++ b/packages/components/src/components/iot-line-chart/iot-line-chart.spec.ts
@@ -31,17 +31,12 @@ const lineChartSpecPage = async (propOverrides: Partial<Components.IotKpi> = {})
     appKit,
     widgetId: 'test-line-chart-widget',
     isEditing: false,
-    query: query.iotsitewise.timeSeriesData({
-      queries: [
-        {
-          source: 'test-mock',
-          assets: [{ assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] }],
-        } as SiteWiseDataStreamQuery,
-      ],
-      request: {
-        viewport,
-      },
-    }),
+    viewport,
+    queries: [
+      query.iotsitewise.timeSeriesData([
+        { assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] },
+      ]),
+    ],
     ...propOverrides,
   };
   update(lineChart, props);

--- a/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.spec.ts
+++ b/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.spec.ts
@@ -31,17 +31,12 @@ const scatterChartSpecPage = async (propOverrides: Partial<Components.IotScatter
     appKit,
     widgetId: 'test-scatter-chart-widget',
     isEditing: false,
-    query: query.iotsitewise.timeSeriesData({
-      queries: [
-        {
-          source: 'test-mock',
-          assets: [{ assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] }],
-        } as SiteWiseDataStreamQuery,
-      ],
-      request: {
-        viewport,
-      },
-    }),
+    viewport,
+    queries: [
+      query.iotsitewise.timeSeriesData([
+        { assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] },
+      ]),
+    ],
     ...propOverrides,
   };
   update(scatterChart, props);

--- a/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.tsx
+++ b/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.tsx
@@ -1,11 +1,12 @@
 import { Component, Prop, h, Listen, State, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream } from '@synchro-charts/core';
+import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   StyleSettingsMap,
   SiteWiseTimeSeriesDataProvider,
   IoTAppKit,
   TimeSeriesQuery,
   TimeSeriesDataRequestSettings,
+  composeSiteWiseProviders,
 } from '@iot-app-kit/core';
 
 @Component({
@@ -13,9 +14,13 @@ import {
   shadow: false,
 })
 export class IotScatterChart {
-  @Prop() appKit: IoTAppKit;
+  @Prop() appKit!: IoTAppKit;
 
-  @Prop() query: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+  @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+
+  @Prop() viewport!: MinimalViewPortConfig;
+
+  @Prop() settings: TimeSeriesDataRequestSettings = {};
 
   @Prop() widgetId: string;
 
@@ -29,13 +34,29 @@ export class IotScatterChart {
     fetchFromStartToEnd: true,
   };
 
-  componentWillLoad() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  buildProvider() {
+    this.provider = composeSiteWiseProviders(
+      this.queries.map((query) =>
+        query.build(this.appKit.session(this.widgetId), {
+          viewport: this.viewport,
+          settings: {
+            ...this.defaultSettings,
+            ...this.settings,
+          },
+        })
+      )
+    );
   }
 
-  @Watch('query')
-  private onQueryUpdate() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  componentWillLoad() {
+    this.buildProvider();
+  }
+
+  @Watch('queries')
+  @Watch('settings')
+  @Watch('viewport')
+  private onPropUpdate() {
+    this.buildProvider();
   }
 
   @Listen('dateRangeChange')

--- a/packages/components/src/components/iot-status-grid/iot-status-grid.spec.ts
+++ b/packages/components/src/components/iot-status-grid/iot-status-grid.spec.ts
@@ -31,17 +31,12 @@ const statusGridSpecPage = async (propOverrides: Partial<Components.IotKpi> = {}
     appKit,
     widgetId: 'test-status-grid-widget',
     isEditing: false,
-    query: query.iotsitewise.timeSeriesData({
-      queries: [
-        {
-          source: 'test-mock',
-          assets: [{ assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] }],
-        } as SiteWiseDataStreamQuery,
-      ],
-      request: {
-        viewport,
-      },
-    }),
+    viewport,
+    queries: [
+      query.iotsitewise.timeSeriesData([
+        { assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] },
+      ]),
+    ],
     ...propOverrides,
   };
   update(statusGrid, props);

--- a/packages/components/src/components/iot-status-grid/iot-status-grid.tsx
+++ b/packages/components/src/components/iot-status-grid/iot-status-grid.tsx
@@ -1,11 +1,12 @@
 import { Component, Prop, h, State, Listen, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream } from '@synchro-charts/core';
+import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   StyleSettingsMap,
   IoTAppKit,
   SiteWiseTimeSeriesDataProvider,
   TimeSeriesQuery,
   TimeSeriesDataRequestSettings,
+  composeSiteWiseProviders,
 } from '@iot-app-kit/core';
 
 @Component({
@@ -13,9 +14,13 @@ import {
   shadow: false,
 })
 export class IotStatusGrid {
-  @Prop() appKit: IoTAppKit;
+  @Prop() appKit!: IoTAppKit;
 
-  @Prop() query: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+  @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+
+  @Prop() viewport!: MinimalViewPortConfig;
+
+  @Prop() settings: TimeSeriesDataRequestSettings = {};
 
   @Prop() widgetId: string;
 
@@ -29,13 +34,29 @@ export class IotStatusGrid {
     fetchMostRecentBeforeEnd: true,
   };
 
-  componentWillLoad() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  buildProvider() {
+    this.provider = composeSiteWiseProviders(
+      this.queries.map((query) =>
+        query.build(this.appKit.session(this.widgetId), {
+          viewport: this.viewport,
+          settings: {
+            ...this.defaultSettings,
+            ...this.settings,
+          },
+        })
+      )
+    );
   }
 
-  @Watch('query')
-  private onQueryUpdate() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  componentWillLoad() {
+    this.buildProvider();
+  }
+
+  @Watch('queries')
+  @Watch('settings')
+  @Watch('viewport')
+  private onPropUpdate() {
+    this.buildProvider();
   }
 
   @Listen('dateRangeChange')

--- a/packages/components/src/components/iot-status-timeline/iot-status-timeline.spec.ts
+++ b/packages/components/src/components/iot-status-timeline/iot-status-timeline.spec.ts
@@ -33,17 +33,12 @@ const statusTimelineSpecPage = async (propOverrides: Partial<Components.IotStatu
     appKit,
     widgetId: 'test-status-timeline-chart-widget',
     isEditing: false,
-    query: query.iotsitewise.timeSeriesData({
-      queries: [
-        {
-          source: 'test-mock',
-          assets: [{ assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] }],
-        } as SiteWiseDataStreamQuery,
-      ],
-      request: {
-        viewport,
-      },
-    }),
+    viewport,
+    queries: [
+      query.iotsitewise.timeSeriesData([
+        { assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] },
+      ]),
+    ],
     ...propOverrides,
   };
   update(statusTimeline, props);

--- a/packages/components/src/components/iot-status-timeline/iot-status-timeline.tsx
+++ b/packages/components/src/components/iot-status-timeline/iot-status-timeline.tsx
@@ -1,11 +1,12 @@
 import { Component, Prop, h, Listen, State, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream } from '@synchro-charts/core';
+import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   StyleSettingsMap,
   SiteWiseTimeSeriesDataProvider,
   IoTAppKit,
   TimeSeriesQuery,
   TimeSeriesDataRequestSettings,
+  composeSiteWiseProviders,
 } from '@iot-app-kit/core';
 
 @Component({
@@ -13,9 +14,13 @@ import {
   shadow: false,
 })
 export class IotStatusTimeline {
-  @Prop() appKit: IoTAppKit;
+  @Prop() appKit!: IoTAppKit;
 
-  @Prop() query: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+  @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+
+  @Prop() viewport!: MinimalViewPortConfig;
+
+  @Prop() settings: TimeSeriesDataRequestSettings = {};
 
   @Prop() widgetId: string;
 
@@ -30,13 +35,29 @@ export class IotStatusTimeline {
     fetchFromStartToEnd: true,
   };
 
-  componentWillLoad() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  buildProvider() {
+    this.provider = composeSiteWiseProviders(
+      this.queries.map((query) =>
+        query.build(this.appKit.session(this.widgetId), {
+          viewport: this.viewport,
+          settings: {
+            ...this.defaultSettings,
+            ...this.settings,
+          },
+        })
+      )
+    );
   }
 
-  @Watch('query')
-  private onQueryUpdate() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  componentWillLoad() {
+    this.buildProvider();
+  }
+
+  @Watch('queries')
+  @Watch('settings')
+  @Watch('viewport')
+  private onPropUpdate() {
+    this.buildProvider();
   }
 
   @Listen('dateRangeChange')

--- a/packages/components/src/components/iot-table/iot-table.spec.ts
+++ b/packages/components/src/components/iot-table/iot-table.spec.ts
@@ -31,17 +31,12 @@ const tableSpecPage = async (propOverrides: Partial<Components.IotKpi> = {}) => 
     appKit,
     widgetId: 'test-table-widget',
     isEditing: false,
-    query: query.iotsitewise.timeSeriesData({
-      queries: [
-        {
-          source: 'test-mock',
-          assets: [{ assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] }],
-        } as SiteWiseDataStreamQuery,
-      ],
-      request: {
-        viewport,
-      },
-    }),
+    viewport,
+    queries: [
+      query.iotsitewise.timeSeriesData([
+        { assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] },
+      ]),
+    ],
     ...propOverrides,
   };
 

--- a/packages/components/src/components/iot-table/iot-table.tsx
+++ b/packages/components/src/components/iot-table/iot-table.tsx
@@ -1,11 +1,12 @@
 import { Component, Prop, h, State, Listen, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream } from '@synchro-charts/core';
+import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   StyleSettingsMap,
   SiteWiseTimeSeriesDataProvider,
   IoTAppKit,
   TimeSeriesQuery,
   TimeSeriesDataRequestSettings,
+  composeSiteWiseProviders,
 } from '@iot-app-kit/core';
 
 @Component({
@@ -13,9 +14,13 @@ import {
   shadow: false,
 })
 export class IotTable {
-  @Prop() appKit: IoTAppKit;
+  @Prop() appKit!: IoTAppKit;
 
-  @Prop() query: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+  @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+
+  @Prop() viewport!: MinimalViewPortConfig;
+
+  @Prop() settings: TimeSeriesDataRequestSettings = {};
 
   @Prop() widgetId: string;
 
@@ -27,13 +32,29 @@ export class IotTable {
     fetchMostRecentBeforeEnd: true,
   };
 
-  componentWillLoad() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  buildProvider() {
+    this.provider = composeSiteWiseProviders(
+      this.queries.map((query) =>
+        query.build(this.appKit.session(this.widgetId), {
+          viewport: this.viewport,
+          settings: {
+            ...this.defaultSettings,
+            ...this.settings,
+          },
+        })
+      )
+    );
   }
 
-  @Watch('query')
-  private onQueryUpdate() {
-    this.provider = this.query.build(this.appKit.session(this.widgetId), this.defaultSettings);
+  componentWillLoad() {
+    this.buildProvider();
+  }
+
+  @Watch('queries')
+  @Watch('settings')
+  @Watch('viewport')
+  private onPropUpdate() {
+    this.buildProvider();
   }
 
   @Listen('dateRangeChange')

--- a/packages/components/src/components/iot-time-series-connector.ts/iot-time-series-connector.spec.ts
+++ b/packages/components/src/components/iot-time-series-connector.ts/iot-time-series-connector.spec.ts
@@ -106,16 +106,8 @@ it('renders', async () => {
   await connectorSpecPage({
     renderFunc,
     provider: query.iotsitewise
-      .timeSeriesData({
-        queries: [
-          {
-            source: 'test-mock',
-            assets: [],
-          } as SiteWiseDataStreamQuery,
-        ],
-        request: { viewport, settings: { fetchMostRecentBeforeEnd: true } },
-      })
-      .build(appKit.session('widgetId')),
+      .timeSeriesData([])
+      .build(appKit.session('widgetId'), { viewport, settings: { fetchMostRecentBeforeEnd: true } }),
   });
 
   await flushPromises();
@@ -135,20 +127,11 @@ it('provides data streams', async () => {
   await connectorSpecPage({
     renderFunc,
     provider: query.iotsitewise
-      .timeSeriesData({
-        queries: [
-          {
-            source: 'test-mock',
-            assets: [{ assetId: assetId_1, properties: [{ propertyId: propertyId_1 }] }],
-          } as SiteWiseDataStreamQuery,
-          {
-            source: 'test-mock',
-            assets: [{ assetId: assetId_2, properties: [{ propertyId: propertyId_2 }] }],
-          } as SiteWiseDataStreamQuery,
-        ],
-        request: { viewport, settings: { fetchMostRecentBeforeEnd: true } },
-      })
-      .build(appKit.session('widgetId')),
+      .timeSeriesData([
+        { assetId: assetId_1, properties: [{ propertyId: propertyId_1 }] },
+        { assetId: assetId_2, properties: [{ propertyId: propertyId_2 }] },
+      ])
+      .build(appKit.session('widgetId'), { viewport, settings: { fetchMostRecentBeforeEnd: true } }),
   });
 
   await flushPromises();
@@ -184,16 +167,8 @@ it('populates the name, unit, and data type from the asset model information fro
   await connectorSpecPage({
     renderFunc,
     provider: query.iotsitewise
-      .timeSeriesData({
-        queries: [
-          {
-            source: 'test-mock',
-            assets: [{ assetId: assetId_1, properties: [{ propertyId: propertyId_1 }] }],
-          } as SiteWiseDataStreamQuery,
-        ],
-        request: { viewport, settings: { fetchMostRecentBeforeEnd: true } },
-      })
-      .build(appKit.session('widgetId')),
+      .timeSeriesData([{ assetId: assetId_1, properties: [{ propertyId: propertyId_1 }] }])
+      .build(appKit.session('widgetId'), { viewport, settings: { fetchMostRecentBeforeEnd: true } }),
   });
 
   await flushPromises();
@@ -229,31 +204,15 @@ it('populates the name, unit, and data type from the asset model information fro
   const { connector, page } = await connectorSpecPage({
     renderFunc,
     provider: query.iotsitewise
-      .timeSeriesData({
-        queries: [
-          {
-            source: 'test-mock',
-            assets: [],
-          } as SiteWiseDataStreamQuery,
-        ],
-        request: { viewport, settings: { fetchMostRecentBeforeEnd: true } },
-      })
-      .build(appKit.session('widgetId')),
+      .timeSeriesData([])
+      .build(appKit.session('widgetId'), { viewport, settings: { fetchMostRecentBeforeEnd: true } }),
   });
 
   await flushPromises();
 
   connector.provider = query.iotsitewise
-    .timeSeriesData({
-      queries: [
-        {
-          source: 'test-mock',
-          assets: [{ assetId: assetId_1, properties: [{ propertyId: propertyId_1 }] }],
-        } as SiteWiseDataStreamQuery,
-      ],
-      request: { viewport, settings: { fetchMostRecentBeforeEnd: true } },
-    })
-    .build(appKit.session('widgetId'));
+    .timeSeriesData([{ assetId: assetId_1, properties: [{ propertyId: propertyId_1 }] }])
+    .build(appKit.session('widgetId'), { viewport, settings: { fetchMostRecentBeforeEnd: true } });
 
   await page.waitForChanges();
   await flushPromises();
@@ -282,35 +241,18 @@ it('updates with new queries', async () => {
   const { connector, page } = await connectorSpecPage({
     renderFunc,
     provider: query.iotsitewise
-      .timeSeriesData({
-        queries: [
-          {
-            source: 'test-mock',
-            assets: [],
-          } as SiteWiseDataStreamQuery,
-        ],
-        request: { viewport, settings: { fetchMostRecentBeforeEnd: true } },
-      })
-      .build(appKit.session('widgetId')),
+      .timeSeriesData([])
+      .build(appKit.session('widgetId'), { viewport, settings: { fetchMostRecentBeforeEnd: true } }),
   });
 
   await flushPromises();
 
   connector.provider = query.iotsitewise
-    .timeSeriesData({
-      queries: [
-        {
-          source: 'test-mock',
-          assets: [{ assetId: assetId_1, properties: [{ propertyId: propertyId_1 }] }],
-        } as SiteWiseDataStreamQuery,
-        {
-          source: 'test-mock',
-          assets: [{ assetId: assetId_2, properties: [{ propertyId: propertyId_2 }] }],
-        } as SiteWiseDataStreamQuery,
-      ],
-      request: { viewport, settings: { fetchMostRecentBeforeEnd: true } },
-    })
-    .build(appKit.session('widgetId'));
+    .timeSeriesData([
+      { assetId: assetId_1, properties: [{ propertyId: propertyId_1 }] },
+      { assetId: assetId_2, properties: [{ propertyId: propertyId_2 }] },
+    ])
+    .build(appKit.session('widgetId'), { viewport, settings: { fetchMostRecentBeforeEnd: true } });
 
   await page.waitForChanges();
 
@@ -339,16 +281,8 @@ it('binds styles to data streams', async () => {
   await connectorSpecPage({
     renderFunc,
     provider: query.iotsitewise
-      .timeSeriesData({
-        queries: [
-          {
-            source: 'test-mock',
-            assets: [{ assetId, properties: [{ propertyId, refId: REF_ID }] }],
-          } as SiteWiseDataStreamQuery,
-        ],
-        request: { viewport, settings: { fetchMostRecentBeforeEnd: true } },
-      })
-      .build(appKit.session('widgetId')),
+      .timeSeriesData([{ assetId, properties: [{ propertyId, refId: REF_ID }] }])
+      .build(appKit.session('widgetId'), { viewport, settings: { fetchMostRecentBeforeEnd: true } }),
     styleSettings: {
       [REF_ID]: {
         color: 'red',

--- a/packages/components/src/testing/createMockSource.ts
+++ b/packages/components/src/testing/createMockSource.ts
@@ -20,7 +20,7 @@ const associatedProperty = (query: SiteWiseDataStreamQuery, dataStreamId: string
 };
 
 export const createMockSource = (dataStreams: DataStream[]): DataSource => ({
-  name: 'test-mock',
+  name: 'site-wise',
   initiateRequest: ({ onSuccess }: DataSourceRequest<AnyDataStreamQuery>) => onSuccess(dataStreams),
   getRequestsFromQuery: ({ query }) =>
     dataStreams

--- a/packages/components/src/testing/renderChart.tsx
+++ b/packages/components/src/testing/renderChart.tsx
@@ -7,7 +7,9 @@ import {
   query,
   TimeSeriesQuery,
   SiteWiseTimeSeriesDataProvider,
+  TimeSeriesDataRequestSettings,
 } from '@iot-app-kit/core';
+import { MinimalViewPortConfig } from '@synchro-charts/core';
 import { MINUTE_IN_MS } from '@iot-app-kit/core/src/common/time';
 const { applyPolyfills, defineCustomElements } = require('@iot-app-kit/components/loader');
 import '@synchro-charts/core/dist/synchro-charts/synchro-charts.css';
@@ -39,39 +41,36 @@ const end = new Date(start.getTime() + 5 * MINUTE_IN_MS);
 
 const defaultViewport = { start, end };
 
-const defaultQuery = query.iotsitewise.timeSeriesData({
-  queries: [
+const defaultQueries = [
+  query.iotsitewise.timeSeriesData([
     {
-      source: 'site-wise',
-      assets: [
-        {
-          assetId: 'some-asset-id',
-          properties: [{ propertyId: 'some-property-id' }],
-        },
-      ],
+      assetId: 'some-asset-id',
+      properties: [{ propertyId: 'some-property-id' }],
     },
-  ],
-  request: {
-    viewport: defaultViewport,
-    settings: defaultSettings,
-  },
-});
+  ]),
+];
 
 export const renderChart = (
   {
     chartType = defaultChartType,
     appKit = newDefaultAppKit,
-    query = defaultQuery,
+    queries = defaultQueries,
+    viewport = defaultViewport,
+    settings = defaultSettings,
     styleSettings,
   }: {
     chartType?: string;
     appKit?: IoTAppKit;
-    query?: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>;
+    queries?: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+    viewport: MinimalViewPortConfig;
+    settings: TimeSeriesDataRequestSettings;
     styleSettings?: StyleSettingsMap;
   } = {
     chartType: defaultChartType,
     appKit: newDefaultAppKit,
-    query: defaultQuery,
+    queries: defaultQueries,
+    viewport: defaultViewport,
+    settings: defaultSettings,
   }
 ) => {
   mount({
@@ -82,7 +81,7 @@ export const renderChart = (
     },
     render: function () {
       const containerProps = { class: testChartContainerClassName, style: { width: '400px', height: '500px' } };
-      const chartProps: any = { appKit, query, styleSettings };
+      const chartProps: any = { appKit, queries, viewport, settings, styleSettings };
 
       return (
         <div {...containerProps}>

--- a/packages/components/src/testing/testing-ground/testing-ground.tsx
+++ b/packages/components/src/testing/testing-ground/testing-ground.tsx
@@ -59,77 +59,53 @@ export class TestingGround {
           <br />
           <iot-kpi
             appKit={this.appKit}
-            query={query.iotsitewise.timeSeriesData({
-              queries: [
+            viewport={VIEWPORT}
+            queries={[
+              query.iotsitewise.timeSeriesData([
                 {
-                  source: 'site-wise',
-                  assets: [
-                    {
-                      assetId: DEMO_TURBINE_ASSET_1,
-                      properties: [
-                        { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_1 },
-                        { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_2 },
-                        { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_3 },
-                        { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_4 },
-                      ],
-                    },
+                  assetId: DEMO_TURBINE_ASSET_1,
+                  properties: [
+                    { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_1 },
+                    { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_2 },
+                    { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_3 },
+                    { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_4 },
                   ],
                 },
-              ],
-              request: {
-                viewport: VIEWPORT,
-              },
-            })}
+              ]),
+            ]}
           />
           <div style={{ width: '400px', height: '500px' }}>
             <iot-line-chart
               appKit={this.appKit}
-              query={query.iotsitewise.timeSeriesData({
-                queries: [
+              viewport={{ duration: '5m', group: 'in-sync' }}
+              queries={[
+                query.iotsitewise.timeSeriesData([
                   {
-                    source: 'site-wise',
-                    assets: [
-                      {
-                        assetId: DEMO_TURBINE_ASSET_1,
-                        properties: [{ propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_3 }],
-                      },
-                    ],
+                    assetId: DEMO_TURBINE_ASSET_1,
+                    properties: [{ propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_3 }],
                   },
+                ]),
+                query.iotsitewise.timeSeriesData([
                   {
-                    source: 'site-wise',
-                    assets: [
-                      {
-                        assetId: DEMO_TURBINE_ASSET_1,
-                        properties: [{ propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_1 }],
-                      },
-                    ],
+                    assetId: DEMO_TURBINE_ASSET_1,
+                    properties: [{ propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_1 }],
                   },
-                ],
-                request: {
-                  viewport: { duration: '5m', group: 'in-sync' },
-                },
-              })}
+                ]),
+              ]}
             />
           </div>
           <div style={{ width: '400px', height: '500px' }}>
             <iot-line-chart
               appKit={this.appKit}
-              query={query.iotsitewise.timeSeriesData({
-                queries: [
+              viewport={{ duration: '5m', group: 'in-sync' }}
+              queries={[
+                query.iotsitewise.timeSeriesData([
                   {
-                    source: 'site-wise',
-                    assets: [
-                      {
-                        assetId: DEMO_TURBINE_ASSET_1,
-                        properties: [{ propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_2 }],
-                      },
-                    ],
+                    assetId: DEMO_TURBINE_ASSET_1,
+                    properties: [{ propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_2 }],
                   },
-                ],
-                request: {
-                  viewport: { duration: '5m', group: 'in-sync' },
-                },
-              })}
+                ]),
+              ]}
             />
           </div>
         </div>
@@ -153,16 +129,8 @@ export class TestingGround {
         <div style={{ width: '400px', height: '500px' }}>
           <iot-line-chart
             appKit={this.appKit}
-            query={query.iotsitewise.timeSeriesData({
-              queries: [AGGREGATED_DATA_QUERY],
-              request: {
-                settings: {
-                  resolution: this.resolution,
-                  requestBuffer: 1,
-                },
-                viewport: this.viewport,
-              },
-            })}
+            viewport={this.viewport}
+            queries={[query.iotsitewise.timeSeriesData(AGGREGATED_DATA_QUERY.assets)]}
           />
         </div>
         <iot-asset-details query={ASSET_DETAILS_QUERY} />

--- a/packages/core/src/interface.d.ts
+++ b/packages/core/src/interface.d.ts
@@ -11,7 +11,7 @@ import { Credentials, Provider } from '@aws-sdk/types';
 import { SiteWiseDataStreamQuery } from './iotsitewise/time-series-data/types';
 import { IotAppKitDataModule } from './data-module/IotAppKitDataModule';
 import { SiteWiseAssetModule } from './asset-modules';
-import { TimeSeriesData, TimeSeriesDataRequestSettings } from './interface';
+import { TimeSeriesData, TimeSeriesDataRequest } from './interface';
 
 export * from './components.d';
 export * from './data-module/types.d';
@@ -50,10 +50,10 @@ export interface IoTAppKitComponentSession extends Closeable {
 }
 
 export interface Query<Provider, Params> {
-  build(session: IoTAppKitComponentSession, params?: Params): Provider;
+  build(session: IoTAppKitComponentSession, params: Params): Provider;
 }
 
-export interface TimeSeriesQuery<Provider> extends Query<Provider, TimeSeriesDataRequestSettings> {}
+export interface TimeSeriesQuery<Provider> extends Query<Provider, TimeSeriesDataRequest> {}
 
 export interface Provider<DataType> {
   subscribe(callback: (data: DataType) => void): void;

--- a/packages/core/src/iotsitewise/time-series-data/provider.spec.ts
+++ b/packages/core/src/iotsitewise/time-series-data/provider.spec.ts
@@ -1,4 +1,4 @@
-import { SiteWiseTimeSeriesDataProvider } from './provider';
+import { composeSiteWiseProviders, SiteWiseTimeSeriesDataProvider } from './provider';
 import { SiteWiseAssetModule } from '../..';
 import { IotAppKitDataModule } from '../../data-module/IotAppKitDataModule';
 import { createSiteWiseAssetDataSource } from './asset-data-source';
@@ -133,4 +133,72 @@ it('subscribes, updates, and unsubscribes to time series data by delegating to u
   jest.advanceTimersByTime(refreshRate);
 
   expect(timeSeriesCallback).not.toHaveBeenCalled();
+});
+
+describe('composeSiteWiseProviders', () => {
+  it('merges the inputs for multiple providers, taking session and request settings from the first provider', () => {
+    const START = new Date(2020, 0, 0);
+    const END = new Date();
+
+    const query1 = { source: 'site-wise', assets: [] };
+    const query2 = { source: 'custom', assets: [] };
+    const query3 = { source: 'my-source', assets: [] };
+    const query4 = {
+      source: 'site-wise',
+      assets: [{ assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] }],
+    };
+
+    const provider1 = new SiteWiseTimeSeriesDataProvider(componentSession, {
+      queries: [query1],
+      request: {
+        viewport: { start: START, end: END },
+        settings: { fetchFromStartToEnd: true },
+      },
+    });
+
+    const provider2 = new SiteWiseTimeSeriesDataProvider(componentSession, {
+      queries: [query2],
+      request: {
+        viewport: { start: START, end: END },
+        settings: { fetchFromStartToEnd: true },
+      },
+    });
+
+    const provider3 = new SiteWiseTimeSeriesDataProvider(componentSession, {
+      queries: [query3, query4],
+      request: {
+        viewport: { start: START, end: END },
+        settings: { fetchFromStartToEnd: false },
+      },
+    });
+
+    const composedProvider = composeSiteWiseProviders([provider1, provider2, provider3]);
+
+    expect(composedProvider.session).toEqual(componentSession);
+    expect(composedProvider.input).toEqual({
+      queries: [query1, query2, query3, query4],
+      request: provider1.input.request,
+    });
+  });
+
+  it('throws error if provider list is empty', () => {
+    expect(() => composeSiteWiseProviders([])).toThrow(
+      'composeSiteWiseProviders must be called with at least one provider'
+    );
+  });
+
+  it('returns the provider if there is only one', () => {
+    const START = new Date(2020, 0, 0);
+    const END = new Date();
+
+    const provider = new SiteWiseTimeSeriesDataProvider(componentSession, {
+      queries: [{ source: 'site-wise', assets: [] }],
+      request: {
+        viewport: { start: START, end: END },
+        settings: { fetchFromStartToEnd: true },
+      },
+    });
+
+    expect(composeSiteWiseProviders([provider])).toBe(provider);
+  });
 });

--- a/packages/core/src/query-namespace.ts
+++ b/packages/core/src/query-namespace.ts
@@ -1,5 +1,5 @@
-import { IoTAppKitComponentSession, TimeSeriesDataRequestSettings, TimeSeriesQuery } from './interface';
-import { AnyDataStreamQuery, DataModuleSubscription } from './data-module/types';
+import { IoTAppKitComponentSession, TimeSeriesDataRequest, TimeSeriesQuery } from './interface';
+import { AnyDataStreamQuery } from './data-module/types';
 import { SiteWiseTimeSeriesDataProvider } from './iotsitewise/time-series-data/provider';
 
 /**
@@ -7,18 +7,17 @@ import { SiteWiseTimeSeriesDataProvider } from './iotsitewise/time-series-data/p
  */
 export namespace query.iotsitewise {
   export const timeSeriesData = (
-    input: DataModuleSubscription<AnyDataStreamQuery>
+    assetQueries: AnyDataStreamQuery /* @todo: better query types */
   ): TimeSeriesQuery<SiteWiseTimeSeriesDataProvider> => ({
-    build: (session: IoTAppKitComponentSession, params?: TimeSeriesDataRequestSettings) =>
+    build: (session: IoTAppKitComponentSession, params: TimeSeriesDataRequest) =>
       new SiteWiseTimeSeriesDataProvider(session, {
-        ...input,
-        request: {
-          ...input.request,
-          settings: {
-            ...(params || {}),
-            ...input.request.settings,
+        queries: [
+          {
+            source: 'site-wise',
+            assets: assetQueries,
           },
-        },
+        ],
+        request: params,
       }),
   });
 }


### PR DESCRIPTION
## Overview
Simplify component interface to accept queries, viewport, and settings as separate top-level props. Multiple queries are composed within the components.

## Tests
https://github.com/boweihan/iot-app-kit/actions/runs/1849141653

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
