### PR TITLE
Fix #144 - Default Refresh Rate

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,7 +54,7 @@
     "@iot-app-kit/related-table": "^1.5.0",
     "@iot-app-kit/source-iotsitewise": "^1.5.0",
     "@stencil/core": "^2.7.0",
-    "@synchro-charts/core": "^5.0.0",
+    "@synchro-charts/core": "^6.0.0",
     "styled-components": "^5.3.0"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "@aws-sdk/client-iotsitewise": "^3.87.0",
     "@aws-sdk/credential-providers": "^3.39.0",
     "@rollup/plugin-typescript": "^8.3.0",
-    "@synchro-charts/core": "^5.0.0",
+    "@synchro-charts/core": "^6.0.0",
     "d3-array": "^2.3.2",
     "flush-promises": "^1.0.2",
     "intervals-fn": "^3.0.3",

--- a/packages/source-iotsitewise/package.json
+++ b/packages/source-iotsitewise/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/client-iotsitewise": "^3.87.0",
     "@iot-app-kit/core": "^1.5.0",
     "@rollup/plugin-typescript": "^8.3.0",
-    "@synchro-charts/core": "^5.0.0",
+    "@synchro-charts/core": "^6.0.0",
     "dataloader": "^2.1.0",
     "flush-promises": "^1.0.2",
     "rxjs": "^7.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,10 +5032,10 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
-"@synchro-charts/core@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@synchro-charts/core/-/core-5.0.0.tgz#354cae51fbf8de1994de06de135670c70e713a58"
-  integrity sha512-zJ7vALPFw9tHCccDWUWFcpR3As7QY380CNGFUgS5ZOn49W1F++VySsGL64XsJYGjoU4/rk5/hAA+BXhsn54dtA==
+"@synchro-charts/core@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@synchro-charts/core/-/core-6.0.0.tgz#7e3247079d7c3f7eba03e72d2cb70bb9baa3d36c"
+  integrity sha512-cOuJUBJEWPuJmNpHmRZlJne3R0hNnWhjmedO/9vS2fU0ud1NxvGH4DeEfGrSu7cJrA9p60eLTC98ApdN+3meiQ==
   dependencies:
     "@stencil/redux" "^0.1.1"
     "@types/d3" "^5.16.4"


### PR DESCRIPTION
## Overview
Fixes https://github.com/awslabs/iot-app-kit/issues/144.

The bug was called by `dateRangeChange` event incorrectly being emitted when a chart viewport updates while in live mode. This bug was fixed in the syncho charts repository in [this pull request](https://github.com/awslabs/synchro-charts/pull/155).

This pull request bumps the syncho-charts/core version from v5 to v6, which fixes the default refresh rate issue.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
