### PR TITLE
fix(composer): fix model shader material color restore

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useEffect } from 'react';
 import { Mesh } from 'three';
+import { isEmpty } from 'lodash';
 
 import { COMPOSER_FEATURES, SceneResourceType } from '../../../interfaces';
 import { ISceneNodeInternal, IColorOverlayComponentInternal, useStore } from '../../../store';
@@ -58,7 +59,7 @@ const ColorOverlayComponent: React.FC<IColorOverlayComponentProps> = ({
   );
 
   useEffect(() => {
-    if (ruleResult !== '') {
+    if (!isEmpty(ruleResult)) {
       transform();
     }
 

--- a/packages/scene-composer/src/hooks/useMaterialEffect.ts
+++ b/packages/scene-composer/src/hooks/useMaterialEffect.ts
@@ -6,12 +6,12 @@ const useMaterialEffect = (callback: (object: Object3D) => void, object?: Object
 
   const restore = useCallback(() => {
     object?.traverse((o) => {
-      if (o instanceof Mesh) {
+      if (o instanceof Mesh && o.userData?.isOriginal) {
         const original = originalMaterialMap.current[o.uuid];
-        o.material = original.clone();
+        o.material = original ? original.clone() : o.material;
       }
     });
-  }, []);
+  }, [object]);
 
   useEffect(() => {
     object?.traverse((o) => {
@@ -21,7 +21,7 @@ const useMaterialEffect = (callback: (object: Object3D) => void, object?: Object
         }
       }
     });
-  }, []);
+  }, [object]);
 
   const transform = () => {
     // Currently can't think of a use case where we'd want to use this to transform a material on a component we own


### PR DESCRIPTION
## Overview
model shader material color not restore properly because the original object passed into useMaterial is undefined

before

https://user-images.githubusercontent.com/9315598/197277320-3a43ff43-c74e-4965-abd9-d5d83d9d70de.mov

after

https://user-images.githubusercontent.com/9315598/197277380-f43cc802-894e-4aac-944a-9ee638281dea.mov


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
