### PR TITLE
feat(core)!: Refactor time series data module / add meta field to data source

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,7 +54,7 @@
     "@iot-app-kit/related-table": "^1.5.0",
     "@iot-app-kit/source-iotsitewise": "^1.5.0",
     "@stencil/core": "^2.7.0",
-    "@synchro-charts/core": "^6.0.0",
+    "@synchro-charts/core": "^6.0.1",
     "styled-components": "^5.3.0"
   },
   "devDependencies": {

--- a/packages/core/src/__mocks__/data-source.ts
+++ b/packages/core/src/__mocks__/data-source.ts
@@ -17,7 +17,6 @@ export const createMockSiteWiseDataSource = (
     onRequestData?: (props: any) => void;
   } = { dataStreams: [], onRequestData: () => {} }
 ): DataSource<SiteWiseDataStreamQuery> => ({
-  name: 'site-wise',
   initiateRequest: jest.fn(
     (
       { query, request, onSuccess = () => {} }: DataSourceRequest<SiteWiseDataStreamQuery>,

--- a/packages/core/src/data-module/data-cache/caching/caching.spec.ts
+++ b/packages/core/src/data-module/data-cache/caching/caching.spec.ts
@@ -9,7 +9,7 @@ import {
   maxCacheDuration,
   getRequestInformations,
 } from './caching';
-import { DEFAULT_CACHE_SETTINGS } from '../../IotAppKitDataModule';
+import { DEFAULT_CACHE_SETTINGS } from '../../TimeSeriesDataModule';
 import { HOUR_IN_MS, MINUTE_IN_MS, SECOND_IN_MS } from '../../../common/time';
 import { DataStreamsStore } from '../types';
 import { IntervalStructure } from '../../../common/intervalStructure';

--- a/packages/core/src/data-module/data-source-store/dataSourceStore.spec.ts
+++ b/packages/core/src/data-module/data-source-store/dataSourceStore.spec.ts
@@ -1,18 +1,9 @@
 import DataSourceStore from './dataSourceStore';
 import { DataSource } from '../types';
 
-it('registers a data source', () => {
-  const dataSourceStore = new DataSourceStore();
-  expect(() =>
-    dataSourceStore.registerDataSource({ name: 'custom', initiateRequest: () => {}, getRequestsFromQuery: () => [] })
-  ).not.toThrowError();
-});
-
 it('initiate a request on a registered data source', () => {
-  const dataSourceStore = new DataSourceStore();
-  const customSource: DataSource = { name: 'custom', initiateRequest: jest.fn(), getRequestsFromQuery: () => [] };
-
-  dataSourceStore.registerDataSource(customSource);
+  const customSource: DataSource = { initiateRequest: jest.fn(), getRequestsFromQuery: () => [] };
+  const dataSourceStore = new DataSourceStore(customSource);
 
   const query = { source: 'custom' };
 
@@ -37,21 +28,4 @@ it('initiate a request on a registered data source', () => {
     },
     []
   );
-});
-
-it('throws error when attempting to initiate a request to a non-existent data source', () => {
-  const dataSourceStore = new DataSourceStore();
-
-  const request = { viewport: { start: new Date(), end: new Date() }, settings: { fetchFromStartToEnd: true } };
-  expect(() =>
-    dataSourceStore.initiateRequest(
-      {
-        request,
-        query: { source: 'some-name' },
-        onSuccess: () => {},
-        onError: () => {},
-      },
-      []
-    )
-  ).toThrowError(/some-name/);
 });

--- a/packages/core/src/data-module/data-source-store/dataSourceStore.ts
+++ b/packages/core/src/data-module/data-source-store/dataSourceStore.ts
@@ -1,6 +1,5 @@
 import {
   DataSource,
-  DataSourceName,
   DataSourceRequest,
   DataStreamQuery,
   RequestInformation,
@@ -8,26 +7,14 @@ import {
 } from '../types';
 import { TimeSeriesDataRequest } from '../data-cache/requestTypes';
 
-/**
- * Manages the collection of registered data sources, as well as delegating requests to the correct data-source.
- *
- * Data sources enable queries to be made to return data streams for use throughout.
- */
-export default class DataSourceStore {
-  // Currently, there are no data sources provided by default, but we will add defaults here as they are produced.
-  private dataSources: { [name: string]: DataSource } = {};
+export default class DataSourceStore<Query extends DataStreamQuery> {
+  private dataSource: DataSource<Query>;
 
-  private getDataSource = (source: DataSourceName): DataSource => {
-    if (this.dataSources[source] == null) {
-      throw new Error(
-        `Expected to find a data source with the name "${source}", but could not find the requested data source.`
-      );
-    }
+  constructor(dataSource: DataSource<Query>) {
+    this.dataSource = dataSource;
+  }
 
-    return this.dataSources[source];
-  };
-
-  public getRequestsFromQueries = <Query extends DataStreamQuery>({
+  public getRequestsFromQueries = ({
     queries,
     request,
   }: {
@@ -35,35 +22,19 @@ export default class DataSourceStore {
     request: TimeSeriesDataRequest;
   }): RequestInformation[] => queries.map((query) => this.getRequestsFromQuery({ query, request })).flat();
 
-  public getRequestsFromQuery = <Query extends DataStreamQuery>({
+  public getRequestsFromQuery = ({
     query,
     request,
   }: {
     query: Query;
     request: TimeSeriesDataRequest;
   }): RequestInformation[] => {
-    const dataSource = this.getDataSource(query.source);
-    return dataSource
+    return this.dataSource
       .getRequestsFromQuery({ query, request })
       .map((request) => ({ ...request, cacheSettings: query.cacheSettings }));
   };
 
-  public initiateRequest = <Query extends DataStreamQuery>(
-    request: DataSourceRequest<Query>,
-    requestInformations: RequestInformationAndRange[]
-  ) => {
-    const dataSource = this.getDataSource(request.query.source);
-    dataSource.initiateRequest(request, requestInformations);
-  };
-
-  public registerDataSource = <Query extends DataStreamQuery>(dataSource: DataSource<Query>) => {
-    if (this.dataSources[dataSource.name] != null) {
-      throw new Error(
-        `Attempted to add a data source with a name of "${dataSource.name}",
-        but the provided data source name is already present.`
-      );
-    }
-
-    this.dataSources[dataSource.name] = dataSource;
+  public initiateRequest = (request: DataSourceRequest<Query>, requestInformations: RequestInformationAndRange[]) => {
+    this.dataSource.initiateRequest(request, requestInformations);
   };
 }

--- a/packages/core/src/data-module/subscription-store/subscriptionStore.spec.ts
+++ b/packages/core/src/data-module/subscription-store/subscriptionStore.spec.ts
@@ -1,16 +1,14 @@
 import SubscriptionStore from './subscriptionStore';
-import { SiteWiseDataStreamQuery, Subscription } from '../types';
+import { DataSource, SiteWiseDataStreamQuery, Subscription } from '../types';
 import { DataCache } from '../data-cache/dataCacheWrapped';
 import DataSourceStore from '../data-source-store/dataSourceStore';
-import { DEFAULT_CACHE_SETTINGS } from '../IotAppKitDataModule';
+import { DEFAULT_CACHE_SETTINGS } from '../TimeSeriesDataModule';
 
 const createSubscriptionStore = () => {
-  const store = new DataSourceStore();
-  store.registerDataSource({
-    name: 'site-wise',
+  const store = new DataSourceStore({
     initiateRequest: () => {},
     getRequestsFromQuery: () => [],
-  });
+  } as DataSource<SiteWiseDataStreamQuery>);
 
   return new SubscriptionStore({
     dataCache: new DataCache(),
@@ -21,7 +19,7 @@ const createSubscriptionStore = () => {
 
 const MOCK_SUBSCRIPTION: Subscription<SiteWiseDataStreamQuery> = {
   emit: () => {},
-  queries: [{ source: 'site-wise', assets: [] }],
+  queries: [{ assets: [] }],
   request: {
     viewport: { start: new Date(2000, 0, 0), end: new Date() },
     settings: {
@@ -47,7 +45,6 @@ it('updates subscription', () => {
 
   const queries = [
     {
-      source: 'site-wise',
       assets: [{ assetId: '123', properties: [{ propertyId: 'prop1' }, { propertyId: 'prop2' }] }],
     },
   ];

--- a/packages/core/src/data-module/subscription-store/subscriptionStore.ts
+++ b/packages/core/src/data-module/subscription-store/subscriptionStore.ts
@@ -11,8 +11,8 @@ import { maxCacheDuration } from '../data-cache/caching/caching';
  *
  * Manages the collection of subscriptions
  */
-export default class SubscriptionStore {
-  private dataSourceStore: DataSourceStore;
+export default class SubscriptionStore<Query extends DataStreamQuery> {
+  private dataSourceStore: DataSourceStore<Query>;
   private dataCache: DataCache;
   private cacheSettings: CacheSettings;
   private unsubscribeMap: { [subscriberId: string]: () => void } = {};
@@ -24,7 +24,7 @@ export default class SubscriptionStore {
     dataCache,
     cacheSettings,
   }: {
-    dataSourceStore: DataSourceStore;
+    dataSourceStore: DataSourceStore<Query>;
     dataCache: DataCache;
     cacheSettings: CacheSettings;
   }) {
@@ -33,7 +33,7 @@ export default class SubscriptionStore {
     this.cacheSettings = cacheSettings;
   }
 
-  addSubscription<Query extends DataStreamQuery>(subscriptionId: string, subscription: Subscription<Query>): void {
+  addSubscription(subscriptionId: string, subscription: Subscription<Query>): void {
     if (this.subscriptions[subscriptionId] == null) {
       /**
        * If the subscription is query based
@@ -91,10 +91,7 @@ export default class SubscriptionStore {
     }
   }
 
-  updateSubscription<Query extends DataStreamQuery>(
-    subscriptionId: string,
-    subscriptionUpdate: SubscriptionUpdate<Query>
-  ): void {
+  updateSubscription(subscriptionId: string, subscriptionUpdate: SubscriptionUpdate<Query>): void {
     if (this.subscriptions[subscriptionId] == null) {
       throw new Error(
         `Attempted to update a subscription with an id of "${subscriptionId}", but the requested subscription does not exist.`

--- a/packages/core/src/data-module/types.ts
+++ b/packages/core/src/data-module/types.ts
@@ -47,11 +47,11 @@ export interface DataStream<T extends Primitive = Primitive> {
   isLoading?: boolean;
   isRefreshing?: boolean;
   error?: ErrorDetails;
+  // Mechanism to associate some information about the data stream
+  meta?: Record<string, string | number | boolean>;
 }
 
 export type DataSource<Query extends DataStreamQuery = AnyDataStreamQuery> = {
-  // An identifier for the name of the source, i.e. 'site-wise', 'roci', etc..
-  name: DataSourceName; // this is unique
   initiateRequest: (request: DataSourceRequest<Query>, requestInformations: RequestInformationAndRange[]) => void;
   getRequestsFromQuery: ({ query, request }: { query: Query; request: TimeSeriesDataRequest }) => RequestInformation[];
 };
@@ -80,7 +80,6 @@ export type DataModuleSubscription<Query extends DataStreamQuery> = {
 };
 
 export type DataStreamQuery = {
-  source: DataSourceName;
   cacheSettings?: CacheSettings;
 };
 
@@ -111,21 +110,13 @@ export type DataSourceRequest<Query extends DataStreamQuery> = {
  * Adds a subscription to the data-module.
  * The data-module will ensure that the requested data is provided to the subscriber.
  */
-type SubscribeToDataStreams = <Query extends DataStreamQuery>(
+type SubscribeToDataStreams<Query extends DataStreamQuery> = (
   { queries, request }: DataModuleSubscription<Query>,
   callback: (data: TimeSeriesData) => void
 ) => {
   unsubscribe: () => void;
   update: (subscriptionUpdate: SubscriptionUpdate<Query>) => void;
 };
-
-/**
- * The core of the IoT App Kit, manages the data, and getting data to those who subscribe.
- */
-export interface DataModule {
-  registerDataSource: <Query extends DataStreamQuery>(dataSource: DataSource<Query>) => void;
-  subscribeToDataStreams: SubscribeToDataStreams;
-}
 
 export type StyleSettingsMap = { [refId: string]: BaseStyleSettings };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,6 @@ export * from './common/viewport';
 export * from './common/time';
 export * from './common/combineProviders';
 
-export * from './data-module/IotAppKitDataModule';
+export * from './data-module/TimeSeriesDataModule';
 
 export * from './mockWidgetProperties';

--- a/packages/source-iotsitewise/src/component-session.ts
+++ b/packages/source-iotsitewise/src/component-session.ts
@@ -1,5 +1,6 @@
-import { DataModuleSession, IotAppKitDataModule, Session } from '@iot-app-kit/core';
+import { DataModuleSession, TimeSeriesDataModule, Session } from '@iot-app-kit/core';
 import { SiteWiseAssetModule } from './asset-modules';
+import { SiteWiseAssetDataStreamQuery } from './time-series-data/types';
 
 /**
  * Component session to manage component data module sessions.
@@ -8,7 +9,7 @@ import { SiteWiseAssetModule } from './asset-modules';
 export class SiteWiseComponentSession implements Session {
   public componentId: string;
 
-  public siteWiseTimeSeriesModule: IotAppKitDataModule;
+  public siteWiseTimeSeriesModule: TimeSeriesDataModule<SiteWiseAssetDataStreamQuery>;
 
   public siteWiseAssetModule: SiteWiseAssetModule;
 
@@ -20,7 +21,7 @@ export class SiteWiseComponentSession implements Session {
     siteWiseAssetModule,
   }: {
     componentId: string;
-    siteWiseTimeSeriesModule: IotAppKitDataModule;
+    siteWiseTimeSeriesModule: TimeSeriesDataModule<SiteWiseAssetDataStreamQuery>;
     siteWiseAssetModule: SiteWiseAssetModule;
   }) {
     this.componentId = componentId;

--- a/packages/source-iotsitewise/src/sessions.ts
+++ b/packages/source-iotsitewise/src/sessions.ts
@@ -1,8 +1,11 @@
-import { IotAppKitDataModule } from '@iot-app-kit/core';
+import { TimeSeriesDataModule } from '@iot-app-kit/core';
 import { SiteWiseComponentSession } from './component-session';
 import { SiteWiseAssetSession } from './asset-modules';
+import { SiteWiseAssetDataStreamQuery } from './time-series-data/types';
 
-export const timeSeriesDataSession = (session: SiteWiseComponentSession): IotAppKitDataModule => {
+export const timeSeriesDataSession = (
+  session: SiteWiseComponentSession
+): TimeSeriesDataModule<SiteWiseAssetDataStreamQuery> => {
   return session.siteWiseTimeSeriesModule;
 };
 

--- a/packages/source-iotsitewise/src/time-series-data/data-source.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/data-source.spec.ts
@@ -1,7 +1,7 @@
 import flushPromises from 'flush-promises';
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
-import { createDataSource, SITEWISE_DATA_SOURCE } from './data-source';
-import { MINUTE_IN_MS, HOUR_IN_MS, MONTH_IN_MS, IotAppKitDataModule, TimeSeriesDataRequest } from '@iot-app-kit/core';
+import { createDataSource } from './data-source';
+import { MINUTE_IN_MS, HOUR_IN_MS, MONTH_IN_MS, TimeSeriesDataModule, TimeSeriesDataRequest } from '@iot-app-kit/core';
 import { SiteWiseDataStreamQuery } from './types';
 import {
   AGGREGATE_VALUES,
@@ -74,7 +74,6 @@ describe('initiateRequest', () => {
         onError: noop,
         onSuccess: noop,
         query: {
-          source: SITEWISE_DATA_SOURCE,
           assets: [],
         },
         request: LAST_MINUTE_REQUEST,
@@ -102,7 +101,6 @@ describe('initiateRequest', () => {
       const PROPERTY_2 = 'prop-2';
 
       const query: SiteWiseDataStreamQuery = {
-        source: SITEWISE_DATA_SOURCE,
         assets: [{ assetId: ASSET_ID, properties: [{ propertyId: PROPERTY_1 }, { propertyId: PROPERTY_2 }] }],
       };
 
@@ -182,7 +180,6 @@ describe('initiateRequest', () => {
       const PROPERTY_2 = 'prop-2';
 
       const query: SiteWiseDataStreamQuery = {
-        source: SITEWISE_DATA_SOURCE,
         assets: [
           { assetId: ASSET_1, properties: [{ propertyId: PROPERTY_1 }] },
           { assetId: ASSET_2, properties: [{ propertyId: PROPERTY_2 }] },
@@ -265,7 +262,6 @@ describe('initiateRequest', () => {
       const PROPERTY_2 = 'prop-2';
 
       const query: SiteWiseDataStreamQuery = {
-        source: SITEWISE_DATA_SOURCE,
         assets: [{ assetId: ASSET_ID, properties: [{ propertyId: PROPERTY_1 }, { propertyId: PROPERTY_2 }] }],
       };
 
@@ -331,7 +327,6 @@ describe('initiateRequest', () => {
       const PROPERTY_2 = 'prop-2';
 
       const query: SiteWiseDataStreamQuery = {
-        source: SITEWISE_DATA_SOURCE,
         assets: [
           { assetId: ASSET_1, properties: [{ propertyId: PROPERTY_1 }] },
           { assetId: ASSET_2, properties: [{ propertyId: PROPERTY_2 }] },
@@ -399,7 +394,6 @@ describe('initiateRequest', () => {
       const PROPERTY_2 = 'prop-2';
 
       const query: SiteWiseDataStreamQuery = {
-        source: SITEWISE_DATA_SOURCE,
         assets: [{ assetId: ASSET_ID, properties: [{ propertyId: PROPERTY_1 }, { propertyId: PROPERTY_2 }] }],
       };
 
@@ -470,7 +464,6 @@ it('requests raw data if specified per asset property', async () => {
   const dataSource = createDataSource(mockSDK);
 
   const query: SiteWiseDataStreamQuery = {
-    source: SITEWISE_DATA_SOURCE,
     assets: [
       {
         assetId: 'some-asset-id',
@@ -560,14 +553,10 @@ it('requests raw data if specified per asset property', async () => {
 describe('e2e through data-module', () => {
   describe('fetching range of historical data', () => {
     it('reports error occurred on request initiation', async () => {
-      const dataModule = new IotAppKitDataModule();
-
       const batchGetAssetPropertyAggregates = jest.fn().mockResolvedValue(BATCH_ASSET_PROPERTY_ERROR);
-
       const mockSDK = createMockSiteWiseSDK({ batchGetAssetPropertyAggregates });
       const dataSource = createDataSource(mockSDK);
-
-      dataModule.registerDataSource(dataSource);
+      const dataModule = new TimeSeriesDataModule(dataSource);
 
       const timeSeriesCallback = jest.fn();
       const assetId = 'asset-id';
@@ -578,7 +567,6 @@ describe('e2e through data-module', () => {
           queries: [
             {
               assets: [{ assetId, properties: [{ propertyId }] }],
-              source: dataSource.name,
             } as SiteWiseDataStreamQuery,
           ],
           request: HISTORICAL_REQUEST,
@@ -605,15 +593,12 @@ describe('e2e through data-module', () => {
 
   describe('fetching latest value', () => {
     it('reports error occurred on request initiation', async () => {
-      const dataModule = new IotAppKitDataModule();
-
       const batchGetAssetPropertyValueHistory = jest.fn().mockResolvedValue(BATCH_ASSET_PROPERTY_VALUE_HISTORY);
       const batchGetAssetPropertyValue = jest.fn().mockResolvedValue(BATCH_ASSET_PROPERTY_ERROR);
 
       const mockSDK = createMockSiteWiseSDK({ batchGetAssetPropertyValueHistory, batchGetAssetPropertyValue });
       const dataSource = createDataSource(mockSDK);
-
-      dataModule.registerDataSource(dataSource);
+      const dataModule = new TimeSeriesDataModule(dataSource);
 
       const timeSeriesCallback = jest.fn();
       const assetId = 'asset-id';
@@ -624,7 +609,6 @@ describe('e2e through data-module', () => {
           queries: [
             {
               assets: [{ assetId, properties: [{ propertyId }] }],
-              source: dataSource.name,
             } as SiteWiseDataStreamQuery,
           ],
           request: {
@@ -670,7 +654,6 @@ describe.skip('aggregated data', () => {
     const dataSource = createDataSource(mockSDK);
 
     const query: SiteWiseDataStreamQuery = {
-      source: SITEWISE_DATA_SOURCE,
       assets: [{ assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] }],
     };
 
@@ -772,7 +755,6 @@ describe.skip('aggregated data', () => {
     const dataSource = createDataSource(mockSDK);
 
     const query: SiteWiseDataStreamQuery = {
-      source: SITEWISE_DATA_SOURCE,
       assets: [{ assetId: 'some-asset-id', properties: [{ propertyId: 'some-property-id' }] }],
     };
 
@@ -864,7 +846,6 @@ describe.skip('aggregated data', () => {
     const resolution = '1m';
 
     const query: SiteWiseDataStreamQuery = {
-      source: SITEWISE_DATA_SOURCE,
       assets: [
         {
           assetId: 'some-asset-id',
@@ -991,7 +972,6 @@ describe.skip('aggregated data', () => {
     const dataSource = createDataSource(mockSDK);
 
     const query: SiteWiseDataStreamQuery = {
-      source: SITEWISE_DATA_SOURCE,
       assets: [],
     };
 
@@ -1034,7 +1014,6 @@ describe('gets requests from query', () => {
     const REF_ID = 'some-ref';
 
     const query: SiteWiseDataStreamQuery = {
-      source: SITEWISE_DATA_SOURCE,
       assets: [
         {
           assetId: 'asset',
@@ -1059,14 +1038,11 @@ describe('gets requests from query', () => {
 });
 
 it.skip('only fetches uncached data for multiple properties', async () => {
-  const dataModule = new IotAppKitDataModule();
-
   const getAssetPropertyValueHistory = jest.fn().mockResolvedValue(ASSET_PROPERTY_VALUE_HISTORY);
 
   const mockSDK = createMockSiteWiseSDK({ getAssetPropertyValueHistory });
 
   const query: SiteWiseDataStreamQuery = {
-    source: SITEWISE_DATA_SOURCE,
     assets: [
       {
         assetId: 'some-asset-id',
@@ -1076,8 +1052,7 @@ it.skip('only fetches uncached data for multiple properties', async () => {
   };
 
   const dataSource = createDataSource(mockSDK);
-
-  dataModule.registerDataSource(dataSource);
+  const dataModule = new TimeSeriesDataModule(dataSource);
 
   const START_1 = new Date(2000, 1, 1);
   const END_1 = new Date(2000, 2, 1);
@@ -1109,7 +1084,6 @@ it.skip('only fetches uncached data for multiple properties', async () => {
   (getAssetPropertyValueHistory as Mock).mockClear();
 
   const updatedQuery: SiteWiseDataStreamQuery = {
-    source: SITEWISE_DATA_SOURCE,
     assets: [
       {
         assetId: 'some-asset-id',
@@ -1158,14 +1132,11 @@ it.skip('only fetches uncached data for multiple properties', async () => {
 });
 
 it.skip('requests buffered data', async () => {
-  const dataModule = new IotAppKitDataModule();
-
   const getAssetPropertyValueHistory = jest.fn().mockResolvedValue(ASSET_PROPERTY_VALUE_HISTORY);
 
   const mockSDK = createMockSiteWiseSDK({ getAssetPropertyValueHistory });
 
   const query: SiteWiseDataStreamQuery = {
-    source: SITEWISE_DATA_SOURCE,
     assets: [
       {
         assetId: 'some-asset-id',
@@ -1175,8 +1146,7 @@ it.skip('requests buffered data', async () => {
   };
 
   const dataSource = createDataSource(mockSDK);
-
-  dataModule.registerDataSource(dataSource);
+  const dataModule = new TimeSeriesDataModule(dataSource);
 
   const START = new Date(2000, 1, 1);
   const BUFFERED_START = new Date(2000, 0, 4, 15, 33, 20);

--- a/packages/source-iotsitewise/src/time-series-data/data-source.ts
+++ b/packages/source-iotsitewise/src/time-series-data/data-source.ts
@@ -13,8 +13,6 @@ import {
 } from '@iot-app-kit/core';
 import { SupportedResolutions } from './util/resolution';
 
-export const SITEWISE_DATA_SOURCE = 'site-wise';
-
 const DEFAULT_RESOLUTION_MAPPING = {
   [MINUTE_IN_MS * 15]: SupportedResolutions.ONE_MINUTE,
   [HOUR_IN_MS * 15]: SupportedResolutions.ONE_HOUR,
@@ -66,7 +64,6 @@ export const createDataSource = (
 ): DataSource<SiteWiseDataStreamQuery> => {
   const client = new SiteWiseClient(siteWise, settings);
   return {
-    name: SITEWISE_DATA_SOURCE,
     initiateRequest: ({ onSuccess, onError }, requestInformations) =>
       Promise.all([
         client.getLatestPropertyDataPoint({ onSuccess, onError, requestInformations }),

--- a/packages/source-iotsitewise/src/time-series-data/provider.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/provider.spec.ts
@@ -1,5 +1,5 @@
 import { SiteWiseTimeSeriesDataProvider } from './provider';
-import { IotAppKitDataModule, DataSource, DataStream, MINUTE_IN_MS, DATA_STREAM } from '@iot-app-kit/core';
+import { TimeSeriesDataModule, DataSource, DataStream, MINUTE_IN_MS, DATA_STREAM } from '@iot-app-kit/core';
 import { createSiteWiseAssetDataSource } from '../asset-modules/asset-data-source';
 import { DESCRIBE_ASSET_RESPONSE } from '../__mocks__/asset';
 import { SiteWiseComponentSession } from '../component-session';
@@ -8,14 +8,12 @@ import { createMockSiteWiseSDK } from '../__mocks__/iotsitewiseSDK';
 import { SiteWiseAssetModule } from '../asset-modules';
 
 const createMockSource = (dataStreams: DataStream[]): DataSource<SiteWiseDataStreamQuery> => ({
-  name: 'site-wise',
   initiateRequest: jest.fn(({ onSuccess }: { onSuccess: any }) => onSuccess(dataStreams)),
   getRequestsFromQuery: () => dataStreams.map((dataStream) => ({ id: dataStream.id, resolution: '0' })),
 });
 
-const timeSeriesModule = new IotAppKitDataModule();
 const dataSource = createMockSource([DATA_STREAM]);
-timeSeriesModule.registerDataSource(dataSource);
+const timeSeriesModule = new TimeSeriesDataModule(dataSource);
 
 const assetModule = new SiteWiseAssetModule(
   createSiteWiseAssetDataSource(
@@ -46,7 +44,7 @@ it.skip('subscribes, updates, and unsubscribes to time series data by delegating
   const refreshRate = MINUTE_IN_MS;
 
   const provider = new SiteWiseTimeSeriesDataProvider(componentSession, {
-    queries: [{ source: 'site-wise', assets: [] }],
+    queries: [{ assets: [] }],
     request: {
       viewport: { start: START_1, end: END_1 },
       settings: { fetchFromStartToEnd: true, refreshRate },

--- a/packages/source-iotsitewise/src/time-series-data/subscribeToTimeSeriesData.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/subscribeToTimeSeriesData.spec.ts
@@ -1,7 +1,7 @@
 import { subscribeToTimeSeriesData } from './subscribeToTimeSeriesData';
 import { createSiteWiseAssetDataSource } from '../asset-modules/asset-data-source';
 import { createMockSiteWiseSDK } from '../__mocks__/iotsitewiseSDK';
-import { IotAppKitDataModule } from '@iot-app-kit/core';
+import { TimeSeriesDataModule } from '@iot-app-kit/core';
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import flushPromises from 'flush-promises';
 import { createDataSource } from './data-source';
@@ -14,8 +14,7 @@ const initializeSubscribeToTimeSeriesData = (client: IoTSiteWiseClient) => {
   const assetDataSource: SiteWiseAssetDataSource = createSiteWiseAssetDataSource(client);
   const siteWiseAssetModule = new SiteWiseAssetModule(assetDataSource);
   const siteWiseAssetModuleSession = siteWiseAssetModule.startSession();
-  const dataModule = new IotAppKitDataModule();
-  dataModule.registerDataSource(createDataSource(client));
+  const dataModule = new TimeSeriesDataModule(createDataSource(client));
 
   return subscribeToTimeSeriesData(dataModule, siteWiseAssetModuleSession);
 };
@@ -35,7 +34,7 @@ it('unsubscribes', () => {
   const assetDataSource: SiteWiseAssetDataSource = createSiteWiseAssetDataSource(createMockSiteWiseSDK());
   const siteWiseAssetModule = new SiteWiseAssetModule(assetDataSource);
   const siteWiseAssetModuleSession = siteWiseAssetModule.startSession();
-  const dataModule = new IotAppKitDataModule();
+  const dataModule = new TimeSeriesDataModule(createDataSource(createMockSiteWiseSDK()));
 
   const unsubscribeSpy = jest.fn();
   jest.spyOn(dataModule, 'subscribeToDataStreams').mockImplementation(() => ({
@@ -85,7 +84,6 @@ it('provides time series data from iotsitewise', async () => {
     {
       queries: [
         {
-          source: 'site-wise',
           assets: [
             {
               assetId: ASSET_ID,
@@ -187,7 +185,6 @@ it('provides timeseries data from iotsitewise when subscription is updated', asy
   update({
     queries: [
       {
-        source: 'site-wise',
         assets: [
           {
             assetId: ASSET_ID,

--- a/packages/source-iotsitewise/src/time-series-data/subscribeToTimeSeriesData.ts
+++ b/packages/source-iotsitewise/src/time-series-data/subscribeToTimeSeriesData.ts
@@ -4,7 +4,7 @@ import { SiteWiseDataStreamQuery } from './types';
 import { MinimalViewPortConfig } from '@synchro-charts/core';
 import {
   ErrorDetails,
-  DataModule,
+  TimeSeriesDataModule,
   DataModuleSubscription,
   DataStream,
   TimeSeriesData,
@@ -13,7 +13,7 @@ import {
 import { SiteWiseAssetSession } from '../asset-modules';
 
 export const subscribeToTimeSeriesData =
-  (dataModule: DataModule, assetModuleSession: SiteWiseAssetSession) =>
+  (dataModule: TimeSeriesDataModule<SiteWiseDataStreamQuery>, assetModuleSession: SiteWiseAssetSession) =>
   ({ queries, request }: DataModuleSubscription<SiteWiseDataStreamQuery>, callback: (data: TimeSeriesData) => void) => {
     let dataStreams: DataStream[] = [];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5063,6 +5063,37 @@
     uuid "^3.3.2"
     validator "^13.6.0"
 
+"@synchro-charts/core@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@synchro-charts/core/-/core-6.0.1.tgz#b82788d027b598dab68862e17332398ceed3fd53"
+  integrity sha512-I0r2ckc8Bv1EKjv16TTb+0TVI5yqyVrIh6dZ1AopdpiIJO00jlxHDO7QtJnvXtjAbO4pThsDspRB88uXMiuaoQ==
+  dependencies:
+    "@stencil/redux" "^0.1.1"
+    "@types/d3" "^5.16.4"
+    d3-array "^2.3.2"
+    d3-axis "^1.0.12"
+    d3-brush "^1.1.3"
+    d3-drag "^1.2.5"
+    d3-scale "^3.2.0"
+    d3-selection "^1.3.1"
+    d3-zoom "^1.8.3"
+    detect-browser "^5.0.0"
+    immutability-helper "^3.0.1"
+    lodash.clonedeep "^4.5.0"
+    lodash.isequal "^4.5.0"
+    lodash.isnumber "^3.0.3"
+    lodash.round "^4.0.4"
+    lodash.throttle "^4.1.1"
+    lodash.uniq "^4.5.0"
+    lodash.uniqby "^4.7.0"
+    parse-duration "^1.0.0"
+    redux "^4.0.4"
+    resize-observer-polyfill "^1.5.1"
+    three "^0.125.0"
+    tippy.js "^5.2.0"
+    uuid "^3.3.2"
+    validator "^13.6.0"
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -5917,10 +5948,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
 
-"@types/node@^14.0.10", "@types/node@^14.14.31":
+"@types/node@^14.0.10":
   version "14.18.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.12.tgz#0d4557fd3b94497d793efd4e7d92df2f83b4ef24"
   integrity sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==
+
+"@types/node@^14.14.31":
+  version "14.18.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.24.tgz#406b220dc748947e1959d8a38a75979e87166704"
+  integrity sha512-aJdn8XErcSrfr7k8ZDDfU6/2OgjZcB2Fu9d+ESK8D7Oa5mtsv8Fa8GpcwTA0v60kuZBaalKPzuzun4Ov1YWO/w==
 
 "@types/node@^15.12.2":
   version "15.14.9"
@@ -6935,9 +6971,9 @@ ansi-colors@^3.0.0:
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
 ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
 ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
@@ -8953,9 +8989,9 @@ colord@^2.9.1, colord@^2.9.2:
   integrity sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==
 
 colorette@^2.0.16:
-  version "2.0.16"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
-  integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
+  integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
 colors@1.4.0:
   version "1.4.0"
@@ -9866,9 +9902,9 @@ cypress@^6.9.1:
     yauzl "^2.10.0"
 
 cypress@^9.6.1:
-  version "9.6.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.6.1.tgz#a7d6b5a53325b3dc4960181f5800a5ade0f085eb"
-  integrity sha512-ECzmV7pJSkk+NuAhEw6C3D+RIRATkSb2VAHXDY6qGZbca/F9mv5pPsj2LO6Ty6oIFVBTrwCyL9agl28MtJMe2g==
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.7.0.tgz#bf55b2afd481f7a113ef5604aa8b693564b5e744"
+  integrity sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -10147,7 +10183,12 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-dayjs@^1.10.4, dayjs@^1.9.3:
+dayjs@^1.10.4:
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.5.tgz#00e8cc627f231f9499c19b38af49f56dc0ac5e93"
+  integrity sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==
+
+dayjs@^1.9.3:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.0.tgz#009bf7ef2e2ea2d5db2e6583d2d39a4b5061e805"
   integrity sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==
@@ -11369,10 +11410,15 @@ event-pubsub@4.3.0:
   resolved "https://registry.yarnpkg.com/event-pubsub/-/event-pubsub-4.3.0.tgz#f68d816bc29f1ec02c539dc58c8dd40ce72cb36e"
   integrity sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==
 
-eventemitter2@^6.4.2, eventemitter2@^6.4.3:
+eventemitter2@^6.4.2:
   version "6.4.5"
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.5.tgz#97380f758ae24ac15df8353e0cc27f8b95644655"
   integrity sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==
+
+eventemitter2@^6.4.3:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
+  integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
 eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
@@ -19748,7 +19794,7 @@ proxy-addr@~2.0.7:
 proxy-from-env@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
-  integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
+  integrity sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==
 
 prr@~1.0.1:
   version "1.0.1"
@@ -20972,10 +21018,17 @@ rxjs@^6.2.0, rxjs@^6.3.3, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.4.0, rxjs@^7.5.1:
+rxjs@^7.4.0:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
+  dependencies:
+    tslib "^2.1.0"
+
+rxjs@^7.5.1:
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
+  integrity sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==
   dependencies:
     tslib "^2.1.0"
 


### PR DESCRIPTION
## Overview

- Add `meta` field to dataStream type to support sources providing meta information into data sources. This will help support alarm feature within the package `@iot-app-kit/source-twinmaker` which is a work in progress. Related commit in Synchro Charts: https://github.com/awslabs/synchro-charts/commit/e3ff0e10c14b45bdd4affffb08bcdd34b39f2aaf

- BREAKING CHANGE: Refactored export from `@iot-app-kit/core` IoTAppKitDataModule to be named TimeSeriesDataModule, and removed the concept of multiple data sources per time series data module

- Remove the `name` fields in queries internally, since it is no longer necessary as each time series data module only maps to one data source, as opposed to a single repository of all time series data sources.

- Upgrade Synchro Charts to latest version, 6.0.1

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
