### PR TITLE
Create Separate File for Dashboard State Update

### DIFF
--- a/packages/dashboard/src/dashboard-actions/dashboardReducer.ts
+++ b/packages/dashboard/src/dashboard-actions/dashboardReducer.ts
@@ -7,6 +7,7 @@ import { deleteWidgets } from './delete';
 import { paste } from './paste';
 import { undo } from './undo';
 import { redo } from './redo';
+import { updateDashboardState } from './updateDashboardState';
 import { dashboardConfig } from './../testing/mocks';
 import { createWidget } from './createWidget';
 
@@ -169,17 +170,18 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
       };
 
     case 'UPDATE':
-      return {
-        ...(state = { ...state, ...action.payload.fieldsToUpdate }),
+      return updateDashboardState(state, {
+        ...action.payload.fieldsToUpdate,
         undoQueue: state.undoQueue.concat(action),
         redoQueue: [],
-      };
+      });
 
     case 'SELECT':
       return {
         ...state,
         selectedWidgetIds: action.payload.widgetIds,
       };
+
     default:
       return state;
   }

--- a/packages/dashboard/src/dashboard-actions/updateDashboardState.spec.ts
+++ b/packages/dashboard/src/dashboard-actions/updateDashboardState.spec.ts
@@ -1,0 +1,52 @@
+import { updateDashboardState } from './updateDashboardState';
+import { dashboardConfig, MOCK_KPI_WIDGET } from '../testing/mocks';
+import { DashboardState } from '../types';
+
+const state: DashboardState = {
+  dashboardConfiguration: dashboardConfig,
+  intermediateDashboardConfiguration: undefined,
+  selectedWidgetIds: [],
+  numTimesCopyGroupHasBeenPasted: 0,
+  copyGroup: [],
+  stretchToFit: false,
+  width: 1000,
+  cellSize: 10,
+  undoQueue: [],
+  redoQueue: [],
+  previousPosition: undefined,
+};
+
+describe('updateDashboardState()', () => {
+  it('updates single property', () => {
+    const fieldsToUpdate = { width: 500 };
+    const expectedState = { ...state, width: 500 };
+
+    expect(updateDashboardState(state, fieldsToUpdate)).toStrictEqual(expectedState);
+  });
+
+  it('updates multiple properties', () => {
+    const fieldsToUpdate = { cellSize: 20, stretchToFit: true };
+    const expectedState = { ...state, cellSize: 20, stretchToFit: true };
+
+    expect(updateDashboardState(state, fieldsToUpdate)).toStrictEqual(expectedState);
+  });
+
+  it('updates array with recursive merge', () => {
+    const initialState = { ...state, selectedWidgetIds: ['1'] };
+    const fieldsToUpdate = { selectedWidgetIds: ['2'] };
+    const expectedState = { ...state, selectedWidgetIds: ['1', '2'] };
+
+    expect(updateDashboardState(initialState, fieldsToUpdate)).toStrictEqual(expectedState);
+  });
+
+  it('updates object with recursive merge', () => {
+    const initialState = { ...state, dashboardConfiguration: { viewport: { duration: '5m' }, widgets: [] } };
+    const fieldsToUpdate = { dashboardConfiguration: { viewport: { duration: '1m' }, widgets: [MOCK_KPI_WIDGET] } };
+    const expectedState = {
+      ...state,
+      dashboardConfiguration: { viewport: { duration: '1m' }, widgets: [MOCK_KPI_WIDGET] },
+    };
+
+    expect(updateDashboardState(initialState, fieldsToUpdate)).toStrictEqual(expectedState);
+  });
+});

--- a/packages/dashboard/src/dashboard-actions/updateDashboardState.ts
+++ b/packages/dashboard/src/dashboard-actions/updateDashboardState.ts
@@ -1,0 +1,12 @@
+import { DashboardState } from '../types';
+import deepMerge from 'deepmerge';
+
+/**
+ * Deeply updates the dashboard state object.
+ *
+ * @param initialState
+ * @param fieldsToUpdate
+ * @returns A new object of the same type as the initialState, with the passed fields updated.
+ */
+export const updateDashboardState = (initialState: DashboardState, fieldsToUpdate: Partial<DashboardState>) =>
+  deepMerge(initialState, fieldsToUpdate);


### PR DESCRIPTION
## Overview
Completes https://github.com/awslabs/iot-app-kit/pull/205/files. Not able to update through the original pull request since the source branch is on a fork of app-kit that can't be pushed to.

Creates a separate file for updating the dashboard.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
