### PR TITLE
feat: support fetchMostRecentBeforeStart time series data request setting

### DIFF
--- a/packages/components/src/integration/iot-connector/iot-connector.spec.component.ts
+++ b/packages/components/src/integration/iot-connector/iot-connector.spec.component.ts
@@ -14,22 +14,41 @@ describe('handles gestures', () => {
 
   before(() => {
     cy.intercept('/properties/history?*', (req) => {
-      req.reply(
-        mockGetAggregatedOrRawResponse({
-          startDate: new Date(req.query.startDate),
-          endDate: new Date(req.query.endDate),
-        })
-      );
+      if (new Date(req.query.startDate).getUTCFullYear() === 1899) {
+        req.reply(
+          mockGetAggregatedOrRawResponse({
+            startDate: new Date(new Date(req.query.endDate).getTime() - SECOND_IN_MS),
+            endDate: new Date(req.query.endDate),
+          })
+        );
+      } else {
+        req.reply(
+          mockGetAggregatedOrRawResponse({
+            startDate: new Date(req.query.startDate),
+            endDate: new Date(req.query.endDate),
+          })
+        );
+      }
     });
 
     cy.intercept('/properties/aggregates?*', (req) => {
-      req.reply(
-        mockGetAggregatedOrRawResponse({
-          startDate: new Date(req.query.startDate),
-          endDate: new Date(req.query.endDate),
-          resolution: req.query.resolution as string,
-        })
-      );
+      if (new Date(req.query.startDate).getUTCFullYear() === 1899) {
+        req.reply(
+          mockGetAggregatedOrRawResponse({
+            startDate: new Date(new Date(req.query.endDate).getTime() - 60 * SECOND_IN_MS),
+            endDate: new Date(req.query.endDate),
+            resolution: req.query.resolution as string,
+          })
+        );
+      } else {
+        req.reply(
+          mockGetAggregatedOrRawResponse({
+            startDate: new Date(req.query.startDate),
+            endDate: new Date(req.query.endDate),
+            resolution: req.query.resolution as string,
+          })
+        );
+      }
     });
 
     cy.intercept(`/assets/${assetId}`, (req) => {

--- a/packages/components/src/integration/iot-line-chart/iot-line-chart.spec.component.ts
+++ b/packages/components/src/integration/iot-line-chart/iot-line-chart.spec.component.ts
@@ -14,13 +14,23 @@ describe('line chart', () => {
 
   before(() => {
     cy.intercept('/properties/aggregates?*', (req) => {
-      req.reply(
-        mockGetAggregatedOrRawResponse({
-          startDate: new Date(req.query.startDate),
-          endDate: new Date(req.query.endDate),
-          resolution: req.query.resolution as string,
-        })
-      );
+      if (new Date(req.query.startDate).getUTCFullYear() === 1899) {
+        req.reply(
+          mockGetAggregatedOrRawResponse({
+            startDate: new Date(new Date(req.query.endDate).getTime() - 60 * SECOND_IN_MS),
+            endDate: new Date(req.query.endDate),
+            resolution: req.query.resolution as string,
+          })
+        );
+      } else {
+        req.reply(
+          mockGetAggregatedOrRawResponse({
+            startDate: new Date(req.query.startDate),
+            endDate: new Date(req.query.endDate),
+            resolution: req.query.resolution as string,
+          })
+        );
+      }
     });
 
     cy.intercept(`/assets/${assetId}`, (req) => {

--- a/packages/components/src/integration/iot-status-grid/iot-status-grid.spec.component.ts
+++ b/packages/components/src/integration/iot-status-grid/iot-status-grid.spec.component.ts
@@ -1,6 +1,7 @@
 import { renderChart } from '../../testing/renderChart';
 import { mockLatestValueResponse } from '../../testing/mocks/mockGetAggregatedOrRawResponse';
 import { mockGetAssetSummary } from '../../testing/mocks/mockGetAssetSummaries';
+import { COMPARISON_OPERATOR } from '@synchro-charts/core';
 
 const SECOND_IN_MS = 1000;
 
@@ -27,7 +28,7 @@ describe('status grid', () => {
       chartType: 'iot-status-grid',
       settings: { resolution: '0' },
       viewport: { duration: '1m' },
-      annotations: { y: [{ color: '#FF0000', comparisonOperator: 'GT', value: 25 }] },
+      annotations: { y: [{ color: '#FF0000', comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN, value: 25 }] },
     });
 
     cy.wait(SECOND_IN_MS * 2);

--- a/packages/core/src/__mocks__/data-source.ts
+++ b/packages/core/src/__mocks__/data-source.ts
@@ -3,10 +3,9 @@ import {
   DataSourceRequest,
   DataStream,
   RequestInformationAndRange,
-  SiteWiseDataStreamQuery
-} from "../data-module/types";
-import { toDataStreamId } from "../common/dataStreamId";
-import { toId } from "@iot-app-kit/source-iotsitewise";
+  SiteWiseDataStreamQuery,
+} from '../data-module/types';
+import { toDataStreamId } from '../common/dataStreamId';
 
 // A simple mock data source, which will always immediately return a successful response of your choosing.
 export const createMockSiteWiseDataSource = (
@@ -19,24 +18,34 @@ export const createMockSiteWiseDataSource = (
   } = { dataStreams: [], onRequestData: () => {} }
 ): DataSource<SiteWiseDataStreamQuery> => ({
   name: 'site-wise',
-  initiateRequest: jest.fn(({ query, request, onSuccess = () => {} }: DataSourceRequest<SiteWiseDataStreamQuery>, requestInformations: RequestInformationAndRange[]) => {
-    query.assets.forEach(({ assetId, properties }) =>
-      properties.forEach(({ propertyId }) => {
-        const correspondingRequestInfo = requestInformations.find(({ id }) => `${ assetId }---${propertyId}` === id);
-        if (correspondingRequestInfo) {
-          onRequestData({ assetId, propertyId, request });
-          onSuccess(dataStreams, 'fetchFromStartToEnd', correspondingRequestInfo.start, correspondingRequestInfo.end);
-        }
-      })
-    );
-  }),
+  initiateRequest: jest.fn(
+    (
+      { query, request, onSuccess = () => {} }: DataSourceRequest<SiteWiseDataStreamQuery>,
+      requestInformations: RequestInformationAndRange[]
+    ) => {
+      query.assets.forEach(({ assetId, properties }) =>
+        properties.forEach(({ propertyId }) => {
+          const correspondingRequestInfo = requestInformations.find(({ id }) => `${assetId}---${propertyId}` === id);
+          if (correspondingRequestInfo) {
+            onRequestData({ assetId, propertyId, request });
+            onSuccess(
+              dataStreams,
+              correspondingRequestInfo,
+              correspondingRequestInfo.start,
+              correspondingRequestInfo.end
+            );
+          }
+        })
+      );
+    }
+  ),
   getRequestsFromQuery: ({ query }) =>
     query.assets
       .map(({ assetId, properties }) =>
         properties.map(({ propertyId, refId }) => ({
           id: toDataStreamId({ assetId, propertyId }),
           refId,
-          resolution: '0'
+          resolution: '0',
         }))
       )
       .flat(),

--- a/packages/core/src/data-module/IotAppKitDataModule.spec.ts
+++ b/packages/core/src/data-module/IotAppKitDataModule.spec.ts
@@ -226,7 +226,14 @@ describe('initial request', () => {
         query: DATA_STREAM_QUERY,
         request: { viewport: { start: START, end: END }, settings: { fetchFromStartToEnd: true } },
       }),
-      [{ id: DATA_STREAM.id, resolution: DATA_STREAM.resolution.toString(), start: START, end: END }]
+      [
+        expect.objectContaining({
+          id: DATA_STREAM.id,
+          resolution: DATA_STREAM.resolution.toString(),
+          start: START,
+          end: END,
+        }),
+      ]
     );
   });
 });
@@ -395,6 +402,7 @@ it('subscribes to multiple queries on the same data source', () => {
 
   const request: TimeSeriesDataRequest = {
     viewport: { start: START, end: END },
+    settings: { fetchFromStartToEnd: true },
   };
 
   const dataModule = new IotAppKitDataModule();
@@ -530,6 +538,7 @@ it('subscribes to multiple data streams on multiple data sources', () => {
 
   const request: TimeSeriesDataRequest = {
     viewport: { start: START, end: END },
+    settings: { fetchFromStartToEnd: true },
   };
 
   const dataModule = new IotAppKitDataModule();
@@ -810,12 +819,12 @@ describe('caching', () => {
         request: { viewport: { start: START_1, end: END_1 }, settings: { fetchFromStartToEnd: true } },
       }),
       [
-        {
+        expect.objectContaining({
           id: DATA_STREAM.id,
           resolution: DATA_STREAM.resolution.toString(),
           start: START_1,
           end: END_1,
-        },
+        }),
       ]
     );
 
@@ -833,18 +842,18 @@ describe('caching', () => {
         request: { viewport: { start: START_2, end: END_2 }, settings: { fetchFromStartToEnd: true } },
       }),
       [
-        {
+        expect.objectContaining({
           id: DATA_STREAM.id,
           resolution: DATA_STREAM.resolution.toString(),
           start: START_2,
           end: START_1,
-        },
-        {
+        }),
+        expect.objectContaining({
           id: DATA_STREAM.id,
           resolution: DATA_STREAM.resolution.toString(),
           start: END_1,
           end: END_2,
-        },
+        }),
       ]
     );
   });
@@ -874,21 +883,21 @@ describe('caching', () => {
     (dataSource.initiateRequest as Mock).mockClear();
 
     update({
-      request: { viewport: { start: START_2, end: END_2 } },
+      request: { viewport: { start: START_2, end: END_2 }, settings: { fetchFromStartToEnd: true } },
     });
 
     expect(dataSource.initiateRequest).toBeCalledWith(
       expect.objectContaining({
         query: DATA_STREAM_QUERY,
-        request: { viewport: { start: START_2, end: END_2 } },
+        request: { viewport: { start: START_2, end: END_2 }, settings: { fetchFromStartToEnd: true } },
       }),
       [
-        {
+        expect.objectContaining({
           id: DATA_STREAM_INFO.id,
           resolution: DATA_STREAM_INFO.resolution.toString(),
           start: START_2,
           end: END_2,
-        },
+        }),
       ]
     );
   });
@@ -927,13 +936,13 @@ describe('caching', () => {
         },
       }),
       [
-        {
+        expect.objectContaining({
           id: DATA_STREAM_INFO.id,
           resolution: DATA_STREAM_INFO.resolution.toString(),
           // 1 minute time advancement invalidates 3 minutes of cache by default, which is 2 minutes from END_1
           start: new Date(END.getTime() - 2 * MINUTE_IN_MS),
           end: END,
-        },
+        }),
       ]
     );
   });
@@ -1101,7 +1110,7 @@ describe('request scheduler', () => {
         queries: [DATA_STREAM_QUERY],
         request: {
           viewport: { start: START, end: END },
-          settings: { refreshRate: SECOND_IN_MS * 0.1 },
+          settings: { fetchFromStartToEnd: true, refreshRate: SECOND_IN_MS * 0.1 },
         },
       },
       timeSeriesCallback
@@ -1276,7 +1285,7 @@ describe('request scheduler', () => {
     const { update } = dataModule.subscribeToDataStreams(
       {
         queries: [DATA_STREAM_QUERY],
-        request: { viewport: { duration: SECOND_IN_MS } },
+        request: { viewport: { duration: SECOND_IN_MS }, settings: { fetchFromStartToEnd: true } },
       },
       timeSeriesCallback
     );
@@ -1287,7 +1296,7 @@ describe('request scheduler', () => {
     update({
       request: {
         viewport: { start: START, end: END },
-        settings: { refreshRate: SECOND_IN_MS * 0.1 },
+        settings: { refreshRate: SECOND_IN_MS * 0.1, fetchFromStartToEnd: true },
       },
     });
     timeSeriesCallback.mockClear();
@@ -1313,7 +1322,7 @@ it('when data is requested from the viewport start to end with a buffer, include
   const { unsubscribe } = dataModule.subscribeToDataStreams(
     {
       queries: [DATA_STREAM_QUERY],
-      request: { viewport: { start, end }, settings: { requestBuffer } },
+      request: { viewport: { start, end }, settings: { requestBuffer, fetchFromStartToEnd: true } },
     },
     timeSeriesCallback
   );
@@ -1323,6 +1332,7 @@ it('when data is requested from the viewport start to end with a buffer, include
       request: {
         settings: {
           requestBuffer,
+          fetchFromStartToEnd: true,
         },
         viewport: {
           start,

--- a/packages/core/src/data-module/data-cache/dataActions.ts
+++ b/packages/core/src/data-module/data-cache/dataActions.ts
@@ -1,8 +1,7 @@
 import { Action, Dispatch } from 'redux';
 import { DataStreamId, Resolution } from '@synchro-charts/core';
-import { DataStream, TypeOfRequest } from '../types';
+import { DataStream, RequestInformationAndRange } from '../types';
 import { ErrorDetails } from '../../common/types';
-import { TimeSeriesDataRequest } from './requestTypes';
 
 /**
  *
@@ -19,15 +18,7 @@ import { TimeSeriesDataRequest } from './requestTypes';
 export const REQUEST = 'REQUEST';
 export interface RequestData extends Action<'REQUEST'> {
   type: typeof REQUEST;
-  payload: {
-    id: DataStreamId;
-    resolution: Resolution;
-    request: TimeSeriesDataRequest;
-    // the first date of data to fetch, exclusive
-    first: Date;
-    // the most recent date of data to fetch, inclusive
-    last: Date;
-  };
+  payload: RequestInformationAndRange;
 }
 
 export type OnRequest = (payload: RequestData['payload']) => [Date, Date][];
@@ -80,7 +71,7 @@ export interface SuccessResponse extends Action<'SUCCESS'> {
     data: DataStream;
     first: Date;
     last: Date;
-    typeOfRequest: TypeOfRequest;
+    requestInformation: RequestInformationAndRange;
   };
 }
 export const onSuccessAction = (
@@ -88,7 +79,7 @@ export const onSuccessAction = (
   data: DataStream,
   first: Date,
   last: Date,
-  typeOfRequest: TypeOfRequest
+  requestInformation: RequestInformationAndRange
 ): SuccessResponse => ({
   type: SUCCESS,
   payload: {
@@ -96,14 +87,14 @@ export const onSuccessAction = (
     data,
     first,
     last,
-    typeOfRequest,
+    requestInformation,
   },
 });
 
 export const onSuccess =
-  (id: DataStreamId, data: DataStream, first: Date, last: Date, typeOfRequest: TypeOfRequest) =>
+  (id: DataStreamId, data: DataStream, first: Date, last: Date, requestInformation: RequestInformationAndRange) =>
   (dispatch: Dispatch) => {
-    dispatch(onSuccessAction(id, data, first, last, typeOfRequest));
+    dispatch(onSuccessAction(id, data, first, last, requestInformation));
   };
 
 export type AsyncActions = RequestData | ErrorResponse | SuccessResponse;

--- a/packages/core/src/data-module/data-cache/dataCacheWrapped.spec.ts
+++ b/packages/core/src/data-module/data-cache/dataCacheWrapped.spec.ts
@@ -86,10 +86,9 @@ describe('actions', () => {
 
     dataCache.onRequest({
       id: ID,
-      resolution: RESOLUTION,
-      first: new Date(),
-      last: new Date(),
-      request: { viewport: { duration: '1m' } },
+      resolution: '1s',
+      start: new Date(),
+      end: new Date(),
     });
     const state = dataCache.getState() as any;
 
@@ -129,7 +128,21 @@ describe('actions', () => {
     };
     const dataCache = new DataCache();
 
-    dataCache.onSuccess([DATA_STREAM], 'fetchFromStartToEnd', new Date(2000, 0, 0), new Date(2000, 1, 1));
+    const start = new Date(2000, 0, 0);
+    const end = new Date(2000, 1, 1);
+
+    dataCache.onSuccess(
+      [DATA_STREAM],
+      {
+        id: 'some-id',
+        resolution: '0',
+        fetchFromStartToEnd: true,
+        start,
+        end,
+      },
+      start,
+      end
+    );
     const state = dataCache.getState() as any;
 
     expect(state[DATA_STREAM.id][DATA_STREAM.resolution]).toBeDefined();

--- a/packages/core/src/data-module/data-cache/dataReducer.spec.ts
+++ b/packages/core/src/data-module/data-cache/dataReducer.spec.ts
@@ -11,6 +11,7 @@ const FIRST_DATE = new Date(2000, 0, 0);
 const LAST_DATE = new Date(2001, 0, 0);
 
 const DATE_NOW = new Date(2001, 0, 2);
+const DATE_BEFORE = new Date(2000, 11, 0);
 
 beforeEach(() => {
   // @ts-ignore
@@ -26,10 +27,10 @@ describe('loading status', () => {
       {}, // Empty original state
       onRequestAction({
         id: ID,
-        resolution: RESOLUTION,
-        first: FIRST_DATE,
-        last: LAST_DATE,
-        request: { viewport: { duration: '1d' }, settings: { fetchFromStartToEnd: true } },
+        resolution: '1s',
+        start: FIRST_DATE,
+        end: LAST_DATE,
+        fetchFromStartToEnd: true,
       })
     );
 
@@ -37,10 +38,10 @@ describe('loading status', () => {
       requestState,
       onRequestAction({
         id: ID,
-        resolution: RESOLUTION,
-        first: FIRST_DATE,
-        last: LAST_DATE,
-        request: { viewport: { duration: '1d' }, settings: { fetchFromStartToEnd: true } },
+        resolution: '1s',
+        start: FIRST_DATE,
+        end: LAST_DATE,
+        fetchFromStartToEnd: true,
       })
     ) as any;
 
@@ -59,16 +60,20 @@ describe('loading status', () => {
       {}, // Empty original state
       onRequestAction({
         id: ID,
-        resolution: RESOLUTION,
-        first: FIRST_DATE,
-        last: LAST_DATE,
-        request: { viewport: { duration: '1d' }, settings: { fetchFromStartToEnd: true } },
+        resolution: '1s',
+        start: FIRST_DATE,
+        end: LAST_DATE,
+        fetchFromStartToEnd: true,
       })
     );
 
     const errorState = dataReducer(
       requestState,
-      onErrorAction(ID, RESOLUTION, { msg: 'some-error', type: 'ResourceNotFoundException', status: '404' })
+      onErrorAction(ID, RESOLUTION, {
+        msg: 'some-error',
+        type: 'ResourceNotFoundException',
+        status: '404',
+      })
     ) as any;
 
     expect(errorState[ID][RESOLUTION]).toEqual(
@@ -86,10 +91,10 @@ describe('loading status', () => {
       {}, // Empty original state
       onRequestAction({
         id: ID,
-        resolution: RESOLUTION,
-        first: FIRST_DATE,
-        last: LAST_DATE,
-        request: { viewport: { duration: '1d' }, settings: { fetchFromStartToEnd: true } },
+        resolution: '1s',
+        start: FIRST_DATE,
+        end: LAST_DATE,
+        fetchFromStartToEnd: true,
       })
     ) as any;
 
@@ -104,15 +109,17 @@ describe('loading status', () => {
     const ID = 'some-id';
     const RESOLUTION = SECOND_IN_MS;
 
+    const requestInformation = {
+      id: ID,
+      resolution: '1s',
+      start: FIRST_DATE,
+      end: LAST_DATE,
+      fetchFromStartToEnd: true,
+    };
+
     const state1 = dataReducer(
       {}, // Empty original state
-      onRequestAction({
-        id: ID,
-        resolution: RESOLUTION,
-        first: FIRST_DATE,
-        last: LAST_DATE,
-        request: { viewport: { duration: '10m' }, settings: { fetchFromStartToEnd: true } },
-      })
+      onRequestAction(requestInformation)
     );
 
     const state2 = dataReducer(
@@ -128,7 +135,7 @@ describe('loading status', () => {
         },
         FIRST_DATE,
         LAST_DATE,
-        'fetchFromStartToEnd'
+        requestInformation
       )
     );
 
@@ -136,10 +143,10 @@ describe('loading status', () => {
       state2,
       onRequestAction({
         id: ID,
-        resolution: RESOLUTION,
-        first: new Date(LAST_DATE.getTime() + DAY_IN_MS),
-        last: new Date(LAST_DATE.getTime() + 2 * DAY_IN_MS),
-        request: { viewport: { duration: '1d' }, settings: { fetchFromStartToEnd: true } },
+        resolution: '1s',
+        start: new Date(LAST_DATE.getTime() + DAY_IN_MS),
+        end: new Date(LAST_DATE.getTime() + 2 * DAY_IN_MS),
+        fetchFromStartToEnd: true,
       })
     ) as any;
 
@@ -155,15 +162,17 @@ describe('loading status', () => {
     const ID = 'some-id';
     const RESOLUTION = SECOND_IN_MS;
 
+    const requestInformation = {
+      id: ID,
+      resolution: '1s',
+      start: FIRST_DATE,
+      end: LAST_DATE,
+      fetchFromStartToEnd: true,
+    };
+
     const state1 = dataReducer(
       {}, // Empty original state
-      onRequestAction({
-        id: ID,
-        resolution: RESOLUTION,
-        first: FIRST_DATE,
-        last: LAST_DATE,
-        request: { viewport: { duration: '1m' }, settings: { fetchFromStartToEnd: true } },
-      })
+      onRequestAction(requestInformation)
     );
 
     const successState = dataReducer(
@@ -179,7 +188,7 @@ describe('loading status', () => {
         },
         FIRST_DATE,
         LAST_DATE,
-        'fetchFromStartToEnd'
+        requestInformation
       )
     ) as any;
 
@@ -217,10 +226,10 @@ describe('on request', () => {
         INITIAL_STATE,
         onRequestAction({
           id: ID,
-          resolution: RESOLUTION,
-          first: FIRST_DATE,
-          last: LAST_DATE,
-          request: { viewport: { duration: '1d' }, settings: { fetchFromStartToEnd: true } },
+          resolution: '1s',
+          start: FIRST_DATE,
+          end: LAST_DATE,
+          fetchFromStartToEnd: true,
         })
       );
 
@@ -315,7 +324,12 @@ it('sets the data when a success action occurs with aggregated data', () => {
   };
   const newState = dataReducer(
     INITIAL_STATE,
-    onSuccessAction(ID, DATA, FIRST_DATE, LAST_DATE, 'fetchMostRecentBeforeEnd')
+    onSuccessAction(ID, DATA, FIRST_DATE, LAST_DATE, {
+      id: ID,
+      resolution: '1s',
+      start: FIRST_DATE,
+      end: LAST_DATE,
+    })
   ) as any;
   expect(newState[ID][RESOLUTION]).toEqual(
     expect.objectContaining({
@@ -374,7 +388,12 @@ it('sets the data when a success action occurs', () => {
   };
   const newState = dataReducer(
     INITIAL_STATE,
-    onSuccessAction(ID, DATA, FIRST_DATE, LAST_DATE, 'fetchMostRecentBeforeStart')
+    onSuccessAction(ID, DATA, FIRST_DATE, LAST_DATE, {
+      id: ID,
+      resolution: '1s',
+      start: FIRST_DATE,
+      end: LAST_DATE,
+    })
   ) as any;
   expect(newState[ID][RESOLUTION]).toEqual(
     expect.objectContaining({
@@ -392,6 +411,129 @@ it('sets the data when a success action occurs', () => {
       dataCache: {
         intervals: [[FIRST_DATE.getTime(), LAST_DATE.getTime()]],
         items: [newDataPoints],
+      },
+      requestCache: expect.objectContaining({
+        intervals: [[FIRST_DATE.getTime(), LAST_DATE.getTime()]],
+      }),
+    })
+  );
+});
+
+it('sets the data with the correct cache intervals when a success action occurs with fetchMostRecentBeforeStart', () => {
+  const ID = 'my-id';
+  const RESOLUTION = SECOND_IN_MS;
+
+  const INITIAL_STATE = {
+    [ID]: {
+      [RESOLUTION]: {
+        id: ID,
+        resolution: RESOLUTION,
+        isLoading: true,
+        isRefreshing: true,
+        requestHistory: [],
+        dataCache: EMPTY_CACHE,
+        requestCache: EMPTY_CACHE,
+      },
+    },
+  };
+
+  const newDataPoints = [{ x: DATE_BEFORE.getTime(), y: 100 }];
+
+  const DATA: DataStream = {
+    id: ID,
+    name: 'some name',
+    resolution: RESOLUTION,
+    aggregates: {
+      [RESOLUTION]: newDataPoints,
+    },
+    data: [],
+    dataType: DataType.NUMBER,
+  };
+  const newState = dataReducer(
+    INITIAL_STATE,
+    onSuccessAction(ID, DATA, FIRST_DATE, LAST_DATE, {
+      id: ID,
+      resolution: '1s',
+      start: FIRST_DATE,
+      end: LAST_DATE,
+      fetchMostRecentBeforeStart: true,
+    })
+  ) as any;
+  expect(newState[ID][RESOLUTION]).toEqual(
+    expect.objectContaining({
+      id: ID,
+      resolution: RESOLUTION,
+      error: undefined,
+      isLoading: false,
+      requestHistory: [
+        expect.objectContaining({
+          end: expect.any(Date),
+          requestedAt: expect.any(Date),
+          start: expect.any(Date),
+        }),
+      ],
+      dataCache: {
+        intervals: [[DATE_BEFORE.getTime(), LAST_DATE.getTime()]],
+        items: [newDataPoints],
+      },
+      requestCache: expect.objectContaining({
+        intervals: [[DATE_BEFORE.getTime(), LAST_DATE.getTime()]],
+      }),
+    })
+  );
+});
+
+it('sets the data with the correct cache intervals when a success action occurs with fetchMostRecentBeforeStart if no data is returned', () => {
+  const ID = 'my-id';
+  const RESOLUTION = SECOND_IN_MS;
+
+  const INITIAL_STATE = {
+    [ID]: {
+      [RESOLUTION]: {
+        id: ID,
+        resolution: RESOLUTION,
+        isLoading: true,
+        isRefreshing: true,
+        requestHistory: [],
+        dataCache: EMPTY_CACHE,
+        requestCache: EMPTY_CACHE,
+      },
+    },
+  };
+
+  const DATA: DataStream = {
+    id: ID,
+    name: 'some name',
+    resolution: RESOLUTION,
+    data: [],
+    dataType: DataType.NUMBER,
+  };
+  const newState = dataReducer(
+    INITIAL_STATE,
+    onSuccessAction(ID, DATA, FIRST_DATE, LAST_DATE, {
+      id: ID,
+      resolution: '1s',
+      start: FIRST_DATE,
+      end: LAST_DATE,
+      fetchMostRecentBeforeStart: true,
+    })
+  ) as any;
+  expect(newState[ID][RESOLUTION]).toEqual(
+    expect.objectContaining({
+      id: ID,
+      resolution: RESOLUTION,
+      error: undefined,
+      isLoading: false,
+      requestHistory: [
+        expect.objectContaining({
+          end: expect.any(Date),
+          requestedAt: expect.any(Date),
+          start: expect.any(Date),
+        }),
+      ],
+      dataCache: {
+        intervals: [[FIRST_DATE.getTime(), LAST_DATE.getTime()]],
+        items: [[]],
       },
       requestCache: expect.objectContaining({
         intervals: [[FIRST_DATE.getTime(), LAST_DATE.getTime()]],
@@ -462,10 +604,21 @@ it('merges data into existing data cache', () => {
     resolution: SECOND_IN_MS,
     dataType: DataType.NUMBER,
   };
+
+  const START_DATE_1 = new Date(2000, 8, 0);
+  const END_DATE_1 = new Date(DATE_THREE);
+
   const successState = dataReducer(
     INITIAL_STATE,
-    onSuccessAction(ID, dataStream, new Date(2000, 8, 0), new Date(DATE_THREE), 'fetchMostRecentBeforeStart')
+    onSuccessAction(ID, dataStream, START_DATE_1, END_DATE_1, {
+      id: ID,
+      resolution: '1s',
+      start: START_DATE_1,
+      end: END_DATE_1,
+      fetchMostRecentBeforeEnd: true,
+    })
   );
+
   expect(getDataStreamStore(ID, SECOND_IN_MS, successState)).toEqual({
     ...getDataStreamStore(ID, SECOND_IN_MS, INITIAL_STATE),
     isLoading: false,
@@ -478,6 +631,51 @@ it('merges data into existing data cache', () => {
     },
     requestCache: expect.objectContaining({
       intervals: [[DATE_ONE, DATE_FOUR]],
+    }),
+    requestHistory: expect.any(Array),
+  });
+
+  const BEFORE_START_DATA_POINT = { x: new Date(1990, 11, 0).getTime(), y: 500 };
+
+  const beforeStartDataStream = {
+    name: 'some name',
+    id: ID,
+    aggregates: {
+      [SECOND_IN_MS]: [BEFORE_START_DATA_POINT],
+    },
+    data: [],
+    resolution: SECOND_IN_MS,
+    dataType: DataType.NUMBER,
+  };
+
+  const START_DATE_2 = new Date(1999, 0, 0);
+  const END_DATE_2 = new Date(DATE_ONE);
+
+  const beforeStartSuccessState = dataReducer(
+    successState,
+    onSuccessAction(ID, beforeStartDataStream, START_DATE_2, END_DATE_2, {
+      id: ID,
+      resolution: '1s',
+      start: START_DATE_2,
+      end: END_DATE_2,
+      fetchMostRecentBeforeStart: true,
+    })
+  );
+
+  expect(getDataStreamStore(ID, SECOND_IN_MS, beforeStartSuccessState)).toEqual({
+    ...getDataStreamStore(ID, SECOND_IN_MS, successState),
+    isLoading: false,
+    isRefreshing: false,
+    id: ID,
+    error: undefined,
+    dataCache: {
+      intervals: [[BEFORE_START_DATA_POINT.x, DATE_FOUR]],
+      items: [
+        [BEFORE_START_DATA_POINT, ...DATA_POINTS_ONE, OLDER_DATA_POINT_2, NEWER_DATA_POINT_1, ...DATA_POINTS_TWO],
+      ],
+    },
+    requestCache: expect.objectContaining({
+      intervals: [[BEFORE_START_DATA_POINT.x, DATE_FOUR]],
     }),
     requestHistory: expect.any(Array),
   });
@@ -514,19 +712,19 @@ describe('requests to different resolutions', () => {
       data: [],
       dataType: DataType.NUMBER,
     };
-    const requestState = dataReducer(
-      INITIAL_STATE,
-      onRequestAction({
-        id: ID,
-        resolution: SECOND_IN_MS / 2,
-        first: NEW_FIRST_DATE,
-        last: NEW_LAST_DATE,
-        request: { viewport: { duration: '1d' }, settings: { fetchFromStartToEnd: true } },
-      })
-    );
+
+    const requestInformation = {
+      id: ID,
+      resolution: '500ms',
+      start: NEW_FIRST_DATE,
+      end: NEW_LAST_DATE,
+      fetchFromStartToEnd: true,
+    };
+
+    const requestState = dataReducer(INITIAL_STATE, onRequestAction(requestInformation));
     const newState = dataReducer(
       requestState,
-      onSuccessAction(ID, DATA, NEW_FIRST_DATE, NEW_LAST_DATE, 'fetchFromStartToEnd')
+      onSuccessAction(ID, DATA, NEW_FIRST_DATE, NEW_LAST_DATE, requestInformation)
     );
     expect(newState).toEqual({
       [ID]: {
@@ -576,16 +774,14 @@ describe('requests to different resolutions', () => {
     const NEW_LAST_DATE = new Date(2001, 0, 0);
     const RESOLUTION = SECOND_IN_MS / 2;
 
-    const requestState = dataReducer(
-      INITIAL_STATE,
-      onRequestAction({
-        id: ID,
-        resolution: RESOLUTION,
-        first: NEW_FIRST_DATE,
-        last: NEW_LAST_DATE,
-        request: { viewport: { duration: '1d' }, settings: { fetchFromStartToEnd: true } },
-      })
-    );
+    const requestInformation = {
+      id: ID,
+      resolution: '500ms',
+      start: NEW_FIRST_DATE,
+      end: NEW_LAST_DATE,
+      fetchFromStartToEnd: true,
+    };
+    const requestState = dataReducer(INITIAL_STATE, onRequestAction(requestInformation));
     const ERROR = { msg: 'error!', type: 'ResourceNotFoundException', status: '404' };
     const newState = dataReducer(requestState, onErrorAction(ID, RESOLUTION, ERROR)) as any;
 

--- a/packages/core/src/data-module/types.ts
+++ b/packages/core/src/data-module/types.ts
@@ -17,6 +17,9 @@ export type RequestInformation = {
   resolution: string;
   refId?: RefId;
   cacheSettings?: CacheSettings;
+  fetchMostRecentBeforeStart?: boolean;
+  fetchMostRecentBeforeEnd?: boolean;
+  fetchFromStartToEnd?: boolean;
 };
 export type RequestInformationAndRange = RequestInformation & { start: Date; end: Date };
 
@@ -53,15 +56,13 @@ export type DataSource<Query extends DataStreamQuery = AnyDataStreamQuery> = {
   getRequestsFromQuery: ({ query, request }: { query: Query; request: TimeSeriesDataRequest }) => RequestInformation[];
 };
 
-export type DataStreamCallback = (dataStreams: DataStream[], typeOfRequest: TypeOfRequest) => void;
+export type DataStreamCallback = (dataStreams: DataStream[], requestInformation: RequestInformationAndRange) => void;
 export type OnSuccessCallback = (
   dataStreams: DataStream[],
-  typeOfRequest: TypeOfRequest,
+  requestInformation: RequestInformationAndRange,
   start: Date,
   end: Date
 ) => void;
-
-export type TypeOfRequest = 'fetchMostRecentBeforeStart' | 'fetchMostRecentBeforeEnd' | 'fetchFromStartToEnd';
 
 export type QuerySubscription<Query extends DataStreamQuery> = {
   queries: Query[];

--- a/packages/source-iotsitewise/src/time-series-data/client/client.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/client.spec.ts
@@ -42,6 +42,7 @@ describe('getHistoricalPropertyDataPoints', () => {
         start: startDate,
         end: endDate,
         resolution: '0',
+        fetchFromStartToEnd: true,
       },
     ];
 
@@ -77,6 +78,7 @@ describe('getHistoricalPropertyDataPoints', () => {
         start: startDate,
         end: endDate,
         resolution: '0',
+        fetchFromStartToEnd: true,
       },
     ];
 
@@ -104,7 +106,13 @@ describe('getHistoricalPropertyDataPoints', () => {
           ],
         }),
       ],
-      'fetchFromStartToEnd',
+      expect.objectContaining({
+        id: toId({ assetId, propertyId }),
+        start: startDate,
+        end: endDate,
+        resolution: '0',
+        fetchFromStartToEnd: true,
+      }),
       startDate,
       endDate
     );
@@ -129,6 +137,7 @@ describe('getLatestPropertyDataPoint', () => {
         start,
         end,
         resolution: '0',
+        fetchMostRecentBeforeEnd: true,
       },
     ];
 
@@ -151,7 +160,13 @@ describe('getLatestPropertyDataPoint', () => {
           ],
         }),
       ],
-      'fetchMostRecentBeforeEnd',
+      expect.objectContaining({
+        id: toId({ assetId, propertyId }),
+        start,
+        end,
+        resolution: '0',
+        fetchMostRecentBeforeEnd: true,
+      }),
       start,
       end
     );
@@ -178,6 +193,7 @@ describe('getLatestPropertyDataPoint', () => {
         start: new Date(),
         end: new Date(),
         resolution: '0',
+        fetchMostRecentBeforeEnd: true,
       },
     ];
 
@@ -211,6 +227,7 @@ describe('getAggregatedPropertyDataPoints', () => {
         start: startDate,
         end: endDate,
         resolution,
+        fetchFromStartToEnd: true,
       },
     ];
 
@@ -245,6 +262,7 @@ describe('getAggregatedPropertyDataPoints', () => {
         start: startDate,
         end: endDate,
         resolution,
+        fetchFromStartToEnd: true,
       },
     ];
 
@@ -284,7 +302,13 @@ describe('getAggregatedPropertyDataPoints', () => {
           },
         }),
       ],
-      'fetchFromStartToEnd',
+      expect.objectContaining({
+        id: toId({ assetId, propertyId }),
+        start: startDate,
+        end: endDate,
+        resolution,
+        fetchFromStartToEnd: true,
+      }),
       startDate,
       endDate
     );

--- a/packages/source-iotsitewise/src/time-series-data/client/client.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/client.ts
@@ -19,36 +19,28 @@ export class SiteWiseClient {
     return getLatestPropertyDataPoint({ client: this.siteWiseSdk, ...options });
   }
 
-  async getHistoricalPropertyDataPoints(options: {
+  getHistoricalPropertyDataPoints(options: {
     requestInformations: RequestInformationAndRange[];
     maxResults?: number;
     onError: ErrorCallback;
     onSuccess: OnSuccessCallback;
   }): Promise<void> {
-    return getHistoricalPropertyDataPoints({ client: this.siteWiseSdk, ...options });
+    return getHistoricalPropertyDataPoints({
+      client: this.siteWiseSdk,
+      ...options,
+    });
   }
 
-  async getMostRecentPropertyDataPointBeforeDate(options: {
-    requestInformations: RequestInformationAndRange[];
-    date: Date;
-    onError: ErrorCallback;
-    onSuccess: OnSuccessCallback;
-  }): Promise<void> {
-    const requestInformations = options.requestInformations.map((info) => ({
-      ...info,
-      start: new Date(0, 0, 0),
-      end: options.date,
-    }));
-    return getHistoricalPropertyDataPoints({ client: this.siteWiseSdk, ...options, requestInformations });
-  }
-
-  async getAggregatedPropertyDataPoints(options: {
+  getAggregatedPropertyDataPoints(options: {
     requestInformations: RequestInformationAndRange[];
     aggregateTypes: AggregateType[];
     maxResults?: number;
     onError: ErrorCallback;
     onSuccess: OnSuccessCallback;
   }): Promise<void> {
-    return getAggregatedPropertyDataPoints({ client: this.siteWiseSdk, ...options });
+    return getAggregatedPropertyDataPoints({
+      client: this.siteWiseSdk,
+      ...options,
+    });
   }
 }

--- a/packages/source-iotsitewise/src/time-series-data/data-source.ts
+++ b/packages/source-iotsitewise/src/time-series-data/data-source.ts
@@ -64,30 +64,17 @@ export const createDataSource = (siteWise: IoTSiteWiseClient): DataSource<SiteWi
   const client = new SiteWiseClient(siteWise);
   return {
     name: SITEWISE_DATA_SOURCE,
-    initiateRequest: ({ query, request, onSuccess, onError }, requestInformations) => {
-      const requests = [];
-
-      if (request.settings?.fetchMostRecentBeforeEnd) {
-        requests.push(client.getLatestPropertyDataPoint({ onSuccess, onError, requestInformations }));
-      }
-
-      if (request.settings?.fetchFromStartToEnd) {
-        const aggregateTypes = [AggregateType.AVERAGE];
-
-        requests.push(
-          client.getAggregatedPropertyDataPoints({
-            requestInformations,
-            onSuccess,
-            onError,
-            aggregateTypes,
-          })
-        );
-
-        requests.push(client.getHistoricalPropertyDataPoints({ requestInformations, onSuccess, onError }));
-      }
-
-      return Promise.all(requests);
-    },
+    initiateRequest: ({ onSuccess, onError }, requestInformations) =>
+      Promise.all([
+        client.getLatestPropertyDataPoint({ onSuccess, onError, requestInformations }),
+        client.getAggregatedPropertyDataPoints({
+          requestInformations,
+          onSuccess,
+          onError,
+          aggregateTypes: [AggregateType.AVERAGE],
+        }),
+        client.getHistoricalPropertyDataPoints({ requestInformations, onSuccess, onError }),
+      ]),
     getRequestsFromQuery: ({ query, request }) => {
       const resolution = determineResolution({
         resolution: request.settings?.resolution,


### PR DESCRIPTION
## Overview
`fetchMostRecentBeforeStart` is needed for the line chart to display leading lines and for the status timeline to display pre-viewport status. This PR adds support for this time series data request setting.

Example of leading line:
<img width="450" alt="Screen Shot 2022-03-03 at 1 26 22 PM" src="https://user-images.githubusercontent.com/10264198/156636628-98333b72-3b4d-459b-b99e-0fa498e3cfde.png">

The current cache behaviour needs to be adjusted so that cache intervals for `fetchMostRecentBeforeStart` requests don't start at `Date(0,0,0)` _unless_ there was no data returned. Core cache logic was added for this case to start at the data point returned.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
