### PR TITLE
fix(composer): fix adding tag always attached to root

### DIFF
--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -79,7 +79,7 @@ export const AddObjectMenu = () => {
 
   const selectedSceneNode = useMemo(() => {
     return getSceneNodeByRef(selectedSceneNodeRef);
-  }, [selectedSceneNodeRef]);
+  }, [getSceneNodeByRef, selectedSceneNodeRef]);
 
   const sceneContainsEnvironmentModel = useMemo(() => {
     return (
@@ -135,7 +135,7 @@ export const AddObjectMenu = () => {
 
   const getRefForParenting = useCallback(() => {
     return !isEnvironmentNode(selectedSceneNode) ? selectedSceneNodeRef : undefined;
-  }, [getSceneNodeByRef, selectedSceneNodeRef, selectedSceneNode]);
+  }, [selectedSceneNodeRef, selectedSceneNode]);
 
   const handleAddAnchor = useCallback(() => {
     const anchorComponent: IAnchorComponent = {
@@ -151,7 +151,7 @@ export const AddObjectMenu = () => {
     } else {
       appendSceneNode(node);
     }
-  }, [enhancedEditingEnabled]);
+  }, [enhancedEditingEnabled, getRefForParenting, appendSceneNode, setAddingWidget]);
 
   const handleAddColorOverlay = () => {
     // Requires a selected scene node


### PR DESCRIPTION
## Overview
`handleAddAnchor` is not listening to the change of `getRefForParenting` which cause the value of new node's `parentRef` to always be the same, so the tag is always attached to root.


https://user-images.githubusercontent.com/9315598/196309048-ddf49881-5f19-4264-bba8-a774bd918c1c.mov



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
