### PR TITLE
fix: layout glitch on widgets being positioned on invalid rows/col

### DIFF
--- a/packages/dashboard/src/components/iot-dashboard/__snapshots__/iot-dashboard.spec.tsx.snap
+++ b/packages/dashboard/src/components/iot-dashboard/__snapshots__/iot-dashboard.spec.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders 1`] = `
+<iot-dashboard-widget style="grid-column-start: 1; grid-column-end: 2; grid-row-start: 1; grid-row-end: 2;">
+  <div class="false widget" id="widget-id">
+    <div class="widget-content">
+      my-widget
+    </div>
+  </div>
+</iot-dashboard-widget>
+`;

--- a/packages/dashboard/src/dashboard-actions/move.spec.ts
+++ b/packages/dashboard/src/dashboard-actions/move.spec.ts
@@ -25,6 +25,18 @@ describe('getMovedDashboardConfiguration', () => {
     ).toEqual([{ x: 1.1, y: 1, width: 1, height: 1, id: 'some-id', widget: 'line-chart' }]);
   });
 
+  it('does not shift off of the grid', () => {
+    expect(
+      getMovedDashboardConfiguration({
+        dashboardConfiguration: [{ x: 1, y: 1, width: 1, height: 1, id: 'some-id', widget: 'line-chart' }],
+        cellSize: 10,
+        position: { x: 10, y: 10 },
+        previousPosition: { x: 10000, y: 10000 },
+        selectedWidgetIds: ['some-id'],
+      })
+    ).toEqual([{ x: 1, y: 1, width: 1, height: 1, id: 'some-id', widget: 'line-chart' }]);
+  });
+
   it('does not shift widget that is not selected', () => {
     const WIDGET = { x: 1, y: 1, width: 1, height: 1, id: 'some-id', widget: 'line-chart' };
     expect(

--- a/packages/dashboard/src/dashboard-actions/move.ts
+++ b/packages/dashboard/src/dashboard-actions/move.ts
@@ -23,8 +23,10 @@ export const getMovedDashboardConfiguration = ({
     if (selectedWidgetIds.includes(widget.id)) {
       return {
         ...widget,
-        x: widget.x + delta.x,
-        y: widget.y + delta.y,
+        // widgets utilize css-grids to position, where x and y map to row and columns.
+        // 1 represents the first row or column, so we ignore anything below that.
+        x: Math.max(1, widget.x + delta.x),
+        y: Math.max(1, widget.y + delta.y),
       };
     }
     return widget;


### PR DESCRIPTION
## Overview
Fixes widget movement when widgets are dragged to the very top or far left of the grid.
Also adds in a missing snapshot that wasn't generated.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
