### PR TITLE
feat: add createTableItems method...

### DIFF
--- a/packages/components/src/components/iot-table/createTableItems.ts
+++ b/packages/components/src/components/iot-table/createTableItems.ts
@@ -1,0 +1,54 @@
+import { DataStream, Viewport } from '@iot-app-kit/core';
+import { getDataBeforeDate } from '../../ulti/dataFilter';
+import { getDataPoints } from '../../ulti/getDataPoints';
+
+export type ItemRef = {
+  $cellRef: {
+    id: string;
+    resolution: number;
+  };
+};
+
+export type Item = {
+  [key in string]: ItemRef | unknown;
+};
+
+export const createTableItems = ({
+  dataStreams,
+  viewport,
+  items,
+}: {
+  dataStreams: DataStream[];
+  items: Item[];
+  viewport: Viewport;
+}) => {
+  return items.map((item) => {
+    const keys = Object.keys(item);
+    const keyValuePairs = keys.map((key) => {
+      if (typeof item[key] === 'object' && (item[key] as object).hasOwnProperty('$cellRef')) {
+        const { $cellRef } = item[key] as ItemRef;
+        const dataStream = dataStreams.find(({ id }) => id === $cellRef.id);
+
+        if (dataStream) {
+          const dataPoints = getDataPoints(dataStream, $cellRef.resolution);
+          if ('end' in viewport && dataPoints) {
+            const point = getDataBeforeDate(dataPoints, viewport.end).pop();
+            return { key, value: point?.y };
+          } else {
+            return { key, value: dataPoints.slice(-1)[0].y };
+          }
+        }
+        return { key, value: undefined };
+      }
+      return { key, value: item[key] };
+    });
+
+    return keyValuePairs.reduce(
+      (previousItem, { key, value }) => ({
+        ...previousItem,
+        [key]: value,
+      }),
+      {}
+    );
+  });
+};

--- a/packages/components/src/testing/createTableItems.spec.ts
+++ b/packages/components/src/testing/createTableItems.spec.ts
@@ -1,0 +1,104 @@
+import { DataStream, Viewport } from '@iot-app-kit/core';
+import { createTableItems } from '../components/iot-table/createTableItems';
+
+const dataStreams: DataStream[] = [
+  {
+    id: 'data-1',
+    data: [
+      { y: 0, x: new Date(2021, 1, 1, 0, 0, 1).getTime() },
+      { y: 1, x: new Date(2022, 1, 1, 0, 0, 2).getTime() },
+      { y: 2, x: new Date(2022, 1, 1, 0, 0, 3).getTime() },
+      { y: 3, x: new Date(2022, 1, 1, 0, 0, 4).getTime() },
+      { y: 4, x: new Date(2022, 1, 1, 0, 0, 5).getTime() },
+    ],
+    resolution: 0,
+  },
+  {
+    id: 'data-2',
+    data: [{ y: 11, x: new Date(2022, 1, 1, 0, 0, 1).getTime() }],
+    resolution: 0,
+  },
+];
+
+const viewport = {
+  duration: '1000',
+};
+
+const itemWithRef = [
+  {
+    value1: {
+      $cellRef: {
+        id: 'data-1',
+        resolution: 0,
+      },
+    },
+    value2: {
+      $cellRef: {
+        id: 'data-2',
+        resolution: 0,
+      },
+    },
+    noRef: {
+      data: [1, 2, 3, 4],
+    },
+    rawValue: 10,
+  },
+  {
+    data: {
+      $cellRef: {
+        id: 'data-1',
+        resolution: 0,
+      },
+    },
+    invalid: {
+      $cellRef: {
+        id: 'invalid-data-stream',
+        resolution: 0,
+      },
+    },
+  },
+];
+
+describe('createTableItems method', () => {
+  it('should create table items', () => {
+    const items = createTableItems({ dataStreams, viewport, items: itemWithRef });
+    expect(items).toEqual([
+      {
+        value1: 4,
+        value2: 15,
+        noRef: {
+          data: [1, 2, 3, 4],
+        },
+        rawValue: 10,
+      },
+      { data: 4, invalid: undefined },
+    ]);
+  });
+
+  it('should get different data points on different viewports on the same data stream', () => {
+    const viewport1: Viewport = {
+      start: new Date(2022, 1, 1, 0, 0, 1),
+      end: new Date(2022, 1, 1, 0, 0, 2),
+    };
+
+    const viewport2 = {
+      start: new Date(2022, 1, 1, 0, 0, 1),
+      end: new Date(2022, 1, 1, 0, 0, 3),
+    };
+
+    const itemDef = [
+      {
+        value1: {
+          $cellRef: {
+            id: 'data-1',
+            resolution: 0,
+          },
+        },
+      },
+    ];
+    const items1 = createTableItems({ dataStreams, viewport: viewport1, items: itemDef });
+    const items2 = createTableItems({ dataStreams, viewport: viewport2, items: itemDef });
+
+    expect(items1).not.toEqual(items2);
+  });
+});

--- a/packages/components/src/ulti/dataFilter.ts
+++ b/packages/components/src/ulti/dataFilter.ts
@@ -1,0 +1,28 @@
+import { bisector } from 'd3-array';
+import { DataPoint, Primitive } from '@synchro-charts/core';
+
+// By doing the mapping to a date within the bisector
+// we eliminate the need to iterate over the entire data.
+// (As opposed to mapping entire data to an array of dates)
+export const pointBisector = bisector((p: DataPoint<Primitive>) => p.x);
+
+/**
+ * Returns all data before or at the given date.
+ *
+ * Assumes data is ordered chronologically.
+ */
+export const getDataBeforeDate = <T extends Primitive>(data: DataPoint<T>[], date: Date): DataPoint<T>[] => {
+  // If there is no data
+  if (data.length === 0) {
+    return [];
+  }
+  // If all data is after the view port
+  if (date.getTime() < data[0].x) {
+    return [];
+  }
+
+  // Otherwise return all the data within the viewport, plus an additional single data point that falls outside of
+  // the viewport in either direction.
+  const endIndex = Math.min(pointBisector.right(data, date) - 1, data.length - 1);
+  return data.slice(0, endIndex + 1);
+};

--- a/packages/components/src/ulti/getDataPoints.ts
+++ b/packages/components/src/ulti/getDataPoints.ts
@@ -1,0 +1,17 @@
+/**
+ * Get the points for a given resolution from a data stream
+ */
+import { DataStream } from '@iot-app-kit/core';
+import { DataPoint, Primitive, Resolution } from '@synchro-charts/core';
+
+export const getDataPoints = <T extends Primitive>(stream: DataStream<T>, resolution: Resolution): DataPoint<T>[] => {
+  if (resolution === 0) {
+    return stream.data;
+  }
+
+  if (stream.aggregates == null) {
+    return [];
+  }
+
+  return stream.aggregates[resolution] || [];
+};


### PR DESCRIPTION
...for AWS-UI table component integration.

## Overview
It's a part of AWS-UI table component integration. The goal is to replace sc-table with AWS-UI table component. This PR is just for adding a method that can turn data stream to object that AWS-UI table component can accept.

Also added unit tests to createTableItems method.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
