### PR TITLE
feat: expand children in resource explorer

### DIFF
--- a/docs/ResourceExplorer.md
+++ b/docs/ResourceExplorer.md
@@ -256,7 +256,7 @@ The `empty` object contains the following fields:
 
 Type: Boolean
 
-### `expand`
+### `expanded`
 
 (Optional) If set to `true` will expand all children. Defaults to the value `false`.
 

--- a/docs/ResourceExplorer.md
+++ b/docs/ResourceExplorer.md
@@ -256,3 +256,9 @@ The `empty` object contains the following fields:
 
 Type: Boolean
 
+### `expand`
+
+(Optional) If set to `true` will expand all children. Defaults to the value `false`.
+
+Type: Boolean
+

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,6 +56,7 @@
     "@types/cypress-image-snapshot": "^3.1.6",
     "@types/react": ">=16.9.0",
     "@types/react-dom": ">=16.9.0",
+    "@types/uuid": "^8.3.4",
     "@vue/cli-plugin-typescript": "^4.5.15",
     "@vue/cli-service": "^4.5.15",
     "@vue/compiler-dom": "^3.2.26",
@@ -64,6 +65,7 @@
     "cypress-wait-until": "^1.7.2",
     "jest": "26.3.0",
     "jest-cli": "^26.5.1",
+    "uuid": "^8.3.2",
     "vue": "^3.2.26"
   },
   "license": "Apache-2.0"

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -43,6 +43,7 @@ export namespace Components {
     interface IotResourceExplorer {
         "columnDefinitions": ColumnDefinition<any>[];
         "empty"?: EmptyStateProps;
+        "expand"?: boolean;
         "filterEnabled": boolean;
         "filterTexts"?: FilterTexts;
         "loadingText"?: string;
@@ -106,6 +107,7 @@ export namespace Components {
         "collectionOptions": UseTreeCollection<unknown>;
         "columnDefinitions": TableProps.ColumnDefinition<any>[];
         "empty": EmptyStateProps;
+        "expand": boolean;
         "filterPlaceholder": string;
         "isItemDisabled": (item: unknown) => boolean;
         "items": unknown[];
@@ -266,6 +268,7 @@ declare namespace LocalJSX {
     interface IotResourceExplorer {
         "columnDefinitions"?: ColumnDefinition<any>[];
         "empty"?: EmptyStateProps;
+        "expand"?: boolean;
         "filterEnabled"?: boolean;
         "filterTexts"?: FilterTexts;
         "loadingText"?: string;
@@ -329,6 +332,7 @@ declare namespace LocalJSX {
         "collectionOptions": UseTreeCollection<unknown>;
         "columnDefinitions": TableProps.ColumnDefinition<any>[];
         "empty"?: EmptyStateProps;
+        "expand"?: boolean;
         "filterPlaceholder"?: string;
         "isItemDisabled"?: (item: unknown) => boolean;
         "items": unknown[];

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -43,7 +43,7 @@ export namespace Components {
     interface IotResourceExplorer {
         "columnDefinitions": ColumnDefinition<any>[];
         "empty"?: EmptyStateProps;
-        "expand"?: boolean;
+        "expanded"?: boolean;
         "filterEnabled": boolean;
         "filterTexts"?: FilterTexts;
         "loadingText"?: string;
@@ -107,7 +107,7 @@ export namespace Components {
         "collectionOptions": UseTreeCollection<unknown>;
         "columnDefinitions": TableProps.ColumnDefinition<any>[];
         "empty": EmptyStateProps;
-        "expand": boolean;
+        "expanded": boolean;
         "filterPlaceholder": string;
         "isItemDisabled": (item: unknown) => boolean;
         "items": unknown[];
@@ -268,7 +268,7 @@ declare namespace LocalJSX {
     interface IotResourceExplorer {
         "columnDefinitions"?: ColumnDefinition<any>[];
         "empty"?: EmptyStateProps;
-        "expand"?: boolean;
+        "expanded"?: boolean;
         "filterEnabled"?: boolean;
         "filterTexts"?: FilterTexts;
         "loadingText"?: string;
@@ -332,7 +332,7 @@ declare namespace LocalJSX {
         "collectionOptions": UseTreeCollection<unknown>;
         "columnDefinitions": TableProps.ColumnDefinition<any>[];
         "empty"?: EmptyStateProps;
-        "expand"?: boolean;
+        "expanded"?: boolean;
         "filterPlaceholder"?: string;
         "isItemDisabled"?: (item: unknown) => boolean;
         "items": unknown[];

--- a/packages/components/src/components/iot-bar-chart/iot-bar-chart.tsx
+++ b/packages/components/src/components/iot-bar-chart/iot-bar-chart.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h, Listen, State, Watch } from '@stencil/core';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 import { Annotations, DataStream as SynchroChartsDataStream } from '@synchro-charts/core';
 import {
   TimeSeriesDataRequestSettings,
@@ -28,7 +28,7 @@ export class IotBarChart {
 
   @Prop() settings: TimeSeriesDataRequestSettings = {};
 
-  @Prop() widgetId: string = uuid.v4();
+  @Prop() widgetId: string = uuidv4();
 
   @Prop() isEditing: boolean | undefined;
 

--- a/packages/components/src/components/iot-kpi/iot-kpi.tsx
+++ b/packages/components/src/components/iot-kpi/iot-kpi.tsx
@@ -10,7 +10,7 @@ import {
   TimeSeriesDataRequest,
   ProviderWithViewport,
 } from '@iot-app-kit/core';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 @Component({
   tag: 'iot-kpi',
@@ -25,7 +25,7 @@ export class IotKpi {
 
   @Prop() settings: TimeSeriesDataRequestSettings = {};
 
-  @Prop() widgetId: string = uuid.v4();
+  @Prop() widgetId: string = uuidv4();
 
   @Prop() isEditing: boolean | undefined;
 

--- a/packages/components/src/components/iot-line-chart/iot-line-chart.tsx
+++ b/packages/components/src/components/iot-line-chart/iot-line-chart.tsx
@@ -10,7 +10,7 @@ import {
   Viewport,
   ProviderWithViewport,
 } from '@iot-app-kit/core';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 @Component({
   tag: 'iot-line-chart',
@@ -25,7 +25,7 @@ export class IotLineChart {
 
   @Prop() settings: TimeSeriesDataRequestSettings = {};
 
-  @Prop() widgetId: string = uuid.v4();
+  @Prop() widgetId: string = uuidv4();
 
   @Prop() isEditing: boolean | undefined;
 

--- a/packages/components/src/components/iot-resource-explorer/iot-resource-explorer.tsx
+++ b/packages/components/src/components/iot-resource-explorer/iot-resource-explorer.tsx
@@ -55,7 +55,7 @@ export class IotResourceExplorer {
 
   @State() provider: TreeProvider<SiteWiseAssetTreeNode[], BranchReference>;
   @State() items: SiteWiseAssetResource[] = [];
-  @State() expandedItems: string[] = [];
+  @State() expandedItems: { [id: string]: boolean } = {};
 
   @State() errors: ErrorDetails[] = [];
 
@@ -102,15 +102,19 @@ export class IotResourceExplorer {
   @Watch('items')
   watchItems(newItems: ITreeNode<SiteWiseAssetResource>[]) {
     if (this.expanded) {
+      const newExpandedItems: { [id: string]: boolean } = {};
+
       newItems.forEach(({ id, hierarchies, hasChildren }) => {
-        if (!this.expandedItems.includes(id) && hasChildren) {
+        if (!this.expandedItems[id] && hasChildren) {
           hierarchies?.forEach((hierarchy) => {
             this.provider.expand(new BranchReference(id, hierarchy.id as string));
           });
+
+          newExpandedItems[id] = true;
         }
       });
 
-      this.expandedItems = [...new Set([...this.expandedItems, ...newItems.map(({ id }) => id)])];
+      this.expandedItems = { ...this.expandedItems, ...newExpandedItems };
     }
   }
 

--- a/packages/components/src/components/iot-resource-explorer/iot-resource-explorer.tsx
+++ b/packages/components/src/components/iot-resource-explorer/iot-resource-explorer.tsx
@@ -51,7 +51,7 @@ export class IotResourceExplorer {
   @Prop() wrapLines = false;
   @Prop() widgetId: string = uuidv4();
   @Prop() onSelectionChange: (event: NonCancelableCustomEvent<TableProps.SelectionChangeDetail<unknown>>) => void;
-  @Prop() expand?: boolean = false;
+  @Prop() expanded?: boolean = false;
 
   @State() provider: TreeProvider<SiteWiseAssetTreeNode[], BranchReference>;
   @State() items: SiteWiseAssetResource[] = [];
@@ -145,7 +145,7 @@ export class IotResourceExplorer {
         empty={empty}
         sortingDisabled={!this.sortingEnabled}
         wrapLines={this.wrapLines}
-        expand={this.expand}
+        expanded={this.expanded}
       ></iot-tree-table>
     );
   }

--- a/packages/components/src/components/iot-resource-explorer/iot-resource-explorer.tsx
+++ b/packages/components/src/components/iot-resource-explorer/iot-resource-explorer.tsx
@@ -6,7 +6,7 @@ import { EmptyStateProps, ITreeNode, UseTreeCollection } from '@iot-app-kit/rela
 import { parseSitewiseAssetTree } from './utils';
 import { TableProps } from '@awsui/components-react/table';
 import { NonCancelableCustomEvent } from '@awsui/components-react';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 const DEFAULT_COLUMNS: ColumnDefinition<SiteWiseAssetResource>[] = [
   {
@@ -49,8 +49,9 @@ export class IotResourceExplorer {
   @Prop() sortingEnabled = true;
   @Prop() paginationEnabled = true;
   @Prop() wrapLines = false;
-  @Prop() widgetId: string = uuid.v4();
+  @Prop() widgetId: string = uuidv4();
   @Prop() onSelectionChange: (event: NonCancelableCustomEvent<TableProps.SelectionChangeDetail<unknown>>) => void;
+  @Prop() expand?: boolean = false;
 
   @State() provider: TreeProvider<SiteWiseAssetTreeNode[], BranchReference>;
   @State() items: SiteWiseAssetResource[] = [];
@@ -144,6 +145,7 @@ export class IotResourceExplorer {
         empty={empty}
         sortingDisabled={!this.sortingEnabled}
         wrapLines={this.wrapLines}
+        expand={this.expand}
       ></iot-tree-table>
     );
   }

--- a/packages/components/src/components/iot-resource-explorer/iot-tree-table.tsx
+++ b/packages/components/src/components/iot-resource-explorer/iot-tree-table.tsx
@@ -24,6 +24,7 @@ export class IotTreeTable {
   @Prop() items!: unknown[];
   @Prop() columnDefinitions!: TableProps.ColumnDefinition<any>[];
   @Prop() collectionOptions!: UseTreeCollection<unknown>;
+  @Prop() expand: boolean;
 
   @Prop() loading: boolean;
   @Prop() loadingText: string;
@@ -51,6 +52,7 @@ export class IotTreeTable {
       items: this.items,
       columnDefinitions: this.columnDefinitions,
       collectionOptions: this.collectionOptions,
+      expand: this.expand,
 
       loading: this.loading,
       loadingText: this.loadingText,

--- a/packages/components/src/components/iot-resource-explorer/iot-tree-table.tsx
+++ b/packages/components/src/components/iot-resource-explorer/iot-tree-table.tsx
@@ -24,7 +24,7 @@ export class IotTreeTable {
   @Prop() items!: unknown[];
   @Prop() columnDefinitions!: TableProps.ColumnDefinition<any>[];
   @Prop() collectionOptions!: UseTreeCollection<unknown>;
-  @Prop() expand: boolean;
+  @Prop() expanded: boolean;
 
   @Prop() loading: boolean;
   @Prop() loadingText: string;
@@ -52,7 +52,7 @@ export class IotTreeTable {
       items: this.items,
       columnDefinitions: this.columnDefinitions,
       collectionOptions: this.collectionOptions,
-      expand: this.expand,
+      expanded: this.expanded,
 
       loading: this.loading,
       loadingText: this.loadingText,

--- a/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.tsx
+++ b/packages/components/src/components/iot-scatter-chart/iot-scatter-chart.tsx
@@ -10,7 +10,7 @@ import {
   ProviderWithViewport,
   combineProviders,
 } from '@iot-app-kit/core';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 @Component({
   tag: 'iot-scatter-chart',
@@ -25,7 +25,7 @@ export class IotScatterChart {
 
   @Prop() settings: TimeSeriesDataRequestSettings = {};
 
-  @Prop() widgetId: string = uuid.v4();
+  @Prop() widgetId: string = uuidv4();
 
   @Prop() isEditing: boolean | undefined;
 

--- a/packages/components/src/components/iot-status-grid/iot-status-grid.tsx
+++ b/packages/components/src/components/iot-status-grid/iot-status-grid.tsx
@@ -10,7 +10,7 @@ import {
   ProviderWithViewport,
   combineProviders,
 } from '@iot-app-kit/core';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 @Component({
   tag: 'iot-status-grid',
@@ -25,7 +25,7 @@ export class IotStatusGrid {
 
   @Prop() settings: TimeSeriesDataRequestSettings = {};
 
-  @Prop() widgetId: string = uuid.v4();
+  @Prop() widgetId: string = uuidv4();
 
   @Prop() isEditing: boolean | undefined;
 

--- a/packages/components/src/components/iot-status-timeline/iot-status-timeline.tsx
+++ b/packages/components/src/components/iot-status-timeline/iot-status-timeline.tsx
@@ -10,7 +10,7 @@ import {
   ProviderWithViewport,
   combineProviders,
 } from '@iot-app-kit/core';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 @Component({
   tag: 'iot-status-timeline',
@@ -25,7 +25,7 @@ export class IotStatusTimeline {
 
   @Prop() settings: TimeSeriesDataRequestSettings = {};
 
-  @Prop() widgetId: string = uuid.v4();
+  @Prop() widgetId: string = uuidv4();
 
   @Prop() isEditing: boolean | undefined;
 

--- a/packages/components/src/components/iot-table/iot-table.tsx
+++ b/packages/components/src/components/iot-table/iot-table.tsx
@@ -10,7 +10,7 @@ import {
   TimeSeriesDataRequest,
   ProviderWithViewport,
 } from '@iot-app-kit/core';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 @Component({
   tag: 'iot-table',
@@ -27,7 +27,7 @@ export class IotTable {
 
   @Prop() settings: TimeSeriesDataRequestSettings = {};
 
-  @Prop() widgetId: string = uuid.v4();
+  @Prop() widgetId: string = uuidv4();
 
   @Prop() styleSettings: StyleSettingsMap | undefined;
 

--- a/packages/components/src/integration/iot-resource-explorer/iot-resource-explorer.spec.component.ts
+++ b/packages/components/src/integration/iot-resource-explorer/iot-resource-explorer.spec.component.ts
@@ -56,7 +56,7 @@ it('expand row', () => {
 });
 
 it('expands all nodes', () => {
-  renderComponent({ propOverrides: { expanded: true }});
+  renderComponent({ propOverrides: { expanded: true } });
 
   cy.contains('Engine 1').should('be.visible');
   cy.contains('Engine 2').should('be.visible');

--- a/packages/components/src/integration/iot-resource-explorer/iot-resource-explorer.spec.component.ts
+++ b/packages/components/src/integration/iot-resource-explorer/iot-resource-explorer.spec.component.ts
@@ -54,3 +54,10 @@ it('expand row', () => {
   cy.waitUntil(() => cy.get(getTableRowsSelector()).then((rows) => rows.length === 4));
   cy.matchImageSnapshotOnCI('expand row');
 });
+
+it('expands all nodes', () => {
+  renderComponent({ propOverrides: { expanded: true }});
+
+  cy.contains('Engine 1').should('be.visible');
+  cy.contains('Engine 2').should('be.visible');
+});

--- a/packages/components/src/integration/iot-resource-explorer/setup.tsx
+++ b/packages/components/src/integration/iot-resource-explorer/setup.tsx
@@ -9,7 +9,9 @@ import { Components } from '../../components.d';
 applyPolyfills().then(() => defineCustomElements());
 
 export const testContainerClassName = 'test-container';
-export const renderComponent = ({ propOverrides }: { propOverrides?: Partial<Components.IotResourceExplorer> } = {}) => {
+export const renderComponent = ({
+  propOverrides,
+}: { propOverrides?: Partial<Components.IotResourceExplorer> } = {}) => {
   mount({
     render: function () {
       const { query } = initialize({

--- a/packages/components/src/integration/iot-resource-explorer/setup.tsx
+++ b/packages/components/src/integration/iot-resource-explorer/setup.tsx
@@ -4,11 +4,12 @@ import { initialize } from '@iot-app-kit/source-iotsitewise';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { applyPolyfills, defineCustomElements } = require('@iot-app-kit/components/loader');
 import '../../styles/awsui.css';
+import { Components } from '../../components.d';
 
 applyPolyfills().then(() => defineCustomElements());
 
 export const testContainerClassName = 'test-container';
-export const renderComponent = () => {
+export const renderComponent = ({ propOverrides }: { propOverrides?: Partial<Components.IotResourceExplorer> } = {}) => {
   mount({
     render: function () {
       const { query } = initialize({
@@ -19,7 +20,7 @@ export const renderComponent = () => {
         awsRegion: 'us-east-1',
       });
       const containerProps = { class: testContainerClassName };
-      const compProps: any = { query: query.assetTree.fromRoot() };
+      const compProps: any = { query: query.assetTree.fromRoot(), ...propOverrides };
       return (
         <div {...containerProps}>
           <iot-resource-explorer {...compProps} />

--- a/packages/related-table/package.json
+++ b/packages/related-table/package.json
@@ -58,6 +58,7 @@
     "@types/react": ">=17.0.2",
     "@types/react-dom": ">=17.0.2",
     "@types/styled-components": "^5.1.10",
+    "@types/uuid": "^8.3.4",
     "autoprefixer": "^10.2.6",
     "babel-loader": "^8.2.2",
     "barrelsby": "^2.2.0",
@@ -78,6 +79,7 @@
     "typescript": "^4.3.0"
   },
   "dependencies": {
-    "mutationobserver-shim": "^0.3.7"
+    "mutationobserver-shim": "^0.3.7",
+    "uuid": "^8.3.2"
   }
 }

--- a/packages/related-table/src/HOC/withUseTreeCollection.tsx
+++ b/packages/related-table/src/HOC/withUseTreeCollection.tsx
@@ -12,6 +12,7 @@ export interface RelatedTableExtendedProps<T> extends Omit<RelatedTableProps<T>,
   empty: EmptyStateProps;
   collectionOptions: UseTreeCollection<T>;
   filterPlaceholder?: string;
+  expanded?: boolean;
 }
 
 export const withUseTreeCollection = (RelatedTableComp: React.FC<any>) => {
@@ -25,6 +26,7 @@ export const withUseTreeCollection = (RelatedTableComp: React.FC<any>) => {
       filterPlaceholder,
       onSortingChange,
       onSelectionChange,
+      expanded,
     } = wrapperProps;
     const {
       expandNode,
@@ -32,10 +34,14 @@ export const withUseTreeCollection = (RelatedTableComp: React.FC<any>) => {
       collectionProps,
       filterProps,
       paginationProps,
-    } = useTreeCollection(items, {
-      ...collectionOptions,
-      columnDefinitions,
-    });
+    } = useTreeCollection(
+      items,
+      {
+        ...collectionOptions,
+        columnDefinitions,
+      },
+      expanded
+    );
 
     const emptyComponent = React.createElement(EmptyState, empty);
     const filterComponent = React.createElement(TextFilter, {

--- a/packages/related-table/src/Hooks/useTreeCollection.test.ts
+++ b/packages/related-table/src/Hooks/useTreeCollection.test.ts
@@ -87,4 +87,25 @@ describe('useTreeCollection', () => {
 
     expect(result.current.items[0].isExpanded()).toEqual(false);
   });
+  it('should expand all nodes', () => {
+    const { result } = renderHook(() =>
+      useTreeCollection(
+        items,
+        {
+          columnDefinitions,
+          keyPropertyName: 'id',
+          parentKeyPropertyName: 'parentId',
+          sorting: {},
+          selection: {
+            trackBy: 'entityId',
+          },
+        },
+        true
+      )
+    );
+
+    expect(result.current.items[0].isExpanded()).toEqual(true);
+    expect(result.current.items[1].isExpanded()).toEqual(true);
+    expect(result.current.items[2].isExpanded()).toEqual(true);
+  });
 });

--- a/packages/related-table/src/Hooks/useTreeCollection.ts
+++ b/packages/related-table/src/Hooks/useTreeCollection.ts
@@ -74,13 +74,13 @@ export const useTreeCollection = <T>(
 
   useEffect(() => {
     if (expanded) {
-      let newNodesExpanded: { [key: string]: boolean } = {};
+      const newNodesExpanded: { [key: string]: boolean } = {};
 
       nodes.forEach((node) => {
         if (!nodesExpanded[node.id]) {
           node.toggleExpandCollapse();
           node.setVisible(true);
-          newNodesExpanded = { ...newNodesExpanded, [node.id]: true };
+          newNodesExpanded[node.id] = true;
         }
       });
 

--- a/packages/related-table/src/Model/TreeNode.ts
+++ b/packages/related-table/src/Model/TreeNode.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 export enum ExpandableTableNodeStatus {
   normal,
   loading,
@@ -25,6 +27,8 @@ export type TreeMap<T> = Map<string, ITreeNode<T>>;
 
 class InternalTreeNode<T> {
   public hasChildren: boolean = false;
+
+  public id: string = uuidv4();
 
   private metadata: Metadata<T> = {
     prefix: [],

--- a/packages/source-iotsitewise/src/asset-modules/sitewise/requestProcessor.spec.ts
+++ b/packages/source-iotsitewise/src/asset-modules/sitewise/requestProcessor.spec.ts
@@ -148,6 +148,10 @@ describe('Request the root assets', () => {
     requestProcessor.getAssetHierarchy({ assetHierarchyId: HIERARCHY_ROOT_ID }, observer);
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('waits for the root assets to become loaded', (done) => {
     observable.subscribe((result) => {
       // the worker returns the completed list of assets:
@@ -156,6 +160,23 @@ describe('Request the root assets', () => {
         assets: [sampleAssetSummary],
         loadingState: LoadingStateEnum.LOADED,
       }).toEqual(result);
+
+      expect(mockListAssets).toHaveBeenCalled();
+      done();
+    });
+  });
+
+  // this test relies on previous test, since they use the same observer
+  // we want to verify that we emit the cached data if we have already requested it
+  it('emits cached data', (done) => {
+    observable.subscribe((result) => {
+      expect({
+        assetHierarchyId: HIERARCHY_ROOT_ID,
+        assets: [sampleAssetSummary],
+        loadingState: LoadingStateEnum.LOADED,
+      }).toEqual(result);
+
+      expect(mockListAssets).not.toHaveBeenCalled();
       done();
     });
   });

--- a/packages/source-iotsitewise/src/asset-modules/sitewise/requestProcessor.ts
+++ b/packages/source-iotsitewise/src/asset-modules/sitewise/requestProcessor.ts
@@ -286,7 +286,7 @@ export class RequestProcessor {
   public getAssetHierarchy(query: AssetHierarchyQuery, observer: Subscriber<HierarchyAssetSummaryList>) {
     const cachedValue = this.hierarchyFromCache(query);
     if (cachedValue && cachedValue.loadingState === LoadingStateEnum.LOADED) {
-      return cachedValue;
+      observer.next(cachedValue);
     }
 
     this.hierarchyWorkers.subscribe(query, observer);

--- a/packages/source-iotsitewise/src/asset-modules/sitewise/requestProcessor.ts
+++ b/packages/source-iotsitewise/src/asset-modules/sitewise/requestProcessor.ts
@@ -286,7 +286,7 @@ export class RequestProcessor {
   public getAssetHierarchy(query: AssetHierarchyQuery, observer: Subscriber<HierarchyAssetSummaryList>) {
     const cachedValue = this.hierarchyFromCache(query);
     if (cachedValue && cachedValue.loadingState === LoadingStateEnum.LOADED) {
-      observer.next(cachedValue);
+      return observer.next(cachedValue);
     }
 
     this.hierarchyWorkers.subscribe(query, observer);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5607,6 +5607,11 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.10.tgz#637d3c8431f112edf6728ac9bdfadfe029540f48"
   integrity sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A==
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/webpack-dev-server@^3.11.0":
   version "3.11.6"
   resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-3.11.6.tgz#d8888cfd2f0630203e13d3ed7833a4d11b8a34dc"


### PR DESCRIPTION
## Overview
Introduce `expanded` feature to `iot-resource-explorer`. When true, recursively expands nodes that have children.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
