### PR TITLE
fix(dashboard):Remove previous position from internal dashboard

### DIFF
--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard-internal.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard-internal.tsx
@@ -71,12 +71,6 @@ export class IotDashboardInternal {
   private end: Position | undefined;
 
   /**
-   * Move gesture
-   */
-
-  private previousPosition: Position | undefined;
-
-  /**
    * Resize gesture
    */
   /** If the active gesture is resize, this represents which anchor point the resize is being done relative to */
@@ -178,7 +172,6 @@ export class IotDashboardInternal {
       this.setSelectedWidgets();
     }
 
-    this.previousPosition = { x, y };
     if (this.selectedWidgetIds.length === 0) {
       this.moveStartWidgetIds = intersectedWidgetIds;
       this.selectWidgets({
@@ -204,16 +197,11 @@ export class IotDashboardInternal {
   }
 
   onMove({ x, y }: Position) {
-    if (this.previousPosition) {
-      this.move({
-        position: { x, y },
-        prevPosition: this.previousPosition,
-        widgetIds: this.moveStartWidgetIds,
-        isActionComplete: false,
-      });
-
-      this.previousPosition = { x, y };
-    }
+    this.move({
+      position: { x, y },
+      widgetIds: this.moveStartWidgetIds,
+      isActionComplete: false,
+    });
   }
 
   onSelection = (event: MouseEvent) => {
@@ -269,7 +257,6 @@ export class IotDashboardInternal {
       isActionComplete: true,
     });
 
-    this.previousPosition = undefined;
     this.activeGesture = undefined;
   }
 

--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard.tsx
@@ -47,6 +47,7 @@ export class IotDashboard {
     intermediateDashboardConfiguration: undefined,
     undoQueue: [],
     redoQueue: [],
+    previousPosition: undefined,
   };
 
   /**

--- a/packages/dashboard/src/dashboard-actions/dashboardReducer.ts
+++ b/packages/dashboard/src/dashboard-actions/dashboardReducer.ts
@@ -21,6 +21,7 @@ const initialState: DashboardState = {
   cellSize: 10,
   undoQueue: [],
   redoQueue: [],
+  previousPosition: undefined,
 };
 
 export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
@@ -34,10 +35,11 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
         return {
           ...state,
           selectedWidgetIds: action.payload.widgetIds,
+          previousPosition: action.payload.position,
           intermediateDashboardConfiguration: move({
             dashboardConfiguration: state.intermediateDashboardConfiguration || state.dashboardConfiguration,
             position: action.payload.position,
-            previousPosition: action.payload.prevPosition,
+            previousPosition: state.previousPosition,
             selectedWidgetIds: action.payload.widgetIds,
             cellSize: state.cellSize,
           }),
@@ -55,6 +57,7 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
         intermediateDashboardConfiguration: undefined,
         undoQueue: state.undoQueue.concat(action),
         redoQueue: [],
+        previousPosition: undefined,
       };
 
     case 'RESIZE':

--- a/packages/dashboard/src/dashboard-actions/move.ts
+++ b/packages/dashboard/src/dashboard-actions/move.ts
@@ -22,8 +22,8 @@ export const move = ({
   const { x, y } = position;
 
   const delta = {
-    x: (x - (previousPosition ? previousPosition.x : 0)) / cellSize,
-    y: (y - (previousPosition ? previousPosition.y : 0)) / cellSize,
+    x: (previousPosition ? x - previousPosition.x : 0) / cellSize,
+    y: (previousPosition ? y - previousPosition.y : 0) / cellSize,
   };
 
   return mapWidgets(dashboardConfiguration, (widget) => {

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -46,4 +46,5 @@ export type DashboardState = {
   cellSize: number;
   undoQueue: UndoQueue;
   redoQueue: UndoQueue;
+  previousPosition: Position | undefined;
 };


### PR DESCRIPTION
## Overview
Move managing the previous widget position into dashboard state instead of the internal dashboard

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
