### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.2.1 (2022-03-11)
+
+
+### Bug Fixes
+
+* unsubrscribe data provider on component updates ([a9154ef](https://github.com/awslabs/iot-app-kit/commit/a9154eff3f3fcd55eb5ae501354de8530f706108))
+
+
+
+
+
 # 1.2.0 (2022-03-03)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.2.1",
   "packages": [
     "packages/*"
   ],

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.2.1 (2022-03-11)
+
+
+### Bug Fixes
+
+* unsubrscribe data provider on component updates ([a9154ef](https://github.com/awslabs/iot-app-kit/commit/a9154eff3f3fcd55eb5ae501354de8530f706108))
+
+
+
+
+
 # 1.2.0 (2022-03-03)
 
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "IoT App Kit Components",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",
@@ -41,9 +41,9 @@
     "@awsui/collection-hooks": "^1.0.0",
     "@awsui/components-react": "^3.0.0",
     "@awsui/design-tokens": "^3.0.0",
-    "@iot-app-kit/core": "^1.2.0",
-    "@iot-app-kit/related-table": "^1.2.0",
-    "@iot-app-kit/source-iotsitewise": "^1.2.0",
+    "@iot-app-kit/core": "^1.2.1",
+    "@iot-app-kit/related-table": "^1.2.1",
+    "@iot-app-kit/source-iotsitewise": "^1.2.1",
     "@stencil/core": "^2.7.0",
     "@synchro-charts/core": "^2.0.0",
     "styled-components": "^5.3.0"

--- a/packages/components/src/components/iot-bar-chart/iot-bar-chart.tsx
+++ b/packages/components/src/components/iot-bar-chart/iot-bar-chart.tsx
@@ -66,6 +66,7 @@ export class IotBarChart {
   @Watch('settings')
   @Watch('viewport')
   private onPropUpdate() {
+    this.provider.unsubscribe();
     this.buildProvider();
   }
 

--- a/packages/components/src/components/iot-kpi/iot-kpi.tsx
+++ b/packages/components/src/components/iot-kpi/iot-kpi.tsx
@@ -60,6 +60,7 @@ export class IotKpi {
   @Watch('settings')
   @Watch('viewport')
   private onPropUpdate() {
+    this.provider.unsubscribe();
     this.buildProvider();
   }
 

--- a/packages/components/src/components/iot-line-chart/iot-line-chart.tsx
+++ b/packages/components/src/components/iot-line-chart/iot-line-chart.tsx
@@ -60,6 +60,7 @@ export class IotLineChart {
   @Watch('settings')
   @Watch('viewport')
   private onPropUpdate() {
+    this.provider.unsubscribe();
     this.buildProvider();
   }
 

--- a/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.tsx
+++ b/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.tsx
@@ -59,6 +59,7 @@ export class IotScatterChart {
   @Watch('settings')
   @Watch('viewport')
   private onPropUpdate() {
+    this.provider.unsubscribe();
     this.buildProvider();
   }
 

--- a/packages/components/src/components/iot-status-grid/iot-status-grid.tsx
+++ b/packages/components/src/components/iot-status-grid/iot-status-grid.tsx
@@ -60,6 +60,7 @@ export class IotStatusGrid {
   @Watch('settings')
   @Watch('viewport')
   private onPropUpdate() {
+    this.provider.unsubscribe();
     this.buildProvider();
   }
 

--- a/packages/components/src/components/iot-status-timeline/iot-status-timeline.tsx
+++ b/packages/components/src/components/iot-status-timeline/iot-status-timeline.tsx
@@ -61,6 +61,7 @@ export class IotStatusTimeline {
   @Watch('settings')
   @Watch('viewport')
   private onPropUpdate() {
+    this.provider.unsubscribe();
     this.buildProvider();
   }
 

--- a/packages/components/src/components/iot-table/iot-table.tsx
+++ b/packages/components/src/components/iot-table/iot-table.tsx
@@ -60,6 +60,7 @@ export class IotTable {
   @Watch('settings')
   @Watch('viewport')
   private onPropUpdate() {
+    this.provider.unsubscribe();
     this.buildProvider();
   }
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.2.1 (2022-03-11)
+
+
+### Bug Fixes
+
+* unsubrscribe data provider on component updates ([a9154ef](https://github.com/awslabs/iot-app-kit/commit/a9154eff3f3fcd55eb5ae501354de8530f706108))
+
+
+
+
+
 # 1.2.0 (2022-03-03)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "IoT Application Kit core",
   "main": "./dist/index.cj.js",
   "module": "./dist/index.js",

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.2.1 (2022-03-11)
+
+
+### Bug Fixes
+
+* unsubrscribe data provider on component updates ([a9154ef](https://github.com/awslabs/iot-app-kit/commit/a9154eff3f3fcd55eb5ae501354de8530f706108))
+
+
+
+
+
 # 1.2.0 (2022-03-03)
 
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "sideEffects": false,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "React specific wrapper for IoT Application Kit",
   "author": {
     "name": "Amazon Web Services",
@@ -41,7 +41,7 @@
     "typescript": "^3.3.4000"
   },
   "dependencies": {
-    "@iot-app-kit/components": "^1.2.0"
+    "@iot-app-kit/components": "^1.2.1"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/related-table/CHANGELOG.md
+++ b/packages/related-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.2.1 (2022-03-11)
+
+
+### Bug Fixes
+
+* unsubrscribe data provider on component updates ([a9154ef](https://github.com/awslabs/iot-app-kit/commit/a9154eff3f3fcd55eb5ae501354de8530f706108))
+
+
+
+
+
 # 1.2.0 (2022-03-03)
 
 

--- a/packages/related-table/package.json
+++ b/packages/related-table/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "IoT Application Kit - Related Table component",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/packages/source-iotsitewise/CHANGELOG.md
+++ b/packages/source-iotsitewise/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.2.1 (2022-03-11)
+
+
+### Bug Fixes
+
+* unsubrscribe data provider on component updates ([a9154ef](https://github.com/awslabs/iot-app-kit/commit/a9154eff3f3fcd55eb5ae501354de8530f706108))
+
+
+
+
+
 # 1.2.0 (2022-03-03)
 
 

--- a/packages/source-iotsitewise/package.json
+++ b/packages/source-iotsitewise/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "AWS IoT SiteWise source for IoT Application Kit",
   "homepage": "https://github.com/awslabs/iot-app-kit#readme",
   "license": "Apache-2.0",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-iotsitewise": "^3.39.0",
-    "@iot-app-kit/core": "^1.2.0",
+    "@iot-app-kit/core": "^1.2.1",
     "@rollup/plugin-typescript": "^8.3.0",
     "@synchro-charts/core": "^1.1.1",
     "flush-promises": "^1.0.2",


### PR DESCRIPTION
## Overview
* Unsubscribe data provider on component updates. This will allow updating the query without continuously requesting previous query, causing glitches on the charts.
* Bump patch version to 1.2.1

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
