### PR TITLE
fix(SceneHierarchyPerformance): SceneHierarchy Tree Performance

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -154,10 +154,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 77.40,
-        "statements": 76.52,
-        "functions": 77.02,
-        "branches": 63.51,
+        "lines": 77.47,
+        "statements": 76.6,
+        "functions": 77.57,
+        "branches": 63.58,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/ComponentTypeIcon.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/ComponentTypeIcon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Icon } from '@awsui/components-react';
+
+import { Camera, Light, Modelref, Tag } from '../../../../../assets/auto-gen/icons';
+import { KnownComponentType } from '../../../../../interfaces';
+
+const ComponentTypeIcon = ({ type, ...props }: { type: string }) => {
+  switch (type) {
+    case KnownComponentType.Camera:
+      return <Icon svg={<Camera {...props} />} />;
+    case KnownComponentType.Light:
+      return <Icon svg={<Light {...props} />} />;
+    case KnownComponentType.ModelRef:
+    case KnownComponentType.SubModelRef:
+      return <Icon svg={<Modelref {...props} />} />;
+    case KnownComponentType.Tag:
+      return <Icon svg={<Tag {...props} />} />;
+    default:
+      return <></>;
+  }
+};
+
+ComponentTypeIcon.displayName = ComponentTypeIcon;
+
+export default ComponentTypeIcon;

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneNodeLabel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneNodeLabel.tsx
@@ -1,54 +1,46 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import { Button, Icon } from '@awsui/components-react';
 
 import VisibilityToggle from '../../../../../components/VisibilityToggle';
 import { KnownComponentType } from '../../../../../interfaces';
-import { Camera, Light, Modelref, Tag } from '../../../../../assets/auto-gen/icons';
 import './SceneNodeLabel.scss';
 import { DeleteSvg } from '../../../../../assets/svgs';
+import { useSceneHierarchyData } from '../../SceneHierarchyDataProvider';
 
-const ComponentTypeIcon = ({ type, ...props }: { type: string }) => {
-  switch (type) {
-    case KnownComponentType.Camera:
-      return <Icon svg={<Camera {...props} />} />;
-    case KnownComponentType.Light:
-      return <Icon svg={<Light {...props} />} />;
-    case KnownComponentType.ModelRef:
-    case KnownComponentType.SubModelRef:
-      return <Icon svg={<Modelref {...props} />} />;
-    case KnownComponentType.Tag:
-      return <Icon svg={<Tag {...props} />} />;
-    default:
-      return <></>;
-  }
-};
+import ComponentTypeIcon from './ComponentTypeIcon';
+
 interface SceneNodeLabelProps {
+  objectRef: string;
   labelText: string;
   componentTypes?: string[];
-  error?: string;
-  visible?: boolean;
-  onVisibilityChange?: (newVisibility: boolean) => void;
-  onDelete: () => void;
 }
 
-const SceneNodeLabel: FC<SceneNodeLabelProps> = ({
-  labelText,
-  componentTypes,
-  error,
-  visible,
-  onVisibilityChange = () => {},
-  onDelete,
-}) => {
-  const toggleVisibility = useCallback(
-    (show: boolean) => {
-      onVisibilityChange(show);
-    },
-    [onVisibilityChange],
-  );
+const SceneNodeLabel: FC<SceneNodeLabelProps> = ({ objectRef, labelText, componentTypes }) => {
+  const { show, hide, remove, validationErrors } = useSceneHierarchyData();
+  const [visible, setVisible] = useState(true);
+
+  const error = validationErrors[objectRef];
 
   const componentTypeIcons = componentTypes
     ?.filter((type) => !!type && Object.keys(KnownComponentType).includes(type))
     .map((type) => <ComponentTypeIcon key={type} type={type} />);
+
+  const toggleVisibility = useCallback(
+    (newVisibility) => {
+      if (newVisibility) {
+        show(objectRef);
+      } else {
+        hide(objectRef);
+      }
+
+      setVisible(newVisibility);
+    },
+    [objectRef, visible, show, hide],
+  );
+
+  const onDelete = useCallback(() => {
+    remove(objectRef);
+  }, [objectRef]);
 
   return (
     <span className={`tm-scene-node-label ${error ? 'error' : ''}`.trim()} title={error}>

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/SceneNodeLabel.specs.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/SceneNodeLabel.specs.tsx
@@ -1,0 +1,102 @@
+import React, { useCallback } from 'react';
+import { render } from '@testing-library/react';
+
+import SceneNodeLabel from '../SceneNodeLabel';
+import { useSceneHierarchyData } from '../../../SceneHierarchyDataProvider';
+import { KnownComponentType } from '../../../../../../interfaces';
+
+jest.mock('../../../../../../components/VisibilityToggle', () => 'VisibilityToggle');
+jest.mock('../../../../../../assets/svgs', () => ({
+  DeleteSvg: 'DeleteSVG',
+}));
+
+jest.mock('../ComponentTypeIcon', () => 'ComponentTypeIcon');
+
+jest.mock('../../../SceneHierarchyDataProvider');
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useCallback: jest.fn(),
+}));
+
+describe('SceneNodeLabel', () => {
+  const show = jest.fn();
+  const hide = jest.fn();
+  const remove = jest.fn();
+  const validationErrors = jest.fn();
+  let callbacks: any[] = [];
+
+  beforeEach(() => {
+    callbacks = [];
+
+    (useSceneHierarchyData as unknown as jest.Mock).mockImplementation(() => {
+      return {
+        show,
+        hide,
+        remove,
+        validationErrors,
+      };
+    });
+
+    (useCallback as jest.Mock).mockImplementation((cb) => callbacks.push(cb));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it(`should render with no errors`, () => {
+    const { container } = render(
+      <SceneNodeLabel objectRef={'123'} labelText={'Text'} componentTypes={[KnownComponentType.ModelRef]} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it(`should allow deleting node if there's errors`, () => {
+    const objectRef = 'Batman';
+
+    (useSceneHierarchyData as unknown as jest.Mock).mockImplementation(() => {
+      return {
+        validationErrors: { [objectRef]: 'There is an error' },
+      };
+    });
+
+    const { container } = render(
+      <SceneNodeLabel objectRef={objectRef} labelText={'Text'} componentTypes={[KnownComponentType.ModelRef]} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should toggle visibility', () => {
+    const objectRef = 'Batman';
+    render(<SceneNodeLabel objectRef={objectRef} labelText={'Text'} componentTypes={[KnownComponentType.ModelRef]} />);
+
+    const [toggleVisibility] = callbacks;
+
+    toggleVisibility(true);
+
+    expect(show).toBeCalledWith(objectRef);
+
+    toggleVisibility(false);
+
+    expect(hide).toBeCalledWith(objectRef);
+  });
+
+  it('should delete node when delete button is clicked', () => {
+    const objectRef = 'Batman';
+
+    (useSceneHierarchyData as unknown as jest.Mock).mockImplementation(() => {
+      return {
+        validationErrors: { [objectRef]: 'There is an error' },
+        remove,
+      };
+    });
+
+    render(<SceneNodeLabel objectRef={objectRef} labelText={'Text'} componentTypes={[]} />);
+
+    const [, onDelete] = callbacks;
+
+    onDelete();
+
+    expect(remove).toBeCalledWith(objectRef);
+  });
+});

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/__snapshots__/SceneHierarchyTreeItem.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/__snapshots__/SceneHierarchyTreeItem.spec.tsx.snap
@@ -2,207 +2,50 @@
 
 exports[`SceneHierarchyTreeItem should bubble up when expanded 1`] = `
 <div>
-  <li
-    acceptdrop="ModelRef,Camera,Light,Tag,ModelShader,MotionIndicator,Space,default"
-    class="tm-tree-item"
+  <enhancedtreeitem
+    acceptdrop="AcceptableDropTypes"
     data="[object Object]"
     datatype="modelRef"
-    role="treeitem"
+    labeltext="[object Object]"
+    selectionmode="single"
   >
-    <div
-      aria-selected="true"
-      class="tm-tree-item-inner selected"
+    <enhancedtree
+      acceptdrop="AcceptableDropTypes"
     >
-      <div
-        data-mocked="Checkbox"
+      <enhancedtreeitem
+        acceptdrop="AcceptableDropTypes"
+        data="[object Object]"
+        datatype="default"
+        labeltext="[object Object]"
+        selectionmode="single"
       >
-        <span
-          class="tm-scene-node-label"
-        >
-          <p
-            class="tm-scene-node-label-inner"
-          >
-            Label 1
-          </p>
-          <span
-            class="actions"
-          >
-            <div
-              class="tm-visibility-toggle visible tm-icon-button"
-              data-mocked="Button"
-              variant="inline-icon"
-            >
-              <div>
-                <span>
-                  <svg
-                    fill="none"
-                    height="14"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      clip-path="url(#show_svg__a)"
-                      fill="currentColor"
-                    >
-                      <path
-                        class="show_svg__center-dot"
-                        d="M8 8.89a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"
-                        stroke="currentColor"
-                        stroke-miterlimit="10"
-                      />
-                      <path
-                        d="M7.85 3c2.27 0 4.57 1.31 6.85 3.9-1.07 1.22-3.77 3.88-7 3.88-2.25 0-4.42-1.31-6.46-3.9C2.16 5.69 4.61 3 7.85 3Zm0-1C3.11 2 0 6.89 0 6.89c2.67 3.67 5.33 4.89 7.7 4.89 4.74 0 8.3-4.89 8.3-4.89C13 3.22 10.22 2 7.85 2Z"
-                      />
-                    </g>
-                    <defs>
-                      <clippath
-                        id="show_svg__a"
-                      >
-                        <path
-                          d="M0 0h16v9.78H0z"
-                          fill="currentColor"
-                          transform="translate(0 2)"
-                        />
-                      </clippath>
-                    </defs>
-                  </svg>
-                </span>
-              </div>
-            </div>
-          </span>
-        </span>
-      </div>
-    </div>
-    <ol
-      acceptdrop="ModelRef,Camera,Light,Tag,ModelShader,MotionIndicator,Space,default"
-      class="tm-tree"
-      role="tree"
-    />
-  </li>
+        <enhancedtree
+          acceptdrop="AcceptableDropTypes"
+        />
+      </enhancedtreeitem>
+    </enhancedtree>
+  </enhancedtreeitem>
 </div>
 `;
 
 exports[`SceneHierarchyTreeItem should render SubModelTree when item has a model, and not in view mode 1`] = `
 <div>
-  <li
-    acceptdrop="ModelRef,Camera,Light,Tag,ModelShader,MotionIndicator,Space,default"
-    class="tm-tree-item"
+  <enhancedtreeitem
+    acceptdrop="AcceptableDropTypes"
     data="[object Object]"
     datatype="ModelRef"
-    role="treeitem"
+    labeltext="[object Object]"
+    selectionmode="single"
   >
-    <div
-      aria-selected="true"
-      class="tm-tree-item-inner selected"
-    >
-      <div
-        data-mocked="Checkbox"
-      >
-        <span
-          class="tm-scene-node-label"
-        >
-          <div
-            data-mocked="Icon"
-          >
-            <div>
-              <svg
-                fill="none"
-                height="14"
-                width="14"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  clip-path="url(#modelref_svg__a)"
-                  stroke="currentColor"
-                  stroke-miterlimit="10"
-                >
-                  <path
-                    d="M6.946 13.48.465 10.24V3.758L6.946.518l6.482 3.24v6.482l-6.482 3.24Z"
-                  />
-                  <path
-                    d="M.465 3.76 6.946 7l6.482-3.24M6.945 7v6.482"
-                  />
-                </g>
-                <defs>
-                  <clippath
-                    id="modelref_svg__a"
-                  >
-                    <path
-                      d="M0 0h13.889v14H0z"
-                      fill="#fff"
-                    />
-                  </clippath>
-                </defs>
-              </svg>
-            </div>
-          </div>
-          <p
-            class="tm-scene-node-label-inner"
-          >
-            Label 1
-          </p>
-          <span
-            class="actions"
-          >
-            <div
-              class="tm-visibility-toggle visible tm-icon-button"
-              data-mocked="Button"
-              variant="inline-icon"
-            >
-              <div>
-                <span>
-                  <svg
-                    fill="none"
-                    height="14"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      clip-path="url(#show_svg__a)"
-                      fill="currentColor"
-                    >
-                      <path
-                        class="show_svg__center-dot"
-                        d="M8 8.89a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"
-                        stroke="currentColor"
-                        stroke-miterlimit="10"
-                      />
-                      <path
-                        d="M7.85 3c2.27 0 4.57 1.31 6.85 3.9-1.07 1.22-3.77 3.88-7 3.88-2.25 0-4.42-1.31-6.46-3.9C2.16 5.69 4.61 3 7.85 3Zm0-1C3.11 2 0 6.89 0 6.89c2.67 3.67 5.33 4.89 7.7 4.89 4.74 0 8.3-4.89 8.3-4.89C13 3.22 10.22 2 7.85 2Z"
-                      />
-                    </g>
-                    <defs>
-                      <clippath
-                        id="show_svg__a"
-                      >
-                        <path
-                          d="M0 0h16v9.78H0z"
-                          fill="currentColor"
-                          transform="translate(0 2)"
-                        />
-                      </clippath>
-                    </defs>
-                  </svg>
-                </span>
-              </div>
-            </div>
-          </span>
-        </span>
-      </div>
-    </div>
-    <ol
-      acceptdrop="ModelRef,Camera,Light,Tag,ModelShader,MotionIndicator,Space,default"
-      class="tm-tree"
-      role="tree"
+    <enhancedtree
+      acceptdrop="AcceptableDropTypes"
     >
       <div
         data-mocked="SubModelTree"
         object3d="[object Object]"
         parentref="1"
       />
-    </ol>
-  </li>
+    </enhancedtree>
+  </enhancedtreeitem>
 </div>
 `;

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/__snapshots__/SceneNodeLabel.specs.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/__snapshots__/SceneNodeLabel.specs.tsx.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SceneNodeLabel should allow deleting node if there's errors 1`] = `
+<div>
+  <span
+    class="tm-scene-node-label error"
+    title="There is an error"
+  >
+    <componenttypeicon
+      type="ModelRef"
+    />
+    <p
+      class="tm-scene-node-label-inner"
+    >
+      Text
+    </p>
+    <span
+      class="actions"
+    >
+      <div
+        data-mocked="Button"
+        iconsvg="DeleteSVG"
+        variant="inline-icon"
+      />
+      <visibilitytoggle />
+    </span>
+  </span>
+</div>
+`;
+
+exports[`SceneNodeLabel should render with no errors 1`] = `
+<div>
+  <span
+    class="tm-scene-node-label"
+  >
+    <componenttypeicon
+      type="ModelRef"
+    />
+    <p
+      class="tm-scene-node-label-inner"
+    >
+      Text
+    </p>
+    <span
+      class="actions"
+    >
+      <visibilitytoggle />
+    </span>
+  </span>
+</div>
+`;

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/model/ISceneHierarchyNode.ts
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/model/ISceneHierarchyNode.ts
@@ -1,6 +1,7 @@
 interface ISceneHierarchyNode {
   objectRef: string;
   name: string;
+  childRefs: string[];
   componentTypes?: string[];
   parentRef?: string;
 }


### PR DESCRIPTION
- Reduces the number of rerenders significantly in the SceneHierarchy Tree view whenever actions like activating, selecting and removing happen
- Removes redundent On2 loop when computing children for a scene hierarchy node
- Cleans up some new responsibilities for TreeItem and Tree Label that were added in the wrong places.

## Overview
Provide an explanation of what the change is

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
