### PR TITLE
feat(core): Support caching of dataType, name and other fields descri…

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "fix:eslint": "eslint --fix --ext .js,.ts,.tsx .",
     "fix:stylelint": "stylelint '**/*.css' --fix",
     "test": "npm-run-all -p test:unit test:eslint test:stylelint test:git",
-    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=49",
+    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=47",
     "test:stylelint": "stylelint '**/*.css' --max-warnings 0",
     "test:unit": "lerna run test --stream --concurrency 1",
     "test:git": "git diff --exit-code",

--- a/packages/core/src/data-module/data-cache/dataReducer.spec.ts
+++ b/packages/core/src/data-module/data-cache/dataReducer.spec.ts
@@ -745,6 +745,8 @@ it('merges data into existing data cache', () => {
     isLoading: false,
     isRefreshing: false,
     id: ID,
+    dataType: 'NUMBER',
+    name: 'some name',
     error: undefined,
     dataCache: {
       intervals: [[DATE_ONE, DATE_FOUR]],
@@ -855,6 +857,8 @@ describe('requests to different resolutions', () => {
           isLoading: false,
           isRefreshing: false,
           error: undefined,
+          dataType: 'NUMBER',
+          name: 'some name',
           requestHistory: [
             {
               start: NEW_FIRST_DATE,

--- a/packages/core/src/data-module/data-cache/dataReducer.ts
+++ b/packages/core/src/data-module/data-cache/dataReducer.ts
@@ -63,14 +63,14 @@ export const dataReducer: Reducer<DataStreamsStore, AsyncActions> = (
     }
 
     case SUCCESS: {
-      const { id, data, first, last, requestInformation } = action.payload;
-      const streamStore = getDataStreamStore(id, data.resolution, state);
+      const { id, data: dataStream, first, last, requestInformation } = action.payload;
+      const streamStore = getDataStreamStore(id, dataStream.resolution, state);
       // Updating request cache is a hack to deal with latest value update
       // TODO: clean this to one single source of truth cache
       const requestCache = streamStore != null ? streamStore.requestCache : EMPTY_CACHE;
 
       // We always want data in ascending order in the cache
-      const sortedData = getDataPoints(data, data.resolution).sort((a, b) => a.x - b.x);
+      const sortedData = getDataPoints(dataStream, dataStream.resolution).sort((a, b) => a.x - b.x);
 
       /**
        * Based on the type of request, determine the actual range requested.
@@ -98,14 +98,16 @@ export const dataReducer: Reducer<DataStreamsStore, AsyncActions> = (
 
       const existingRequestHistory = streamStore ? streamStore.requestHistory : [];
 
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { data, aggregates, ...restOfDataStream } = dataStream;
+
       return {
         ...state,
         [id]: {
           ...state[id],
-          [data.resolution]: {
+          [dataStream.resolution]: {
             ...streamStore,
-            resolution: data.resolution,
-            id,
+            ...restOfDataStream,
             requestHistory: mergeHistoricalRequests(existingRequestHistory, {
               start: intervalStart,
               end: last,

--- a/packages/core/src/data-module/data-cache/toDataStreams.spec.ts
+++ b/packages/core/src/data-module/data-cache/toDataStreams.spec.ts
@@ -64,6 +64,9 @@ const rawStore = {
   }),
   requestCache: EMPTY_CACHE,
   requestHistory: [],
+  meta: { key: 1000 },
+  name: 'somedatastreamname',
+  dataType: 'NUMBER',
   isLoading: false,
   isRefreshing: false,
 };
@@ -110,6 +113,17 @@ it('returns a single data stream containing all the available resolutions', () =
   // expect(stream.streamType).toEqual(ALARM_STREAM_INFO.streamType);
   expect(stream.data).toEqual(ALARM_STREAM.data);
   expect(stream.aggregates![MINUTE_IN_MS]).toEqual(NUMBER_STREAM_1.data);
+});
+
+it('appends additional information about dataStream that is cached', () => {
+  const [stream] = toDataStreams({
+    requestInformations: [{ ...ALARM_STREAM_INFO, resolution: '0' }],
+    dataStreamsStores: STORE_WITH_NUMBERS_ONLY,
+  });
+
+  expect(stream.dataType).toEqual(rawStore.dataType);
+  expect(stream.name).toEqual(rawStore.name);
+  expect(stream.meta).toEqual(rawStore.meta);
 });
 
 it('appends the refId from the request information', () => {

--- a/packages/core/src/data-module/data-cache/toDataStreams.ts
+++ b/packages/core/src/data-module/data-cache/toDataStreams.ts
@@ -1,5 +1,5 @@
 import { DataPoint } from '@synchro-charts/core';
-import { DataStreamsStore } from './types';
+import { DataStreamsStore, DataStreamStore } from './types';
 import { isDefined } from '../../common/predicates';
 import { DataStream, RequestInformation } from '../types';
 import { parseDuration } from '../../common/time';
@@ -32,17 +32,19 @@ export const toDataStreams = ({
       {}
     );
 
-    const activeStore = streamsResolutions[parseDuration(info.resolution)];
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { dataCache, requestCache, requestHistory, ...restOfStream } = streamsResolutions[
+      parseDuration(info.resolution)
+    ] as DataStreamStore;
+
     const rawData: DataPoint[] = streamsResolutions[0] ? streamsResolutions[0].dataCache.items.flat() : [];
 
     // Create new data stream for the corresponding info
     return {
+      ...restOfStream,
       id: info.id,
       refId: info.refId,
       resolution: parseDuration(info.resolution),
-      isLoading: activeStore ? activeStore.isLoading : false,
-      isRefreshing: activeStore ? activeStore.isRefreshing : false,
-      error: activeStore ? activeStore.error : undefined,
       data: rawData,
       aggregates,
     };

--- a/packages/core/src/data-module/data-cache/types.ts
+++ b/packages/core/src/data-module/data-cache/types.ts
@@ -1,6 +1,7 @@
 import { DataPoint, Primitive } from '@synchro-charts/core';
 import { IntervalStructure } from '../../common/intervalStructure';
 import { ErrorDetails } from '../../common/types';
+import { DataStream } from '../types';
 
 type TTL = number;
 export type TTLDurationMapping = {
@@ -27,7 +28,7 @@ export type DataStreamStore = {
   // When data is being requested, whether or not data has been previously requested
   isRefreshing: boolean;
   error?: ErrorDetails;
-};
+} & Omit<DataStream, 'data' | 'aggregates'>;
 
 export type DataStreamsStore = {
   [dataStreamId: string]:

--- a/packages/core/src/data-module/types.ts
+++ b/packages/core/src/data-module/types.ts
@@ -104,20 +104,6 @@ export type DataSourceRequest<Query extends DataStreamQuery> = {
   onError: ErrorCallback;
 };
 
-/**
- * Subscribe to data streams
- *
- * Adds a subscription to the data-module.
- * The data-module will ensure that the requested data is provided to the subscriber.
- */
-type SubscribeToDataStreams<Query extends DataStreamQuery> = (
-  { queries, request }: DataModuleSubscription<Query>,
-  callback: (data: TimeSeriesData) => void
-) => {
-  unsubscribe: () => void;
-  update: (subscriptionUpdate: SubscriptionUpdate<Query>) => void;
-};
-
 export type StyleSettingsMap = { [refId: string]: BaseStyleSettings };
 
 // Style settings sharable by all components

--- a/packages/source-iotsitewise/src/time-series-data/provider.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/provider.spec.ts
@@ -1,5 +1,12 @@
 import { SiteWiseTimeSeriesDataProvider } from './provider';
-import { TimeSeriesDataModule, DataSource, DataStream, MINUTE_IN_MS, DATA_STREAM } from '@iot-app-kit/core';
+import {
+  TimeSeriesDataModule,
+  DataSource,
+  DataStream,
+  MINUTE_IN_MS,
+  DATA_STREAM,
+  OnSuccessCallback,
+} from '@iot-app-kit/core';
 import { createSiteWiseAssetDataSource } from '../asset-modules/asset-data-source';
 import { DESCRIBE_ASSET_RESPONSE } from '../__mocks__/asset';
 import { SiteWiseComponentSession } from '../component-session';
@@ -8,7 +15,9 @@ import { createMockSiteWiseSDK } from '../__mocks__/iotsitewiseSDK';
 import { SiteWiseAssetModule } from '../asset-modules';
 
 const createMockSource = (dataStreams: DataStream[]): DataSource<SiteWiseDataStreamQuery> => ({
-  initiateRequest: jest.fn(({ onSuccess }: { onSuccess: any }) => onSuccess(dataStreams)),
+  initiateRequest: jest.fn(({ onSuccess }: { onSuccess: OnSuccessCallback }) =>
+    onSuccess(dataStreams, { start: new Date(), resolution: '1m', end: new Date(), id: '123' }, new Date(), new Date())
+  ),
   getRequestsFromQuery: () => dataStreams.map((dataStream) => ({ id: dataStream.id, resolution: '0' })),
 });
 


### PR DESCRIPTION
## Overview
Add changes to the core of the TimeSeriesDataModule to support data sources which can directly provide information about data streams. This helps support the development of the TwinMaker time-series data source.

- Update caching layer to cache information about datastreams, allowing datastream names, dataTypes, and meta information to be cached.
- Update logic which constructs datastreams from cache, to utilize additional datastream fields
- fix minor eslint warnings, reduced count of total warnings.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
