### PR TITLE
build: npm publish with npm workspaces

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,7 +20,33 @@ jobs:
         run: |
           npm ci
           npm run build
-      - name: Publish
-        run: npm run publishToNpm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @iot-app-kit/core
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          package: './packages/core/package.json'
+          token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @iot-app-kit/components
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          package: './packages/components/package.json'
+          token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @iot-app-kit/source-iotsitewise
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          package: './packages/source-iotsitewise/package.json'
+          token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @iot-app-kit/related-table
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          package: './packages/related-table/package.json'
+          token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @iot-app-kit/react-components
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          package: './packages/react-components/package.json'
+          token: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "link": "npm link -ws",
     "versionup:patch": "npm version --no-git-tag-version -ws patch",
     "versionup:minor": "npm version --no-git-tag-version -ws minor",
-    "versionup:major": "npm version --no-git-tag-version -ws major",
-    "publishToNpm": "npm publish -ws"
+    "versionup:major": "npm version --no-git-tag-version -ws major"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",


### PR DESCRIPTION
## Overview

After switching to NPM workspaces (https://github.com/awslabs/iot-app-kit/pull/231) the Github Action for publishing to NPM started to fail because the behaviour of `npm publish -ws` is different from `lerna publish`. Lerna checks the existing version in the registry before publishing but `npm publish` publishes optimistically, which causes the action to 403 if the version was not incremented in the latest push and therefore already exists in NPM.

This change leverages https://github.com/marketplace/actions/npm-publish with `check-version` to mimic the old Lerna behaviour.

## Testing

I tested this using Docker and https://github.com/nektos/act.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
