### PR TITLE
expose batchDuration as a configurable setting on sitewise source

### DIFF
--- a/packages/source-iotsitewise/src/initialize.ts
+++ b/packages/source-iotsitewise/src/initialize.ts
@@ -1,6 +1,6 @@
 import { SiteWiseTimeSeriesDataProvider } from './time-series-data/provider';
 import { IotAppKitDataModule, TreeQuery, TimeQuery, TimeSeriesData, TimeSeriesDataRequest } from '@iot-app-kit/core';
-import { SiteWiseAssetQuery } from './time-series-data/types';
+import { SiteWiseAssetQuery, SiteWiseDataSourceSettings } from './time-series-data/types';
 import {
   BranchReference,
   RootedSiteWiseAssetTreeQueryArguments,
@@ -18,7 +18,7 @@ import { Credentials, Provider as AWSCredentialsProvider } from '@aws-sdk/types'
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { assetSession } from './sessions';
 
-type IoTAppKitInitInputs =
+type SiteWiseDataSourceInitInputs = (
   | {
       registerDataSources?: boolean;
       iotSiteWiseClient: IoTSiteWiseClient;
@@ -27,7 +27,10 @@ type IoTAppKitInitInputs =
       registerDataSources?: boolean;
       awsCredentials: Credentials | AWSCredentialsProvider<Credentials>;
       awsRegion: string;
-    };
+    }
+) & {
+  settings?: SiteWiseDataSourceSettings;
+};
 
 export type SiteWiseQuery = {
   timeSeriesData: (query: SiteWiseAssetQuery) => TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>;
@@ -43,7 +46,7 @@ export type SiteWiseQuery = {
  * @param awsCredentials - https://www.npmjs.com/package/@aws-sdk/credential-providers
  * @param awsRegion - Region for AWS based data sources to point towards, i.e. us-east-1
  */
-export const initialize = (input: IoTAppKitInitInputs) => {
+export const initialize = (input: SiteWiseDataSourceInitInputs) => {
   const siteWiseTimeSeriesModule = new IotAppKitDataModule();
   const siteWiseSdk =
     'iotSiteWiseClient' in input ? input.iotSiteWiseClient : sitewiseSdk(input.awsCredentials, input.awsRegion);
@@ -53,7 +56,7 @@ export const initialize = (input: IoTAppKitInitInputs) => {
 
   if (input.registerDataSources !== false) {
     /** Automatically registered data sources */
-    siteWiseTimeSeriesModule.registerDataSource(createDataSource(siteWiseSdk));
+    siteWiseTimeSeriesModule.registerDataSource(createDataSource(siteWiseSdk, input.settings));
   }
 
   return {

--- a/packages/source-iotsitewise/src/time-series-data/client/client.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/client.ts
@@ -4,6 +4,7 @@ import { batchGetHistoricalPropertyDataPoints } from './batchGetHistoricalProper
 import { OnSuccessCallback, ErrorCallback, RequestInformationAndRange } from '@iot-app-kit/core';
 import { batchGetAggregatedPropertyDataPoints } from './batchGetAggregatedPropertyDataPoints';
 import { batchGetLatestPropertyDataPoints } from './batchGetLatestPropertyDataPoints';
+import { SiteWiseDataSourceSettings } from '../types';
 
 export type LatestPropertyParams = {
   requestInformations: RequestInformationAndRange[];
@@ -28,13 +29,15 @@ export type AggregatedPropertyParams = {
 
 export class SiteWiseClient {
   private siteWiseSdk: IoTSiteWiseClient;
+  private settings: SiteWiseDataSourceSettings;
 
   private latestPropertyDataLoader: DataLoader<LatestPropertyParams, void>;
   private historicalPropertyDataLoader: DataLoader<HistoricalPropertyParams, void>;
   private aggregatedPropertyDataLoader: DataLoader<AggregatedPropertyParams, void>;
 
-  constructor(siteWiseSdk: IoTSiteWiseClient) {
+  constructor(siteWiseSdk: IoTSiteWiseClient, settings: SiteWiseDataSourceSettings = {}) {
     this.siteWiseSdk = siteWiseSdk;
+    this.settings = settings;
     this.instantiateDataLoaders();
   }
 
@@ -42,25 +45,43 @@ export class SiteWiseClient {
    * Instantiate batch data loaders for latest, historical, and aggregated data.
    * by default, data loaders will schedule batches for each frame of execution which ensures
    * no additional latency when capturing many related requests in a single batch.
-   *
-   * @todo: adjust batch frequency for optimal sitewise request batching (latency vs. #requests)
-   * @todo: switch out existing APIs for batch APIs
    */
   private instantiateDataLoaders() {
-    this.latestPropertyDataLoader = new DataLoader<LatestPropertyParams, void>(async (keys) => {
-      batchGetLatestPropertyDataPoints({ params: keys.flat(), client: this.siteWiseSdk });
-      return keys.map(() => undefined); // values are updated in data cache and don't need to be rebroadcast
-    });
+    this.latestPropertyDataLoader = new DataLoader<LatestPropertyParams, void>(
+      async (keys) => {
+        batchGetLatestPropertyDataPoints({ params: keys.flat(), client: this.siteWiseSdk });
+        return keys.map(() => undefined); // values are updated in data cache and don't need to be rebroadcast
+      },
+      {
+        batchScheduleFn: this.settings.batchDuration
+          ? (callback) => setTimeout(callback, this.settings.batchDuration)
+          : undefined,
+      }
+    );
 
-    this.historicalPropertyDataLoader = new DataLoader<HistoricalPropertyParams, void>(async (keys) => {
-      batchGetHistoricalPropertyDataPoints({ params: keys.flat(), client: this.siteWiseSdk });
-      return keys.map(() => undefined);
-    });
+    this.historicalPropertyDataLoader = new DataLoader<HistoricalPropertyParams, void>(
+      async (keys) => {
+        batchGetHistoricalPropertyDataPoints({ params: keys.flat(), client: this.siteWiseSdk });
+        return keys.map(() => undefined);
+      },
+      {
+        batchScheduleFn: this.settings.batchDuration
+          ? (callback) => setTimeout(callback, this.settings.batchDuration)
+          : undefined,
+      }
+    );
 
-    this.aggregatedPropertyDataLoader = new DataLoader<AggregatedPropertyParams, void>(async (keys) => {
-      batchGetAggregatedPropertyDataPoints({ params: keys.flat(), client: this.siteWiseSdk });
-      return keys.map(() => undefined);
-    });
+    this.aggregatedPropertyDataLoader = new DataLoader<AggregatedPropertyParams, void>(
+      async (keys) => {
+        batchGetAggregatedPropertyDataPoints({ params: keys.flat(), client: this.siteWiseSdk });
+        return keys.map(() => undefined);
+      },
+      {
+        batchScheduleFn: this.settings.batchDuration
+          ? (callback) => setTimeout(callback, this.settings.batchDuration)
+          : undefined,
+      }
+    );
   }
 
   getLatestPropertyDataPoint(params: LatestPropertyParams): Promise<void> {

--- a/packages/source-iotsitewise/src/time-series-data/data-source.ts
+++ b/packages/source-iotsitewise/src/time-series-data/data-source.ts
@@ -1,5 +1,5 @@
 import { IoTSiteWiseClient, AggregateType } from '@aws-sdk/client-iotsitewise';
-import { SiteWiseDataStreamQuery } from './types';
+import { SiteWiseDataSourceSettings, SiteWiseDataStreamQuery } from './types';
 import { SiteWiseClient } from './client/client';
 import { toId } from './util/dataStreamId';
 import {
@@ -60,8 +60,11 @@ export const determineResolution = ({
   }
 };
 
-export const createDataSource = (siteWise: IoTSiteWiseClient): DataSource<SiteWiseDataStreamQuery> => {
-  const client = new SiteWiseClient(siteWise);
+export const createDataSource = (
+  siteWise: IoTSiteWiseClient,
+  settings?: SiteWiseDataSourceSettings
+): DataSource<SiteWiseDataStreamQuery> => {
+  const client = new SiteWiseClient(siteWise, settings);
   return {
     name: SITEWISE_DATA_SOURCE,
     initiateRequest: ({ onSuccess, onError }, requestInformations) =>

--- a/packages/source-iotsitewise/src/time-series-data/types.ts
+++ b/packages/source-iotsitewise/src/time-series-data/types.ts
@@ -27,3 +27,7 @@ export type SiteWiseAssetQuery = {
 export type SiteWiseAssetDataStreamQuery = DataStreamQuery & SiteWiseAssetQuery;
 
 export type SiteWiseDataStreamQuery = SiteWiseAssetDataStreamQuery;
+
+export type SiteWiseDataSourceSettings = {
+  batchDuration?: number;
+};


### PR DESCRIPTION
## Overview
The ideal batch duration (timeframe in which requests are batched) observed by the sitewise source is highly dependent on factors such as dashboard configuration, widget configuration, browser performance, and latency. Batching by a single browser tick is fine as a default behaviour but needs to be customizable for the use-case.

This change exposes batchDuration as a setting on the sitewise source (and thus on app kit initialize). batchDuration accepts a numeric value representing the batching window in ms.

Documentation to follow.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
