### PR TITLE
fix(dashboard): move messageOverrides merge to componentWillUpdate()

### DIFF
--- a/packages/dashboard/src/components.d.ts
+++ b/packages/dashboard/src/components.d.ts
@@ -111,6 +111,7 @@ export namespace Components {
     interface IotDashboardWidget {
         "cellSize": number;
         "isSelected": boolean;
+        "messageOverrides": DashboardMessages;
         "viewport": MinimalViewPortConfig;
         "widget": Widget;
         "width": number;
@@ -321,6 +322,7 @@ declare namespace LocalJSX {
     interface IotDashboardWidget {
         "cellSize"?: number;
         "isSelected"?: boolean;
+        "messageOverrides"?: DashboardMessages;
         "viewport"?: MinimalViewPortConfig;
         "widget"?: Widget;
         "width"?: number;

--- a/packages/dashboard/src/components/iot-dashboard/__snapshots__/iot-dashboard.spec.tsx.snap
+++ b/packages/dashboard/src/components/iot-dashboard/__snapshots__/iot-dashboard.spec.tsx.snap
@@ -7,3 +7,11 @@ exports[`renders 1`] = `
   </div>
 </iot-dashboard-widget>
 `;
+
+exports[`renders correct messageOverride: before messageOverride change 1`] = `
+<iot-dashboard-widget style="position: absolute; z-index: 1; top: 5px; left: 5px; width: 40px; height: 25px;">
+  <div class="false widget" id="mock-kpi-widget">
+    <iot-dashboard-dynamic-widget componenttag="iot-kpi" invalidtagerrorheader="__Invalid tag header__" invalidtagerrorsubheader="__Invalid tag subheader__" widgetid="mock-kpi-widget"></iot-dashboard-dynamic-widget>
+  </div>
+</iot-dashboard-widget>
+`;

--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard-internal.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard-internal.tsx
@@ -446,6 +446,7 @@ export class IotDashboardInternal {
             cellSize={this.cellSize}
             widget={widget}
             viewport={this.dashboardConfiguration.viewport}
+            messageOverrides={this.messageOverrides}
           />
         ))}
 

--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard-widget/iot-dashboard-widget.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard-widget/iot-dashboard-widget.tsx
@@ -1,6 +1,7 @@
 import { Component, Prop, h, Host } from '@stencil/core';
 import { MinimalViewPortConfig } from '@synchro-charts/core';
-import { Widget } from '../../../types';
+import { RecursivePartial, Widget } from '../../../types';
+import { DashboardMessages } from '../../../messages';
 
 @Component({
   tag: 'iot-dashboard-widget',
@@ -13,15 +14,13 @@ export class IotDashboardWidget {
   @Prop() width: number;
   @Prop() widget: Widget;
   @Prop() viewport: MinimalViewPortConfig;
+  @Prop() messageOverrides: DashboardMessages;
 
   render() {
     const { x, y, z, width, height, id, componentTag, queries, properties, annotations } = this.widget;
     const { cellSize } = this;
 
-    // I18n?
-    const invalidTagErrorHeader = 'Widget failed to load';
-    const invalidTagErrorSubheader = 'Please try again later or contact an admin for help.';
-
+    const { invalidTagHeader, invalidTagSubheader } = this.messageOverrides.widgets;
     return (
       <Host
         style={{
@@ -41,8 +40,8 @@ export class IotDashboardWidget {
             viewport={this.viewport}
             componentTag={componentTag}
             widgetId={id}
-            invalidTagErrorHeader={invalidTagErrorHeader}
-            invalidTagErrorSubheader={invalidTagErrorSubheader}
+            invalidTagErrorHeader={invalidTagHeader}
+            invalidTagErrorSubheader={invalidTagSubheader}
           />
         </div>
       </Host>

--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard.spec.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard.spec.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable import/first */
 
 jest.mock('resize-observer-polyfill');
-
 import { MockDashboardFactory, MOCK_EMPTY_DASHBOARD, MOCK_KPI_WIDGET } from '../../testing/mocks';
 
 import { newSpecPage, jestSetupTestFramework } from '@stencil/core/testing';
@@ -11,6 +10,7 @@ import { Components } from '../../components.d';
 import { CustomHTMLElement } from '../../testing/types';
 import { update } from '../../testing/update';
 import { IotDashboardInternal } from './iot-dashboard-internal';
+import { DefaultDashboardMessages } from '../../messages';
 
 const dashboardSpecPage = async (propOverrides: Partial<Components.IotDashboardInternal> = {}) => {
   const page = await newSpecPage({
@@ -40,6 +40,7 @@ it('renders', async () => {
     dashboardConfiguration: MockDashboardFactory.get({ widgets: [MOCK_KPI_WIDGET] }),
     cellSize: 5,
     width: 500,
+    messageOverrides: DefaultDashboardMessages,
   });
 
   const widgets = dashboard.querySelectorAll('iot-dashboard-widget');
@@ -49,4 +50,26 @@ it('renders', async () => {
   expect(widget.widget).toEqual(MOCK_KPI_WIDGET);
   expect(widget).toMatchSnapshot();
   expect(widget).not.toHaveAttribute('isSelected');
+});
+
+it('renders correct messageOverride', async () => {
+  const messageOverrides = {
+    widgets: {
+      invalidTagHeader: '__Invalid tag header__',
+      invalidTagSubheader: '__Invalid tag subheader__',
+    },
+  } as Components.IotDashboardInternal['messageOverrides'];
+  const { dashboard } = await dashboardSpecPage({
+    dashboardConfiguration: MockDashboardFactory.get({ widgets: [MOCK_KPI_WIDGET] }),
+    cellSize: 5,
+    width: 500,
+    messageOverrides,
+  });
+
+  const widgets = dashboard.querySelectorAll('iot-dashboard-widget');
+  expect(widgets.length).toBe(1);
+  const widget = widgets[0];
+
+  expect(widget.widget).toEqual(MOCK_KPI_WIDGET);
+  expect(widget).toMatchSnapshot('before messageOverride change');
 });

--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard.tsx
@@ -150,7 +150,10 @@ export class IotDashboard {
       this.state.dashboardConfiguration.widgets = this.state.dashboardConfiguration.widgets.map(trimWidgetPosition);
       this.onDashboardConfigurationChange(this.state.dashboardConfiguration);
     });
-    this.messages = merge(this.messageOverrides, DefaultDashboardMessages);
+  }
+
+  componentWillRender() {
+    this.messages = merge(DefaultDashboardMessages, this.messageOverrides);
   }
 
   render() {


### PR DESCRIPTION
feat(iot-dashboard-widget): add messageOverrides support
test(dashboard): add the test case for messageOverrides to `iot-dashboard.spec.tsx`


## Overview
- fix(dashboard): move messageOverrides merge to componentWillRender()
  -  Old version may have a bug: when user changed messageOverride, changes would not be updated. Fix it by placing merge to correct lifecycle method.
-  feat(iot-dashboard-widget): add messageOverrides support
-  test(dashboard): add one test case for messageOverrides

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
