### PR TITLE
fix: Fix the camera zoom field locked to 1 or greater

### DIFF
--- a/packages/scene-composer/src/components/panels/scene-components/CameraComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/CameraComponentEditor.tsx
@@ -217,7 +217,7 @@ const CameraComponentEditor: React.FC<ICameraComponentEditorProps> = ({
 
   const updateZoom = (value: number) => {
     const zoomOptionIndex = zoomOptions.findIndex((option) => option.value === value.toString());
-    if (zoomOptionIndex > 1) {
+    if (zoomOptionIndex > -1) {
       setSelectedZoomOption(zoomOptions[zoomOptionIndex]);
     } else {
       setSelectedZoomOption({


### PR DESCRIPTION
## Overview
Camera zoom could be changed to less than 1 but the inspector UI did not reflect the changes. Fixed the missing negative sign to determine if the value index existed

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
