### PR TITLE
fix(dashboard): add touch support for context menu

### DIFF
--- a/packages/dashboard/src/components/iot-dashboard/getDashboardPosition.ts
+++ b/packages/dashboard/src/components/iot-dashboard/getDashboardPosition.ts
@@ -2,9 +2,30 @@ import { Position } from '../../types';
 
 export const DASHBOARD_CONTAINER_ID = 'container';
 
-export const getDashboardPosition = (event: MouseEvent): Position => {
-  let totalOffsetX = event.offsetX;
-  let totalOffsetY = event.offsetY;
+const getOffsets = (event: MouseEvent | TouchEvent | PointerEvent) => {
+  if (event instanceof TouchEvent) {
+    const ev = event.touches[0];
+
+    const rect = (ev.target as HTMLElement).getBoundingClientRect();
+    const offsetX = ev.clientX - rect.x;
+    const offsetY = ev.clientY - rect.y;
+
+    return {
+      offsetX,
+      offsetY,
+    };
+  }
+
+  return {
+    offsetX: event.offsetX,
+    offsetY: event.offsetY,
+  };
+};
+
+export const getDashboardPosition = (event: MouseEvent | TouchEvent | PointerEvent): Position => {
+  const { offsetX, offsetY } = getOffsets(event);
+  let totalOffsetX = offsetX;
+  let totalOffsetY = offsetY;
   let currElement: HTMLElement | null = event.target as HTMLElement;
 
   while (currElement && currElement.id != DASHBOARD_CONTAINER_ID) {

--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard.tsx
@@ -153,6 +153,13 @@ export class IotDashboard {
     this.messages = merge(this.messageOverrides, DefaultDashboardMessages);
   }
 
+  /**
+   * this is to resolve the 'compiler optimization issue':
+   * lifecycle events not being called when not explicitly declared in at least one of components from bundle
+   */
+  connectedCallback() {}
+  disconnectedCallback() {}
+
   render() {
     return (
       this.state.dashboardConfiguration && (

--- a/packages/dashboard/src/decorators/events.ts
+++ b/packages/dashboard/src/decorators/events.ts
@@ -1,0 +1,39 @@
+import { ComponentInterface, getElement } from '@stencil/core';
+import { noop } from 'lodash';
+
+import { PressEvents, PressOptions, withPressHandler } from './press';
+
+// Inspiration:
+// https://medium.com/stencil-tricks/stenciljs-creating-custom-decorators-d4d8e78c5717
+// https://www.npmjs.com/package/stencil-click-outside
+
+type EventDecorator = (target: ComponentInterface, propertyKey: string) => void;
+
+type EventerEvent = PressEvents;
+type EventerOptions = PressOptions;
+
+export function CustomEvent(event: EventerEvent, opts?: EventerOptions): EventDecorator {
+  return (proto: ComponentInterface, methodName: string) => {
+    const { connectedCallback, disconnectedCallback } = proto;
+
+    let unsubscribe: () => void = noop;
+
+    proto.connectedCallback = function () {
+      const host = getElement(this);
+      const method = this[methodName];
+
+      switch (event) {
+        case 'press':
+          unsubscribe = withPressHandler(this, host, opts as PressOptions, method);
+          break;
+      }
+
+      return connectedCallback && connectedCallback.call(this);
+    };
+
+    proto.disconnectedCallback = function () {
+      unsubscribe();
+      return disconnectedCallback && disconnectedCallback.call(this);
+    };
+  };
+}

--- a/packages/dashboard/src/decorators/press.ts
+++ b/packages/dashboard/src/decorators/press.ts
@@ -1,0 +1,138 @@
+import { ComponentInterface } from '@stencil/core';
+import { noop } from 'lodash';
+import { Position } from '../types';
+import { distance } from '../util/distance';
+
+export type PressEvents = 'press';
+
+type PressTrigger = 'mouse' | 'touch' | 'all';
+type PressTarget = 'parent' | 'self';
+/**
+ * Options to configure a press event handler
+ *
+ * @type PressOptions
+ * @property {number} [duration=500] time in ms that a press needs to be held for before the event occurs.
+ * @property {number} [threshold=5] distance the press pointer can move before cancelling the press event.
+ * @property {'mouse' | 'touch' | 'all'} [trigger='touch'] the type of Pointer event that will trigger a press. Must be one of 'mouse' | 'touch' | 'all'
+ * @property {'parent' | 'self'} [target='self'] the target the event will trigger from. Must be one of 'parent' | 'self'
+ */
+export type PressOptions = {
+  duration?: number;
+  threshold?: number;
+  trigger?: PressTrigger;
+  target?: PressTarget;
+};
+
+const defaultOptions: Required<PressOptions> = {
+  duration: 500,
+  threshold: 5,
+  trigger: 'touch',
+  target: 'self',
+};
+
+type EventTypess = {
+  start: 'mousedown' | 'touchstart' | 'pointerdown';
+  move: 'mousemove' | 'touchmove' | 'pointermove';
+  end: 'mouseup' | 'touchend' | 'pointerup';
+  cancel: 'touchcancel' | 'pointercancel' | null;
+};
+
+const getEvents = (trigger: PressTrigger): EventTypess => {
+  switch (trigger) {
+    case 'mouse':
+      return {
+        start: 'mousedown',
+        move: 'mousemove',
+        end: 'mouseup',
+        cancel: null,
+      };
+    case 'touch':
+      return {
+        start: 'touchstart',
+        move: 'touchmove',
+        end: 'touchend',
+        cancel: 'touchcancel',
+      };
+    case 'all':
+      return {
+        start: 'pointerdown',
+        move: 'pointermove',
+        end: 'pointerup',
+        cancel: 'pointercancel',
+      };
+  }
+};
+
+export const getEvent = (event: Event) =>
+  (event as TouchEvent).touches ? (event as TouchEvent).touches[0] : (event as MouseEvent);
+
+export const withPressHandler = (
+  component: ComponentInterface,
+  el: HTMLElement,
+  options: PressOptions,
+  cb: (event: Event) => void
+): (() => void) => {
+  let startPosition: Position | null = null;
+  let pressTimeout: NodeJS.Timeout;
+
+  const { duration, threshold, trigger, target } = Object.assign({}, defaultOptions, options);
+  const targetElement = target === 'parent' ? el.parentElement : el;
+
+  if (!targetElement) return noop;
+
+  const { start, move, end, cancel } = getEvents(trigger);
+
+  const reset = () => {
+    startPosition = null;
+    clearTimeout(pressTimeout);
+  };
+
+  const pressStartHandler = (event: Event) => {
+    const ev = getEvent(event);
+    if (!ev) return;
+    startPosition = {
+      x: ev.clientX,
+      y: ev.clientY,
+    };
+    pressTimeout = setTimeout(() => {
+      cb.call(component, event);
+      reset();
+    }, duration);
+  };
+  const pressEndHandler = (event: Event) => {
+    if (!startPosition || event.type === 'mouseup' || event.type === 'pointerup') {
+      reset();
+      return;
+    }
+    const ev = getEvent(event);
+    if (!ev) {
+      reset();
+      return;
+    }
+
+    const endPosition: Position = {
+      x: ev.clientX,
+      y: ev.clientY,
+    };
+    if (distance(startPosition, endPosition) > threshold) {
+      reset();
+      return;
+    }
+  };
+
+  targetElement.addEventListener(start, pressStartHandler);
+  targetElement.addEventListener(move, pressEndHandler);
+  targetElement.addEventListener(end, pressEndHandler);
+  if (cancel !== null) {
+    targetElement.addEventListener(cancel, pressEndHandler);
+  }
+
+  return () => {
+    targetElement.removeEventListener(start, pressStartHandler);
+    targetElement.removeEventListener(move, pressEndHandler);
+    targetElement.removeEventListener(end, pressEndHandler);
+    if (cancel !== null) {
+      targetElement.removeEventListener(cancel, pressEndHandler);
+    }
+  };
+};

--- a/packages/dashboard/src/integration/iot-dashboard-context-menu.spec.component.ts
+++ b/packages/dashboard/src/integration/iot-dashboard-context-menu.spec.component.ts
@@ -97,6 +97,15 @@ it('brings an item to the front and send an item to back from the menu', () => {
   });
 });
 
+it('renders in a mobile context', () => {
+  renderContextMenu();
+  cy.get('#context-menu-target').trigger('touchstart');
+
+  cy.wait(750);
+
+  cy.get('iot-dashboard-context-menu').should('be.visible');
+});
+
 it('renders', () => {
   renderContextMenu();
   cy.get('#context-menu-target').rightclick();

--- a/packages/dashboard/src/util/distance.spec.ts
+++ b/packages/dashboard/src/util/distance.spec.ts
@@ -1,0 +1,6 @@
+import { distance } from './distance';
+
+it('can calculate the distance between 2 points', () => {
+  expect(distance({ x: 0, y: 0 }, { x: 0, y: 0 })).toBe(0);
+  expect(distance({ x: 0, y: 3 }, { x: 4, y: 0 })).toBe(5);
+});

--- a/packages/dashboard/src/util/distance.ts
+++ b/packages/dashboard/src/util/distance.ts
@@ -1,0 +1,9 @@
+import { Position } from '../types';
+
+export const distance = (pos1: Position, pos2: Position): number => {
+  const { x: x1, y: y1 } = pos1;
+  const { x: x2, y: y2 } = pos2;
+  const y = x2 - x1;
+  const x = y2 - y1;
+  return Math.sqrt(x * x + y * y);
+};


### PR DESCRIPTION
## Overview
This adds support for the context menu on a touch device. The trigger is a long press (500ms) on the dashboard grid area. The implementation uses a custom decorator to register the event listeners.

## Tests
[Include a link to the passing GitHub action running the test suite here.]

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
