### PR TITLE
feat(dashboard): add undo redo for bring to front/ send to back 

### DIFF
--- a/packages/dashboard/src/dashboard-actions/actions.ts
+++ b/packages/dashboard/src/dashboard-actions/actions.ts
@@ -14,6 +14,7 @@ export enum DashboardActionType {
   UPDATE = 'UPDATE',
   BRING_TO_FRONT = 'BRING_TO_FRONT',
   SEND_TO_BACK = 'SEND_TO_BACK',
+  CHANGE_LAYER = 'CHANGE_LAYER',
 }
 
 export interface MoveAction extends Action<DashboardActionType.MOVE> {
@@ -166,6 +167,20 @@ export const onSendToBackAction = (payload: SendToBackAction['payload']): SendTo
 
 export type SendToBackActionInput = SendToBackAction['payload'];
 
+export interface ChangeLayerAction extends Action<DashboardActionType.CHANGE_LAYER> {
+  type: typeof DashboardActionType.CHANGE_LAYER;
+  payload: {
+    widgets: Widget[];
+    zOffset: number;
+  };
+}
+export const onChangeLayerAction = (payload: ChangeLayerAction['payload']): ChangeLayerAction => ({
+  type: DashboardActionType.CHANGE_LAYER,
+  payload,
+});
+
+export type ChangeLayerActionInput = ChangeLayerAction['payload'];
+
 export type DashboardAction =
   | MoveAction
   | ResizeAction
@@ -178,4 +193,5 @@ export type DashboardAction =
   | UpdateAction
   | SelectAction
   | BringToFrontAction
-  | SendToBackAction;
+  | SendToBackAction
+  | ChangeLayerAction;

--- a/packages/dashboard/src/dashboard-actions/changeLayer.spec.ts
+++ b/packages/dashboard/src/dashboard-actions/changeLayer.spec.ts
@@ -1,0 +1,60 @@
+import { changeLayer } from './changeLayer';
+import {
+  MOCK_EMPTY_DASHBOARD,
+  MockWidgetFactory,
+  MockDashboardFactory,
+  MOCK_KPI_WIDGET,
+  MOCK_LINE_CHART_WIDGET,
+} from '../testing/mocks';
+
+it('returns empty dashboard when provided empty dashboard', () => {
+  expect(changeLayer({ dashboardConfiguration: MOCK_EMPTY_DASHBOARD, widgets: [], zOffset: 0 })).toEqual(
+    MOCK_EMPTY_DASHBOARD
+  );
+});
+
+it('returns empty dashboard when provided empty dashboard and non-existent widgets', () => {
+  expect(
+    changeLayer({
+      dashboardConfiguration: MOCK_EMPTY_DASHBOARD,
+      widgets: [MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET],
+      zOffset: 0,
+    })
+  ).toEqual(MOCK_EMPTY_DASHBOARD);
+});
+
+it('moves selected widgets by an offset', () => {
+  const MOCK_WIDGET = MockWidgetFactory.getKpiWidget({
+    id: 'widget-1',
+  });
+  const MOCK_WIDGET_2 = MockWidgetFactory.getKpiWidget({
+    id: 'widget-2',
+    z: MOCK_WIDGET.z - 1, // A z-index lower than `MOCK_WIDGET`'s z-index
+  });
+
+  const dashboardConfiguration = MockDashboardFactory.get({ widgets: [MOCK_WIDGET, MOCK_WIDGET_2] });
+
+  expect(changeLayer({ dashboardConfiguration, widgets: [MOCK_WIDGET, MOCK_WIDGET_2], zOffset: 1 })).toEqual({
+    ...dashboardConfiguration,
+    widgets: [
+      expect.objectContaining({
+        z: MOCK_WIDGET.z + 1,
+      }),
+      expect.objectContaining({
+        z: MOCK_WIDGET_2.z + 1,
+      }),
+    ],
+  });
+
+  expect(changeLayer({ dashboardConfiguration, widgets: [MOCK_WIDGET, MOCK_WIDGET_2], zOffset: -1 })).toEqual({
+    ...dashboardConfiguration,
+    widgets: [
+      expect.objectContaining({
+        z: MOCK_WIDGET.z - 1,
+      }),
+      expect.objectContaining({
+        z: MOCK_WIDGET_2.z - 1,
+      }),
+    ],
+  });
+});

--- a/packages/dashboard/src/dashboard-actions/changeLayer.ts
+++ b/packages/dashboard/src/dashboard-actions/changeLayer.ts
@@ -1,0 +1,26 @@
+import { DashboardConfiguration, Widget } from '../types';
+import { mapWidgets } from '../util/dashboardConfiguration';
+
+/**
+ * Returns a dashboard with the provided widget id's all with their z-index shifted by the offset.
+ */
+export const changeLayer = ({
+  dashboardConfiguration,
+  widgets,
+  zOffset,
+}: {
+  dashboardConfiguration: DashboardConfiguration;
+  widgets: Widget[];
+  zOffset: number;
+}): DashboardConfiguration => {
+  const widgetIds = widgets.map((widget) => widget.id);
+  return mapWidgets(dashboardConfiguration, (widget) => {
+    if (widgetIds.includes(widget.id)) {
+      return {
+        ...widget,
+        z: widget.z + zOffset,
+      };
+    }
+    return widget;
+  });
+};

--- a/packages/dashboard/src/dashboard-actions/dashboardReducer.ts
+++ b/packages/dashboard/src/dashboard-actions/dashboardReducer.ts
@@ -7,7 +7,6 @@ import { deleteWidgets } from './delete';
 import { paste } from './paste';
 import { undo } from './undo';
 import { redo } from './redo';
-import { updateDashboardState } from './updateDashboardState';
 import { dashboardConfig } from './../testing/mocks';
 import { createWidget } from './createWidget';
 import { bringToFront } from './bringToFront';
@@ -40,6 +39,7 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
           dashboardConfiguration: state.dashboardConfiguration,
           widgetIds: action.payload.widgets.map((w) => w.id),
         }),
+        undoQueue: state.undoQueue.concat(action),
       };
 
     case 'SEND_TO_BACK':
@@ -49,6 +49,7 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
           dashboardConfiguration: state.dashboardConfiguration,
           widgetIds: action.payload.widgets.map((w) => w.id),
         }),
+        undoQueue: state.undoQueue.concat(action),
       };
 
     case 'MOVE':
@@ -192,18 +193,18 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
       };
 
     case 'UPDATE':
-      return updateDashboardState(state, {
+      return {
+        ...state,
         ...action.payload.fieldsToUpdate,
         undoQueue: state.undoQueue.concat(action),
         redoQueue: [],
-      });
+      };
 
     case 'SELECT':
       return {
         ...state,
         selectedWidgetIds: action.payload.widgetIds,
       };
-
     default:
       return state;
   }

--- a/packages/dashboard/src/dashboard-actions/redo.ts
+++ b/packages/dashboard/src/dashboard-actions/redo.ts
@@ -5,6 +5,8 @@ import { resize } from './resize';
 import { deleteWidgets } from './delete';
 import { createWidget } from './createWidget';
 import { paste } from './paste';
+import { bringToBack } from './bringToBack';
+import { bringToFront } from './bringToFront';
 
 export const redo = ({
   dashboardAction,
@@ -14,6 +16,24 @@ export const redo = ({
   dashboardState: DashboardState;
 }): DashboardState => {
   switch (dashboardAction.type) {
+    case 'SEND_TO_BACK':
+      return {
+        ...dashboardState,
+        dashboardConfiguration: bringToBack({
+          dashboardConfiguration: dashboardState.dashboardConfiguration,
+          widgetIds: dashboardAction.payload.widgets.map((widget) => widget.id),
+        }),
+      };
+
+    case 'BRING_TO_FRONT':
+      return {
+        ...dashboardState,
+        dashboardConfiguration: bringToFront({
+          dashboardConfiguration: dashboardState.dashboardConfiguration,
+          widgetIds: dashboardAction.payload.widgets.map((widget) => widget.id),
+        }),
+      };
+
     case 'MOVE':
       return {
         ...dashboardState,

--- a/packages/dashboard/src/dashboard-actions/reverse-actions/reverseBringToFront.ts
+++ b/packages/dashboard/src/dashboard-actions/reverse-actions/reverseBringToFront.ts
@@ -1,0 +1,23 @@
+import { DashboardConfiguration } from '../../types';
+import { BringToFrontAction, ChangeLayerAction, onChangeLayerAction } from '../actions';
+
+export const reverseBringToFront = ({
+  dashboardConfiguration,
+  action,
+}: {
+  dashboardConfiguration: DashboardConfiguration;
+  action: BringToFrontAction;
+}): ChangeLayerAction => {
+  const widgets = action.payload.widgets;
+  const widgetIds = widgets.map((widget) => widget.id);
+  const topZIndex = Math.max(
+    ...dashboardConfiguration.widgets.filter((widget) => !widgetIds.includes(widget.id)).map(({ z }) => z)
+  );
+  const minSelectedZ = Math.min(...widgets.map(({ z }) => z));
+
+  const zOffset = (topZIndex + 1 - minSelectedZ) * -1;
+  return onChangeLayerAction({
+    widgets,
+    zOffset,
+  });
+};

--- a/packages/dashboard/src/dashboard-actions/reverse-actions/reverseSendToBack.spec.ts
+++ b/packages/dashboard/src/dashboard-actions/reverse-actions/reverseSendToBack.spec.ts
@@ -1,0 +1,38 @@
+import { MockDashboardFactory, MockWidgetFactory } from '../../testing/mocks';
+import { SendToBackAction, DashboardActionType, onSendToBackAction } from '../actions';
+import { bringToBack } from '../bringToBack';
+import { reverseSendToBack } from './reverseSendToBack';
+
+it('returns a change layer action for the specified widget', () => {
+  const widgets = [MockWidgetFactory.getKpiWidget({ z: 2 }), MockWidgetFactory.getKpiWidget({ z: 1 })];
+  const dashboardConfiguration = bringToBack({
+    dashboardConfiguration: MockDashboardFactory.get({ widgets }),
+    widgetIds: [widgets[0].id],
+  });
+  const action: SendToBackAction = onSendToBackAction({
+    widgets: [widgets[0]],
+  });
+  expect(reverseSendToBack({ dashboardConfiguration, action })).toEqual({
+    payload: { widgets: [widgets[0]], zOffset: 2 },
+    type: DashboardActionType.CHANGE_LAYER,
+  });
+});
+
+it('returns a change layer action for multiple widgets', () => {
+  const widgets = [
+    MockWidgetFactory.getKpiWidget({ z: 3 }),
+    MockWidgetFactory.getKpiWidget({ z: 2 }),
+    MockWidgetFactory.getKpiWidget({ z: 1 }),
+  ];
+  const dashboardConfiguration = bringToBack({
+    dashboardConfiguration: MockDashboardFactory.get({ widgets }),
+    widgetIds: [widgets[0].id, widgets[1].id],
+  });
+  const action: SendToBackAction = onSendToBackAction({
+    widgets: [widgets[0], widgets[1]],
+  });
+  expect(reverseSendToBack({ dashboardConfiguration, action })).toEqual({
+    payload: { widgets: [widgets[0], widgets[1]], zOffset: 3 },
+    type: DashboardActionType.CHANGE_LAYER,
+  });
+});

--- a/packages/dashboard/src/dashboard-actions/reverse-actions/reverseSendToBack.ts
+++ b/packages/dashboard/src/dashboard-actions/reverse-actions/reverseSendToBack.ts
@@ -1,0 +1,24 @@
+import { DashboardConfiguration } from '../../types';
+import { ChangeLayerAction, onChangeLayerAction, SendToBackAction } from '../actions';
+
+export const reverseSendToBack = ({
+  dashboardConfiguration,
+  action,
+}: {
+  dashboardConfiguration: DashboardConfiguration;
+  action: SendToBackAction;
+}): ChangeLayerAction => {
+  const widgets = action.payload.widgets;
+  const widgetIds = widgets.map((widget) => widget.id);
+
+  const bottomZIndex = Math.min(
+    ...dashboardConfiguration.widgets.filter((widget) => !widgetIds.includes(widget.id)).map(({ z }) => z)
+  );
+  const maxSelectedZ = Math.max(...widgets.map(({ z }) => z));
+
+  const zOffset = (bottomZIndex - 1 - maxSelectedZ) * -1;
+  return onChangeLayerAction({
+    widgets,
+    zOffset,
+  });
+};

--- a/packages/dashboard/src/dashboard-actions/reverse-actions/reverstBringToFront.spec.ts
+++ b/packages/dashboard/src/dashboard-actions/reverse-actions/reverstBringToFront.spec.ts
@@ -1,0 +1,38 @@
+import { MockDashboardFactory, MockWidgetFactory } from '../../testing/mocks';
+import { BringToFrontAction, DashboardActionType, onBringToFrontAction } from '../actions';
+import { bringToFront } from '../bringToFront';
+import { reverseBringToFront } from './reverseBringToFront';
+
+it('returns a change layer action for the specified widget', () => {
+  const widgets = [MockWidgetFactory.getKpiWidget({ z: 2 }), MockWidgetFactory.getKpiWidget({ z: 1 })];
+  const dashboardConfiguration = bringToFront({
+    dashboardConfiguration: MockDashboardFactory.get({ widgets }),
+    widgetIds: [widgets[1].id],
+  });
+  const action: BringToFrontAction = onBringToFrontAction({
+    widgets: [widgets[1]],
+  });
+  expect(reverseBringToFront({ dashboardConfiguration, action })).toEqual({
+    payload: { widgets: [widgets[1]], zOffset: -2 },
+    type: DashboardActionType.CHANGE_LAYER,
+  });
+});
+
+it('returns a change layer action for multiple widgets', () => {
+  const widgets = [
+    MockWidgetFactory.getKpiWidget({ z: 3 }),
+    MockWidgetFactory.getKpiWidget({ z: 2 }),
+    MockWidgetFactory.getKpiWidget({ z: 1 }),
+  ];
+  const dashboardConfiguration = bringToFront({
+    dashboardConfiguration: MockDashboardFactory.get({ widgets }),
+    widgetIds: [widgets[1].id, widgets[2].id],
+  });
+  const action: BringToFrontAction = onBringToFrontAction({
+    widgets: [widgets[1], widgets[2]],
+  });
+  expect(reverseBringToFront({ dashboardConfiguration, action })).toEqual({
+    payload: { widgets: [widgets[1], widgets[2]], zOffset: -3 },
+    type: DashboardActionType.CHANGE_LAYER,
+  });
+});

--- a/packages/dashboard/src/dashboard-actions/undo.spec.ts
+++ b/packages/dashboard/src/dashboard-actions/undo.spec.ts
@@ -1,4 +1,10 @@
-import { dashboardConfig, MOCK_EMPTY_DASHBOARD, MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET } from '../testing/mocks';
+import {
+  dashboardConfig,
+  MockWidgetFactory,
+  MOCK_EMPTY_DASHBOARD,
+  MOCK_KPI_WIDGET,
+  MOCK_LINE_CHART_WIDGET,
+} from '../testing/mocks';
 import {
   onDeleteAction,
   onCreateAction,
@@ -7,6 +13,8 @@ import {
   ResizeAction,
   onPasteAction,
   onUpdateAction,
+  onSendToBackAction,
+  onBringToFrontAction,
 } from '../dashboard-actions/actions';
 import { DashboardConfiguration, DashboardState, Position } from '../types';
 import { undo } from './undo';
@@ -19,6 +27,8 @@ import { reverseCreate } from './reverse-actions/reverseCreate';
 import { reverseDelete } from './reverse-actions/reverseDelete';
 import { dashboardReducer } from './dashboardReducer';
 import { trimWidgetPosition } from '../components/iot-dashboard/trimWidgetPosition';
+import { bringToBack } from './bringToBack';
+import { bringToFront } from './bringToFront';
 
 const state: DashboardState = {
   dashboardConfiguration: {
@@ -277,5 +287,63 @@ describe('MULTIPLE ACTIONS', () => {
         }),
       }).dashboardConfiguration.widgets.map(trimWidgetPosition)
     ).toEqual({ ...state }.dashboardConfiguration.widgets);
+  });
+});
+
+describe('SEND_TO_BACK', () => {
+  it('restores original widget position', () => {
+    const widgets = [MockWidgetFactory.getKpiWidget({ z: 2 }), MockWidgetFactory.getKpiWidget({ z: 1 })];
+    const widgetToSendToBack = widgets[0];
+    const selectedWidgetIds = [widgetToSendToBack.id];
+
+    const dashboardState = {
+      ...state,
+      dashboardConfiguration: bringToBack({
+        dashboardConfiguration: {
+          ...state.dashboardConfiguration,
+          widgets,
+        },
+        widgetIds: selectedWidgetIds,
+      }),
+      selectedWidgetIds,
+    };
+
+    expect(
+      undo({
+        dashboardAction: onSendToBackAction({
+          widgets: [widgetToSendToBack],
+        }),
+        dashboardState,
+      }).dashboardConfiguration.widgets
+    ).toEqual(widgets);
+  });
+});
+
+describe('BRING_TO_FRONT', () => {
+  it('restores original widget position', () => {
+    const widgets = [MockWidgetFactory.getKpiWidget({ z: 2 }), MockWidgetFactory.getKpiWidget({ z: 1 })];
+    const widgetToSendToBack = widgets[1];
+    const selectedWidgetIds = [widgetToSendToBack.id];
+
+    const dashboardState = {
+      ...state,
+      dashboardConfiguration: bringToFront({
+        dashboardConfiguration: {
+          ...state.dashboardConfiguration,
+          widgets,
+        },
+        widgetIds: selectedWidgetIds,
+      }),
+      selectedWidgetIds,
+    };
+
+    expect(
+      undo({
+        dashboardAction: onBringToFrontAction({
+          widgets: [widgetToSendToBack],
+        }),
+        dashboardState,
+      }).dashboardConfiguration.widgets
+    ).toEqual(widgets);
   });
 });

--- a/packages/dashboard/src/dashboard-actions/undo.ts
+++ b/packages/dashboard/src/dashboard-actions/undo.ts
@@ -9,6 +9,9 @@ import { deleteWidgets } from './delete';
 import { reverseDelete } from './reverse-actions/reverseDelete';
 import { createWidget } from './createWidget';
 import { reversePaste } from './reverse-actions/reversePaste';
+import { reverseSendToBack } from './reverse-actions/reverseSendToBack';
+import { changeLayer } from './changeLayer';
+import { reverseBringToFront } from './reverse-actions/reverseBringToFront';
 
 export const undo = ({
   dashboardAction,
@@ -18,6 +21,32 @@ export const undo = ({
   dashboardState: DashboardState;
 }): DashboardState => {
   switch (dashboardAction.type) {
+    case 'SEND_TO_BACK': {
+      return {
+        ...dashboardState,
+        dashboardConfiguration: changeLayer({
+          dashboardConfiguration: dashboardState.dashboardConfiguration,
+          ...reverseSendToBack({
+            dashboardConfiguration: dashboardState.dashboardConfiguration,
+            action: dashboardAction,
+          }).payload,
+        }),
+      };
+    }
+
+    case 'BRING_TO_FRONT': {
+      return {
+        ...dashboardState,
+        dashboardConfiguration: changeLayer({
+          dashboardConfiguration: dashboardState.dashboardConfiguration,
+          ...reverseBringToFront({
+            dashboardConfiguration: dashboardState.dashboardConfiguration,
+            action: dashboardAction,
+          }).payload,
+        }),
+      };
+    }
+
     case 'MOVE':
       return {
         ...(dashboardAction = reverseMove(dashboardAction)),


### PR DESCRIPTION
## Overview
Bring to front and Send to back did not have an implementation for undo / redo. This PR adds those implementations.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
