### PR TITLE
fix: Fix the tag scaling with parent scale regression

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -154,10 +154,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 76.84,
-        "statements": 75.97,
-        "functions": 76.16,
-        "branches": 62.5,
+        "lines": 77.42,
+        "statements": 76.55,
+        "functions": 77.02,
+        "branches": 63.64,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -154,10 +154,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 77.42,
-        "statements": 76.55,
+        "lines": 77.40,
+        "statements": 76.52,
         "functions": 77.02,
-        "branches": 63.64,
+        "branches": 63.51,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
@@ -200,13 +200,11 @@ export function AsyncLoadedAnchorWidget({
   }, [linesRef.current]);
 
   const parentScale = new THREE.Vector3(1, 1, 1);
-  let targetParent;
   if (parent) {
-    targetParent = getObject3DFromSceneNodeRef(parent.userData.targetRef);
-    targetParent ? targetParent.getWorldScale(parentScale) : parent.getWorldScale(parentScale);
+    parent.getWorldScale(parentScale);
   }
 
-  const finalScale = targetParent ? new THREE.Vector3(1, 1, 1).divide(parentScale) : new THREE.Vector3(1, 1, 1);
+  const finalScale = parent ? new THREE.Vector3(1, 1, 1).divide(parentScale) : new THREE.Vector3(1, 1, 1);
 
   return (
     <group scale={finalScale}>

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
@@ -200,11 +200,21 @@ export function AsyncLoadedAnchorWidget({
   }, [linesRef.current]);
 
   const parentScale = new THREE.Vector3(1, 1, 1);
+  let targetParent;
   if (parent) {
-    parent.getWorldScale(parentScale);
+    const hierarchicalParentNode = getSceneNodeByRef(parent.userData.nodeRef);
+    let physicalParent = parent;
+    if (findComponentByType(hierarchicalParentNode, KnownComponentType.SubModelRef)) {
+      while (physicalParent) {
+        if (physicalParent.userData.componentTypes?.includes(KnownComponentType.ModelRef)) break;
+        physicalParent = physicalParent.parent as THREE.Object3D<Event>;
+      }
+    }
+    targetParent = physicalParent;
+    targetParent.getWorldScale(parentScale);
   }
 
-  const finalScale = parent ? new THREE.Vector3(1, 1, 1).divide(parentScale) : new THREE.Vector3(1, 1, 1);
+  const finalScale = targetParent ? new THREE.Vector3(1, 1, 1).divide(parentScale) : new THREE.Vector3(1, 1, 1);
 
   return (
     <group scale={finalScale}>

--- a/packages/scene-composer/tests/augmentations/components/three-fiber/anchor/AnchorWidget.spec.tsx
+++ b/packages/scene-composer/tests/augmentations/components/three-fiber/anchor/AnchorWidget.spec.tsx
@@ -119,7 +119,7 @@ describe('AnchorWidget', () => {
 
     const parent = new THREE.Group();
     parent.scale.set(2, 2, 2);
-    getObject3DBySceneNodeRef.mockReturnValue(parent);
+    getObject3DBySceneNodeRef.mockReturnValueOnce(parent);
 
     const container = renderer.create(<AnchorWidget node={node as any} defaultIcon={DefaultAnchorStatus.Info} />);
 


### PR DESCRIPTION
With the effort to update enhanced editing one of the initial ideas was to use a targetRef. This is no longer something we did at the end but this file remained intact.

To fix the regression the targetRef changes needed to be undone

Also changes the test such that the previous regression would have failed