### PR TITLE
docs: Fix KPI docs and explain behavior of querying timer-series data…

### DIFF
--- a/docs/AWSIoTSiteWiseSource.md
+++ b/docs/AWSIoTSiteWiseSource.md
@@ -84,6 +84,13 @@ Each asset contains the following fields:
 
       (Optional) The time interval over which to aggregate data (for example, average, minimum, and maximum). For example, if the resolution is `1d`, IoT Application Kit aggregates your data once every 24 hours (1 day). For more information about the supported units and format, see [parse-duration](https://github.com/jkroso/parse-duration) on GitHub.
 
+      If left blank, the default behavior will be to display data in a more aggregated form, as the time period of data being shown is increased, as follows:
+     
+      * When a `viewport` with less than 15 minutes of data is being displayed, request raw data.
+      * When a `viewport` with less than 15 hours of data is being displayed, request minute aggregated data.
+      * When a `viewport` with less than 60 days of data is being displayed, request hourly aggregated data.
+      * When a `viewport` with more than 60 days of data is being displayed, request daily aggregated data.
+
       The valid resolutions for AWS IoT SiteWise are the following:
 
       * `0` - Raw data (unaggregated data). IoT Application Kit uses the [GetAssetPropertyValueHistory](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_GetAssetPropertyValueHistory.html) operation to fetch your data.

--- a/docs/KPI.md
+++ b/docs/KPI.md
@@ -2,7 +2,7 @@
 
 The Key Performance Indicator (KPI) component provides a compact representation when you need an overview of your asset properties. This overview gives you the most critical insights into the overall performance of your devices, equipment, or processes. With the KPI, you can interact with IoT data from one or more data sources.
 
-The status grid only supports showing the latest value. If the `viewport` is configured to visualize historical data, the KPI displays the disabled state.
+The KPI only supports showing the latest value. If the `viewport` is configured to visualize historical data, the KPI displays the disabled state.
 
 To view and interact with a KPI example, visit [KPI](https://synchrocharts.com/#/Components/KPI) in the Synchro Charts documentation.
 
@@ -92,7 +92,7 @@ A viewport contains the following fields:
 
 ### `annotations`
 
-(Optional) Defines thresholds for the line chart. To view and interact with an annotation example, see [Annotation](https://synchrocharts.com/#/Features/Annotation) in the Synchro Charts documentation. For more information about the `annotations` API, see [Properties](https://synchrocharts.com/#/API/Properties) in the Synchro Charts documentation. 
+(Optional) Defines thresholds for the KPI. Annotations that aren't also thresholds will be ignored. To view and interact with an annotation example, see [Annotation](https://synchrocharts.com/#/Features/Annotation) in the Synchro Charts documentation. For more information about the `annotations` API, see [Properties](https://synchrocharts.com/#/API/Properties) in the Synchro Charts documentation. 
 
 Type: Object
 

--- a/docs/StatusGrid.md
+++ b/docs/StatusGrid.md
@@ -104,7 +104,7 @@ A viewport contains the following fields:
 
 ### `annotations`
 
-(Optional) Defines thresholds for the status grid. To view and interact with an annotation example, see [Annotation](https://synchrocharts.com/#/Features/Annotation) in the Synchro Charts documentation. For more information about the `annotations` API, see [Properties](https://synchrocharts.com/#/API/Properties) in the Synchro Charts documentation. 
+(Optional) Defines thresholds for the status grid. Note that annotations that are not thresholds will be ignored. To view and interact with an annotation example, see [Annotation](https://synchrocharts.com/#/Features/Annotation) in the Synchro Charts documentation. For more information about the `annotations` API, see [Properties](https://synchrocharts.com/#/API/Properties) in the Synchro Charts documentation. 
 
 Type: Object
 


### PR DESCRIPTION
## Overview
 Fix KPI docs and explain behavior of querying timer-series data when resolution is omitted

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
