### PR TITLE
chore(components): reduce concurrent workers in testing

### DIFF
--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -20,6 +20,7 @@ const credentials = (() => {
 export const config: Config = {
   namespace: 'iot-app-kit-components',
   globalStyle: 'src/styles/global.css',
+  maxConcurrentWorkers: 2,
   testing: {
     moduleNameMapper: {
       '@iot-app-kit/core': '<rootDir>/../../packages/core/src',


### PR DESCRIPTION
## Overview
Github action provides a "2-core CPU" runner for tests. Stencil uses 8 workers by default, which might cause some issues. So we are reducing the max workers limits to 2. 

And this change does not increase the execution time for local testing. It even reduces the total running time. 
2 workers:
```
> time npm run test

> @iot-app-kit/components@2.1.0 test
> stencil test --spec

[02:46.3]  @stencil/core
[02:46.5]  v2.17.4 🐞

[ WARN  ]  Build Warn
           dist-custom-elements-bundle is deprecated and will be removed in a future major version release. Use
           "dist-custom-elements" instead. If "dist-custom-elements" does not meet your needs, please add a comment to
           https://github.com/ionic-team/stencil/issues/3136.

[02:46.7]  testing spec files
[02:46.7]  jest args: --spec --max-workers=2
...
Test Suites: 12 passed, 12 total
Tests:       32 passed, 32 total
Snapshots:   0 total
Time:        7.306 s
Ran all test suites.

npm run test  13.58s user 2.64s system 174% cpu 9.316 total
```
default 8 workers:
```
> time npm run test

> @iot-app-kit/components@2.1.0 test
> stencil test --spec

[03:42.1]  @stencil/core
[03:42.3]  v2.17.4 🐞

[ WARN  ]  Build Warn
           dist-custom-elements-bundle is deprecated and will be removed in a future major version release. Use
           "dist-custom-elements" instead. If "dist-custom-elements" does not meet your needs, please add a comment to
           https://github.com/ionic-team/stencil/issues/3136.

[03:42.4]  testing spec files
[03:42.4]  jest args: --spec --max-workers=8
...
Test Suites: 12 passed, 12 total
Tests:       32 passed, 32 total
Snapshots:   0 total
Time:        8.512 s
Ran all test suites.

npm run test  28.37s user 6.01s system 329% cpu 10.446 total

```
My guess is creating a worker consumes more time.


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
