### PR TITLE
docs(core): Add documentation for viewportManager; export viewportManager from pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ IoT Application Kit is a development library for creating web applications to vi
 
 [Creating a custom source](https://github.com/awslabs/iot-app-kit/tree/main/docs/CustomSources.md) - Learn how to create a custom source for your needs.
 
+[Viewport manager](https://github.com/awslabs/iot-app-kit/tree/main/docs/CustomSources.md) - Learn how to make your custom IoT App Kit components synchronize with viewport groups
 
 ## Packages
 

--- a/docs/CodingGuidelines.md
+++ b/docs/CodingGuidelines.md
@@ -86,15 +86,17 @@ Guidelines that code authors and code reviewers are expected to adhere to in the
         - If the viewport contains a duration the component should visualize the last duaration ms.
 
         - If the viewport contains start and end dates the component should visualize data between the start and end.
+  
+        - The widget must subscribe to the viewport group provided within the viewport, through the `viewportManager`. [Learn more about viewportManager in the docs](https://github.com/awslabs/iot-app-kit/tree/main/docs/CustomSources.md). 
 
-    - Example:
-        ```
-        <iot-line-chart  
-            viewport={{ duration: 1000 }}  
-            queries={...}  
-            ...  
-        />  
-        ```
+    - Example usage of viewport:
+       ```
+       <iot-line-chart  
+           viewport={{ duration: 1000 }}  
+           queries={...}  
+           ...  
+       />  
+       ```
 
 ---
 

--- a/docs/ViewportManager.md
+++ b/docs/ViewportManager.md
@@ -1,0 +1,41 @@
+# Viewport manager
+
+The viewport manager is an exposed utility of `@iot-app-kit/core` which allows IoT App Kit components to synchronize their viewport within their
+specified viewport group.
+
+You can see a live demo of this within the (SynchroCharts demo on synchronization)[https://synchrocharts.com/#/Features/Synchronization]. This example
+demonstrates 3 line charts within the same viewport group - when you pan one chart, it communicates it's updated viewport to the entire group. This is the functionality that the viewport manager enables.
+
+## How to use
+
+Within your component, import the `viewportManager` and subscribe to it:
+
+```
+import { viewportManager } from '@iot-app-kit/core';
+
+const { viewport, unsubscribe } = viewportManager.subscribe(viewport.group, (viewport) => {
+  // Use the updated viewport
+})
+```
+
+## Method summary
+
+### `subscribe(viewportGroup, callback) -> { viewport, unsubscribe }`
+
+Method to subscribe to viewport updates from the specified viewport group. Every time the viewport group has an update passed to it, the callback will
+be fired with the updated viewport.
+
+**Returns**:
+
+- `viewport`: The current viewport of the group at the point in time of subscribing. Returns `undefined` if there is no current viewport associated with the group.
+- `unsubscribe() -> void`: Unsubscribe method to the viewport updates. Once called, the callback will no longer be fired with the viewport group has updates.
+
+### `update(viewportGroup, viewport) -> void`
+
+Provides updated viewport to the specified viewport group.
+
+### `reset() -> void`
+
+Completely resets all viewport groups, including removing all subscriptions and removing all viewports associated to viewport groups.
+
+

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,5 +9,5 @@ export * from './common/time';
 export * from './common/combineProviders';
 
 export * from './data-module/TimeSeriesDataModule';
-
 export * from './mockWidgetProperties';
+export * from './viewportManager/viewportManager';


### PR DESCRIPTION
## Overview
Add documentation for the `viewportManager`. 

Also export `viewportManager` from `@iot-app-kit/core`.

This will enable widgets to subscribe and broadcast to viewport group updates. For more information, read the documentation contained in the PR.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
