### PR TITLE
chore(TagResize): Add flag to resizable tags

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -154,10 +154,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 76.64,
-        "statements": 75.75,
-        "functions": 76.03,
-        "branches": 62.22,
+        "lines": 76.84,
+        "statements": 75.97,
+        "functions": 76.16,
+        "branches": 62.5,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
@@ -5,7 +5,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import { Checkbox, FormField, Input, TextContent } from '@awsui/components-react';
 
 import useLifecycleLogging from '../../logger/react-logger/hooks/useLifecycleLogging';
-import { KnownComponentType } from '../../interfaces';
+import { COMPOSER_FEATURES, KnownComponentType } from '../../interfaces';
 import { RecursivePartial } from '../../utils/typeUtils';
 import { ISceneNodeInternal, useEditorState, useSceneDocument } from '../../store';
 import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
@@ -14,9 +14,10 @@ import { toNumber } from '../../utils/stringUtils';
 import { isLinearPlaneMotionIndicator } from '../../utils/sceneComponentUtils';
 import LogProvider from '../../logger/react-logger/log-provider';
 import { findComponentByType, isEnvironmentNode } from '../../utils/nodeUtils';
+import { getGlobalSettings } from '../../common/GlobalSettings';
 
 import { ComponentEditor } from './ComponentEditor';
-import { Matrix3XInputGrid, ExpandableInfoSection, Triplet } from './CommonPanelComponents';
+import { ExpandableInfoSection, Matrix3XInputGrid, Triplet } from './CommonPanelComponents';
 import DebugInfoPanel from './scene-components/debug/DebugPanel';
 
 export const SceneNodeInspectorPanel: React.FC = () => {
@@ -26,6 +27,8 @@ export const SceneNodeInspectorPanel: React.FC = () => {
   const { getSceneNodeByRef, updateSceneNodeInternal } = useSceneDocument(sceneComposerId);
   const selectedSceneNode = getSceneNodeByRef(selectedSceneNodeRef);
   const intl = useIntl();
+
+  const tagResizeEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagResize];
 
   const i18nKnownComponentTypesStrings = defineMessages({
     [KnownComponentType.ModelRef]: {
@@ -76,6 +79,13 @@ export const SceneNodeInspectorPanel: React.FC = () => {
     () => !!findComponentByType(selectedSceneNode, KnownComponentType.Camera),
     [selectedSceneNode],
   );
+
+  const isTagComponent = useMemo(
+    () => !!findComponentByType(selectedSceneNode, KnownComponentType.Tag),
+    [selectedSceneNode],
+  );
+
+  const shouldShowScale = !((isTagComponent && !tagResizeEnabled) || isCameraComponent);
 
   const readonly: Triplet<boolean> = [false, false, false];
 
@@ -157,7 +167,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
                 applySnapToFloorConstraint();
               }, 100)}
             />
-            {!isCameraComponent && (
+            {shouldShowScale && (
               <Matrix3XInputGrid
                 name={intl.formatMessage({ defaultMessage: 'Scale', description: 'Input Grid title name' })}
                 labels={['X', 'Y', 'Z']}

--- a/packages/scene-composer/src/components/three-fiber/EditorTransformControls.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EditorTransformControls.tsx
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { useThree } from '@react-three/fiber';
 
 import useLogger from '../../logger/react-logger/hooks/useLogger';
@@ -8,7 +8,9 @@ import { useStore } from '../../store';
 import { TransformControls as TransformControlsImpl } from '../../three/TransformControls';
 import { snapObjectToFloor } from '../../three/transformUtils';
 import { isLinearPlaneMotionIndicator } from '../../utils/sceneComponentUtils';
-import { isEnvironmentNode } from '../../utils/nodeUtils';
+import { findComponentByType, isEnvironmentNode } from '../../utils/nodeUtils';
+import { getGlobalSettings } from '../../common/GlobalSettings';
+import { COMPOSER_FEATURES, KnownComponentType } from '../../interfaces';
 
 export function EditorTransformControls() {
   const { domElement } = useThree(({ gl }) => gl);
@@ -16,6 +18,7 @@ export function EditorTransformControls() {
   const camera = useThree(({ camera }) => camera);
   const sceneComposerId = useContext(sceneComposerIdContext);
   const transformControlMode = useStore(sceneComposerId)((state) => state.transformControlMode);
+  const setTransformControlsMode = useStore(sceneComposerId)((state) => state.setTransformControlMode);
   const setTransformControls = useStore(sceneComposerId)((state) => state.setTransformControls);
   const selectedSceneNodeRef = useStore(sceneComposerId)((state) => state.selectedSceneNodeRef);
   const selectedSceneNode = useStore(sceneComposerId)((state) => state.getSceneNodeByRef(selectedSceneNodeRef));
@@ -23,6 +26,12 @@ export function EditorTransformControls() {
   const addingWidget = useStore(sceneComposerId)((state) => state.addingWidget);
 
   const [transformControls] = useState(() => new TransformControlsImpl(camera, domElement));
+  const tagResizeEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagResize];
+
+  const isTagComponent = useMemo(
+    () => !!findComponentByType(selectedSceneNode, KnownComponentType.Tag),
+    [selectedSceneNode],
+  );
 
   // Set transform controls' camera
   useEffect(() => {
@@ -42,6 +51,10 @@ export function EditorTransformControls() {
 
   useEffect(() => {
     if (selectedSceneNode) {
+      if (isTagComponent && !tagResizeEnabled && transformControlMode === 'scale') {
+        // Prevent the scale from being enabled
+        setTransformControlsMode('translate');
+      }
       // TODO: Fix TransformControls typings so we can remove @ts-ignore directive
       // TransformControls defines properties using Object.defineProperty but TypeScript cannot infer the types
       // https://github.com/microsoft/TypeScript/issues/28694

--- a/packages/scene-composer/src/interfaces/feature.ts
+++ b/packages/scene-composer/src/interfaces/feature.ts
@@ -10,6 +10,7 @@ export enum COMPOSER_FEATURES {
   ENHANCED_EDITING = 'ENHANCED_EDITING',
   CameraView = 'CameraView',
   EnvironmentModel = 'EnvironmentModel',
+  TagResize = 'TagResize',
 }
 
 export type FeatureConfig = Partial<Record<COMPOSER_FEATURES, boolean>>;

--- a/packages/scene-composer/stories/SceneComposer.stories.tsx
+++ b/packages/scene-composer/stories/SceneComposer.stories.tsx
@@ -151,6 +151,7 @@ const knobsConfigurationDecorator = [
         [COMPOSER_FEATURES.ENHANCED_EDITING]: true,
         [COMPOSER_FEATURES.CameraView]: true,
         [COMPOSER_FEATURES.EnvironmentModel]: false,
+        [COMPOSER_FEATURES.TagResize]: true,
         ...args.config.featureConfig,
       },
       ...args.config,

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -299,10 +299,6 @@
     "note": "label",
     "text": "Add color rule"
   },
-  "LztKh8": {
-    "note": "Menu label",
-    "text": "Scale"
-  },
   "MZtQw3": {
     "note": "75mm lens",
     "text": "75mm"


### PR DESCRIPTION
## Overview
In an effort to prevent the release of resizable tags outright we lock it behind a feature flag.

Flag disabled features:
* Scale row is removed for Tag component in inspector
* Editor Transform Controls will switch back to translate when switching to Tag
* Scale button is disabled in floating toolbar with tag selected

Flag enabled:
* Tags can be resized via inspector
* Tags can be resized via transform controls

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
