### PR TITLE
Update docs. Remove unnecessary jest configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 # 2.0.0 (2022-08-24)
 
 ### Features
-* (**breaking changes**) add supports of sorting and filtering to iot-table. ([commit hash TBA]())
-  * iot-table now uses AWS-UI's table components (wrapped as a separated [package](https://github.com/awslabs/iot-app-kit/blob/main/packages/table)) instead of Synchro-chart's table component. 
-Check this [documentation](https://github.com/awslabs/iot-app-kit/blob/main/docs/Table.md) for more information about new APIs and migration from old API.
+* add supports of sorting and filtering to iot-table. ([commit hash TBA]())
+  * (**breaking API changes**) iot-table now uses AWS-UI's table components (wrapped as a separated [table package](https://github.com/awslabs/iot-app-kit/blob/main/packages/table)) instead of Synchro-chart's table component.
+    Because of this change, we have new APIs for iot-table component. Check this [documentation](https://github.com/awslabs/iot-app-kit/blob/main/docs/Table.md) for more information about new APIs and migration from old APIs.
 
 
 # 1.4.0 (2022-06-09)

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,9 +6,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 # 2.0.0 (2022-08-24)
 
 ### Features
-* (**breaking changes**) add supports of sorting and filtering to iot-table. ([commit hash TBA]())
-  * iot-table now uses AWS-UI's table components (wrapped as a separated [package](https://github.com/awslabs/iot-app-kit/blob/main/packages/table)) instead of Synchro-chart's table component.
-    Check this [documentation](https://github.com/awslabs/iot-app-kit/blob/main/docs/Table.md) for more information about new APIs and migration from old API.
+* add supports of sorting and filtering to iot-table. ([commit hash TBA]())
+  * (**breaking API changes**) iot-table now uses AWS-UI's table components (wrapped as a separated [table package](https://github.com/awslabs/iot-app-kit/blob/main/packages/table)) instead of Synchro-chart's table component.
+    Because of this change, we have new APIs for iot-table component. Check this [documentation](https://github.com/awslabs/iot-app-kit/blob/main/docs/Table.md) for more information about new APIs and migration from old APIs.
 
 # 1.5.0 (2022-07-09)
 

--- a/packages/table/jest.config.js
+++ b/packages/table/jest.config.js
@@ -9,7 +9,6 @@ module.exports = {
   coverageReporters: ['text-summary', 'cobertura', 'html', 'json', 'json-summary'],
   moduleNameMapper: {
     '\\.(css|scss|svg)$': 'identity-obj-proxy',
-    'd3-array': '<rootDir>/node_modules/d3-array/dist/d3-array.min.js',
   },
   transform: {
     '.+\\.js$': 'babel-jest',


### PR DESCRIPTION
## Overview
- Update change logs to clearify breaking changes.
- Remove unnecessary jest configuration 
  - 'd3-array' map is no longer needed because babel is used in Jest transformation (https://github.com/awslabs/iot-app-kit/pull/215).

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
