### PR TITLE
fix(dashboard): fix selection bug 

### DIFF
--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard-internal.css
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard-internal.css
@@ -16,6 +16,7 @@
 .select-rect {
   border: var(--selection-border-width) solid var(--selection-color);
   position: absolute;
+  z-index: var(--stack-order-selection-box);
 }
 
 .grid-image {

--- a/packages/dashboard/src/dashboard-actions/paste.spec.ts
+++ b/packages/dashboard/src/dashboard-actions/paste.spec.ts
@@ -86,3 +86,29 @@ it('pastes a widget at a specific location', () => {
     widgets: [WIDGET_A, { ...WIDGET_A, id: expect.any(String), x: 1, y: 1 }],
   });
 });
+
+it('pastes multiple widgets at a specific location', () => {
+  const WIDGET_A = MockWidgetFactory.getKpiWidget({ id: 'widget-1', x: 6, y: 6 });
+  const WIDGET_B = MockWidgetFactory.getKpiWidget({ id: 'widget-2', x: 7, y: 7 });
+  const WIDGET_C = MockWidgetFactory.getKpiWidget({ id: 'widget-3', x: 8, y: 8 });
+  const dashboardConfiguration = MockDashboardFactory.get({ widgets: [WIDGET_A, WIDGET_B, WIDGET_C] });
+  expect(
+    paste({
+      dashboardConfiguration,
+      copyGroup: [WIDGET_A, WIDGET_B, WIDGET_C],
+      numTimesCopyGroupHasBeenPasted: 0,
+      cellSize: 10,
+      position: { x: 5, y: 5 },
+    })
+  ).toEqual({
+    ...dashboardConfiguration,
+    widgets: [
+      WIDGET_A,
+      WIDGET_B,
+      WIDGET_C,
+      { ...WIDGET_A, id: expect.any(String), x: 1, y: 1 },
+      { ...WIDGET_B, id: expect.any(String), x: 2, y: 2 },
+      { ...WIDGET_C, id: expect.any(String), x: 3, y: 3 },
+    ],
+  });
+});

--- a/packages/dashboard/src/dashboard-actions/paste.ts
+++ b/packages/dashboard/src/dashboard-actions/paste.ts
@@ -1,4 +1,5 @@
 import { v4 } from 'uuid';
+import first from 'lodash/first';
 import { DashboardConfiguration, Position, Widget } from '../types';
 import { concatWidgets } from '../util/dashboardConfiguration';
 
@@ -19,18 +20,30 @@ export const paste = ({
   position?: Position;
   cellSize: number;
 }): DashboardConfiguration => {
-  const cellPosition: Partial<Position> = {
-    x: position && Math.floor(position.x / cellSize),
-    y: position && Math.floor(position.y / cellSize),
+  let offset: Position = {
+    x: 0,
+    y: 0,
   };
+  if (position !== undefined) {
+    const cellPosition: Position = {
+      x: position && Math.floor(position.x / cellSize),
+      y: position && Math.floor(position.y / cellSize),
+    };
+
+    const widgetToCompare = first(copyGroup);
+    offset = {
+      x: cellPosition.x - (widgetToCompare?.x ?? 0),
+      y: cellPosition.y - (widgetToCompare?.y ?? 0),
+    };
+  }
 
   return concatWidgets(
     dashboardConfiguration,
     copyGroup.map((widget) => ({
       ...widget,
       id: v4(),
-      x: (cellPosition.x ?? widget.x) + numTimesCopyGroupHasBeenPasted + 1,
-      y: (cellPosition.y ?? widget.y) + numTimesCopyGroupHasBeenPasted + 1,
+      x: offset.x + widget.x + numTimesCopyGroupHasBeenPasted + 1,
+      y: offset.y + widget.y + numTimesCopyGroupHasBeenPasted + 1,
     }))
   );
 };

--- a/packages/dashboard/src/integration/iot-dashboard.spec.component.ts
+++ b/packages/dashboard/src/integration/iot-dashboard.spec.component.ts
@@ -70,3 +70,18 @@ it('undoes and redoes a move action', () => {
     'position: absolute; z-index: 1; top: 100px; left: 100px; width: 40px; height: 40px;'
   );
 });
+
+it('clears a selection', () => {
+  renderDashboard({
+    dashboardConfiguration: {
+      viewport: { duration: '5m' },
+      widgets: [createWidget()],
+    },
+  });
+
+  cy.get('iot-dashboard-widget').should('exist');
+  cy.get('iot-dashboard-widget').click();
+  cy.get('iot-selection-box').should('exist');
+  cy.get('body').type('{esc}', { release: true });
+  cy.get('iot-selection-box').should('not.exist');
+});

--- a/packages/dashboard/src/util/select.ts
+++ b/packages/dashboard/src/util/select.ts
@@ -1,12 +1,7 @@
 import { DashboardConfiguration, Rect } from '../types';
 import { isContained } from './isContained';
 
-/**
- * Returns all widget id's of the widgets which intersect the given selection.
- *
- * This is utilized to determine what widgets are selected upon making a selection gesture.
- */
-export const getSelectedWidgetIds = ({
+export const getSelectedWidgets = ({
   selectedRect,
   cellSize,
   dashboardConfiguration,
@@ -27,5 +22,20 @@ export const getSelectedWidgetIds = ({
           selectedRect
         )
       : false;
-  return dashboardConfiguration.widgets.filter(isSelected).map(({ id }) => id);
+  return dashboardConfiguration.widgets.filter(isSelected);
 };
+
+/**
+ * Returns all widget id's of the widgets which intersect the given selection.
+ *
+ * This is utilized to determine what widgets are selected upon making a selection gesture.
+ */
+export const getSelectedWidgetIds = ({
+  selectedRect,
+  cellSize,
+  dashboardConfiguration,
+}: {
+  selectedRect: Rect | undefined;
+  cellSize: number;
+  dashboardConfiguration: DashboardConfiguration;
+}) => getSelectedWidgets({ selectedRect, cellSize, dashboardConfiguration }).map((widget) => widget.id);


### PR DESCRIPTION
## Overview
This PR addresses 3 bugs.
1. The selection box not disappearing on completing the selection action. This was because the gesture was not reactive.
2. Clicking on an element selects all elements that overlap that pixel (not the top most element). To fix this we can sort by the z index and select the highest one in the selection.
3. Paste at position with a selection pastes all the widgets at that position (not the selection at that position). To fix this we can offset the copy group by the difference of paste position.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
