### PR TITLE
chore: remove unnecessary template section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,5 @@
 ## Overview
 Provide an explanation of what the change is
 
-## Tests
-[Include a link to the passing GitHub action running the test suite here.]
-
 ## Legal
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).


### PR DESCRIPTION
## Overview
Remove necessary test section from template. Tests are ran in the CI, and the results are automatically posted already. having sections of a template that everyone ignores, trains people to in general ignore the PR template which is bad.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
