### PR TITLE
feat(core,source-iotsitewise)!: Async getRequestsFromQueries

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "fix:eslint": "eslint --fix --ext .js,.ts,.tsx .",
     "fix:stylelint": "stylelint '**/*.css' --fix",
     "test": "npm-run-all -p test:unit test:eslint test:stylelint test:git",
-    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=47",
+    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=37",
     "test:stylelint": "stylelint '**/*.css' --max-warnings 0",
     "test:unit": "lerna run test --stream --concurrency 1",
     "test:git": "git diff --exit-code",

--- a/packages/core/src/__mocks__/data-source.ts
+++ b/packages/core/src/__mocks__/data-source.ts
@@ -39,7 +39,7 @@ export const createMockSiteWiseDataSource = (
     }
   ),
   getRequestsFromQuery: ({ query }) =>
-    query.assets
+    Promise.resolve(query.assets
       .map(({ assetId, properties }) =>
         properties.map(({ propertyId, refId }) => ({
           id: toDataStreamId({ assetId, propertyId }),
@@ -47,5 +47,5 @@ export const createMockSiteWiseDataSource = (
           resolution: '0',
         }))
       )
-      .flat(),
+      .flat()),
 });

--- a/packages/core/src/data-module/data-source-store/dataSourceStore.spec.ts
+++ b/packages/core/src/data-module/data-source-store/dataSourceStore.spec.ts
@@ -2,7 +2,7 @@ import DataSourceStore from './dataSourceStore';
 import { DataSource } from '../types';
 
 it('initiate a request on a registered data source', () => {
-  const customSource: DataSource = { initiateRequest: jest.fn(), getRequestsFromQuery: () => [] };
+  const customSource: DataSource = { initiateRequest: jest.fn(), getRequestsFromQuery: () => Promise.resolve([]) };
   const dataSourceStore = new DataSourceStore(customSource);
 
   const query = { source: 'custom' };

--- a/packages/core/src/data-module/subscription-store/subscriptionStore.spec.ts
+++ b/packages/core/src/data-module/subscription-store/subscriptionStore.spec.ts
@@ -7,7 +7,7 @@ import { DEFAULT_CACHE_SETTINGS } from '../TimeSeriesDataModule';
 const createSubscriptionStore = () => {
   const store = new DataSourceStore({
     initiateRequest: () => {},
-    getRequestsFromQuery: () => [],
+    getRequestsFromQuery: () => Promise.resolve([]),
   } as DataSource<SiteWiseDataStreamQuery>);
 
   return new SubscriptionStore({
@@ -30,16 +30,16 @@ const MOCK_SUBSCRIPTION: Subscription<SiteWiseDataStreamQuery> = {
   fulfill: () => {},
 };
 
-it('adds subscription', () => {
+it('adds subscription', async () => {
   const subscriptionStore = createSubscriptionStore();
-  subscriptionStore.addSubscription('some-id', MOCK_SUBSCRIPTION);
+  await subscriptionStore.addSubscription('some-id', MOCK_SUBSCRIPTION);
 
   expect(subscriptionStore.getSubscriptions()).toEqual([MOCK_SUBSCRIPTION]);
 
   subscriptionStore.removeSubscription('some-id');
 });
 
-it('updates subscription', () => {
+it('updates subscription', async () => {
   const SUBSCRIPTION_ID = 'some-id';
   const subscriptionStore = createSubscriptionStore();
 
@@ -49,35 +49,35 @@ it('updates subscription', () => {
     },
   ];
 
-  subscriptionStore.addSubscription(SUBSCRIPTION_ID, MOCK_SUBSCRIPTION);
-  subscriptionStore.updateSubscription(SUBSCRIPTION_ID, { queries });
+  await subscriptionStore.addSubscription(SUBSCRIPTION_ID, MOCK_SUBSCRIPTION);
+  await subscriptionStore.updateSubscription(SUBSCRIPTION_ID, { queries });
 
   expect(subscriptionStore.getSubscriptions()).toEqual([{ ...MOCK_SUBSCRIPTION, queries }]);
 
   subscriptionStore.removeSubscription(SUBSCRIPTION_ID);
 });
 
-it('removes subscription', () => {
+it('removes subscription', async () => {
   const SUBSCRIPTION_ID = 'some-id';
   const subscriptionStore = createSubscriptionStore();
-  subscriptionStore.addSubscription(SUBSCRIPTION_ID, MOCK_SUBSCRIPTION);
+  await subscriptionStore.addSubscription(SUBSCRIPTION_ID, MOCK_SUBSCRIPTION);
   subscriptionStore.removeSubscription(SUBSCRIPTION_ID);
 
   expect(subscriptionStore.getSubscriptions()).toBeEmpty();
 });
 
-it('gets subscription by subscriptionId', () => {
+it('gets subscription by subscriptionId', async () => {
   const subscriptionStore = createSubscriptionStore();
-  subscriptionStore.addSubscription('some-id', MOCK_SUBSCRIPTION);
+  await subscriptionStore.addSubscription('some-id', MOCK_SUBSCRIPTION);
 
   expect(subscriptionStore.getSubscription('some-id')).toEqual(MOCK_SUBSCRIPTION);
   subscriptionStore.removeSubscription('some-id');
 });
 
 describe('throws errors when', () => {
-  it('throws error when trying to update non-existent subscription', () => {
+  it('throws error when trying to update non-existent subscription', async () => {
     const subscriptionStore = createSubscriptionStore();
-    expect(() => subscriptionStore.updateSubscription('some-id', {})).toThrowError(/some-id/);
+    await expect(subscriptionStore.updateSubscription('some-id', {})).rejects.toThrowError(/some-id/);
   });
 
   it('throws error when trying to remove non-existent subscription', () => {
@@ -85,12 +85,12 @@ describe('throws errors when', () => {
     expect(() => subscriptionStore.removeSubscription('some-id')).toThrowError(/some-id/);
   });
 
-  it('throws error when trying to add the same subscription id twice', () => {
+  it('throws error when trying to add the same subscription id twice', async () => {
     const SUBSCRIPTION_ID = 'some-id';
     const subscriptionStore = createSubscriptionStore();
 
-    subscriptionStore.addSubscription(SUBSCRIPTION_ID, MOCK_SUBSCRIPTION);
-    expect(() => subscriptionStore.addSubscription(SUBSCRIPTION_ID, MOCK_SUBSCRIPTION)).toThrowError(/some-id/);
+    await subscriptionStore.addSubscription(SUBSCRIPTION_ID, MOCK_SUBSCRIPTION);
+    await expect(subscriptionStore.addSubscription(SUBSCRIPTION_ID, MOCK_SUBSCRIPTION)).rejects.toThrowError(/some-id/);
 
     subscriptionStore.removeSubscription('some-id');
   });

--- a/packages/core/src/data-module/types.ts
+++ b/packages/core/src/data-module/types.ts
@@ -53,7 +53,13 @@ export interface DataStream<T extends Primitive = Primitive> {
 
 export type DataSource<Query extends DataStreamQuery = AnyDataStreamQuery> = {
   initiateRequest: (request: DataSourceRequest<Query>, requestInformations: RequestInformationAndRange[]) => void;
-  getRequestsFromQuery: ({ query, request }: { query: Query; request: TimeSeriesDataRequest }) => RequestInformation[];
+  getRequestsFromQuery: ({
+    query,
+    request,
+  }: {
+    query: Query;
+    request: TimeSeriesDataRequest;
+  }) => Promise<RequestInformation[]>;
 };
 
 export type DataStreamCallback = (dataStreams: DataStream[], requestInformation: RequestInformationAndRange) => void;
@@ -118,7 +124,7 @@ export type SubscriptionResponse<Query extends DataStreamQuery> = {
   unsubscribe: () => void;
 
   /** Update the subscription. This will immediately evaluate if a new query must be requested */
-  update: (subscriptionUpdate: SubscriptionUpdate<Query>) => void;
+  update: (subscriptionUpdate: SubscriptionUpdate<Query>) => Promise<void>;
 };
 
 // SiteWise specific types - eventually remove these from here

--- a/packages/related-table/src/Hooks/useTreeCollection.ts
+++ b/packages/related-table/src/Hooks/useTreeCollection.ts
@@ -47,10 +47,12 @@ export const useTreeCollection = <T>(
   const expandNode = (node: ITreeNode<T>) => {
     if (node) {
       const key = (node as any)[keyPropertyName];
-      const internalNode = nodes.find((n) => (n as any)[keyPropertyName] === key)!;
-      internalNode.toggleExpandCollapse();
-      expandOrCollapseChildren(internalNode, treeMap, keyPropertyName);
-      treeMap.set(key, internalNode);
+      const internalNode = nodes.find((n) => (n as any)[keyPropertyName] === key);
+      if (internalNode) {
+        internalNode.toggleExpandCollapse();
+        expandOrCollapseChildren(internalNode, treeMap, keyPropertyName);
+        treeMap.set(key, internalNode);
+      }
       const updatedNodes = nodes.concat([]);
       setNodes(updatedNodes);
       setTreeMap(treeMap);

--- a/packages/related-table/src/RelatedTable/RelatedTable.test.tsx
+++ b/packages/related-table/src/RelatedTable/RelatedTable.test.tsx
@@ -62,7 +62,7 @@ it('expand button correctly', () => {
   expect(buttons.length).toEqual(1);
 
   act(() => {
-    buttons[0]!.click();
+    buttons[0]?.click();
   });
 
   expect(onExpandChildren).toHaveBeenCalled();

--- a/packages/related-table/src/utils/build.ts
+++ b/packages/related-table/src/utils/build.ts
@@ -47,7 +47,8 @@ const createNode = <T>(
 
 const prepareNode = <T>(node: ITreeNode<T>, treeMap: TreeMap<T>, keyPropertyName: string): ITreeNode<T> => {
   const key = (node as any)[keyPropertyName];
-  const isVisible = node.getParent() ? node.getParent()!.isExpanded() && node.getParent()!.isVisible() : true;
+  const parent = node.getParent();
+  const isVisible = parent ? parent.isExpanded() && parent.isVisible() : true;
   node.setVisible(isVisible);
   node.setStatus(
     node.hasChildren || node.getChildren().length > 0
@@ -79,7 +80,8 @@ export const buildTreeNodes = <T>(
 };
 
 export const recursiveBuildTreePrefix = <T>(node: ITreeNode<T>, index: number, parentLastChildPath: boolean[]) => {
-  const isLastChild = node.getParent() ? node.getParent()!.getChildren().length - 1 === index : true;
+  const parent = node.getParent();
+  const isLastChild = parent ? parent.getChildren().length - 1 === index : true;
   node.buildPrefix(isLastChild, parentLastChildPath);
   node
     .getChildren()

--- a/packages/related-table/src/utils/cleanup.ts
+++ b/packages/related-table/src/utils/cleanup.ts
@@ -4,9 +4,11 @@ const removeNode = <T>(node: ITreeNode<T>, keyPropertyName: string, treeMap: Tre
   const key = (node as any)[keyPropertyName];
 
   if (node.getParent()) {
-    const parentChildren = node.getParent()!.getChildren();
-    const childIndex = parentChildren.findIndex((child) => child === node);
-    parentChildren.splice(childIndex, 1);
+    const parentChildren = node.getParent()?.getChildren();
+    const childIndex = parentChildren?.findIndex((child) => child === node);
+    if (childIndex != null) {
+      parentChildren?.splice(childIndex, 1);
+    }
     node.setParentNode(undefined);
   }
 

--- a/packages/related-table/src/utils/sort.ts
+++ b/packages/related-table/src/utils/sort.ts
@@ -27,10 +27,10 @@ export const sortTree = <T>(
 ) => {
   const { sortingColumn } = sortState;
   if (sortingColumn && sortingColumn.sortingField) {
-    const columnDefinition = columnsDefinitions.find((column) => column.sortingField === sortingColumn.sortingField)!;
+    const columnDefinition = columnsDefinitions.find((column) => column.sortingField === sortingColumn.sortingField);
     const direction = sortState.isDescending ? -1 : 1;
     const comparator =
-      columnDefinition.sortingComparator || defaultComparator(sortState.sortingColumn.sortingField as keyof T);
+      columnDefinition?.sortingComparator || defaultComparator(sortState.sortingColumn.sortingField as keyof T);
 
     tree
       .sort((a: T, b: T) => comparator(a, b) * direction)

--- a/packages/related-table/src/utils/utils.test.ts
+++ b/packages/related-table/src/utils/utils.test.ts
@@ -71,7 +71,7 @@ describe('TreeUtility', () => {
     nodes.forEach((node) => treeMap.set(node.id, node));
 
     const newItems = [...items];
-    const parentIndex = newItems.findIndex((item) => item.name === 'Parent')!;
+    const parentIndex = newItems.findIndex((item) => item.name === 'Parent');
     const newParentItem = {
       ...items[parentIndex],
       priority: 99,
@@ -81,7 +81,7 @@ describe('TreeUtility', () => {
     const newNodes = flatTree(buildTreeNodes(newItems, treeMap, 'id', 'parentId'));
     const parentNode = newNodes.find((item) => item.name === 'Parent');
     expect(parentNode).toBeDefined();
-    expect(parentNode!.priority).toBe(newParentItem.priority);
+    expect(parentNode?.priority).toBe(newParentItem.priority);
   });
 
   it('delete nodes', () => {
@@ -89,7 +89,7 @@ describe('TreeUtility', () => {
     nodes.forEach((node) => treeMap.set(node.id, node));
 
     const newItems = [...items];
-    const parentIndex = newItems.findIndex((item) => item.name === 'Parent')!;
+    const parentIndex = newItems.findIndex((item) => item.name === 'Parent');
     newItems.splice(parentIndex, 1);
 
     const newNodes = flatTree(buildTreeNodes(newItems, treeMap, 'id', 'parentId'));

--- a/packages/source-iotsitewise/src/time-series-data/data-source.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/data-source.spec.ts
@@ -1007,7 +1007,7 @@ describe.skip('aggregated data', () => {
 });
 
 describe('gets requests from query', () => {
-  it("appends refId's to the requests from the query", () => {
+  it("appends refId's to the requests from the query", async () => {
     const mockSDK = createMockSiteWiseSDK({});
 
     const dataSource = createDataSource(mockSDK);
@@ -1033,7 +1033,9 @@ describe('gets requests from query', () => {
       },
     };
 
-    expect(dataSource.getRequestsFromQuery({ query, request })).toEqual([expect.objectContaining({ refId: REF_ID })]);
+    const requestInfos = await dataSource.getRequestsFromQuery({ query, request });
+
+    expect(requestInfos).toEqual([expect.objectContaining({ refId: REF_ID })]);
   });
 });
 
@@ -1092,7 +1094,7 @@ it.skip('only fetches uncached data for multiple properties', async () => {
     ],
   };
 
-  update({ queries: [updatedQuery], request: { viewport: { start: START_2, end: END_2 } } });
+  await update({ queries: [updatedQuery], request: { viewport: { start: START_2, end: END_2 } } });
 
   await flushPromises();
 

--- a/packages/source-iotsitewise/src/time-series-data/data-source.ts
+++ b/packages/source-iotsitewise/src/time-series-data/data-source.ts
@@ -75,7 +75,7 @@ export const createDataSource = (
         }),
         client.getHistoricalPropertyDataPoints({ requestInformations, onSuccess, onError }),
       ]),
-    getRequestsFromQuery: ({ query, request }) => {
+    getRequestsFromQuery: async ({ query, request }) => {
       const resolution = determineResolution({
         resolution: request.settings?.resolution,
         start: viewportStartDate(request.viewport),

--- a/packages/source-iotsitewise/src/time-series-data/provider.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/provider.spec.ts
@@ -18,7 +18,7 @@ const createMockSource = (dataStreams: DataStream[]): DataSource<SiteWiseDataStr
   initiateRequest: jest.fn(({ onSuccess }: { onSuccess: OnSuccessCallback }) =>
     onSuccess(dataStreams, { start: new Date(), resolution: '1m', end: new Date(), id: '123' }, new Date(), new Date())
   ),
-  getRequestsFromQuery: () => dataStreams.map((dataStream) => ({ id: dataStream.id, resolution: '0' })),
+  getRequestsFromQuery: async () => dataStreams.map((dataStream) => ({ id: dataStream.id, resolution: '0' })),
 });
 
 const dataSource = createMockSource([DATA_STREAM]);

--- a/packages/source-iotsitewise/src/time-series-data/subscribeToTimeSeriesData.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/subscribeToTimeSeriesData.spec.ts
@@ -39,7 +39,7 @@ it('unsubscribes', () => {
   const unsubscribeSpy = jest.fn();
   jest.spyOn(dataModule, 'subscribeToDataStreams').mockImplementation(() => ({
     unsubscribe: unsubscribeSpy,
-    update: () => {},
+    update: async () => {},
   }));
 
   const subscribe = subscribeToTimeSeriesData(dataModule, siteWiseAssetModuleSession);


### PR DESCRIPTION
## Overview
Refactor the core TimeSeriesDataModule to make `getRequestsFromQueries` be async. This allows data sources to be implemented where network calls or other async processes are required to interpret a query. This supports TwinMaker, which requires additional network requests to determine the underlying entity structure from a query, however this is useful more generically.

This change to an async getRequestFromQueries is a *BREAKING CHANGE*. To migrate, a data source created utilizing the TimeSeriesDataModule must refactor `getRequestFromQueries` to return a promise.

Additionally resolved more eslint warnings.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
