### PR TITLE
Release 1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ __diff_output__
 
 # Local development hard-coded credentials for use with the AWS SDK.
 creds.json
+
+# NPM publish artifcats
+packages/components/styles.css
+**/NOTICE
+**/LICENSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.1.0 (2022-03-01)
+
+
+### Features
+
+* Export global styles. This will allow imports from @iot-app-kit/components/styles.css ([#72](https://github.com/awslabs/iot-app-kit/issues/72))
+
+
+
+
+
 # 1.0.0 (2022-02-28)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "packages": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "iot-app-kit",
-  "version": "0.0.1",
   "private": true,
   "description": "IoT Application Kit",
   "main": "index.js",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.1.0 (2022-03-01)
+
+
+### Features
+
+* Export global styles. This will allow imports from @iot-app-kit/components/styles.css ([#72](https://github.com/awslabs/iot-app-kit/issues/72))
+
+
+
+
+
 # 1.0.0 (2022-02-28)
 
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "IoT App Kit Components",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",
@@ -15,10 +15,18 @@
   "unpkg": "dist/iot-app-kit-components/iot-app-kit-components.esm.js",
   "files": [
     "dist/",
-    "loader/"
+    "loader/",
+    "*styles.css",
+    "CHANGELOG.md",
+    "*NOTICE"
   ],
   "scripts": {
     "build": "stencil build",
+    "copy:license": "cp ../../LICENSE LICENSE",
+    "copy:notice": "cp ../../NOTICE NOTICE",
+    "copy:styles": "cp dist/iot-app-kit-components/iot-app-kit-components.css styles.css",
+    "prepack": "npm run copy:license && npm run copy:notice && npm run copy:styles",
+    "pack": "npm pack",
     "start": "stencil build --dev --watch --serve",
     "test": "stencil test --spec",
     "test.watch": "stencil test --spec --watchAll",
@@ -33,9 +41,9 @@
     "@awsui/collection-hooks": "^1.0.0",
     "@awsui/components-react": "^3.0.0",
     "@awsui/design-tokens": "^3.0.0",
-    "@iot-app-kit/core": "^1.0.0",
-    "@iot-app-kit/related-table": "^1.0.0",
-    "@iot-app-kit/source-iotsitewise": "^1.0.0",
+    "@iot-app-kit/core": "^1.1.0",
+    "@iot-app-kit/related-table": "^1.1.0",
+    "@iot-app-kit/source-iotsitewise": "^1.1.0",
     "@stencil/core": "^2.7.0",
     "@synchro-charts/core": "^2.0.0",
     "styled-components": "^5.3.0"

--- a/packages/components/src/testing/renderChart.tsx
+++ b/packages/components/src/testing/renderChart.tsx
@@ -12,7 +12,7 @@ import { initialize } from '@iot-app-kit/source-iotsitewise';
 import { MinimalViewPortConfig, Annotations } from '@synchro-charts/core';
 import { MINUTE_IN_MS } from '@iot-app-kit/core/src/common/time';
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
-import '@synchro-charts/core/dist/synchro-charts/synchro-charts.css';
+import '../styles/global.css';
 
 defineCustomElements();
 

--- a/packages/components/src/testing/testing-ground/testing-ground.css
+++ b/packages/components/src/testing/testing-ground/testing-ground.css
@@ -1,4 +1,4 @@
-@import "~@synchro-charts/core/dist/synchro-charts/synchro-charts.css";
+@import "../../styles/global.css";
 
 /* We are setting our testing ground's base font size to match Polaris, which currently has a 10px font-size */
 html {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.1.0 (2022-03-01)
+
+
+### Features
+
+* Export global styles. This will allow imports from @iot-app-kit/components/styles.css ([#72](https://github.com/awslabs/iot-app-kit/issues/72))
+
+
+
+
+
 # 1.0.0 (2022-02-28)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,13 +4,15 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "IoT Application Kit core",
   "main": "./dist/index.cj.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/"
+    "dist/",
+    "CHANGELOG.md",
+    "*NOTICE"
   ],
   "author": {
     "name": "Amazon Web Services",
@@ -25,8 +27,6 @@
     "test:typescript": "tsc --noEmit",
     "copy:license": "cp ../../LICENSE LICENSE",
     "copy:notice": "cp ../../NOTICE NOTICE",
-    "release": "yarn run clean && npm-run-all -p build test",
-    "prepublishOnly": "yarn release",
     "prepack": "yarn run copy:license && yarn run copy:notice",
     "pack": "yarn pack"
   },

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.1.0 (2022-03-01)
+
+
+### Features
+
+* Export global styles. This will allow imports from @iot-app-kit/components/styles.css ([#72](https://github.com/awslabs/iot-app-kit/issues/72))
+
+
+
+
+
 # 1.0.0 (2022-02-28)
 
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "sideEffects": false,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "React specific wrapper for IoT Application Kit",
   "author": {
     "name": "Amazon Web Services",
@@ -16,13 +16,19 @@
     "clean": "rm -rf dist",
     "compile": "npm run tsc",
     "tsc": "tsc",
-    "rollup": "rollup -c"
+    "rollup": "rollup -c",
+    "copy:license": "cp ../../LICENSE LICENSE",
+    "copy:notice": "cp ../../NOTICE NOTICE",
+    "prepack": "npm run copy:license && npm run copy:notice",
+    "pack": "npm pack"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/"
+    "dist/",
+    "CHANGELOG.md",
+    "*NOTICE"
   ],
   "devDependencies": {
     "@types/jest": "23.3.9",
@@ -35,7 +41,7 @@
     "typescript": "^3.3.4000"
   },
   "dependencies": {
-    "@iot-app-kit/components": "^1.0.0"
+    "@iot-app-kit/components": "^1.1.0"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/related-table/CHANGELOG.md
+++ b/packages/related-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.1.0 (2022-03-01)
+
+
+### Features
+
+* Export global styles. This will allow imports from @iot-app-kit/components/styles.css ([#72](https://github.com/awslabs/iot-app-kit/issues/72))
+
+
+
+
+
 # 1.0.0 (2022-02-28)
 
 

--- a/packages/related-table/package.json
+++ b/packages/related-table/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "IoT Application Kit - Related Table component",
   "license": "Apache-2.0",
   "main": "dist/index.js",
@@ -12,7 +12,9 @@
   "source": "src/index.ts",
   "files": [
     "dist",
-    "src"
+    "src",
+    "CHANGELOG.md",
+    "*NOTICE"
   ],
   "author": {
     "name": "Amazon Web Services",
@@ -25,7 +27,6 @@
     "test": "jest",
     "test.watch": "TZ=UTC jest --watchAll",
     "storybook": "start-storybook -p 6006",
-    "prepublishOnly": "npm run build",
     "copy:license": "cp ../../LICENSE LICENSE",
     "copy:notice": "cp ../../NOTICE NOTICE",
     "prepack": "npm run copy:license && npm run copy:notice",

--- a/packages/source-iotsitewise/CHANGELOG.md
+++ b/packages/source-iotsitewise/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.1.0 (2022-03-01)
+
+
+### Features
+
+* Export global styles. This will allow imports from @iot-app-kit/components/styles.css ([#72](https://github.com/awslabs/iot-app-kit/issues/72))
+
+
+
+
+
 # 1.0.0 (2022-02-28)
 
 

--- a/packages/source-iotsitewise/package.json
+++ b/packages/source-iotsitewise/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "AWS IoT SiteWise source for IoT Application Kit",
   "homepage": "https://github.com/awslabs/iot-app-kit#readme",
   "license": "Apache-2.0",
@@ -15,7 +15,9 @@
     "test": "__tests__"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "CHANGELOG.md",
+    "*NOTICE"
   ],
   "repository": {
     "type": "git",
@@ -31,14 +33,12 @@
     "test:typescript": "tsc --noEmit",
     "copy:license": "cp ../../LICENSE LICENSE",
     "copy:notice": "cp ../../NOTICE NOTICE",
-    "release": "yarn run clean && npm-run-all -p build test",
-    "prepublishOnly": "yarn release",
     "prepack": "yarn run copy:license && yarn run copy:notice",
     "pack": "yarn pack"
   },
   "dependencies": {
     "@aws-sdk/client-iotsitewise": "^3.39.0",
-    "@iot-app-kit/core": "^1.0.0",
+    "@iot-app-kit/core": "^1.1.0",
     "@rollup/plugin-typescript": "^8.3.0",
     "@synchro-charts/core": "^1.1.1",
     "flush-promises": "^1.0.2",


### PR DESCRIPTION
## Release 1.1.0
* Bump minor version
* Export global styles. This will allow imports from `@iot-app-kit/components/styles.css`
* Remove `release` script. We are already installing and building in the npm publish action
* Copy `NOTICE` and `CHANGELOG.md` to npm package

## Tests
n/a

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
