### PR TITLE
Persist resizable pane position in sessionStorage and prevent collisions on window resize

### DIFF
--- a/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.css
+++ b/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.css
@@ -2,7 +2,7 @@
   display: grid;
   width: 100%;
   max-width: 100%;
-  grid-template-columns: min-content 10px auto 10px min-content;
+  grid-template-columns: max-content 10px auto 10px max-content;
 }
 
 .iot-resizable-panes-pane {
@@ -13,12 +13,12 @@
 .iot-resizable-panes-pane-left,
 .iot-resizable-panes-pane-right {
   width: 15%;
+  min-width: 0;
   height: 100%;
   min-height: calc(100vh - 170px);
 }
 
 .iot-resizable-panes-handle {
-  width: 10px;
   background-color: lightgray;
   cursor: ew-resize;
   z-index: 2;

--- a/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.tsx
+++ b/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.tsx
@@ -2,7 +2,21 @@ import { Component, State, Listen, h } from '@stencil/core';
 
 const LEFT_WIDTH_PERCENT = 0.15;
 const RIGHT_WIDTH_PERCENT = 0.15;
-const CENTER_BUFFER = 50;
+const MINIMUM_CENTER_PANE_WIDTH = 80;
+const MINIMUM_SIDE_PANE_WIDTH = 80;
+const HANDLE_WIDTH = 10;
+const MAXIMUM_PANES_PROPORTION = 0.9;
+const LEFT_WIDTH_PERCENT_STORAGE_KEY = 'iot-dashboard-pane-left-width';
+const RIGHT_WIDTH_PERCENT_STORAGE_KEY = 'iot-dashboard-pane-right-width';
+
+const getSessionStorageNumber = (key: string, fallback: number) => {
+  const stored = sessionStorage.getItem(key);
+  if (stored) return parseFloat(stored);
+  return fallback;
+};
+
+const getStoredLeftWidthPercent = () => getSessionStorageNumber(LEFT_WIDTH_PERCENT_STORAGE_KEY, LEFT_WIDTH_PERCENT);
+const getStoredRightWidthPercent = () => getSessionStorageNumber(RIGHT_WIDTH_PERCENT_STORAGE_KEY, RIGHT_WIDTH_PERCENT);
 
 @Component({
   tag: 'iot-resizable-panes',
@@ -18,7 +32,7 @@ export class IotResizablePanes {
   /** Total x distance moved during a drag, in px */
   @State() movedX: number | null = null;
 
-  /** Current widths of the three panes, in percentage of parent width */
+  /** Current widths of the three panes, in px */
   @State() leftPaneWidth = 0;
   @State() rightPaneWidth = 0;
 
@@ -27,22 +41,45 @@ export class IotResizablePanes {
    */
 
   componentDidLoad() {
+    // On initial load, attempt to get stored widths from sessionStorage.
+    // Otherwise, measure the panes element and set side pane widths to default
+    // percentages of its width, or the minimum width, whichever is larger.
+
     const el = document.querySelector('iot-resizable-panes');
     if (!el) return;
+
+    const storedLeftWidthPercent = getStoredLeftWidthPercent();
+    const storedRightWidthPercent = getStoredRightWidthPercent();
     const elementWidth = el.offsetWidth;
-    this.leftPaneWidth = elementWidth * LEFT_WIDTH_PERCENT;
-    this.rightPaneWidth = elementWidth * RIGHT_WIDTH_PERCENT;
+
+    if (storedLeftWidthPercent) {
+      const storedLeftWidth = elementWidth * storedLeftWidthPercent;
+      this.leftPaneWidth = storedLeftWidth;
+    } else {
+      const computedLeftPaneWidth = elementWidth * LEFT_WIDTH_PERCENT;
+      this.leftPaneWidth =
+        computedLeftPaneWidth > MINIMUM_SIDE_PANE_WIDTH ? computedLeftPaneWidth : MINIMUM_SIDE_PANE_WIDTH;
+    }
+
+    if (storedRightWidthPercent) {
+      const storedRightWidth = elementWidth * storedRightWidthPercent;
+      this.rightPaneWidth = storedRightWidth;
+    } else {
+      const computedRightPaneWidth = elementWidth * RIGHT_WIDTH_PERCENT;
+      this.rightPaneWidth =
+        computedRightPaneWidth > MINIMUM_SIDE_PANE_WIDTH ? computedRightPaneWidth : MINIMUM_SIDE_PANE_WIDTH;
+    }
   }
+
+  /**
+   * Drag event handlers and methods
+   */
 
   cancelDrag() {
     this.currentDragHandle = null;
     this.lastSeenAtX = null;
     this.movedX = null;
   }
-
-  /**
-   * Drag event handlers
-   */
 
   onHandleDragStart(event: MouseEvent) {
     const target = event.target;
@@ -69,29 +106,87 @@ export class IotResizablePanes {
     this.movedX = -(this.lastSeenAtX - event.clientX);
     this.lastSeenAtX = event.clientX;
 
-    if (this.currentDragHandle === 'right') {
-      const nextRightPaneWidth = this.rightPaneWidth - this.movedX;
-      // Stop drag when pane runs into other pane
-      if (nextRightPaneWidth + this.leftPaneWidth >= elementWidth - CENTER_BUFFER) {
-        this.cancelDrag();
-        return;
-      }
-      this.rightPaneWidth = nextRightPaneWidth;
-    }
-
     if (this.currentDragHandle === 'left') {
       const nextLeftPaneWidth = this.leftPaneWidth + this.movedX;
-      // Stop drag when pane runs into other pane
-      if (nextLeftPaneWidth + this.rightPaneWidth >= elementWidth - CENTER_BUFFER) {
+
+      // Stop drag when dragged pane runs into other pane
+      if (nextLeftPaneWidth + this.rightPaneWidth >= elementWidth - MINIMUM_CENTER_PANE_WIDTH) {
         this.cancelDrag();
         return;
       }
+
+      // Persist percentage with sessionStorage
       this.leftPaneWidth = nextLeftPaneWidth;
+      const nextLeftPaneWidthPercent = nextLeftPaneWidth / elementWidth;
+      sessionStorage.setItem(LEFT_WIDTH_PERCENT_STORAGE_KEY, nextLeftPaneWidthPercent.toString());
+    }
+
+    if (this.currentDragHandle === 'right') {
+      const nextRightPaneWidth = this.rightPaneWidth - this.movedX;
+
+      // Stop drag when dragged pane runs into other pane
+      if (nextRightPaneWidth + this.leftPaneWidth >= elementWidth - MINIMUM_CENTER_PANE_WIDTH) {
+        this.cancelDrag();
+        return;
+      }
+
+      // Persist percentage with sessionStorage
+      this.rightPaneWidth = nextRightPaneWidth;
+      const nextRightPaneWidthPercent = nextRightPaneWidth / elementWidth;
+      sessionStorage.setItem(RIGHT_WIDTH_PERCENT_STORAGE_KEY, nextRightPaneWidthPercent.toString());
     }
   }
 
   onHandleDragEnd() {
     this.cancelDrag();
+  }
+
+  /**
+   * Because the width of left/right panes is hardcoded, resizing the screen
+   * to a smaller width can cause collisions. This method resizes side panes
+   * proportionally when the screen is resized to prevent these collisions.
+   */
+
+  resizeSidePanes() {
+    const totalBuffer = MINIMUM_CENTER_PANE_WIDTH + HANDLE_WIDTH * 2;
+    const totalWidth = this.leftPaneWidth + this.rightPaneWidth + totalBuffer;
+    const el = document.querySelector('iot-resizable-panes');
+    if (!el) return;
+    const elementWidth = el.offsetWidth;
+
+    // Set next proportion for panes. If proportions added exceed a threshold,
+    // scale them down until they do not.
+    const leftProportion = this.leftPaneWidth / elementWidth;
+    const rightProportion = this.rightPaneWidth / elementWidth;
+    let nextLeftProportion = leftProportion;
+    let nextRightProportion = rightProportion;
+    if (nextLeftProportion + nextRightProportion > MAXIMUM_PANES_PROPORTION) {
+      while (nextLeftProportion + nextRightProportion > MAXIMUM_PANES_PROPORTION) {
+        nextLeftProportion = nextLeftProportion * 0.99;
+        nextRightProportion = nextRightProportion * 0.99;
+      }
+    }
+
+    // Scale down the panes in proportion to their current size.
+    const maybeNextLeftPaneWidth = elementWidth * nextLeftProportion;
+    const maybeNextRightPaneWidth = elementWidth * nextRightProportion;
+
+    // If proportions are too high, or next pane width is larger than minimum
+    // size, use minimum size as next pane width instead.
+    const nextLeftPaneWidth =
+      maybeNextLeftPaneWidth > MINIMUM_SIDE_PANE_WIDTH ? maybeNextLeftPaneWidth : MINIMUM_SIDE_PANE_WIDTH;
+    const nextRightPaneWidth =
+      maybeNextRightPaneWidth > MINIMUM_SIDE_PANE_WIDTH ? maybeNextRightPaneWidth : MINIMUM_SIDE_PANE_WIDTH;
+
+    // Persist percentages with sessionStorage
+    const nextRightPaneWidthPercent = nextRightPaneWidth / elementWidth;
+    sessionStorage.setItem(RIGHT_WIDTH_PERCENT_STORAGE_KEY, nextRightPaneWidthPercent.toString());
+    const nextLeftPaneWidthPercent = nextLeftPaneWidth / elementWidth;
+    sessionStorage.setItem(LEFT_WIDTH_PERCENT_STORAGE_KEY, nextLeftPaneWidthPercent.toString());
+
+    // Set pane widths
+    this.leftPaneWidth = nextLeftPaneWidth;
+    this.rightPaneWidth = nextRightPaneWidth;
   }
 
   /**
@@ -113,23 +208,40 @@ export class IotResizablePanes {
     this.onHandleDragEnd();
   }
 
+  @Listen('resize', { target: 'window' })
+  onWindowResize() {
+    this.resizeSidePanes();
+  }
+
   render() {
     return (
       <div class="iot-resizable-panes">
         <div
           class="iot-resizable-panes-pane iot-resizable-panes-pane-left"
-          style={{ width: this.leftPaneWidth.toString() + 'px' }}
+          style={{ width: `${this.leftPaneWidth}px` }}
         >
           <slot name="left" />
         </div>
-        <div class="iot-resizable-panes-handle iot-resizable-panes-handle-left" />
+
+        <div
+          class="iot-resizable-panes-handle iot-resizable-panes-handle-left"
+          style={{ width: `${HANDLE_WIDTH}px` }}
+          tabIndex={0}
+        />
+
         <div class="iot-resizable-panes-pane iot-resizable-panes-pane-center">
           <slot name="center" />
         </div>
-        <div class="iot-resizable-panes-handle iot-resizable-panes-handle-right"></div>
+
+        <div
+          class="iot-resizable-panes-handle iot-resizable-panes-handle-right"
+          style={{ width: `${HANDLE_WIDTH}px` }}
+          tabIndex={0}
+        />
+
         <div
           class="iot-resizable-panes-pane iot-resizable-panes-pane-right"
-          style={{ width: this.rightPaneWidth.toString() + 'px' }}
+          style={{ width: `${this.rightPaneWidth}px` }}
         >
           <slot name="right" />
         </div>


### PR DESCRIPTION
## Overview
This PR adds two followup changes from #162, the resizable pane PR:

1. It persists pane position in sessionStorage, so the page can be refreshed and they will appear to not move at all -- it 'just works'.

2. It adds a window resize listener that will, if the resize would cause the panes to collide with one another, scales them down proportionally, as if they are being 'squished together'. This is necessary to prevent situations where one pane's handle is not grabbable due to panes overlapping.


## Tests
https://github.com/awslabs/iot-app-kit/runs/7616444204?check_suite_focus=true

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
