### PR TITLE
feat(dashboard): add time-point annotation functionality

### DIFF
--- a/packages/dashboard/src/components.d.ts
+++ b/packages/dashboard/src/components.d.ts
@@ -5,16 +5,34 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { Anchor, DashboardConfiguration, OnResize, Widget } from "./types";
+import { Anchor, DashboardConfiguration, DashboardState, DashboardStore, OnResize, Widget } from "./types";
 import { AlarmsConfig, Annotations, Axis, LabelsConfig, LayoutConfig, LegendConfig, MessageOverrides, MinimalSizeConfig, MinimalViewPortConfig, MovementConfig, ScaleConfig, Trend } from "@synchro-charts/core";
 import { TimeQuery, TimeSeriesData, TimeSeriesDataRequest } from "@iot-app-kit/core";
 import { DeleteActionInput, MoveActionInput, ResizeActionInput, SelectActionInput } from "./dashboard-actions/actions";
 export namespace Components {
+    interface IotAnnotations {
+        /**
+          * Holds all necessary information about dashboard
+         */
+        "state": DashboardState;
+        /**
+          * App Redux store
+         */
+        "store": DashboardStore;
+    }
     interface IotDashboard {
         /**
           * The configurations which determines which widgets render where with what settings.
          */
         "dashboardConfiguration": DashboardConfiguration;
+        /**
+          * Holds all necessary information about dashboard
+         */
+        "state": DashboardState;
+        /**
+          * App Redux store
+         */
+        "store": DashboardStore;
     }
     interface IotDashboardDynamicWidget {
         "alarms"?: AlarmsConfig;
@@ -96,6 +114,12 @@ export namespace Components {
     }
 }
 declare global {
+    interface HTMLIotAnnotationsElement extends Components.IotAnnotations, HTMLStencilElement {
+    }
+    var HTMLIotAnnotationsElement: {
+        prototype: HTMLIotAnnotationsElement;
+        new (): HTMLIotAnnotationsElement;
+    };
     interface HTMLIotDashboardElement extends Components.IotDashboard, HTMLStencilElement {
     }
     var HTMLIotDashboardElement: {
@@ -145,6 +169,7 @@ declare global {
         new (): HTMLTestingGroundElement;
     };
     interface HTMLElementTagNameMap {
+        "iot-annotations": HTMLIotAnnotationsElement;
         "iot-dashboard": HTMLIotDashboardElement;
         "iot-dashboard-dynamic-widget": HTMLIotDashboardDynamicWidgetElement;
         "iot-dashboard-internal": HTMLIotDashboardInternalElement;
@@ -156,11 +181,29 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    interface IotAnnotations {
+        /**
+          * Holds all necessary information about dashboard
+         */
+        "state"?: DashboardState;
+        /**
+          * App Redux store
+         */
+        "store"?: DashboardStore;
+    }
     interface IotDashboard {
         /**
           * The configurations which determines which widgets render where with what settings.
          */
         "dashboardConfiguration"?: DashboardConfiguration;
+        /**
+          * Holds all necessary information about dashboard
+         */
+        "state"?: DashboardState;
+        /**
+          * App Redux store
+         */
+        "store"?: DashboardStore;
     }
     interface IotDashboardDynamicWidget {
         "alarms"?: AlarmsConfig;
@@ -241,6 +284,7 @@ declare namespace LocalJSX {
     interface TestingGround {
     }
     interface IntrinsicElements {
+        "iot-annotations": IotAnnotations;
         "iot-dashboard": IotDashboard;
         "iot-dashboard-dynamic-widget": IotDashboardDynamicWidget;
         "iot-dashboard-internal": IotDashboardInternal;
@@ -255,6 +299,7 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "iot-annotations": LocalJSX.IotAnnotations & JSXBase.HTMLAttributes<HTMLIotAnnotationsElement>;
             "iot-dashboard": LocalJSX.IotDashboard & JSXBase.HTMLAttributes<HTMLIotDashboardElement>;
             "iot-dashboard-dynamic-widget": LocalJSX.IotDashboardDynamicWidget & JSXBase.HTMLAttributes<HTMLIotDashboardDynamicWidgetElement>;
             "iot-dashboard-internal": LocalJSX.IotDashboardInternal & JSXBase.HTMLAttributes<HTMLIotDashboardInternalElement>;

--- a/packages/dashboard/src/components/iot-annotations/annotations.spec.ts
+++ b/packages/dashboard/src/components/iot-annotations/annotations.spec.ts
@@ -1,0 +1,243 @@
+import { addXAnnotation, deleteXAnnotation, editXAnnotation } from './annotations';
+import { MockWidgetFactory } from '../../testing/mocks';
+import { XAnnotation } from '@synchro-charts/core';
+
+const XANNOTATION_1: XAnnotation = {
+  color: 'red',
+  value: new Date(2000, 1, 0),
+  id: '1',
+};
+
+const XANNOTATION_2: XAnnotation = {
+  color: 'red',
+  value: new Date(2000, 3, 15),
+  id: '2',
+};
+
+const XANNOTATION_3: XAnnotation = {
+  color: 'red',
+  value: new Date(2000, 7, 19),
+  id: '3',
+};
+
+const UNTOUCHED_WIDGET = MockWidgetFactory.getScatterChartWidget({
+  id: 'widget-2',
+});
+
+describe('addXAnnotation', () => {
+  it('adds annotation when adding to a widget with no annotations prop', () => {
+    const INPUT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+    });
+    const RESULT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1],
+      },
+    });
+    expect(
+      addXAnnotation({
+        dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [INPUT_WIDGET, UNTOUCHED_WIDGET] },
+        widgetId: 'widget-1',
+        annotation: XANNOTATION_1,
+      })
+    ).toEqual([RESULT_WIDGET, UNTOUCHED_WIDGET]);
+  });
+
+  it('adds annotation when adding to a widget with an empty annotations prop', () => {
+    const INPUT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [],
+      },
+    });
+    const RESULT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1],
+      },
+    });
+    expect(
+      addXAnnotation({
+        dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [INPUT_WIDGET, UNTOUCHED_WIDGET] },
+        widgetId: 'widget-1',
+        annotation: XANNOTATION_1,
+      })
+    ).toEqual([RESULT_WIDGET, UNTOUCHED_WIDGET]);
+  });
+
+  it('adds annotation when adding to a widget with existing annotations', () => {
+    const INPUT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1],
+      },
+    });
+    const RESULT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1, XANNOTATION_2],
+      },
+    });
+    expect(
+      addXAnnotation({
+        dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [INPUT_WIDGET, UNTOUCHED_WIDGET] },
+        widgetId: 'widget-1',
+        annotation: XANNOTATION_2,
+      })
+    ).toEqual([RESULT_WIDGET, UNTOUCHED_WIDGET]);
+  });
+
+  it('does not add annotation when provided non-existent widgetId', () => {
+    const INPUT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1],
+      },
+    });
+    expect(
+      addXAnnotation({
+        dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [INPUT_WIDGET, UNTOUCHED_WIDGET] },
+        widgetId: 'non-existent-id',
+        annotation: XANNOTATION_2,
+      })
+    ).toEqual([INPUT_WIDGET, UNTOUCHED_WIDGET]);
+  });
+});
+
+describe('deleteXAnnotation', () => {
+  it('deletes annotation from a widget with one annotation', () => {
+    const INPUT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1],
+      },
+    });
+    const RESULT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [],
+      },
+    });
+    expect(
+      deleteXAnnotation({
+        dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [INPUT_WIDGET, UNTOUCHED_WIDGET] },
+        widgetId: 'widget-1',
+        annotationIdToDelete: '1',
+      })
+    ).toEqual([RESULT_WIDGET, UNTOUCHED_WIDGET]);
+  });
+
+  it('deletes annotation from a widget with multiple annotations', () => {
+    const INPUT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1, XANNOTATION_2],
+      },
+    });
+    const RESULT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1],
+      },
+    });
+    expect(
+      deleteXAnnotation({
+        dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [INPUT_WIDGET, UNTOUCHED_WIDGET] },
+        widgetId: 'widget-1',
+        annotationIdToDelete: '2',
+      })
+    ).toEqual([RESULT_WIDGET, UNTOUCHED_WIDGET]);
+  });
+
+  it('does not delete an annotation if it does not exist on a widget', () => {
+    const INPUT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1],
+      },
+    });
+    expect(
+      deleteXAnnotation({
+        dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [INPUT_WIDGET, UNTOUCHED_WIDGET] },
+        widgetId: 'widget-1',
+        annotationIdToDelete: '2',
+      })
+    ).toEqual([INPUT_WIDGET, UNTOUCHED_WIDGET]);
+  });
+
+  it('does not delete an annotation when provided non-existent widgetId', () => {
+    const INPUT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1],
+      },
+    });
+    expect(
+      deleteXAnnotation({
+        dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [INPUT_WIDGET, UNTOUCHED_WIDGET] },
+        widgetId: 'non-existent-widget',
+        annotationIdToDelete: '1',
+      })
+    ).toEqual([INPUT_WIDGET, UNTOUCHED_WIDGET]);
+  });
+});
+
+describe('editXAnnotation', () => {
+  it('does not edit annotation from a widget with no annotations', () => {
+    const INPUT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+    });
+    expect(
+      editXAnnotation({
+        dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [INPUT_WIDGET, UNTOUCHED_WIDGET] },
+        widgetId: 'widget-1',
+        newAnnotation: XANNOTATION_2,
+      })
+    ).toEqual([INPUT_WIDGET, UNTOUCHED_WIDGET]);
+  });
+
+  it('edits an annotation on a widget with one annotation', () => {
+    const INPUT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1],
+      },
+    });
+    const RESULT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [{ ...XANNOTATION_2, id: '1' }],
+      },
+    });
+    expect(
+      editXAnnotation({
+        dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [INPUT_WIDGET, UNTOUCHED_WIDGET] },
+        widgetId: 'widget-1',
+        newAnnotation: { ...XANNOTATION_2, id: '1' },
+      })
+    ).toEqual([RESULT_WIDGET, UNTOUCHED_WIDGET]);
+  });
+
+  it('edits an annotation on a widget with multiple annotations', () => {
+    const INPUT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1, XANNOTATION_2],
+      },
+    });
+    const RESULT_WIDGET = MockWidgetFactory.getScatterChartWidget({
+      id: 'widget-1',
+      annotations: {
+        x: [XANNOTATION_1, { ...XANNOTATION_3, id: '2' }],
+      },
+    });
+    expect(
+      editXAnnotation({
+        dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [INPUT_WIDGET, UNTOUCHED_WIDGET] },
+        widgetId: 'widget-1',
+        newAnnotation: { ...XANNOTATION_3, id: '2' },
+      })
+    ).toEqual([RESULT_WIDGET, UNTOUCHED_WIDGET]);
+  });
+});

--- a/packages/dashboard/src/components/iot-annotations/annotations.ts
+++ b/packages/dashboard/src/components/iot-annotations/annotations.ts
@@ -1,0 +1,71 @@
+import { XAnnotation } from '@synchro-charts/core';
+import { DashboardConfiguration } from '../../types';
+
+export const addXAnnotation = ({
+  dashboardConfiguration,
+  widgetId,
+  annotation,
+}: {
+  dashboardConfiguration: DashboardConfiguration;
+  widgetId: string;
+  annotation: XAnnotation;
+}) => {
+  return dashboardConfiguration.widgets.map((widget) => {
+    if (widget.id === widgetId) {
+      const currAnnotations = widget.annotations || {};
+      const currXAnnotations = currAnnotations.x || [];
+      return { ...widget, annotations: { ...currAnnotations, x: [...currXAnnotations, annotation] } };
+    }
+    return widget;
+  });
+};
+
+export const deleteXAnnotation = ({
+  dashboardConfiguration,
+  widgetId,
+  annotationIdToDelete,
+}: {
+  dashboardConfiguration: DashboardConfiguration;
+  widgetId: string;
+  annotationIdToDelete: string;
+}) => {
+  return dashboardConfiguration.widgets.map((widget) => {
+    if (widget.id !== widgetId) {
+      return widget;
+    }
+    if (widget.annotations && widget.annotations.x) {
+      widget.annotations = {
+        ...widget.annotations,
+        x: widget.annotations.x.filter((annotation) => annotation.id != annotationIdToDelete),
+      };
+    }
+    return {
+      ...widget,
+      annotations: widget.annotations,
+    };
+  });
+};
+
+export const editXAnnotation = ({
+  dashboardConfiguration,
+  widgetId,
+  newAnnotation,
+}: {
+  dashboardConfiguration: DashboardConfiguration;
+  widgetId: string;
+  newAnnotation: XAnnotation;
+}) => {
+  return dashboardConfiguration.widgets.map((widget) => {
+    if (widget.id !== widgetId) {
+      return widget;
+    }
+    if (widget.annotations && widget.annotations.x) {
+      widget.annotations.x = widget.annotations.x.filter((annotation) => annotation.id != newAnnotation.id);
+      widget.annotations = { ...widget.annotations, x: [...widget.annotations.x, newAnnotation] };
+    }
+    return {
+      ...widget,
+      annotations: widget.annotations,
+    };
+  });
+};

--- a/packages/dashboard/src/components/iot-annotations/iot-annotations.tsx
+++ b/packages/dashboard/src/components/iot-annotations/iot-annotations.tsx
@@ -1,0 +1,260 @@
+import { Component, State, Prop, h, Watch } from '@stencil/core';
+import { DashboardState, DashboardStore } from '../../types';
+import { onUpdateAction } from '../../dashboard-actions/actions';
+import { XAnnotation } from '@synchro-charts/core';
+import { addXAnnotation, editXAnnotation, deleteXAnnotation } from './annotations';
+import { viewportEndDate, viewportStartDate } from '@iot-app-kit/core';
+
+const DEFAULT_LIST_VISIBLE_ANNOTATIONS = false;
+const DEFAULT_DATE = new Date(0);
+
+@Component({
+  tag: 'iot-annotations',
+})
+export class IotAnnotations {
+  /** Holds all necessary information about dashboard */
+  @Prop() state: DashboardState;
+
+  /** App Redux store */
+  @Prop() store: DashboardStore;
+
+  @State() onlyListVisibleAnnotations: boolean = DEFAULT_LIST_VISIBLE_ANNOTATIONS;
+
+  @State() addLabel = '';
+  @State() addColor = 'red';
+  @State() addDate: Date = DEFAULT_DATE;
+
+  @State() deleteAnnotationId = '';
+
+  @State() editLabel = '';
+  @State() editColor = 'red';
+  @State() editDate: Date = DEFAULT_DATE;
+  @State() editAnnotationId = '';
+
+  @State() annotationOptions: XAnnotation[] = [];
+
+  @Watch('state')
+  private onPropUpdate() {
+    this.updateAnnotationOptions();
+  }
+
+  onListVisibleAnnotations = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    this.onlyListVisibleAnnotations = target.checked;
+    this.updateAnnotationOptions();
+  };
+
+  /**
+   * Modify annotation data based on input from UI
+   */
+  onSelectWidgetInput = (e: Event) => {
+    e.preventDefault();
+    const target = e.target as HTMLInputElement;
+    const widgetId = target.value;
+    this.state.selectedWidgetIds[0] = widgetId;
+  };
+
+  onAddLabelInput = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    this.addLabel = target.value;
+  };
+
+  onAddColorInput = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    this.addColor = target.value;
+  };
+
+  onAddDateInput = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    this.addDate = new Date(target.value);
+  };
+
+  onDeleteAnnotationIdInput = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    this.deleteAnnotationId = target.value;
+  };
+
+  onEditLabelInput = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    this.editLabel = target.value;
+  };
+
+  onEditColorInput = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    this.editColor = target.value;
+  };
+
+  onEditDateInput = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    this.editDate = new Date(target.value);
+  };
+
+  onEditAnnotationIdInput = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    this.editAnnotationId = target.value;
+    const annotation = this.state.dashboardConfiguration.widgets
+      .find((widget) => widget.id === this.state.selectedWidgetIds[0])
+      ?.annotations?.x?.find((annotation) => annotation.id === this.editAnnotationId);
+    (document.getElementById('editLabel') as HTMLTextAreaElement).value = annotation?.label
+      ? annotation?.label.text
+      : '';
+    (document.getElementById('editColor') as HTMLInputElement).value = annotation?.color ? annotation?.color : 'red';
+  };
+
+  updateAnnotationOptions = () => {
+    this.annotationOptions = this.findAnnotations();
+  };
+
+  /** Update state when annotation add/edit/delete is made */
+  update = (fieldsToUpdate: Partial<DashboardState>, previousField: Partial<DashboardState>) => {
+    this.store.dispatch(onUpdateAction({ fieldsToUpdate, previousField }));
+  };
+
+  addAnnotation = (e: Event) => {
+    e.preventDefault();
+    if (e && this.addDate !== DEFAULT_DATE) {
+      const annotationLabel = { text: this.addLabel, show: true };
+      const XANNOTATION: XAnnotation = {
+        color: this.addColor,
+        value: this.addDate,
+        id: Date.now().toString(),
+        showValue: true,
+        label: annotationLabel,
+      };
+      const newWidgets = addXAnnotation({
+        dashboardConfiguration: this.state.dashboardConfiguration,
+        widgetId: this.state.selectedWidgetIds[0],
+        annotation: XANNOTATION,
+      });
+      this.update(
+        { dashboardConfiguration: { ...this.state.dashboardConfiguration, widgets: newWidgets } },
+        { dashboardConfiguration: this.state.dashboardConfiguration }
+      );
+    }
+    this.updateAnnotationOptions();
+    (document.getElementById('addLabel') as HTMLTextAreaElement).value = '';
+  };
+
+  deleteAnnotation = (e: Event) => {
+    if (window.confirm('Delete annotation?')) {
+      e.preventDefault();
+      const newWidgets = deleteXAnnotation({
+        dashboardConfiguration: this.state.dashboardConfiguration,
+        widgetId: this.state.selectedWidgetIds[0],
+        annotationIdToDelete: this.deleteAnnotationId,
+      });
+      this.update(
+        { dashboardConfiguration: { ...this.state.dashboardConfiguration, widgets: newWidgets } },
+        { dashboardConfiguration: this.state.dashboardConfiguration }
+      );
+    }
+    this.updateAnnotationOptions();
+  };
+
+  editAnnotation = (e: Event) => {
+    if (window.confirm('Edit annotation?')) {
+      e.preventDefault();
+      if (e && this.addDate !== DEFAULT_DATE) {
+        const annotationLabel = { text: this.addLabel, show: true };
+        const oldWidget = this.state.dashboardConfiguration.widgets
+          .find((x) => x.id === this.state.selectedWidgetIds[0])
+          ?.annotations?.x?.find((annotation) => annotation.id === this.editAnnotationId);
+        const XANNOTATION: XAnnotation = {
+          color: this.editColor,
+          value: this.editDate,
+          id: this.editAnnotationId,
+          showValue: true,
+          label: annotationLabel ? annotationLabel : oldWidget?.label,
+        };
+        const newWidgets = editXAnnotation({
+          dashboardConfiguration: this.state.dashboardConfiguration,
+          widgetId: this.state.selectedWidgetIds[0],
+          newAnnotation: XANNOTATION,
+        });
+        this.update(
+          { dashboardConfiguration: { ...this.state.dashboardConfiguration, widgets: newWidgets } },
+          { dashboardConfiguration: this.state.dashboardConfiguration }
+        );
+      }
+      this.updateAnnotationOptions();
+      (document.getElementById('editLabel') as HTMLTextAreaElement).value = '';
+    }
+  };
+
+  isVisible = (annotation: XAnnotation) => {
+    const start = viewportStartDate(this.state.dashboardConfiguration.viewport).getTime();
+    const end = viewportEndDate(this.state.dashboardConfiguration.viewport).getTime();
+    const annotationTime = annotation.value.getTime();
+    return annotationTime >= start && annotationTime <= end;
+  };
+
+  getOnlyVisibleAnnotations = () => {
+    return (
+      this.state.dashboardConfiguration.widgets
+        .find((x) => x.id === this.state.selectedWidgetIds[0])
+        ?.annotations?.x?.filter((annotation) => this.isVisible(annotation)) || []
+    );
+  };
+
+  getAllAnnotations = () => {
+    return (
+      this.state.dashboardConfiguration.widgets.find((x) => x.id === this.state.selectedWidgetIds[0])?.annotations?.x ||
+      []
+    );
+  };
+
+  findAnnotations = () => {
+    return this.onlyListVisibleAnnotations ? this.getOnlyVisibleAnnotations() : this.getAllAnnotations();
+  };
+
+  render() {
+    return (
+      <div>
+        <div>
+          <label>Only list visible annotations</label>
+          <input type="checkbox" checked={this.onlyListVisibleAnnotations} onChange={this.onListVisibleAnnotations} />
+        </div>
+        <br />
+        <br />
+        <div>
+          <label htmlFor="addAnnotation"> Add annotation -</label>
+          <label htmlFor="addLabel"> Label:</label>
+          <input type="text" id="addLabel" onChange={this.onAddLabelInput}></input>
+          <input type="color" value="#FF0000" onChange={this.onAddColorInput}></input>
+          <br />
+          <input type="datetime-local" step="1" onChange={this.onAddDateInput}></input>
+          <input type="button" value="Add" id="addAnnotation" onClick={this.addAnnotation}></input>
+        </div>
+        <br />
+        <br />
+        <div>
+          <label htmlFor="deleteAnnotation"> Delete annotation:</label>
+          <select id="deleteAnnotation" onChange={this.onDeleteAnnotationIdInput}>
+            <option>- Select -</option>
+            {this.annotationOptions.map((annotation) => (
+              <option value={annotation.id}>{annotation.value.toString()}</option>
+            ))}
+          </select>
+          <input type="button" value="Delete" onClick={this.deleteAnnotation}></input>
+        </div>
+        <br />
+        <br />
+        <div>
+          <label htmlFor="editAnnotation"> Edit annotation -</label>
+          <label htmlFor="editLabel"> Label:</label>
+          <input type="text" id="editLabel" onChange={this.onEditLabelInput}></input>
+          <input type="color" value="#FF0000" id="editColor" onChange={this.onEditColorInput}></input>
+          <br />
+          <select id="editAnnotation" onChange={this.onEditAnnotationIdInput}>
+            <option>- Select -</option>
+            {this.annotationOptions.map((annotation) => (
+              <option value={annotation.id}>{annotation.value.toString()}</option>
+            ))}
+          </select>
+          <input type="datetime-local" step="1" id="editDate" onChange={this.onEditDateInput}></input>
+          <input type="button" value="Edit" onClick={this.editAnnotation}></input>
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard.tsx
@@ -1,5 +1,4 @@
-import { Component, h, State, Prop } from '@stencil/core';
-import { createStore } from 'redux';
+import { Component, h, Prop } from '@stencil/core';
 import {
   MoveActionInput,
   onMoveAction,
@@ -17,15 +16,7 @@ import {
   onUpdateAction,
 } from '../../dashboard-actions/actions';
 import { DashboardState, DashboardStore, DashboardConfiguration } from '../../types';
-import { dashboardReducer } from '../../dashboard-actions/dashboardReducer';
 import { getRandomWidget } from '../../testing/getRandomWidget';
-import { trimWidgetPosition } from './trimWidgetPosition';
-import { dashboardConfig } from '../../testing/mocks';
-
-const DEFAULT_STRETCH_TO_FIT = false;
-
-const DEFAULT_CELL_SIZE = 10;
-const DEFAULT_WIDTH = 1000;
 
 @Component({
   tag: 'iot-dashboard',
@@ -36,28 +27,10 @@ export class IotDashboard {
   @Prop() dashboardConfiguration: DashboardConfiguration;
 
   /** Holds all necessary information about dashboard */
-  @State() state: DashboardState = {
-    dashboardConfiguration: dashboardConfig,
-    selectedWidgetIds: [],
-    numTimesCopyGroupHasBeenPasted: 0,
-    copyGroup: [],
-    stretchToFit: DEFAULT_STRETCH_TO_FIT,
-    width: DEFAULT_WIDTH,
-    cellSize: DEFAULT_CELL_SIZE,
-    intermediateDashboardConfiguration: undefined,
-    undoQueue: [],
-    redoQueue: [],
-    previousPosition: undefined,
-  };
+  @Prop() state: DashboardState;
 
-  /**
-   * Callback that is fired every time the dashboard configuration has been altered.
-   *
-   * When a widget is moved, resized, deleted, appended, or altered, then this method is called
-   */
-  onDashboardConfigurationChange = (config: DashboardConfiguration) => {
-    this.dashboardConfiguration = config;
-  };
+  /** App Redux store */
+  @Prop() store: DashboardStore;
 
   /** Calls reducer to move widgets  */
   move(moveInput: MoveActionInput) {
@@ -118,18 +91,6 @@ export class IotDashboard {
   onStretchToFit = () => {
     this.update({ stretchToFit: this.state.stretchToFit ? false : true }, { stretchToFit: this.state.stretchToFit });
   };
-
-  store: DashboardStore;
-
-  componentWillLoad() {
-    this.state.dashboardConfiguration = this.dashboardConfiguration;
-    this.store = createStore(dashboardReducer, this.state);
-    this.store.subscribe(() => {
-      this.state = this.store.getState();
-      this.state.dashboardConfiguration.widgets = this.state.dashboardConfiguration.widgets.map(trimWidgetPosition);
-      this.onDashboardConfigurationChange(this.state.dashboardConfiguration);
-    });
-  }
 
   render() {
     return (

--- a/packages/dashboard/src/integration/iot-dashboard.spec.component.ts
+++ b/packages/dashboard/src/integration/iot-dashboard.spec.component.ts
@@ -13,27 +13,17 @@ const createWidget = (): Widget => ({
 });
 
 it('click and drag moves widget', () => {
-  renderDashboard({
-    dashboardConfiguration: {
-      viewport: { duration: '5m' },
-      widgets: [createWidget()],
-    },
-  });
+  renderDashboard();
   cy.get('iot-dashboard-widget').move({ deltaX: 100, deltaY: 100, force: true });
   cy.get('iot-dashboard-widget').should(
     'have.attr',
     'style',
-    'position: absolute; z-index: 1; top: 100px; left: 100px; width: 40px; height: 40px;'
+    'position: absolute; z-index: 1; top: 110px; left: 110px; width: 80px; height: 50px;'
   );
 });
 
 it('selects and deletes widget', () => {
-  renderDashboard({
-    dashboardConfiguration: {
-      viewport: { duration: '5m' },
-      widgets: [createWidget()],
-    },
-  });
+  renderDashboard();
 
   cy.get('iot-dashboard-widget').should('exist');
   cy.get('iot-dashboard-widget').click();
@@ -42,12 +32,7 @@ it('selects and deletes widget', () => {
 });
 
 it('copy and paste widget', () => {
-  renderDashboard({
-    dashboardConfiguration: {
-      viewport: { duration: '5m' },
-      widgets: [createWidget()],
-    },
-  });
+  renderDashboard();
 
   cy.get('iot-dashboard-widget').click();
   cy.get('body').type('{cmd}c', { release: true }).type('{cmd}v', { release: true });
@@ -55,17 +40,12 @@ it('copy and paste widget', () => {
 });
 
 it('undoes and redoes a move action', () => {
-  renderDashboard({
-    dashboardConfiguration: {
-      viewport: { duration: '5m' },
-      widgets: [createWidget()],
-    },
-  });
+  renderDashboard();
   cy.get('iot-dashboard-widget').move({ deltaX: 100, deltaY: 100, force: true });
   cy.get('body').type('{cmd}z', { release: true }).type('{cmd}{shift}z', { release: true });
   cy.get('iot-dashboard-widget').should(
     'have.attr',
     'style',
-    'position: absolute; z-index: 1; top: 100px; left: 100px; width: 40px; height: 40px;'
+    'position: absolute; z-index: 1; top: 110px; left: 110px; width: 80px; height: 50px;'
   );
 });

--- a/packages/dashboard/src/testing/renderDashboard.tsx
+++ b/packages/dashboard/src/testing/renderDashboard.tsx
@@ -1,15 +1,14 @@
 import { mount } from '@cypress/vue';
 import { h } from 'vue';
-import { DashboardConfiguration } from '../types';
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const { defineCustomElements } = require('@iot-app-kit/dashboard/loader');
 
 defineCustomElements();
 
-export const renderDashboard = ({ dashboardConfiguration }: { dashboardConfiguration: DashboardConfiguration }) => {
+export const renderDashboard = () => {
   mount({
     render: function () {
-      return <iot-dashboard dashboardConfiguration={dashboardConfiguration} />;
+      return <testing-ground />;
     },
   });
 };

--- a/packages/dashboard/src/testing/testing-ground/testing-ground.tsx
+++ b/packages/dashboard/src/testing/testing-ground/testing-ground.tsx
@@ -1,6 +1,14 @@
 import { Component, State, h } from '@stencil/core';
-import { DashboardConfiguration } from '../../types';
+import { createStore } from 'redux';
+import { DashboardState, DashboardStore, DashboardConfiguration } from '../../types';
 import { dashboardConfig } from '../mocks';
+import { dashboardReducer } from '../../dashboard-actions/dashboardReducer';
+import { trimWidgetPosition } from '../../components/iot-dashboard/trimWidgetPosition';
+
+const DEFAULT_STRETCH_TO_FIT = false;
+
+const DEFAULT_CELL_SIZE = 10;
+const DEFAULT_WIDTH = 1000;
 
 @Component({
   tag: 'testing-ground',
@@ -8,6 +16,42 @@ import { dashboardConfig } from '../mocks';
 })
 export class TestingGround {
   @State() dashboardConfiguration: DashboardConfiguration = dashboardConfig;
+
+  /** Holds all necessary information about dashboard */
+  @State() state: DashboardState = {
+    dashboardConfiguration: dashboardConfig,
+    selectedWidgetIds: [],
+    numTimesCopyGroupHasBeenPasted: 0,
+    copyGroup: [],
+    stretchToFit: DEFAULT_STRETCH_TO_FIT,
+    width: DEFAULT_WIDTH,
+    cellSize: DEFAULT_CELL_SIZE,
+    intermediateDashboardConfiguration: undefined,
+    undoQueue: [],
+    redoQueue: [],
+    previousPosition: undefined,
+  };
+
+  /**
+   * Callback that is fired every time the dashboard configuration has been altered.
+   *
+   * When a widget is moved, resized, deleted, appended, or altered, then this method is called
+   */
+  onDashboardConfigurationChange = (config: DashboardConfiguration) => {
+    this.dashboardConfiguration = config;
+  };
+
+  store: DashboardStore;
+
+  componentWillLoad() {
+    this.state.dashboardConfiguration = this.dashboardConfiguration;
+    this.store = createStore(dashboardReducer, this.state);
+    this.store.subscribe(() => {
+      this.state = this.store.getState();
+      this.state.dashboardConfiguration.widgets = this.state.dashboardConfiguration.widgets.map(trimWidgetPosition);
+      this.onDashboardConfigurationChange(this.state.dashboardConfiguration);
+    });
+  }
 
   render() {
     return (
@@ -17,9 +61,10 @@ export class TestingGround {
             <div class="dummy-content">Resource explorer pane</div>
           </div>
           <div slot="center">
-            <iot-dashboard dashboardConfiguration={this.dashboardConfiguration}></iot-dashboard>
+            <iot-dashboard store={this.store} state={this.state}></iot-dashboard>
           </div>
           <div slot="right">
+            <iot-annotations store={this.store} state={this.state}></iot-annotations>
             <div class="dummy-content">Component pane</div>
           </div>
         </iot-resizable-panes>


### PR DESCRIPTION
## Overview
Added time-point annotation functionality to the dashboard. Time-point annotations can be created, edited, and deleted, filtered by visibility, and have label/color specified for each widget on the dashboard.

NOTE: Opening this PR as a continuation of the original PR for time-point annotations (https://github.com/awslabs/iot-app-kit/pull/152), which was automatically merged by Github (a '0 commits merged') after a force-push to the PR's branch. Comments from this original PR have been addressed and added to the code.

<img width="1512" alt="Screen Shot 2022-08-12 at 9 45 31 AM" src="https://user-images.githubusercontent.com/87334439/184405575-c515a974-a55a-49d4-b903-87d57e094c76.png">


## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
