### PR TITLE
chore(IgnoreWordDocs): Ignore Word docs by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ log.txt
 npm-debug.log
 *.sublime-project
 *.sublime-workspace
+*.docx
 
 .idea/
 .vscode/


### PR DESCRIPTION
## Overview
Ignore word docs by default, since we use markdown for documentation.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
