### PR TITLE
Basic resizable panes for dashboard

### DIFF
--- a/packages/dashboard/src/components.d.ts
+++ b/packages/dashboard/src/components.d.ts
@@ -86,6 +86,8 @@ export namespace Components {
          */
         "width": number;
     }
+    interface IotResizablePanes {
+    }
     interface IotSelectionBox {
         "cellSize": number;
         "height": number;
@@ -126,6 +128,12 @@ declare global {
         prototype: HTMLIotDashboardWrapperElement;
         new (): HTMLIotDashboardWrapperElement;
     };
+    interface HTMLIotResizablePanesElement extends Components.IotResizablePanes, HTMLStencilElement {
+    }
+    var HTMLIotResizablePanesElement: {
+        prototype: HTMLIotResizablePanesElement;
+        new (): HTMLIotResizablePanesElement;
+    };
     interface HTMLIotSelectionBoxElement extends Components.IotSelectionBox, HTMLStencilElement {
     }
     var HTMLIotSelectionBoxElement: {
@@ -149,6 +157,7 @@ declare global {
         "iot-dashboard-dynamic-widget": HTMLIotDashboardDynamicWidgetElement;
         "iot-dashboard-widget": HTMLIotDashboardWidgetElement;
         "iot-dashboard-wrapper": HTMLIotDashboardWrapperElement;
+        "iot-resizable-panes": HTMLIotResizablePanesElement;
         "iot-selection-box": HTMLIotSelectionBoxElement;
         "iot-selection-box-anchor": HTMLIotSelectionBoxAnchorElement;
         "testing-ground": HTMLTestingGroundElement;
@@ -232,6 +241,8 @@ declare namespace LocalJSX {
          */
         "width"?: number;
     }
+    interface IotResizablePanes {
+    }
     interface IotSelectionBox {
         "cellSize"?: number;
         "height"?: number;
@@ -251,6 +262,7 @@ declare namespace LocalJSX {
         "iot-dashboard-dynamic-widget": IotDashboardDynamicWidget;
         "iot-dashboard-widget": IotDashboardWidget;
         "iot-dashboard-wrapper": IotDashboardWrapper;
+        "iot-resizable-panes": IotResizablePanes;
         "iot-selection-box": IotSelectionBox;
         "iot-selection-box-anchor": IotSelectionBoxAnchor;
         "testing-ground": TestingGround;
@@ -264,6 +276,7 @@ declare module "@stencil/core" {
             "iot-dashboard-dynamic-widget": LocalJSX.IotDashboardDynamicWidget & JSXBase.HTMLAttributes<HTMLIotDashboardDynamicWidgetElement>;
             "iot-dashboard-widget": LocalJSX.IotDashboardWidget & JSXBase.HTMLAttributes<HTMLIotDashboardWidgetElement>;
             "iot-dashboard-wrapper": LocalJSX.IotDashboardWrapper & JSXBase.HTMLAttributes<HTMLIotDashboardWrapperElement>;
+            "iot-resizable-panes": LocalJSX.IotResizablePanes & JSXBase.HTMLAttributes<HTMLIotResizablePanesElement>;
             "iot-selection-box": LocalJSX.IotSelectionBox & JSXBase.HTMLAttributes<HTMLIotSelectionBoxElement>;
             "iot-selection-box-anchor": LocalJSX.IotSelectionBoxAnchor & JSXBase.HTMLAttributes<HTMLIotSelectionBoxAnchorElement>;
             "testing-ground": LocalJSX.TestingGround & JSXBase.HTMLAttributes<HTMLTestingGroundElement>;

--- a/packages/dashboard/src/components/iot-dashboard/iot-selection-box/iot-selection-box-anchor.css
+++ b/packages/dashboard/src/components/iot-dashboard/iot-selection-box/iot-selection-box-anchor.css
@@ -49,26 +49,26 @@
   cursor: ns-resize;
   height: var(--selection-border-touch-width);
   width: 100%;
-  top: calc(-1/2 * var(--selection-border-touch-width));
+  top: calc(-1 / 2 * var(--selection-border-touch-width));
 }
 
 .selection-box-side-bottom {
   cursor: ns-resize;
   height: var(--selection-border-touch-width);
   width: 100%;
-  bottom: calc(-1/2 * var(--selection-border-touch-width));
+  bottom: calc(-1 / 2 * var(--selection-border-touch-width));
 }
 
 .selection-box-side-right {
   cursor: ew-resize;
   width: var(--selection-border-touch-width);
   height: 100%;
-  right: calc(-1/2 * var(--selection-border-touch-width));
+  right: calc(-1 / 2 * var(--selection-border-touch-width));
 }
 
 .selection-box-side-left {
   cursor: ew-resize;
   width: var(--selection-border-touch-width);
   height: 100%;
-  left: calc(-1/2 * var(--selection-border-touch-width));
+  left: calc(-1 / 2 * var(--selection-border-touch-width));
 }

--- a/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.css
+++ b/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.css
@@ -1,0 +1,30 @@
+.iot-resizable-panes {
+  display: grid;
+  width: 100%;
+  max-width: 100%;
+  grid-template-columns: min-content 10px auto 10px min-content;
+}
+
+.iot-resizable-panes-pane {
+  overflow: hidden;
+  position: relative;
+}
+
+.iot-resizable-panes-pane-left,
+.iot-resizable-panes-pane-right {
+  width: 15%;
+  height: 100%;
+  min-height: calc(100vh - 170px);
+}
+
+.iot-resizable-panes-handle {
+  width: 10px;
+  background-color: lightgray;
+  cursor: ew-resize;
+  z-index: 2;
+  isolation: isolate;
+}
+
+.iot-resizable-panes-handle:hover {
+  background-color: skyblue;
+}

--- a/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.spec.ts
+++ b/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.spec.ts
@@ -1,0 +1,55 @@
+import { newSpecPage, jestSetupTestFramework } from '@stencil/core/testing';
+jestSetupTestFramework();
+import { IotResizablePanes } from './iot-resizable-panes';
+
+const leftSlotContent = `Warp core monitor`;
+const centerSlotContent = `Forward viewscreen`;
+const rightSlotContent = `Phaser controls`;
+
+const components = [IotResizablePanes];
+const html = `
+  <iot-resizable-panes>
+    <div slot="left">
+      <p>${leftSlotContent}</p>
+    </div>
+    <div slot="center">
+      <p>${centerSlotContent}</p>
+    </div>
+    <div slot="right">
+      <p>${rightSlotContent}</p>
+    </div>
+  </iot-resizable-panes>
+`;
+
+describe('iot-resizable-panes', () => {
+  it('should render slots with shadow dom', async () => {
+    const page = await newSpecPage({
+      components,
+      html,
+    });
+    const { root } = page;
+
+    expect(root).toBeTruthy();
+    if (!root) return;
+    const paraEls = root.querySelectorAll('p');
+    expect(paraEls[0].textContent).toEqual(leftSlotContent);
+    expect(paraEls[1].textContent).toEqual(centerSlotContent);
+    expect(paraEls[2].textContent).toEqual(rightSlotContent);
+  });
+
+  it('should render slots without shadow dom', async () => {
+    const page = await newSpecPage({
+      components,
+      html,
+      supportsShadowDom: false,
+    });
+    const { root } = page;
+
+    expect(root).toBeTruthy();
+    if (!root) return;
+    const paraEls = root.querySelectorAll('p');
+    expect(paraEls[0].textContent).toEqual(leftSlotContent);
+    expect(paraEls[1].textContent).toEqual(centerSlotContent);
+    expect(paraEls[2].textContent).toEqual(rightSlotContent);
+  });
+});

--- a/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.tsx
+++ b/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.tsx
@@ -1,0 +1,139 @@
+import { Component, State, Listen, h } from '@stencil/core';
+
+const LEFT_WIDTH_PERCENT = 0.15;
+const RIGHT_WIDTH_PERCENT = 0.15;
+const CENTER_BUFFER = 50;
+
+@Component({
+  tag: 'iot-resizable-panes',
+  styleUrl: 'iot-resizable-panes.css',
+})
+export class IotResizablePanes {
+  /** Currently active drag hangle during a drag, or null if not dragging */
+  @State() currentDragHandle: 'left' | 'right' | null = null;
+
+  /** Last seen mouse x position during a drag, in px from screen left side */
+  @State() lastSeenAtX: number | null = null;
+
+  /** Total x distance moved during a drag, in px */
+  @State() movedX: number | null = null;
+
+  /** Current widths of the three panes, in percentage of parent width */
+  @State() leftPaneWidth = 0;
+  @State() rightPaneWidth = 0;
+
+  /**
+   * Set element width on load
+   */
+
+  componentDidLoad() {
+    const el = document.querySelector('iot-resizable-panes');
+    if (!el) return;
+    const elementWidth = el.offsetWidth;
+    this.leftPaneWidth = elementWidth * LEFT_WIDTH_PERCENT;
+    this.rightPaneWidth = elementWidth * RIGHT_WIDTH_PERCENT;
+  }
+
+  cancelDrag() {
+    this.currentDragHandle = null;
+    this.lastSeenAtX = null;
+    this.movedX = null;
+  }
+
+  /**
+   * Drag event handlers
+   */
+
+  onHandleDragStart(event: MouseEvent) {
+    const target = event.target;
+    if (target instanceof Element) {
+      if (target.classList && target.classList.contains('iot-resizable-panes-handle')) {
+        this.lastSeenAtX = event.clientX;
+        this.movedX = 0;
+        if (target.classList.contains('iot-resizable-panes-handle-left')) {
+          this.currentDragHandle = 'left';
+        } else {
+          this.currentDragHandle = 'right';
+        }
+      }
+    }
+  }
+
+  onHandleDragMove(event: MouseEvent) {
+    const el = document.querySelector('iot-resizable-panes');
+    if (!el) return;
+    const elementWidth = el.offsetWidth;
+
+    if (!this.currentDragHandle || this.lastSeenAtX === null || this.movedX === null) return;
+
+    this.movedX = -(this.lastSeenAtX - event.clientX);
+    this.lastSeenAtX = event.clientX;
+
+    if (this.currentDragHandle === 'right') {
+      const nextRightPaneWidth = this.rightPaneWidth - this.movedX;
+      // Stop drag when pane runs into other pane
+      if (nextRightPaneWidth + this.leftPaneWidth >= elementWidth - CENTER_BUFFER) {
+        this.cancelDrag();
+        return;
+      }
+      this.rightPaneWidth = nextRightPaneWidth;
+    }
+
+    if (this.currentDragHandle === 'left') {
+      const nextLeftPaneWidth = this.leftPaneWidth + this.movedX;
+      // Stop drag when pane runs into other pane
+      if (nextLeftPaneWidth + this.rightPaneWidth >= elementWidth - CENTER_BUFFER) {
+        this.cancelDrag();
+        return;
+      }
+      this.leftPaneWidth = nextLeftPaneWidth;
+    }
+  }
+
+  onHandleDragEnd() {
+    this.cancelDrag();
+  }
+
+  /**
+   * Input bindings
+   */
+
+  @Listen('mousedown')
+  onMouseDown(event: MouseEvent) {
+    this.onHandleDragStart(event);
+  }
+
+  @Listen('mousemove')
+  onMouseMove(event: MouseEvent) {
+    this.onHandleDragMove(event);
+  }
+
+  @Listen('mouseup')
+  onMouseUp() {
+    this.onHandleDragEnd();
+  }
+
+  render() {
+    return (
+      <div class="iot-resizable-panes">
+        <div
+          class="iot-resizable-panes-pane iot-resizable-panes-pane-left"
+          style={{ width: this.leftPaneWidth.toString() + 'px' }}
+        >
+          <slot name="left" />
+        </div>
+        <div class="iot-resizable-panes-handle iot-resizable-panes-handle-left" />
+        <div class="iot-resizable-panes-pane iot-resizable-panes-pane-center">
+          <slot name="center" />
+        </div>
+        <div class="iot-resizable-panes-handle iot-resizable-panes-handle-right"></div>
+        <div
+          class="iot-resizable-panes-pane iot-resizable-panes-pane-right"
+          style={{ width: this.rightPaneWidth.toString() + 'px' }}
+        >
+          <slot name="right" />
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/dashboard/src/testing/testing-ground/testing-ground.css
+++ b/packages/dashboard/src/testing/testing-ground/testing-ground.css
@@ -2,3 +2,14 @@ label {
   margin-right: 0.5em;
   display: inline-block;
 }
+
+.dummy-content {
+  width: calc(100% - 40px);
+  height: calc(100% - 40px);
+  min-height: calc(100vh - 210px);
+  background-color: rgba(0 0 0 / 1%);
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/packages/dashboard/src/testing/testing-ground/testing-ground.tsx
+++ b/packages/dashboard/src/testing/testing-ground/testing-ground.tsx
@@ -74,15 +74,26 @@ export class TestingGround {
           <label>Stretch to fit</label>
           <input type="checkbox" checked={this.stretchToFit} onChange={this.onStretchToFit} />
         </div>
-        <iot-dashboard
-          width={this.width}
-          cellSize={this.cellSize}
-          stretchToFit={this.stretchToFit}
-          dashboardConfiguration={this.dashboardConfiguration}
-          onDashboardConfigurationChange={(newConfig) => {
-            this.dashboardConfiguration = newConfig;
-          }}
-        />
+
+        <iot-resizable-panes>
+          <div slot="left">
+            <div class="dummy-content">Resource explorer pane</div>
+          </div>
+          <div slot="center">
+            <iot-dashboard
+              width={this.width}
+              cellSize={this.cellSize}
+              stretchToFit={this.stretchToFit}
+              dashboardConfiguration={this.dashboardConfiguration}
+              onDashboardConfigurationChange={(newConfig) => {
+                this.dashboardConfiguration = newConfig;
+              }}
+            />
+          </div>
+          <div slot="right">
+            <div class="dummy-content">Component pane</div>
+          </div>
+        </iot-resizable-panes>
       </div>
     );
   }


### PR DESCRIPTION
![Screen Shot 2022-07-14 at 12 39 15 PM](https://user-images.githubusercontent.com/15032398/179070409-5d67bc96-fa80-4b16-bd06-f4b4f6dfe8eb.png)

## Overview
This PR adds a new component, `<resizable-panes/>`. It consists of a left, center, and right pane, with handles between them that dynamically change the widths of the panes when dragged left or right, similar to a library like [Split.js](https://split.js.org/).

This is a basic first step, and needs to be followed up by several additional changes adding enhancements and covering anticipated edge cases, detailed below.

## Next steps
- We will need to expand the mouse event listeners here to touch event listeners as well. [This is coming shortly in a follow-up PR.]
- We will need to save the state of the pane widths in sessionStorage so they can persist across page refreshes. [This is coming shortly in a follow-up PR.]
- We need to add a window resize listener that recalculates the pane widths when the window is resized. (Or potentially not if we figure out a way to automate this with grid values?) [This is coming shortly in a follow-up PR.]
- We have basic unit tests here that check that the panes are successfully rendering their content. I attempted, in vain, to also implement full functionality unit tests that dispatch mouse events to drag the handles and check that the associated style value has updated successfully, but it looks like Stencil's testing framework only allows a limited set of mock events, and those don't seem to include MouseEvents beyond `click`, so we will likely need to implement this in an e2e test instead.
- I haven't yet added any logic to enforce minimum/maximum pane width or prevent collision bugs. In manual testing, it seems to 'just work' as is, but my guess is we will run into weird problems with panes overlapping, becoming undraggable, etc. unless we explicitly seek to prevent this, and/or add a recovery mechanism like a 'reset panes to default' button.
- The styles involved here are meant to be temporary: the drag handles are rather ugly, I have inserted some demonstration content in the left/right panes that should be replaced by the correct components, and I didn't put too much time into making sure the pane width calculations were perfect, so there might be a better way to achieve them with different grid values.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
