### PR TITLE
fix(dashboard): Remove unnecessary moveStartWidgetIds from internal d…

### DIFF
--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard-internal.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard-internal.tsx
@@ -55,8 +55,6 @@ export class IotDashboardInternal {
   private startResize: Position;
   private endResize: Position;
 
-  private moveStartWidgetIds: string[];
-
   /** List of ID's of the currently selected widgets. */
   @Prop() selectedWidgetIds: string[] = [];
 
@@ -173,7 +171,6 @@ export class IotDashboardInternal {
     }
 
     if (this.selectedWidgetIds.length === 0) {
-      this.moveStartWidgetIds = intersectedWidgetIds;
       this.selectWidgets({
         widgetIds: intersectedWidgetIds,
       });
@@ -199,7 +196,6 @@ export class IotDashboardInternal {
   onMove({ x, y }: Position) {
     this.move({
       position: { x, y },
-      widgetIds: this.moveStartWidgetIds,
       isActionComplete: false,
     });
   }
@@ -253,7 +249,6 @@ export class IotDashboardInternal {
     this.move({
       position: this.endMove,
       prevPosition: this.startMove,
-      widgetIds: this.selectedWidgetIds,
       isActionComplete: true,
     });
 

--- a/packages/dashboard/src/dashboard-actions/actions.ts
+++ b/packages/dashboard/src/dashboard-actions/actions.ts
@@ -19,7 +19,6 @@ export interface MoveAction extends Action<DashboardActionType.MOVE> {
   payload: {
     position: Position;
     prevPosition?: Position;
-    widgetIds: string[];
     isActionComplete: boolean;
   };
 }

--- a/packages/dashboard/src/dashboard-actions/dashboardReducer.ts
+++ b/packages/dashboard/src/dashboard-actions/dashboardReducer.ts
@@ -34,13 +34,12 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
       if (!action.payload.isActionComplete) {
         return {
           ...state,
-          selectedWidgetIds: action.payload.widgetIds,
           previousPosition: action.payload.position,
           intermediateDashboardConfiguration: move({
             dashboardConfiguration: state.intermediateDashboardConfiguration || state.dashboardConfiguration,
             position: action.payload.position,
             previousPosition: state.previousPosition,
-            selectedWidgetIds: action.payload.widgetIds,
+            selectedWidgetIds: state.selectedWidgetIds,
             cellSize: state.cellSize,
           }),
         };

--- a/packages/dashboard/src/dashboard-actions/redo.ts
+++ b/packages/dashboard/src/dashboard-actions/redo.ts
@@ -22,7 +22,7 @@ export const redo = ({
           cellSize: dashboardState.cellSize,
           position: dashboardAction.payload.position,
           previousPosition: dashboardAction.payload.prevPosition,
-          selectedWidgetIds: dashboardAction.payload.widgetIds,
+          selectedWidgetIds: dashboardState.selectedWidgetIds,
         }),
       };
 

--- a/packages/dashboard/src/dashboard-actions/reverse-actions/reverseMove.spec.ts
+++ b/packages/dashboard/src/dashboard-actions/reverse-actions/reverseMove.spec.ts
@@ -8,7 +8,6 @@ it('returns move action where position and prevPosition are switched', () => {
       payload: {
         position: { x: 10, y: 10 },
         prevPosition: { x: 11, y: 10 },
-        widgetIds: ['some-id'],
         isActionComplete: true,
       },
     })
@@ -16,7 +15,6 @@ it('returns move action where position and prevPosition are switched', () => {
     payload: {
       position: { x: 11, y: 10 },
       prevPosition: { x: 10, y: 10 },
-      widgetIds: ['some-id'],
       isActionComplete: true,
     },
     type: DashboardActionType.MOVE,
@@ -30,7 +28,6 @@ it('returns same move action when previous position is undefined', () => {
       payload: {
         position: { x: 10, y: 10 },
         prevPosition: undefined,
-        widgetIds: ['some-id'],
         isActionComplete: true,
       },
     })
@@ -38,7 +35,6 @@ it('returns same move action when previous position is undefined', () => {
     payload: {
       position: { x: 10, y: 10 },
       prevPosition: undefined,
-      widgetIds: ['some-id'],
       isActionComplete: true,
     },
     type: DashboardActionType.MOVE,
@@ -52,7 +48,6 @@ it('returns the original action when reversed twice', () => {
         payload: {
           position: { x: 10, y: 10 },
           prevPosition: { x: 11, y: 10 },
-          widgetIds: ['some-id'],
           isActionComplete: true,
         },
       })
@@ -61,7 +56,6 @@ it('returns the original action when reversed twice', () => {
     payload: {
       position: { x: 10, y: 10 },
       prevPosition: { x: 11, y: 10 },
-      widgetIds: ['some-id'],
       isActionComplete: true,
     },
     type: DashboardActionType.MOVE,

--- a/packages/dashboard/src/dashboard-actions/reverse-actions/reverseMove.ts
+++ b/packages/dashboard/src/dashboard-actions/reverse-actions/reverseMove.ts
@@ -8,7 +8,6 @@ export const reverseMove = (moveAction: MoveAction): MoveAction => {
       payload: {
         position: moveAction.payload.prevPosition,
         prevPosition: moveAction.payload.position,
-        widgetIds: moveAction.payload.widgetIds,
         isActionComplete: moveAction.payload.isActionComplete,
       },
     };

--- a/packages/dashboard/src/dashboard-actions/undo.ts
+++ b/packages/dashboard/src/dashboard-actions/undo.ts
@@ -27,7 +27,7 @@ export const undo = ({
           cellSize: dashboardState.cellSize,
           position: dashboardAction.payload.position,
           previousPosition: dashboardAction.payload.prevPosition,
-          selectedWidgetIds: dashboardAction.payload.widgetIds,
+          selectedWidgetIds: dashboardState.selectedWidgetIds,
         }),
       };
 


### PR DESCRIPTION
## Overview
Remove unnecessary moveStartWidgetIds variable from the internal dashboard.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
