### PR TITLE
Fix: Development Quick Start Docs/Scripts

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,45 +1,20 @@
-## Quick start for development
+## Development Quick Start 
 
-1. Environment setup
+### Environment setup
 
-Ensure you have node version 16 and the latest version of yarn installed.
+Iot-App-Kit runs on node and uses yarn for package management. Specific versions are required in order to keep builds working with the current monorepo tooling.
 
+- Node: any `v16` or higher
+- Yarn: any `v1`, but not `v2` or higher
 
-To do this, execute the following commands:
-```
-# Install `n`, a node package manager, globally to help switch between node versions.
-npm i n -g
+### Building Iot-App-Kit
 
-# Update to node version 16
-sudo n 16
+With supported versions of node and yarn installed, you're ready to connect to SiteWise and start building for Iot-App-Kit. You'll need to pull in credentials, specify the SiteWise assets you'd like to connect to, build the project, and then run locally.
 
-# Install the latest version of yarn
-npm i yarn@latest -g
+1. Copy a set of AWS JSON formatted credentials to the account with the access to the SiteWise resources you are requesting, at `<rootDir>/packages/components/creds.json`.
 
-# Optionally, install lerna
-npm i lerna -g
-```
+2. Alter the file `siteWiseQueries` within `@iot-app-kit/components` to point to valid SiteWise asset properties for the account credentials from the prior step.
 
-2. Build project
+3. `yarn bootstrap` installs dependencies and builds the Iot-App-Kit packages. Note: this is different than using `lerna bootstrap`, which installs dependencies but doesn't build the packages.
 
-```
-# Without installing lerna locally...
-npx lerna bootstrap
-
-# With lerna installed locally
-lerna bootstrap
-```
-
-4. Provide credentials
-   Copy a set of AWS JSON formatted credentials to the account with the access to the SiteWise resources you are requesting, at `<rootDir>/packages/components/creds.json`.
-
-These credentials should not be uploaded to the repository.
-
-5. Point to valid SiteWise resources
-
-Alter the file `siteWiseQueries` within `@iot-app-kit/components` to point to valid SiteWise asset properties for the accounts credentials from the prior step.
-
-6. Test locally
-   run `yarn run start` at the project root, and then view `localhost:3333`. Here you should see example IoT App Kit components requesting data from SiteWise.
-
-
+4. `yarn start` will run the project at `localhost:3333`. You should see example IoT App Kit components requesting data from SiteWise.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "repository": "git@github.com:awslabs/iot-app-kit.git",
+  "engines": {
+    "node": ">=16.0.0",
+    "yarn": ">=1.0.0 <2.0.0"
+  },
   "workspaces": {
     "packages": [
       "packages/*"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "start": "cd packages/components && yarn run start",
+    "bootstrap": "yarn install && yarn build",
     "build": "lerna run build --stream",
     "clean": "git clean -dxf -e /.idea -e /.vscode -e creds.json",
     "fix": "npm-run-all -p fix:eslint fix:stylelint",


### PR DESCRIPTION
## Overview
There's been confusion around how to build and run iot-app-kit. The development docs instructed to use `lerna bootstrap` to install dependencies, but after doing so packages weren't being built. I did some investigation and found the following:

- `lerna bootstrap` installs dependencies, but won't build packages by design
- any lerna version doesn't currently work with yarn v2+
- the development docs are out of date, not including any sort of build step between installing dependencies and running the app locally.

To help clarify what is required to build iot-app-kit and the steps to get started, I've changed the following:

- A new bootstrap script was added
- `engines` are now specified in `package.json` to warn people when they try to run iot-app-kit with incompatible node/yarn versions
- updated the quick start docs to clarify what is needed to build/run app kit, and the steps for how to connect to SiteWise data

## Tests
https://github.com/awslabs/iot-app-kit/runs/7240304374?check_suite_focus=true

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
