### PR TITLE
test(react-components, VideoPlayer): fix flaky test for videoPlayer

### DIFF
--- a/packages/core/src/common/viewport.ts
+++ b/packages/core/src/common/viewport.ts
@@ -2,11 +2,11 @@ import { MinimalViewPortConfig } from '@synchro-charts/core';
 import { isMinimalStaticViewport } from './predicates';
 import { parseDuration } from './time';
 
-export const viewportStartDate = (viewportConfig: MinimalViewPortConfig): Date =>
+export const viewportStartDate = (viewportConfig: MinimalViewPortConfig, currentDate?: Date): Date =>
   isMinimalStaticViewport(viewportConfig)
     ? new Date(viewportConfig.start)
-    : new Date(Date.now() - parseDuration(viewportConfig.duration));
+    : new Date((currentDate?.getTime() || Date.now()) - parseDuration(viewportConfig.duration));
 
-export const viewportEndDate = (viewportConfig: MinimalViewPortConfig): Date => {
-  return isMinimalStaticViewport(viewportConfig) ? new Date(viewportConfig.end) : new Date(Date.now());
+export const viewportEndDate = (viewportConfig: MinimalViewPortConfig, currentDate?: Date): Date => {
+  return isMinimalStaticViewport(viewportConfig) ? new Date(viewportConfig.end) : currentDate || new Date(Date.now());
 };

--- a/packages/react-components/src/video-player/videoPlayer.spec.tsx
+++ b/packages/react-components/src/video-player/videoPlayer.spec.tsx
@@ -72,8 +72,7 @@ it('should not update session URL when fields are the same for on demand mode', 
   expect(getKvsStreamSrcFn).toBeCalledWith(PLAYBACKMODE_ON_DEMAND, startTime, endTime);
 });
 
-// TODO: Fix the flaky test
-it.skip('should not update session URL when fields are the same for live mode', async () => {
+it('should not update session URL when fields are the same for live mode', async () => {
   const getKvsStreamSrcFn = jest.spyOn(mockVideoData, 'getKvsStreamSrc').mockResolvedValue(mockLiveURL);
   const { rerender } = render(<VideoPlayer viewport={{ duration: '0' }} videoData={mockVideoData} />);
 

--- a/packages/react-components/src/video-player/videoPlayer.tsx
+++ b/packages/react-components/src/video-player/videoPlayer.tsx
@@ -428,10 +428,13 @@ export class VideoPlayer extends React.Component<IVideoPlayerProps, IVideoPlayer
   };
 
   private propertiesNotChanged = (prevProps: IVideoPlayerProps, prevStates: IVideoPlayerState) => {
+    const currentTime = new Date();
     return (
       this.props.videoData === prevProps.videoData &&
-      viewportStartDate(this.props.viewport).getTime() === viewportStartDate(prevProps.viewport).getTime() &&
-      viewportEndDate(this.props.viewport).getTime() === viewportEndDate(prevProps.viewport).getTime() &&
+      viewportStartDate(this.props.viewport, currentTime).getTime() ===
+        viewportStartDate(prevProps.viewport, currentTime).getTime() &&
+      viewportEndDate(this.props.viewport, currentTime).getTime() ===
+        viewportEndDate(prevProps.viewport, currentTime).getTime() &&
       'duration' in this.props.viewport === 'duration' in prevProps.viewport &&
       this.state.playbackMode === prevStates.playbackMode
     );


### PR DESCRIPTION
## Overview
Due to a bug in `viewportStartDate` from `@iot-app-kit/core`, `propertiesNotChanged` might return `false` for unchanged properties. Add `currentTime` param `viewportStartDate` to fix this issue.

### Details
Basically `viewportStartDate` uses `Date.now()` when the viewport passed in is a duration (no `start`). And function `propertiesNotChanged` compares viewports as following:
```
viewportStartDate(this.props.viewport).getTime() === viewportStartDate(prevProps.viewport).getTime() 
```
Usually `viewportStartDate(this.props.viewport).getTime()` and `viewportStartDate(prevProps.viewport).getTime()` should return the same value for the same viewport. However, if there’s some async ops or it is running in a slow machine (like Github actions runner), the return value can be different - since `Date.now()` returns a new timestamp. Then this behaviour leads to `propertiesNotChanged` return false and causes `getKvsStreamSrcFn` called twice instead expected once.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
