### PR TITLE
fix: add dashboard package to the npm workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       "packages/related-table",
       "packages/table",
       "packages/components",
+      "packages/dashboard",
       "packages/source-iottwinmaker",
       "packages/react-components",
       "packages/scene-composer"


### PR DESCRIPTION
## Overview
Add missing declaration of the `dashboard` package in the npm workspace configuration.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
