### PR TITLE
edge case handling for batching historical data

### DIFF
--- a/packages/components/src/testing/testing-ground/testing-ground.tsx
+++ b/packages/components/src/testing/testing-ground/testing-ground.tsx
@@ -7,7 +7,6 @@ import {
   DEMO_TURBINE_ASSET_1_PROPERTY_2,
   DEMO_TURBINE_ASSET_1_PROPERTY_3,
   DEMO_TURBINE_ASSET_1_PROPERTY_4,
-  AGGREGATED_DATA_QUERY,
 } from './siteWiseQueries';
 import { getEnvCredentials } from './getEnvCredentials';
 

--- a/packages/source-iotsitewise/src/time-series-data/client/batch.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batch.spec.ts
@@ -1,7 +1,14 @@
-import { createEntryBatches } from './batch';
+import {
+  createEntryBatches,
+  calculateNextBatchSize,
+  shouldFetchNextBatch,
+  MAX_BATCH_RESULTS,
+  MAX_BATCH_ENTRIES,
+  NO_LIMIT_BATCH,
+} from './batch';
 
 describe('createEntryBatches', () => {
-  it('buckets entries by maxResults', () => {
+  it('buckets entries by maxResults for a given batch', () => {
     const batches = createEntryBatches([
       {
         id: '1',
@@ -34,7 +41,7 @@ describe('createEntryBatches', () => {
               maxResults: undefined,
             },
           ],
-          4000,
+          NO_LIMIT_BATCH,
         ],
         [
           [
@@ -51,7 +58,7 @@ describe('createEntryBatches', () => {
               maxResults: 2000,
             },
           ],
-          2000,
+          6000,
         ],
         [
           [
@@ -66,8 +73,77 @@ describe('createEntryBatches', () => {
     );
   });
 
+  it('chunks batches that exceed max entry size (16)', () => {
+    const entrySize = 2000;
+
+    const entries = [
+      ...[...Array(MAX_BATCH_ENTRIES * 3)].map((args, index) => ({
+        id: String(index),
+        maxResults: entrySize,
+      })),
+      {
+        id: 'abc',
+        maxResults: 10,
+      },
+    ];
+
+    const batches = createEntryBatches(entries);
+
+    expect(batches).toEqual(
+      expect.arrayContaining([
+        [entries.slice(0, MAX_BATCH_ENTRIES), MAX_BATCH_ENTRIES * entrySize],
+        [entries.slice(MAX_BATCH_ENTRIES, 2 * MAX_BATCH_ENTRIES), MAX_BATCH_ENTRIES * entrySize],
+        [entries.slice(MAX_BATCH_ENTRIES * 2, MAX_BATCH_ENTRIES * 3), MAX_BATCH_ENTRIES * entrySize],
+        [[entries[MAX_BATCH_ENTRIES * 3]], 10],
+      ])
+    );
+  });
+
   it('handles empty input', () => {
     const batches = createEntryBatches([]);
     expect(batches).toEqual([]);
+  });
+});
+
+describe('calculateNextBatchSize', () => {
+  it('returns the correct max batch size for no limit batches', () => {
+    expect(calculateNextBatchSize({ maxResults: NO_LIMIT_BATCH, dataPointsFetched: 0 })).toBe(MAX_BATCH_RESULTS);
+    expect(calculateNextBatchSize({ maxResults: NO_LIMIT_BATCH, dataPointsFetched: 100000 })).toBe(MAX_BATCH_RESULTS);
+  });
+
+  it('returns the correct max batch size when specified and need to fetch more than MAX_BATCH_SIZE', () => {
+    expect(calculateNextBatchSize({ maxResults: MAX_BATCH_RESULTS * 3, dataPointsFetched: 0 })).toBe(MAX_BATCH_RESULTS);
+  });
+
+  it('returns the correct max batch size when specified and need to fetch less than MAX_BATCH SIZE', () => {
+    expect(calculateNextBatchSize({ maxResults: MAX_BATCH_RESULTS / 2, dataPointsFetched: 0 })).toBe(
+      MAX_BATCH_RESULTS / 2
+    );
+    expect(calculateNextBatchSize({ maxResults: MAX_BATCH_RESULTS, dataPointsFetched: MAX_BATCH_RESULTS / 2 })).toBe(
+      MAX_BATCH_RESULTS / 2
+    );
+  });
+});
+
+describe('shouldFetchNextBatch', () => {
+  it('returns true if next token exists and batch has no limit', () => {
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: NO_LIMIT_BATCH, dataPointsFetched: 0 })).toBe(true);
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: NO_LIMIT_BATCH, dataPointsFetched: 500000 })).toBe(
+      true
+    );
+  });
+
+  it('returns true if next token exists and there is still data that needs to be fetched', () => {
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 3000, dataPointsFetched: 0 })).toBe(true);
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 10000, dataPointsFetched: 9999 })).toBe(true);
+  });
+
+  it('returns false if next token exists but data points have already been fetched', () => {
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 3000, dataPointsFetched: 3000 })).toBe(false);
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 0, dataPointsFetched: 0 })).toBe(false);
+  });
+
+  it('returns false if next token does not exist', () => {
+    expect(shouldFetchNextBatch({ nextToken: undefined, maxResults: 3000, dataPointsFetched: 0 })).toBe(false);
   });
 });

--- a/packages/source-iotsitewise/src/time-series-data/client/batch.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batch.ts
@@ -1,9 +1,15 @@
-// current maximum value for maxResults when using batch APIs
-const MAX_BATCH_RESULTS = 4000;
+// current maximum batch size when using batch APIs
+export const MAX_BATCH_RESULTS = 4000;
+
+// current batch API entry limit
+export const MAX_BATCH_ENTRIES = 16;
+
+// use -1 to represent a batch with no max result limit
+export const NO_LIMIT_BATCH = -1;
 
 /**
- * bucket entries by maxResults
- * entries[] => [[entries, 4000], [entries, 1000], [entries, 100]]
+ * bucket entries by maxResults, chunk buckets if required.
+ * entries[] => [[entries, -1], [entries, 1000], [entries, 16]]
  *
  * @param entries
  * @returns buckets: [BatchHistoricalEntry[], number | undefined][]
@@ -12,14 +18,62 @@ export const createEntryBatches = <T extends { maxResults?: number }>(entries: T
   const buckets: { [key: number]: T[] } = {};
 
   entries.forEach((entry) => {
-    const key = entry.maxResults || MAX_BATCH_RESULTS;
+    const maxEntryResults = entry.maxResults || NO_LIMIT_BATCH;
 
-    if (buckets[key]) {
-      buckets[key] = buckets[key].concat([entry]);
+    if (buckets[maxEntryResults]) {
+      buckets[maxEntryResults] = buckets[maxEntryResults].concat([entry]);
     } else {
-      buckets[key] = [entry];
+      buckets[maxEntryResults] = [entry];
     }
   });
 
-  return Object.keys(buckets).map((key) => [buckets[Number(key)], Number(key)]);
+  // chunk buckets that are larger than MAX_BATCH_ENTRIES
+  return Object.keys(buckets)
+    .map((key) => {
+      const maxEntryResults = Number(key);
+      const bucket = buckets[maxEntryResults];
+
+      return chunkBatch(bucket).map((chunk): [T[], number] => [
+        chunk,
+        maxEntryResults === NO_LIMIT_BATCH ? NO_LIMIT_BATCH : chunk.length * maxEntryResults,
+      ]);
+    })
+    .flat();
+};
+
+/**
+ * calculate the required size of the next batch
+ */
+export const calculateNextBatchSize = ({
+  maxResults,
+  dataPointsFetched,
+}: {
+  maxResults: number;
+  dataPointsFetched: number;
+}) => (maxResults === NO_LIMIT_BATCH ? MAX_BATCH_RESULTS : Math.min(maxResults - dataPointsFetched, MAX_BATCH_RESULTS));
+
+/**
+ * check if batch still needs to be paginated.
+ */
+export const shouldFetchNextBatch = ({
+  nextToken,
+  maxResults,
+  dataPointsFetched,
+}: {
+  nextToken: string | undefined;
+  maxResults: number;
+  dataPointsFetched: number;
+}) => !!nextToken && (maxResults === NO_LIMIT_BATCH || dataPointsFetched < maxResults);
+
+/**
+ * chunk batches by MAX_BATCH_ENTRIES
+ */
+const chunkBatch = <T>(batch: T[]): T[][] => {
+  const chunks = [];
+
+  for (let i = 0; i < batch.length; i += MAX_BATCH_ENTRIES) {
+    chunks.push(batch.slice(i, i + MAX_BATCH_ENTRIES));
+  }
+
+  return chunks;
 };

--- a/packages/source-iotsitewise/src/time-series-data/client/client.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/client.spec.ts
@@ -12,6 +12,8 @@ import { SiteWiseDataStreamQuery } from '../types';
 import { toId } from '../util/dataStreamId';
 import { SITEWISE_DATA_SOURCE } from '../data-source';
 import { HOUR_IN_MS } from '@iot-app-kit/core';
+import { MAX_BATCH_RESULTS } from './batch';
+import flushPromises from 'flush-promises';
 
 it('initializes', () => {
   expect(() => new SiteWiseClient(createMockSiteWiseSDK({}))).not.toThrowError();
@@ -53,10 +55,15 @@ describe('getHistoricalPropertyDataPoints', () => {
     );
   });
 
-  it('returns data point on success', async () => {
-    const batchGetAssetPropertyValueHistory = jest.fn().mockResolvedValue(BATCH_ASSET_PROPERTY_VALUE_HISTORY);
-    const assetId = 'some-asset-id';
-    const propertyId = 'some-property-id';
+  it('batches and paginates', async () => {
+    const batchGetAssetPropertyValueHistory = jest
+      .fn()
+      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_VALUE_HISTORY, nextToken: 'nextToken' });
+    const assetId1 = 'some-asset-id-1';
+    const propertyId1 = 'some-property-id-1';
+
+    const assetId2 = 'some-asset-id-2';
+    const propertyId2 = 'some-property-id-2';
 
     const onSuccess = jest.fn();
     const onError = jest.fn();
@@ -66,37 +73,68 @@ describe('getHistoricalPropertyDataPoints', () => {
     const startDate = new Date(2000, 0, 0);
     const endDate = new Date(2001, 0, 0);
 
-    const requestInformations = [
-      {
-        id: toId({ assetId, propertyId }),
-        start: startDate,
-        end: endDate,
-        resolution: '0',
-        fetchFromStartToEnd: true,
-      },
-    ];
+    const requestInformation1 = {
+      id: toId({ assetId: assetId1, propertyId: propertyId1 }),
+      start: startDate,
+      end: endDate,
+      resolution: '0',
+      fetchFromStartToEnd: true,
+    };
 
-    await client.getHistoricalPropertyDataPoints({ requestInformations, onSuccess, onError });
+    const requestInformation2 = {
+      id: toId({ assetId: assetId2, propertyId: propertyId2 }),
+      start: startDate,
+      end: endDate,
+      resolution: '0',
+      fetchFromStartToEnd: true,
+    };
 
-    expect(batchGetAssetPropertyValueHistory).toBeCalledWith(
+    // batches requests that are sent on a single frame
+    client.getHistoricalPropertyDataPoints({
+      requestInformations: [requestInformation1],
+      onSuccess,
+      onError,
+      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
+    });
+    client.getHistoricalPropertyDataPoints({
+      requestInformations: [requestInformation2],
+      onSuccess,
+      onError,
+      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
+    });
+
+    await flushPromises();
+
+    // process the batch and paginate once
+    expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(2);
+
+    const batchHistoryParams = [
       expect.objectContaining({
         entries: expect.arrayContaining([
           expect.objectContaining({
-            assetId,
-            propertyId,
+            assetId: assetId1,
+            propertyId: propertyId1,
+            startDate,
+            endDate,
+          }),
+          expect.objectContaining({
+            assetId: assetId2,
+            propertyId: propertyId2,
             startDate,
             endDate,
           }),
         ]),
-      })
-    );
+      }),
+    ];
+
+    expect(batchGetAssetPropertyValueHistory.mock.calls).toEqual([batchHistoryParams, batchHistoryParams]);
 
     expect(onError).not.toBeCalled();
 
-    expect(onSuccess).toBeCalledWith(
+    const onSuccessParams1 = [
       expect.arrayContaining([
         expect.objectContaining({
-          id: toId({ assetId, propertyId }),
+          id: toId({ assetId: assetId1, propertyId: propertyId1 }),
           data: [
             {
               x: 1000099,
@@ -110,15 +148,42 @@ describe('getHistoricalPropertyDataPoints', () => {
         }),
       ]),
       expect.objectContaining({
-        id: toId({ assetId, propertyId }),
+        id: toId({ assetId: assetId1, propertyId: propertyId1 }),
         start: startDate,
         end: endDate,
         resolution: '0',
         fetchFromStartToEnd: true,
       }),
       startDate,
-      endDate
-    );
+      endDate,
+    ];
+
+    const onSuccessParams2 = [
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: toId({ assetId: assetId2, propertyId: propertyId2 }),
+          data: [
+            {
+              x: 1000099,
+              y: 10.123,
+            },
+          ],
+        }),
+      ]),
+      expect.objectContaining({
+        id: toId({ assetId: assetId2, propertyId: propertyId2 }),
+        start: startDate,
+        end: endDate,
+        resolution: '0',
+        fetchFromStartToEnd: true,
+      }),
+      startDate,
+      endDate,
+    ];
+
+    // call onSuccess for each entry in each batch
+    expect(onSuccess).toBeCalledTimes(4);
+    expect(onSuccess.mock.calls).toEqual([onSuccessParams1, onSuccessParams2, onSuccessParams1, onSuccessParams2]);
   });
 });
 


### PR DESCRIPTION
## Overview
This change implements pagination and edge case fixes for historical data batching. The fixes include:

1. Fixing `maxResults` to handle any positive integer value and ensuring that the `maxResults` for a batch is the sum of the `maxResults` of its entries.
2. Fixing pagination logic so that we only paginate on a batch if there is more data to fetch and we haven't already hit `maxResults` for that batch.
3. Fixing batch chunking so that batches with more than 16 entries are chunked down to at most 16 entries.
4. Add testing for batching and paginating.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
