### PR TITLE
feat(dashboard): add drag and drop event handlers

### DIFF
--- a/packages/dashboard/src/components/iot-dashboard/iot-context-menu/iot-context-menu-option.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-context-menu/iot-context-menu-option.tsx
@@ -9,15 +9,15 @@ export class IotContextMenuOption {
   @Prop() disabled: boolean;
   @Prop() onClick?: (event: MouseEvent) => void;
 
-  handleClick(event: MouseEvent) {
+  handleClick = (event: MouseEvent) => {
     if (this.disabled || !this.onClick) return;
     this.onClick(event);
-  }
+  };
 
   render() {
     return (
       <div
-        onClick={this.handleClick.bind(this)}
+        onClick={this.handleClick}
         class={`iot-context-menu-option ${this.disabled && 'iot-context-menu-option-disabled'}`}
       >
         <slot />

--- a/packages/dashboard/src/components/iot-dashboard/iot-context-menu/iot-context-menu.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-context-menu/iot-context-menu.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, Host, Listen } from '@stencil/core';
+import { Component, Prop, h, Host } from '@stencil/core';
 import { createPopper, Instance } from '@popperjs/core';
 import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow.js';
 import flip from '@popperjs/core/lib/modifiers/flip.js';
@@ -16,12 +16,6 @@ export class IotContextMenu {
   menu!: HTMLElement;
 
   popper: Instance;
-
-  @Listen('mousedown')
-  onMouseDown(event: MouseEvent) {
-    event.stopPropagation();
-    return;
-  }
 
   componentDidRender() {
     this.popper = createPopper(this.placement, this.menu, {

--- a/packages/dashboard/src/components/iot-dashboard/iot-context-menu/iot-dashboard-context-menu.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-context-menu/iot-dashboard-context-menu.tsx
@@ -72,9 +72,18 @@ export class IotDashboardContextMenu {
   onMouseDown(event: MouseEvent) {
     const isContextMenuGesture = event.button === MouseClick.Right;
 
+    /**
+     * prevent mousedown events on the context menu from closing the menu
+     * before the onClick handler can be called
+     */
+    const isAgainstContextMenuTarget =
+      event.target &&
+      (event.target as HTMLElement).matches &&
+      (event.target as HTMLElement).matches('.iot-context-menu-option, .iot-context-menu-section');
+
     if (isContextMenuGesture) {
       this.onContextMenu(event);
-    } else if (!isContextMenuGesture && this.contextMenuOpen) {
+    } else if (!isContextMenuGesture && this.contextMenuOpen && !isAgainstContextMenuTarget) {
       this.hideContextMenu();
     }
   }

--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard-widget/iot-selection-box-anchor.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard-widget/iot-selection-box-anchor.tsx
@@ -13,13 +13,12 @@ export class IotSelectionBoxAnchor {
   @Prop() onResize: OnResize;
   @Prop() anchor: Anchor;
 
-  @Listen('mousedown')
-  onMouseDown(event: MouseEvent) {
+  @Listen('pointerdown')
+  onPointerDown(event: PointerEvent) {
     this.startResize(event);
   }
 
-  startResize = (event: MouseEvent) => {
-    event.stopPropagation();
+  startResize = (event: PointerEvent) => {
     this.onResize({ anchor: this.anchor, currentPosition: { x: event.clientX, y: event.clientY } });
   };
 

--- a/packages/dashboard/src/components/iot-dashboard/iot-dashboard.tsx
+++ b/packages/dashboard/src/components/iot-dashboard/iot-dashboard.tsx
@@ -65,7 +65,7 @@ export class IotDashboard {
    * When a widget is moved, resized, deleted, appended, or altered, then this method is called
    */
   onDashboardConfigurationChange = (config: DashboardConfiguration) => {
-    this.dashboardConfiguration = config;
+    this.state.dashboardConfiguration = config;
   };
 
   /** Calls reducer to move widgets  */

--- a/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.tsx
+++ b/packages/dashboard/src/components/iot-resizable-panes/iot-resizable-panes.tsx
@@ -1,4 +1,5 @@
 import { Component, State, Listen, h } from '@stencil/core';
+import { CustomEvent } from '../../decorators/events';
 
 const LEFT_WIDTH_PERCENT = 0.15;
 const RIGHT_WIDTH_PERCENT = 0.15;
@@ -193,18 +194,18 @@ export class IotResizablePanes {
    * Input bindings
    */
 
-  @Listen('mousedown')
-  onMouseDown(event: MouseEvent) {
+  @CustomEvent('dragstart')
+  onDragStart(event: PointerEvent) {
     this.onHandleDragStart(event);
   }
 
-  @Listen('mousemove')
-  onMouseMove(event: MouseEvent) {
+  @CustomEvent('drag')
+  onDrag(event: PointerEvent) {
     this.onHandleDragMove(event);
   }
 
-  @Listen('mouseup')
-  onMouseUp() {
+  @CustomEvent('dragend')
+  onDragEnd() {
     this.onHandleDragEnd();
   }
 

--- a/packages/dashboard/src/decorators/drag.ts
+++ b/packages/dashboard/src/decorators/drag.ts
@@ -1,0 +1,131 @@
+import { ComponentInterface } from '@stencil/core';
+import { MouseClick } from '../types';
+
+export type DragOptions = Record<string, never>;
+
+const defaultOptions: Required<DragOptions> = {};
+
+export type DragEvents = 'dragstart' | 'drag' | 'dragend';
+
+type DragEvent = MouseEvent | TouchEvent | PointerEvent;
+
+class DragManager {
+  public state: 'idle' | 'dragstaged' | 'drag' = 'idle';
+
+  private callbacks: {
+    start?: (event: DragEvent) => void;
+    move?: (event: DragEvent) => void;
+    end?: (event: DragEvent) => void;
+  } = {};
+
+  private component: ComponentInterface;
+  private el: HTMLElement;
+  private options: DragOptions;
+
+  private setupComplete = false;
+
+  constructor(component: ComponentInterface, el: HTMLElement, options: DragOptions) {
+    this.component = component;
+    this.el = el;
+    this.options = Object.assign({}, options, defaultOptions);
+  }
+
+  handleSetupDrag = (event: DragEvent) => {
+    if (event instanceof PointerEvent && event.button !== MouseClick.Left) {
+      return;
+    }
+    this.state = 'dragstaged';
+    event.stopPropagation();
+  };
+
+  handleDragMove = (event: DragEvent) => {
+    if (this.state === 'dragstaged') {
+      this.state = 'drag';
+      if (this.callbacks.start) {
+        this.callbacks.start.call(this.component, event);
+      }
+    } else if (this.state === 'drag' && this.callbacks.move) {
+      this.callbacks.move.call(this.component, event);
+    }
+    event.stopPropagation();
+  };
+
+  handleDragEnd = (event: DragEvent) => {
+    if (this.state === 'drag' && this.callbacks.end) {
+      this.callbacks.end.call(this.component, event);
+    }
+    this.state = 'idle';
+    event.stopPropagation();
+  };
+
+  addStartHandler = (cb: (event: DragEvent) => void) => {
+    this.callbacks.start = cb;
+  };
+  addMoveHandler = (cb: (event: DragEvent) => void) => {
+    this.callbacks.move = cb;
+  };
+  addEndHandler = (cb: (event: DragEvent) => void) => {
+    this.callbacks.end = cb;
+  };
+
+  setupListeners = (): (() => void) => {
+    if (this.setupComplete) return () => {};
+
+    this.el.addEventListener('pointerdown', this.handleSetupDrag);
+    document.addEventListener('pointermove', this.handleDragMove);
+    document.addEventListener('pointerup', this.handleDragEnd);
+
+    this.setupComplete = true;
+
+    return () => {
+      DragManagerCache.delete(this.component);
+
+      this.el.removeEventListener('pointerdown', this.handleSetupDrag);
+      document.removeEventListener('pointermove', this.handleDragMove);
+      document.removeEventListener('pointerup', this.handleDragEnd);
+    };
+  };
+}
+
+export const DragManagerCache = new Map<ComponentInterface, DragManager>();
+const getOrSetManager = (component: ComponentInterface, el: HTMLElement, options: DragOptions): DragManager => {
+  let manager = DragManagerCache.get(component);
+  if (!manager) {
+    manager = new DragManager(component, el, options);
+    DragManagerCache.set(component, manager);
+  }
+  return manager;
+};
+
+export const withDragStartHandler = (
+  component: ComponentInterface,
+  el: HTMLElement,
+  options: DragOptions,
+  cb: (event: DragEvent) => void
+): (() => void) => {
+  const manager = getOrSetManager(component, el, options);
+  manager.addStartHandler(cb);
+  return manager.setupListeners();
+};
+
+export const withDragHandler = (
+  component: ComponentInterface,
+  el: HTMLElement,
+  options: DragOptions,
+  cb: (event: DragEvent) => void
+): (() => void) => {
+  const manager = getOrSetManager(component, el, options);
+  manager.addMoveHandler(cb);
+  return manager.setupListeners();
+};
+
+export const withDragEndHandler = (
+  component: ComponentInterface,
+  el: HTMLElement,
+  options: DragOptions,
+  cb: (event: DragEvent) => void
+): (() => void) => {
+  const manager = getOrSetManager(component, el, options);
+  manager.addEndHandler(cb);
+  return manager.setupListeners();
+};

--- a/packages/dashboard/src/decorators/events.ts
+++ b/packages/dashboard/src/decorators/events.ts
@@ -2,6 +2,7 @@ import { ComponentInterface, getElement } from '@stencil/core';
 import { noop } from 'lodash';
 
 import { PressEvents, PressOptions, withPressHandler } from './press';
+import { DragEvents, DragOptions, withDragEndHandler, withDragHandler, withDragStartHandler } from './drag';
 
 // Inspiration:
 // https://medium.com/stencil-tricks/stenciljs-creating-custom-decorators-d4d8e78c5717
@@ -9,8 +10,8 @@ import { PressEvents, PressOptions, withPressHandler } from './press';
 
 type EventDecorator = (target: ComponentInterface, propertyKey: string) => void;
 
-type EventerEvent = PressEvents;
-type EventerOptions = PressOptions;
+type EventerEvent = PressEvents | DragEvents;
+type EventerOptions = PressOptions | DragOptions;
 
 export function CustomEvent(event: EventerEvent, opts?: EventerOptions): EventDecorator {
   return (proto: ComponentInterface, methodName: string) => {
@@ -25,6 +26,15 @@ export function CustomEvent(event: EventerEvent, opts?: EventerOptions): EventDe
       switch (event) {
         case 'press':
           unsubscribe = withPressHandler(this, host, opts as PressOptions, method);
+          break;
+        case 'dragstart':
+          unsubscribe = withDragStartHandler(this, host, opts as DragOptions, method);
+          break;
+        case 'drag':
+          unsubscribe = withDragHandler(this, host, opts as DragOptions, method);
+          break;
+        case 'dragend':
+          unsubscribe = withDragEndHandler(this, host, opts as DragOptions, method);
           break;
       }
 

--- a/packages/dashboard/src/integration/iot-dashboard.spec.component.ts
+++ b/packages/dashboard/src/integration/iot-dashboard.spec.component.ts
@@ -19,7 +19,9 @@ it('click and drag moves widget', () => {
       widgets: [createWidget()],
     },
   });
-  cy.get('iot-dashboard-widget').move({ deltaX: 100, deltaY: 100, force: true });
+  cy.get('iot-dashboard-widget').trigger('pointerdown', { force: true, button: 0, offsetX: 25, offsetY: 40 });
+  cy.get('iot-dashboard-widget').trigger('pointermove', { force: true, button: 0, offsetX: 25, offsetY: 40 });
+  cy.get('iot-dashboard-widget').trigger('pointerup', { force: true, button: 0, offsetX: 125, offsetY: 140 });
   cy.get('iot-dashboard-widget').should(
     'have.attr',
     'style',
@@ -61,7 +63,9 @@ it('undoes and redoes a move action', () => {
       widgets: [createWidget()],
     },
   });
-  cy.get('iot-dashboard-widget').move({ deltaX: 100, deltaY: 100, force: true });
+  cy.get('iot-dashboard-widget').trigger('pointerdown', { force: true, button: 0, offsetX: 25, offsetY: 40 });
+  cy.get('iot-dashboard-widget').trigger('pointermove', { force: true, button: 0, offsetX: 25, offsetY: 40 });
+  cy.get('iot-dashboard-widget').trigger('pointerup', { force: true, button: 0, offsetX: 125, offsetY: 140 });
   cy.get('iot-dashboard').click(500, 500);
   cy.get('body').type('{cmd}z', { release: true }).type('{cmd}{shift}z', { release: true });
   cy.get('iot-dashboard-widget').should(

--- a/packages/dashboard/src/testing/testing-ground/testing-ground.tsx
+++ b/packages/dashboard/src/testing/testing-ground/testing-ground.tsx
@@ -11,7 +11,11 @@ export class TestingGround {
 
   render() {
     return (
-      <div>
+      /**
+       * This is required for touch drag and drop. Can be moved to iot-dashboard when
+       * resizable panes is moved into that component.
+       */
+      <div style={{ touchAction: 'none' }}>
         <iot-resizable-panes>
           <div slot="left">
             <div class="dummy-content">Resource explorer pane</div>


### PR DESCRIPTION
## Overview
Adds event handling for drag and drop interactions

Refactor internal dashboard to use those events instead of mouse events. This makes internal dashboard work on touch devices.
Refactor resizable panels to use drag and drop events.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
