### PR TITLE
feat: pass thru annotations

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -6,7 +6,7 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { AssetSummaryQuery, AssetTreeSubscription, IoTAppKit, Provider, SiteWiseAssetTreeQuery, SiteWiseTimeSeriesDataProvider, StyleSettingsMap, TimeSeriesData, TimeSeriesDataRequestSettings, TimeSeriesQuery } from "@iot-app-kit/core";
-import { MinimalViewPortConfig } from "@synchro-charts/core";
+import { Annotations, MinimalViewPortConfig } from "@synchro-charts/core";
 import { ColumnDefinition, FilterTexts, ResourceExplorerQuery, SitewiseAssetResource } from "./components/iot-resource-explorer/types";
 import { TableProps } from "@awsui/components-react/table";
 import { EmptyStateProps, ITreeNode, UseTreeCollection } from "@iot-app-kit/related-table";
@@ -20,6 +20,7 @@ export namespace Components {
         "subscription": AssetTreeSubscription;
     }
     interface IotBarChart {
+        "annotations": Annotations;
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -29,6 +30,7 @@ export namespace Components {
         "widgetId": string;
     }
     interface IotKpi {
+        "annotations": Annotations;
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -38,6 +40,7 @@ export namespace Components {
         "widgetId": string;
     }
     interface IotLineChart {
+        "annotations": Annotations;
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -63,6 +66,7 @@ export namespace Components {
     interface IotResourceExplorerDemo {
     }
     interface IotScatterChart {
+        "annotations": Annotations;
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -72,6 +76,7 @@ export namespace Components {
         "widgetId": string;
     }
     interface IotStatusGrid {
+        "annotations": Annotations;
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -81,6 +86,7 @@ export namespace Components {
         "widgetId": string;
     }
     interface IotStatusTimeline {
+        "annotations": Annotations;
         "appKit": IoTAppKit;
         "isEditing": boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -90,6 +96,7 @@ export namespace Components {
         "widgetId": string;
     }
     interface IotTable {
+        "annotations": Annotations;
         "appKit": IoTAppKit;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
         "settings": TimeSeriesDataRequestSettings;
@@ -274,6 +281,7 @@ declare namespace LocalJSX {
         "subscription"?: AssetTreeSubscription;
     }
     interface IotBarChart {
+        "annotations"?: Annotations;
         "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -283,6 +291,7 @@ declare namespace LocalJSX {
         "widgetId"?: string;
     }
     interface IotKpi {
+        "annotations"?: Annotations;
         "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -292,6 +301,7 @@ declare namespace LocalJSX {
         "widgetId"?: string;
     }
     interface IotLineChart {
+        "annotations"?: Annotations;
         "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -317,6 +327,7 @@ declare namespace LocalJSX {
     interface IotResourceExplorerDemo {
     }
     interface IotScatterChart {
+        "annotations"?: Annotations;
         "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -326,6 +337,7 @@ declare namespace LocalJSX {
         "widgetId"?: string;
     }
     interface IotStatusGrid {
+        "annotations"?: Annotations;
         "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -335,6 +347,7 @@ declare namespace LocalJSX {
         "widgetId"?: string;
     }
     interface IotStatusTimeline {
+        "annotations"?: Annotations;
         "appKit": IoTAppKit;
         "isEditing"?: boolean | undefined;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
@@ -344,6 +357,7 @@ declare namespace LocalJSX {
         "widgetId"?: string;
     }
     interface IotTable {
+        "annotations"?: Annotations;
         "appKit": IoTAppKit;
         "queries": TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
         "settings"?: TimeSeriesDataRequestSettings;

--- a/packages/components/src/components/iot-bar-chart/iot-bar-chart.tsx
+++ b/packages/components/src/components/iot-bar-chart/iot-bar-chart.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h, Listen, State, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
+import { Annotations, DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   TimeSeriesDataRequestSettings,
   StyleSettingsMap,
@@ -15,6 +15,8 @@ import {
 })
 export class IotBarChart {
   @Prop() appKit!: IoTAppKit;
+
+  @Prop() annotations: Annotations;
 
   @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
 
@@ -72,6 +74,7 @@ export class IotBarChart {
         renderFunc={({ dataStreams }) => (
           <sc-bar-chart
             dataStreams={dataStreams as SynchroChartsDataStream[]}
+            annotations={this.annotations}
             viewport={this.provider.input.request.viewport}
             isEditing={this.isEditing}
             widgetId={this.widgetId}

--- a/packages/components/src/components/iot-kpi/iot-kpi.tsx
+++ b/packages/components/src/components/iot-kpi/iot-kpi.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h, State, Listen, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
+import { Annotations, DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   StyleSettingsMap,
   SiteWiseTimeSeriesDataProvider,
@@ -17,6 +17,8 @@ export class IotKpi {
   @Prop() appKit!: IoTAppKit;
 
   @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
+
+  @Prop() annotations: Annotations;
 
   @Prop() viewport!: MinimalViewPortConfig;
 
@@ -72,6 +74,7 @@ export class IotKpi {
         renderFunc={({ dataStreams }) => (
           <sc-kpi
             dataStreams={dataStreams as SynchroChartsDataStream[]}
+            annotations={this.annotations}
             viewport={this.provider.input.request.viewport}
             isEditing={this.isEditing}
             widgetId={this.widgetId}

--- a/packages/components/src/components/iot-line-chart/iot-line-chart.tsx
+++ b/packages/components/src/components/iot-line-chart/iot-line-chart.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h, Listen, State, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
+import { Annotations, DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   StyleSettingsMap,
   IoTAppKit,
@@ -15,6 +15,8 @@ import {
 })
 export class IotLineChart {
   @Prop() appKit!: IoTAppKit;
+
+  @Prop() annotations: Annotations;
 
   @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
 
@@ -74,6 +76,7 @@ export class IotLineChart {
           return (
             <sc-line-chart
               dataStreams={dataStreams as SynchroChartsDataStream[]}
+              annotations={this.annotations}
               viewport={this.provider.input.request.viewport}
               isEditing={this.isEditing}
               widgetId={this.widgetId}

--- a/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.tsx
+++ b/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h, Listen, State, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
+import { Annotations, DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   StyleSettingsMap,
   SiteWiseTimeSeriesDataProvider,
@@ -15,6 +15,8 @@ import {
 })
 export class IotScatterChart {
   @Prop() appKit!: IoTAppKit;
+
+  @Prop() annotations: Annotations;
 
   @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
 
@@ -72,6 +74,7 @@ export class IotScatterChart {
         renderFunc={({ dataStreams }) => (
           <sc-scatter-chart
             dataStreams={dataStreams as SynchroChartsDataStream[]}
+            annotations={this.annotations}
             viewport={this.provider.input.request.viewport}
             isEditing={this.isEditing}
             widgetId={this.widgetId}

--- a/packages/components/src/components/iot-status-grid/iot-status-grid.tsx
+++ b/packages/components/src/components/iot-status-grid/iot-status-grid.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h, State, Listen, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
+import { Annotations, DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   StyleSettingsMap,
   IoTAppKit,
@@ -15,6 +15,8 @@ import {
 })
 export class IotStatusGrid {
   @Prop() appKit!: IoTAppKit;
+
+  @Prop() annotations: Annotations;
 
   @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
 
@@ -72,6 +74,7 @@ export class IotStatusGrid {
         renderFunc={({ dataStreams }) => (
           <sc-status-grid
             dataStreams={dataStreams as SynchroChartsDataStream[]}
+            annotations={this.annotations}
             viewport={this.provider.input.request.viewport}
             isEditing={this.isEditing}
             widgetId={this.widgetId}

--- a/packages/components/src/components/iot-status-timeline/iot-status-timeline.tsx
+++ b/packages/components/src/components/iot-status-timeline/iot-status-timeline.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h, Listen, State, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
+import { Annotations, DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   StyleSettingsMap,
   SiteWiseTimeSeriesDataProvider,
@@ -15,6 +15,8 @@ import {
 })
 export class IotStatusTimeline {
   @Prop() appKit!: IoTAppKit;
+
+  @Prop() annotations: Annotations;
 
   @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
 
@@ -73,6 +75,7 @@ export class IotStatusTimeline {
         renderFunc={({ dataStreams }) => (
           <sc-status-timeline
             dataStreams={dataStreams as SynchroChartsDataStream[]}
+            annotations={this.annotations}
             viewport={this.provider.input.request.viewport}
             isEditing={this.isEditing}
             widgetId={this.widgetId}

--- a/packages/components/src/components/iot-table/iot-table.tsx
+++ b/packages/components/src/components/iot-table/iot-table.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h, State, Listen, Watch } from '@stencil/core';
-import { DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
+import { Annotations, DataStream as SynchroChartsDataStream, MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   StyleSettingsMap,
   SiteWiseTimeSeriesDataProvider,
@@ -15,6 +15,8 @@ import {
 })
 export class IotTable {
   @Prop() appKit!: IoTAppKit;
+
+  @Prop() annotations: Annotations;
 
   @Prop() queries!: TimeSeriesQuery<SiteWiseTimeSeriesDataProvider>[];
 
@@ -70,6 +72,7 @@ export class IotTable {
         renderFunc={({ dataStreams }) => (
           <sc-table
             dataStreams={dataStreams as SynchroChartsDataStream[]}
+            annotations={this.annotations}
             viewport={this.provider.input.request.viewport}
             widgetId={this.widgetId}
           />


### PR DESCRIPTION
## Overview
Add annotations by passing them thru the synchro charts based components which support annotations. This will allow thresholds and annotations to be utilized on the components. Without annotations, status-timeline is effectively useless, and were missing many great features we could offer.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
