### PR TITLE
fix(dashboard): Fix bug with undo move/resize

### DIFF
--- a/packages/dashboard/src/dashboard-actions/actions.ts
+++ b/packages/dashboard/src/dashboard-actions/actions.ts
@@ -20,6 +20,7 @@ export interface MoveAction extends Action<DashboardActionType.MOVE> {
     position: Position;
     prevPosition?: Position;
     isActionComplete: boolean;
+    widgetIds?: string[];
   };
 }
 export const onMoveAction = (payload: MoveAction['payload']): MoveAction => ({
@@ -35,6 +36,7 @@ export interface ResizeAction extends Action<DashboardActionType.RESIZE> {
     anchor: Anchor;
     changeInPosition: Position;
     isActionComplete: boolean;
+    widgetIds?: string[];
   };
 }
 export const onResizeAction = (payload: ResizeAction['payload']): ResizeAction => ({

--- a/packages/dashboard/src/dashboard-actions/dashboardReducer.ts
+++ b/packages/dashboard/src/dashboard-actions/dashboardReducer.ts
@@ -1,6 +1,6 @@
 import { Reducer } from 'redux';
 import { DashboardState } from '../types';
-import { DashboardAction, onPasteAction } from './actions';
+import { DashboardAction, onMoveAction, onPasteAction, onResizeAction } from './actions';
 import { move } from './move';
 import { resize } from './resize';
 import { deleteWidgets } from './delete';
@@ -54,7 +54,14 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
           cellSize: state.cellSize,
         }),
         intermediateDashboardConfiguration: undefined,
-        undoQueue: state.undoQueue.concat(action),
+        undoQueue: state.undoQueue.concat(
+          onMoveAction({
+            position: action.payload.position,
+            widgetIds: state.selectedWidgetIds,
+            isActionComplete: true,
+            prevPosition: action.payload.prevPosition,
+          })
+        ),
         redoQueue: [],
         previousPosition: undefined,
       };
@@ -82,7 +89,14 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
           changeInPosition: action.payload.changeInPosition,
           cellSize: state.cellSize,
         }),
-        undoQueue: state.undoQueue.concat(action),
+        undoQueue: state.undoQueue.concat(
+          onResizeAction({
+            anchor: action.payload.anchor,
+            changeInPosition: action.payload.changeInPosition,
+            isActionComplete: action.payload.isActionComplete,
+            widgetIds: state.selectedWidgetIds,
+          })
+        ),
         redoQueue: [],
       };
 

--- a/packages/dashboard/src/dashboard-actions/redo.ts
+++ b/packages/dashboard/src/dashboard-actions/redo.ts
@@ -22,7 +22,7 @@ export const redo = ({
           cellSize: dashboardState.cellSize,
           position: dashboardAction.payload.position,
           previousPosition: dashboardAction.payload.prevPosition,
-          selectedWidgetIds: dashboardState.selectedWidgetIds,
+          selectedWidgetIds: dashboardAction.payload.widgetIds || dashboardState.selectedWidgetIds,
         }),
       };
 
@@ -32,7 +32,7 @@ export const redo = ({
         dashboardConfiguration: resize({
           anchor: dashboardAction.payload.anchor,
           dashboardConfiguration: dashboardState.dashboardConfiguration,
-          widgetIds: dashboardState.selectedWidgetIds,
+          widgetIds: dashboardAction.payload.widgetIds || dashboardState.selectedWidgetIds,
           changeInPosition: dashboardAction.payload.changeInPosition,
           cellSize: dashboardState.cellSize,
         }),

--- a/packages/dashboard/src/dashboard-actions/reverse-actions/reverseMove.spec.ts
+++ b/packages/dashboard/src/dashboard-actions/reverse-actions/reverseMove.spec.ts
@@ -1,5 +1,6 @@
 import { reverseMove } from './reverseMove';
 import { DashboardActionType } from '../actions';
+import { MOCK_KPI_WIDGET } from '../../testing/mocks';
 
 it('returns move action where position and prevPosition are switched', () => {
   expect(
@@ -9,6 +10,7 @@ it('returns move action where position and prevPosition are switched', () => {
         position: { x: 10, y: 10 },
         prevPosition: { x: 11, y: 10 },
         isActionComplete: true,
+        widgetIds: [MOCK_KPI_WIDGET.id],
       },
     })
   ).toEqual({
@@ -16,6 +18,7 @@ it('returns move action where position and prevPosition are switched', () => {
       position: { x: 11, y: 10 },
       prevPosition: { x: 10, y: 10 },
       isActionComplete: true,
+      widgetIds: [MOCK_KPI_WIDGET.id],
     },
     type: DashboardActionType.MOVE,
   });
@@ -29,6 +32,7 @@ it('returns same move action when previous position is undefined', () => {
         position: { x: 10, y: 10 },
         prevPosition: undefined,
         isActionComplete: true,
+        widgetIds: [MOCK_KPI_WIDGET.id],
       },
     })
   ).toEqual({
@@ -36,6 +40,7 @@ it('returns same move action when previous position is undefined', () => {
       position: { x: 10, y: 10 },
       prevPosition: undefined,
       isActionComplete: true,
+      widgetIds: [MOCK_KPI_WIDGET.id],
     },
     type: DashboardActionType.MOVE,
   });
@@ -49,6 +54,7 @@ it('returns the original action when reversed twice', () => {
           position: { x: 10, y: 10 },
           prevPosition: { x: 11, y: 10 },
           isActionComplete: true,
+          widgetIds: [MOCK_KPI_WIDGET.id],
         },
       })
     )
@@ -57,6 +63,7 @@ it('returns the original action when reversed twice', () => {
       position: { x: 10, y: 10 },
       prevPosition: { x: 11, y: 10 },
       isActionComplete: true,
+      widgetIds: [MOCK_KPI_WIDGET.id],
     },
     type: DashboardActionType.MOVE,
   });

--- a/packages/dashboard/src/dashboard-actions/reverse-actions/reverseMove.ts
+++ b/packages/dashboard/src/dashboard-actions/reverse-actions/reverseMove.ts
@@ -1,13 +1,14 @@
 import { MoveAction } from '../../dashboard-actions/actions';
 
 export const reverseMove = (moveAction: MoveAction): MoveAction => {
-  if (typeof moveAction.payload.prevPosition != 'undefined') {
+  if (moveAction.payload.prevPosition && moveAction.payload.widgetIds) {
     return {
       ...moveAction,
       payload: {
         position: moveAction.payload.prevPosition,
         prevPosition: moveAction.payload.position,
         isActionComplete: moveAction.payload.isActionComplete,
+        widgetIds: moveAction.payload.widgetIds,
       },
     };
   }

--- a/packages/dashboard/src/dashboard-actions/reverse-actions/reverseResize.ts
+++ b/packages/dashboard/src/dashboard-actions/reverse-actions/reverseResize.ts
@@ -10,6 +10,7 @@ export const reverseResize = (resizeAction: ResizeAction): ResizeAction => {
         y: resizeAction.payload.changeInPosition.y * -1,
       },
       isActionComplete: true,
+      widgetIds: resizeAction.payload.widgetIds,
     },
   };
 };

--- a/packages/dashboard/src/dashboard-actions/undo.ts
+++ b/packages/dashboard/src/dashboard-actions/undo.ts
@@ -27,7 +27,7 @@ export const undo = ({
           cellSize: dashboardState.cellSize,
           position: dashboardAction.payload.position,
           previousPosition: dashboardAction.payload.prevPosition,
-          selectedWidgetIds: dashboardState.selectedWidgetIds,
+          selectedWidgetIds: dashboardAction.payload.widgetIds || dashboardState.selectedWidgetIds,
         }),
       };
 
@@ -38,7 +38,7 @@ export const undo = ({
         dashboardConfiguration: resize({
           anchor: dashboardAction.payload.anchor,
           dashboardConfiguration: dashboardState.dashboardConfiguration,
-          widgetIds: dashboardState.selectedWidgetIds,
+          widgetIds: dashboardAction.payload.widgetIds || dashboardState.selectedWidgetIds,
           changeInPosition: dashboardAction.payload.changeInPosition,
           cellSize: dashboardState.cellSize,
         }),

--- a/packages/dashboard/src/integration/iot-dashboard.spec.component.ts
+++ b/packages/dashboard/src/integration/iot-dashboard.spec.component.ts
@@ -62,6 +62,7 @@ it('undoes and redoes a move action', () => {
     },
   });
   cy.get('iot-dashboard-widget').move({ deltaX: 100, deltaY: 100, force: true });
+  cy.get('iot-dashboard').click(500, 500);
   cy.get('body').type('{cmd}z', { release: true }).type('{cmd}{shift}z', { release: true });
   cy.get('iot-dashboard-widget').should(
     'have.attr',


### PR DESCRIPTION
## Overview
In a prior PR, I removed the 'widgetId' fields from the move and resize actions. This became a significant problem when trying to undo/redo these actions. The undo/redo would succeed when the widget was still selected, however it would fail if they were not selected. I added back the widgetId field so they can be undoable even when not selected.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
