### PR TITLE
introduce dataloader to proxy existing sitewise API calls

### DIFF
--- a/packages/source-iotsitewise/package.json
+++ b/packages/source-iotsitewise/package.json
@@ -41,6 +41,7 @@
     "@iot-app-kit/core": "^1.3.0",
     "@rollup/plugin-typescript": "^8.3.0",
     "@synchro-charts/core": "^4.0.0",
+    "dataloader": "^2.1.0",
     "flush-promises": "^1.0.2",
     "rxjs": "^7.4.0",
     "typescript": "4.4.4"

--- a/packages/source-iotsitewise/src/time-series-data/client/client.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/client.ts
@@ -1,46 +1,77 @@
+import DataLoader from 'dataloader';
 import { IoTSiteWiseClient, AggregateType } from '@aws-sdk/client-iotsitewise';
 import { getLatestPropertyDataPoint } from './getLatestPropertyDataPoint';
 import { getHistoricalPropertyDataPoints } from './getHistoricalPropertyDataPoints';
 import { getAggregatedPropertyDataPoints } from './getAggregatedPropertyDataPoints';
 import { OnSuccessCallback, ErrorCallback, RequestInformationAndRange } from '@iot-app-kit/core';
 
+type LatestPropertyParams = {
+  requestInformations: RequestInformationAndRange[];
+  onError: ErrorCallback;
+  onSuccess: OnSuccessCallback;
+};
+
+type HistoricalPropertyParams = {
+  requestInformations: RequestInformationAndRange[];
+  maxResults?: number;
+  onError: ErrorCallback;
+  onSuccess: OnSuccessCallback;
+};
+
+type AggregatedPropertyParams = {
+  requestInformations: RequestInformationAndRange[];
+  aggregateTypes: AggregateType[];
+  maxResults?: number;
+  onError: ErrorCallback;
+  onSuccess: OnSuccessCallback;
+};
+
 export class SiteWiseClient {
   private siteWiseSdk: IoTSiteWiseClient;
 
+  private latestPropertyDataLoader: DataLoader<LatestPropertyParams, void>;
+  private historicalPropertyDataLoader: DataLoader<HistoricalPropertyParams, void>;
+  private aggregatedPropertyDataLoader: DataLoader<AggregatedPropertyParams, void>;
+
   constructor(siteWiseSdk: IoTSiteWiseClient) {
     this.siteWiseSdk = siteWiseSdk;
+    this.instantiateDataLoaders();
   }
 
-  getLatestPropertyDataPoint(options: {
-    requestInformations: RequestInformationAndRange[];
-    onSuccess: OnSuccessCallback;
-    onError: ErrorCallback;
-  }): Promise<void> {
-    return getLatestPropertyDataPoint({ client: this.siteWiseSdk, ...options });
-  }
+  /**
+   * Instantiate batch data loaders for latest, historical, and aggregated data.
+   * by default, data loaders will schedule batches for each frame of execution which ensures
+   * no additional latency when capturing many related requests in a single batch.
+   *
+   * @todo: adjust batch frequency for optimal sitewise request batching (latency vs. #requests)
+   * @todo: switch out existing APIs for batch APIs
+   */
+  private instantiateDataLoaders() {
+    this.latestPropertyDataLoader = new DataLoader<LatestPropertyParams, void>(async (keys) => {
+      keys.forEach((key) => getLatestPropertyDataPoint({ client: this.siteWiseSdk, ...key }));
+      return keys.map(() => undefined); // values are updated in data cache and don't need to be rebroadcast
+    });
 
-  getHistoricalPropertyDataPoints(options: {
-    requestInformations: RequestInformationAndRange[];
-    maxResults?: number;
-    onError: ErrorCallback;
-    onSuccess: OnSuccessCallback;
-  }): Promise<void> {
-    return getHistoricalPropertyDataPoints({
-      client: this.siteWiseSdk,
-      ...options,
+    this.historicalPropertyDataLoader = new DataLoader<HistoricalPropertyParams, void>(async (keys) => {
+      keys.forEach((key) => getHistoricalPropertyDataPoints({ client: this.siteWiseSdk, ...key }));
+      return keys.map(() => undefined);
+    });
+
+    this.aggregatedPropertyDataLoader = new DataLoader<AggregatedPropertyParams, void>(async (keys) => {
+      keys.forEach((key) => getAggregatedPropertyDataPoints({ client: this.siteWiseSdk, ...key }));
+      return keys.map(() => undefined);
     });
   }
 
-  getAggregatedPropertyDataPoints(options: {
-    requestInformations: RequestInformationAndRange[];
-    aggregateTypes: AggregateType[];
-    maxResults?: number;
-    onError: ErrorCallback;
-    onSuccess: OnSuccessCallback;
-  }): Promise<void> {
-    return getAggregatedPropertyDataPoints({
-      client: this.siteWiseSdk,
-      ...options,
-    });
+  getLatestPropertyDataPoint(params: LatestPropertyParams): Promise<void> {
+    return this.latestPropertyDataLoader.load(params);
+  }
+
+  getHistoricalPropertyDataPoints(params: HistoricalPropertyParams): Promise<void> {
+    return this.historicalPropertyDataLoader.load(params);
+  }
+
+  getAggregatedPropertyDataPoints(params: AggregatedPropertyParams): Promise<void> {
+    return this.aggregatedPropertyDataLoader.load(params);
   }
 }

--- a/packages/source-iotsitewise/src/time-series-data/data-source.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/data-source.spec.ts
@@ -210,7 +210,7 @@ describe('initiateRequest', () => {
       ]);
     });
 
-    it('gets latest value for multiple properties', () => {
+    it('gets latest value for multiple properties', async () => {
       const getAssetPropertyValue = jest.fn().mockResolvedValue(ASSET_PROPERTY_DOUBLE_VALUE);
 
       const mockSDK = createMockSiteWiseSDK({ getAssetPropertyValue });
@@ -251,6 +251,8 @@ describe('initiateRequest', () => {
         ]
       );
 
+      await flushPromises();
+
       expect(getAssetPropertyValue).toBeCalledTimes(2);
 
       expect(getAssetPropertyValue).toBeCalledWith({
@@ -264,7 +266,7 @@ describe('initiateRequest', () => {
       });
     });
 
-    it('gets latest value for multiple assets', () => {
+    it('gets latest value for multiple assets', async () => {
       const getAssetPropertyValue = jest.fn().mockResolvedValue(ASSET_PROPERTY_DOUBLE_VALUE);
 
       const mockSDK = createMockSiteWiseSDK({ getAssetPropertyValue });
@@ -309,6 +311,8 @@ describe('initiateRequest', () => {
         ]
       );
 
+      await flushPromises();
+
       expect(getAssetPropertyValue).toBeCalledTimes(2);
 
       expect(getAssetPropertyValue).toBeCalledWith({
@@ -324,7 +328,7 @@ describe('initiateRequest', () => {
   });
 
   describe('fetch latest before start', () => {
-    it('gets latest value before start for multiple properties', () => {
+    it('gets latest value before start for multiple properties', async () => {
       const getAssetPropertyValueHistory = jest.fn().mockResolvedValue(ASSET_PROPERTY_DOUBLE_VALUE);
 
       const mockSDK = createMockSiteWiseSDK({ getAssetPropertyValueHistory });
@@ -364,6 +368,8 @@ describe('initiateRequest', () => {
           },
         ]
       );
+
+      await flushPromises();
 
       expect(getAssetPropertyValueHistory).toBeCalledTimes(2);
 
@@ -386,7 +392,7 @@ describe('initiateRequest', () => {
       );
     });
 
-    it('gets latest value before start for multiple assets', () => {
+    it('gets latest value before start for multiple assets', async () => {
       const getAssetPropertyValueHistory = jest.fn().mockResolvedValue(ASSET_PROPERTY_DOUBLE_VALUE);
 
       const mockSDK = createMockSiteWiseSDK({ getAssetPropertyValueHistory });
@@ -430,6 +436,8 @@ describe('initiateRequest', () => {
           },
         ]
       );
+
+      await flushPromises();
 
       expect(getAssetPropertyValueHistory).toBeCalledTimes(2);
 
@@ -452,7 +460,7 @@ describe('initiateRequest', () => {
       );
     });
 
-    it('gets latest value before start for aggregates', () => {
+    it('gets latest value before start for aggregates', async () => {
       const getAssetPropertyAggregates = jest.fn().mockResolvedValue(ASSET_PROPERTY_DOUBLE_VALUE);
 
       const mockSDK = createMockSiteWiseSDK({ getAssetPropertyAggregates });
@@ -492,6 +500,8 @@ describe('initiateRequest', () => {
           },
         ]
       );
+
+      await flushPromises();
 
       expect(getAssetPropertyAggregates).toBeCalledTimes(2);
 


### PR DESCRIPTION
## Overview
Introduce dataloader concept into IoTAppKit. The current implement proxies the existing API calls to SiteWise.

The default batching behaviour being introduced is batch-by-frame leveraging `process.nextTick`. The current implementation mimics the existing request behaviour (see https://quip-amazon.com/LKcsAKkMayVB/Batch-API-Request-Behaviour for some example waterfall charts).

Follow-up work includes:
- create batchable client requests (i.e. `getBatchAggregatedPropertyDataPoints.ts`).
- identify the optimal batch interval by finding the right balance of latency vs. request frequency (via experimentation with common dashboard configurations).
- (optional) expose batch interval as a configurable property

## Tests
unit tests passing
- 
## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
