### PR TITLE
feat(core): Append meta field to RequestInformation type

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fix:stylelint": "stylelint '**/*.css' --fix",
     "test": "npm-run-all -p test:unit test:eslint test:stylelint test:git",
     "test:integration": "npm run test:integration -ws --if-present",
-    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=49",
+    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=39",
     "test:stylelint": "stylelint '**/*.css' --max-warnings 0",
     "test:unit": "npm run test -ws --if-present",
     "test:git": "git diff --exit-code",

--- a/packages/core/src/__mocks__/data-source.ts
+++ b/packages/core/src/__mocks__/data-source.ts
@@ -12,9 +12,11 @@ export const createMockSiteWiseDataSource = (
   {
     dataStreams = [],
     onRequestData = () => {},
+    meta,
   }: {
     dataStreams?: DataStream[];
     onRequestData?: (props: any) => void;
+    meta?: DataStream["meta"];
   } = { dataStreams: [], onRequestData: () => {} }
 ): DataSource<SiteWiseDataStreamQuery> => ({
   initiateRequest: jest.fn(
@@ -45,6 +47,7 @@ export const createMockSiteWiseDataSource = (
           id: toDataStreamId({ assetId, propertyId }),
           refId,
           resolution: '0',
+          meta,
         }))
       )
       .flat()),

--- a/packages/core/src/data-module/TimeSeriesDataModule.ts
+++ b/packages/core/src/data-module/TimeSeriesDataModule.ts
@@ -86,9 +86,10 @@ export class TimeSeriesDataModule<Query extends DataStreamQuery> {
     const requiredStreams = requestedStreams.filter(isRequestedDataStream);
 
     const requests = requiredStreams
-      .map(({ resolution, id, cacheSettings }) =>
+      .map(({ resolution, id, cacheSettings, meta }) =>
         getRequestInformations({
           request,
+          meta,
           store: this.dataCache.getState(),
           start: viewportStartDate(viewport),
           end: viewportEndDate(viewport),

--- a/packages/core/src/data-module/data-cache/caching/caching.ts
+++ b/packages/core/src/data-module/data-cache/caching/caching.ts
@@ -13,7 +13,7 @@ import { CacheSettings, DataStreamsStore, DataStreamStore, TTLDurationMapping } 
 import { getExpiredCacheIntervals } from './expiredCacheIntervals';
 import { TimeSeriesDataRequestSettings, TimeSeriesDataRequest } from '../requestTypes';
 import { pointBisector } from '../../../common/dataFilters';
-import { RequestInformationAndRange } from '../../types';
+import { RequestInformation, RequestInformationAndRange } from '../../types';
 
 export const unexpiredCacheIntervals = (
   streamStore: DataStreamStore,
@@ -119,6 +119,7 @@ export const getRequestInformations = ({
   store,
   dataStreamId,
   start,
+  meta,
   end,
   resolution,
   cacheSettings,
@@ -128,6 +129,7 @@ export const getRequestInformations = ({
   dataStreamId: string;
   start: Date;
   end: Date;
+  meta?: RequestInformation['meta'];
   resolution: string;
   cacheSettings: CacheSettings;
 }): RequestInformationAndRange[] => {
@@ -151,6 +153,7 @@ export const getRequestInformations = ({
       start: rangeStart,
       end: rangeEnd,
       id: dataStreamId,
+      meta,
       resolution,
       fetchFromStartToEnd,
     }));
@@ -170,6 +173,7 @@ export const getRequestInformations = ({
     requestInformations.push({
       start,
       end,
+      meta,
       id: dataStreamId,
       resolution,
       fetchMostRecentBeforeEnd: true,
@@ -190,6 +194,7 @@ export const getRequestInformations = ({
     requestInformations.unshift({
       start,
       end,
+      meta,
       id: dataStreamId,
       resolution,
       fetchMostRecentBeforeStart: true,

--- a/packages/core/src/data-module/types.ts
+++ b/packages/core/src/data-module/types.ts
@@ -20,6 +20,8 @@ export type RequestInformation = {
   fetchMostRecentBeforeStart?: boolean;
   fetchMostRecentBeforeEnd?: boolean;
   fetchFromStartToEnd?: boolean;
+  // Mechanism to associate some information about how the request should be made
+  meta?: Record<string, string | number | boolean>;
 };
 export type RequestInformationAndRange = RequestInformation & { start: Date; end: Date };
 


### PR DESCRIPTION
## Overview
Append `meta` field to `RequestInformation` type. This allows a data source to specify additional instructions on how it wants to ultimately request data. This is being added to support the TwinMaker data source in being able to look at a query, and construct request Informations which specify it's componentType.
## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
