### PR TITLE
feat(dashboard): select and move actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "fix:eslint": "eslint --fix --ext .js,.ts,.tsx .",
     "fix:stylelint": "stylelint '**/*.css' --fix",
     "test": "npm-run-all -p test:unit test:eslint test:stylelint test:git",
-    "test:integration": "npm run test:integration -ws --if-present",
     "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=39",
     "test:stylelint": "stylelint '**/*.css' --max-warnings 0",
     "test:unit": "npm run test -ws --if-present",
@@ -116,7 +115,7 @@
     "@types/react-dom": "^17.0.2"
   },
   "overrides": {
-    "d3-color": "d3-color-1-fix",
+    "d3-color": "npm:d3-color-1-fix",
     "nth-check": "^2.1.1"
   }
 }

--- a/packages/dashboard/jest.config.ts
+++ b/packages/dashboard/jest.config.ts
@@ -10,7 +10,10 @@ export default {
   // coverageDirectory: 'coverage',
   // coverageProvider: 'v8',
   moduleNameMapper: {
-    '\\.(css|less)$': '<rootDir>/testing/styleMock.js',
+    '\\.(svg|css|less)$': '<rootDir>/testing/styleMock.js',
+    '^react-dnd$': 'react-dnd/dist/cjs',
+    '^dnd-core$': 'dnd-core/dist/cjs',
+    '^react-dnd-touch-backend$': 'react-dnd-touch-backend/dist/cjs',
   },
   testEnvironment: 'jsdom',
   // setupFilesAfterEnv: ['mutationobserver-shim'],

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -9,7 +9,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/awslabs/iot-app-kit.git"
+    "url": "git+https://github.com/awslabs/iot-app-kit.git",
+    "directory": "packages/dashboard"
   },
   "bugs": {
     "url": "https://github.com/awslabs/iot-app-kit/issues"
@@ -22,13 +23,15 @@
     "clean": "rimraf dist",
     "start": "start-storybook -p 6006",
     "storybook": "start-storybook -p 6006",
-    "test": "jest"
+    "test": "jest",
+    "test:cypress-ct": "echo \"Error: no cypress tests specified\" && exit 0"
   },
   "devDependencies": {
     "@babel/core": "^7.19.1",
     "@babel/preset-typescript": "^7.18.6",
     "@reduxjs/toolkit": "^1.8.6",
     "@rollup/plugin-commonjs": "^22.0.2",
+    "@rollup/plugin-json": "^5.0.1",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@storybook/addon-actions": "^6.5.12",
     "@storybook/addon-essentials": "^6.5.12",
@@ -38,12 +41,15 @@
     "@storybook/manager-webpack5": "^6.5.12",
     "@storybook/react": "^6.5.12",
     "@storybook/testing-library": "^0.0.13",
+    "@types/box-intersect": "^1.0.0",
+    "@types/lodash": "^4.14.186",
     "@types/node": "^18.11.4",
     "@types/react": "^17.0.38",
     "babel-loader": "^8.2.5",
     "dotenv": "^16.0.3",
-    "postcss-import": "^14.0.0",
+    "lodash": "^4.17.21",
     "postcss": "^8.2.4",
+    "postcss-import": "^14.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^8.0.4",
@@ -61,7 +67,10 @@
   "dependencies": {
     "@iot-app-kit/core": "^2.3.0",
     "@iot-app-kit/source-iotsitewise": "^2.3.0",
-    "@synchro-charts/core": "^4.0.0"
+    "@synchro-charts/core": "^4.0.0",
+    "box-intersect": "^1.0.2",
+    "react-dnd": "^16.0.1",
+    "react-dnd-touch-backend": "^16.0.1"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/dashboard/rollup.config.js
+++ b/packages/dashboard/rollup.config.js
@@ -5,6 +5,7 @@ import dts from 'rollup-plugin-dts';
 import { terser } from 'rollup-plugin-terser';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import postcss from 'rollup-plugin-postcss';
+import json from '@rollup/plugin-json';
 
 const packageJson = require('./package.json'); // eslint-disable-line
 
@@ -27,6 +28,7 @@ export default [
       peerDepsExternal(),
       nodeResolve(),
       commonjs(),
+      json(),
       typescript({ tsconfig: './tsconfig.json' }),
       postcss(),
       terser(),

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -1,17 +1,28 @@
 import React from 'react';
 import { Provider } from 'react-redux';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
 
-import InternalIotDashboard from '../internalDashboard';
+import InternalDashboard from '../internalDashboard';
 
 import { configureDashboardStore } from '../../store';
 import { DashboardState } from '../../store/state';
 
 export type IotDashboardProps = Pick<DashboardState, 'dashboardConfiguration'>;
 
-const IotDashboard = (props: IotDashboardProps) => (
+const Dashboard = (props: IotDashboardProps) => (
   <Provider store={configureDashboardStore(props)}>
-    <InternalIotDashboard />
+    <DndProvider
+      debugMode={true}
+      backend={TouchBackend}
+      options={{
+        enableMouseEvents: true,
+        enableKeyboardEvents: true,
+      }}
+    >
+      <InternalDashboard />
+    </DndProvider>
   </Provider>
 );
 
-export default IotDashboard;
+export default Dashboard;

--- a/packages/dashboard/src/components/grid/getDashboardPosition.ts
+++ b/packages/dashboard/src/components/grid/getDashboardPosition.ts
@@ -1,0 +1,47 @@
+import { Position } from '../../types';
+
+export const DASHBOARD_CONTAINER_ID = 'container';
+
+const getOffsets = (event: React.MouseEvent | React.TouchEvent | React.PointerEvent) => {
+  if ((event as React.TouchEvent).touches) {
+    const ev = (event as React.TouchEvent).touches[0];
+
+    const rect = (ev.target as HTMLElement).getBoundingClientRect();
+    const offsetX = ev.clientX - rect.x;
+    const offsetY = ev.clientY - rect.y;
+
+    return {
+      offsetX,
+      offsetY,
+    };
+  }
+
+  // return {
+  //   offsetX: event.offsetX,
+  //   offsetY: event.offsetY,
+  // };
+  const ev = event as React.MouseEvent;
+  const rect = (ev.target as HTMLElement).getBoundingClientRect();
+  const offsetX = ev.clientX - rect.x;
+  const offsetY = ev.clientY - rect.y;
+
+  return {
+    offsetX,
+    offsetY,
+  };
+};
+
+export const getDashboardPosition = (event: React.MouseEvent | React.TouchEvent | React.PointerEvent): Position => {
+  const { offsetX, offsetY } = getOffsets(event);
+  let totalOffsetX = offsetX;
+  let totalOffsetY = offsetY;
+  let currElement: HTMLElement | null = event.target as HTMLElement;
+
+  while (currElement && currElement.id != DASHBOARD_CONTAINER_ID) {
+    totalOffsetX += currElement.offsetLeft;
+    totalOffsetY += currElement.offsetTop;
+    currElement = (currElement as HTMLElement).offsetParent as HTMLElement;
+  }
+
+  return { x: totalOffsetX, y: totalOffsetY };
+};

--- a/packages/dashboard/src/components/grid/grid-dot.svg
+++ b/packages/dashboard/src/components/grid/grid-dot.svg
@@ -1,0 +1,6 @@
+<svg height="10" width="10"
+     version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     viewBox="0 0 10 10" xml:space="preserve" preserveAspectRatio="none">
+
+  <circle cx="1.2" cy="1.2" r="0.4" stroke="#e3e3e3" stroke-width="0.3" fill="#e3e3e3" shape-rendering="crispEdges"/>
+</svg>

--- a/packages/dashboard/src/components/grid/index.css
+++ b/packages/dashboard/src/components/grid/index.css
@@ -1,0 +1,23 @@
+.container {
+  position: absolute;
+  height: 100%;
+
+  /* margin: 0.5em; */
+
+  /**  establish a depth context */
+  z-index: 1;
+}
+
+.grid-image {
+  z-index: -999999999;
+  position: absolute;
+
+  /** Offset to make the dot fall in the top left corner */
+  right: 1px;
+  top: -1px;
+  background-position: top left;
+  background-image: url("grid-dot.svg");
+  background-repeat: repeat;
+  width: 100%;
+  height: 100%;
+}

--- a/packages/dashboard/src/components/grid/index.tsx
+++ b/packages/dashboard/src/components/grid/index.tsx
@@ -1,0 +1,143 @@
+import React, { PointerEventHandler, useEffect, useState } from 'react';
+import { useDrag } from 'react-dnd';
+import { useKeyPress } from '../../hooks/useKeyPress';
+import { DashboardState } from '../../store/state';
+import { Position } from '../../types';
+import { gestureable } from '../internalDashboard/determineTargetGestures';
+import { DASHBOARD_CONTAINER_ID, getDashboardPosition } from './getDashboardPosition';
+
+import './index.css';
+
+export type DragEvent = {
+  target?: EventTarget;
+  start: Position;
+  end: Position;
+  vector: Position;
+  union: boolean;
+};
+export type PointClickEvent = {
+  target?: EventTarget;
+  position: Position;
+  union: boolean;
+};
+
+export type GridProps = {
+  grid: DashboardState['grid'];
+  click: (e: PointClickEvent) => void;
+  dragStart: (e: DragEvent) => void;
+  drag: (e: DragEvent) => void;
+  dragEnd: (e: DragEvent) => void;
+};
+
+const defaultDelta = { x: 0, y: 0 };
+
+const Grid: React.FC<GridProps> = ({ grid, click, dragStart, drag, dragEnd, children }) => {
+  const { width, height, cellSize, stretchToFit } = grid;
+
+  const [delta, setDelta] = useState<Position>(defaultDelta);
+  const [cancelClick, setCancelClick] = useState(false);
+  const [start, setStart] = useState<Position>(defaultDelta);
+  const [end, setEnd] = useState<Position>(defaultDelta);
+  const [target, setTarget] = useState<EventTarget | undefined>();
+  const union = useKeyPress((e) => e.shiftKey);
+
+  const [collected, ref] = useDrag(
+    () => ({
+      type: 'grid',
+      item: (monitor) => {
+        setCancelClick(true);
+        dragStart({
+          target,
+          start,
+          end,
+          vector: defaultDelta,
+          union,
+        });
+        setDelta(monitor.getClientOffset() || defaultDelta);
+        return {};
+      },
+      end: () => {
+        setCancelClick(false);
+        dragEnd({
+          target,
+          start,
+          end,
+          vector: defaultDelta,
+          union,
+        });
+        setDelta(defaultDelta);
+      },
+      collect: (monitor) => {
+        return {
+          monitor,
+          type: monitor.getItemType(),
+          isDragging: !!monitor.isDragging(),
+          clientOffset: monitor.getClientOffset(),
+        };
+      },
+    }),
+    [union, start, end]
+  );
+
+  useEffect(() => {
+    const { isDragging, clientOffset } = collected;
+
+    if (isDragging && clientOffset) {
+      const offset = {
+        x: clientOffset.x - delta.x,
+        y: clientOffset.y - delta.y,
+      };
+      const updatedEndPosition = {
+        x: end.x + offset.x,
+        y: end.y + offset.y,
+      };
+
+      drag({
+        target,
+        start,
+        end: updatedEndPosition,
+        vector: offset,
+        union,
+      });
+      setEnd(updatedEndPosition);
+      setDelta(clientOffset);
+      setCancelClick(true);
+    }
+  }, [collected.isDragging, collected.clientOffset]);
+
+  const onPointerDown: PointerEventHandler = (e) => {
+    setTarget(e.target);
+    setCancelClick(false);
+    setStart(getDashboardPosition(e));
+    setEnd(getDashboardPosition(e));
+  };
+
+  const onPointerUp: PointerEventHandler = (e) => {
+    if (!cancelClick) {
+      click({
+        position: getDashboardPosition(e),
+        union,
+      });
+    }
+  };
+
+  return (
+    <div {...gestureable('grid')} ref={ref} onPointerDown={onPointerDown} onPointerUp={onPointerUp}>
+      <div
+        id={DASHBOARD_CONTAINER_ID}
+        tabIndex={0}
+        className="container"
+        style={{
+          width: stretchToFit ? '100%' : `${(width + 1) * cellSize}px`,
+          height: stretchToFit ? '100%' : `${(height + 1) * cellSize}px`,
+          backgroundSize: `${cellSize}px`,
+        }}
+      >
+        <div className="grid-image" style={{ backgroundSize: `${cellSize}px` }} />
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Grid;

--- a/packages/dashboard/src/components/internalDashboard/determineTargetGestures.ts
+++ b/packages/dashboard/src/components/internalDashboard/determineTargetGestures.ts
@@ -1,0 +1,45 @@
+import { DragEvent } from '../grid';
+
+const ATTRIBUTE = 'data-gesture';
+
+type GestureAttribute = 'grid' | 'resize' | 'selection' | 'widget';
+
+export const gestureable = (gesture: GestureAttribute) => ({
+  [ATTRIBUTE]: gesture,
+});
+
+export const determineTargetGestures = (
+  dragEvent: DragEvent
+): {
+  isOnResizeHandle: boolean;
+  isOnWidget: boolean;
+  isOnSelection: boolean;
+} => {
+  const target = dragEvent.target;
+  if (!target) {
+    throw new Error('Gesture target missing.');
+  }
+
+  let isOnResizeHandle = false;
+  let isOnWidget = false;
+  let isOnSelection = false;
+
+  let targetElement = target as HTMLElement;
+  while ((targetElement.getAttribute(ATTRIBUTE) as GestureAttribute) !== 'grid') {
+    const attribute = targetElement.getAttribute(ATTRIBUTE) as GestureAttribute;
+
+    if (attribute === 'resize') isOnResizeHandle = true;
+    else if (attribute === 'selection') isOnSelection = true;
+    else if (attribute === 'widget') isOnWidget = true;
+
+    const parentElement = targetElement.parentElement;
+    if (!parentElement) break;
+    targetElement = parentElement;
+  }
+
+  return {
+    isOnResizeHandle,
+    isOnWidget,
+    isOnSelection,
+  };
+};

--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -9,16 +9,12 @@
 
 .iot-dashboard-toolbar {
   grid-area: toolbar;
-  background-color: red;
 }
 
 .iot-dashboard-grid {
   grid-area: grid;
-  background-color: yellow;
-}
-
-.iot-resizable-panel {
-  background-color: pink;
+  position: relative;
+  overflow: scroll;
 }
 
 .iot-resizable-panel-left {

--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
 
 import { act } from 'react-dom/test-utils';
 
-import InternalIotDashboard from './index';
+import InternalDashboard from './index';
 import { configureDashboardStore } from '../../store';
 
-describe('InternalIotDashboard', () => {
+describe('InternalDashboard', () => {
   it('should render', function () {
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -22,7 +24,16 @@ describe('InternalIotDashboard', () => {
     act(() => {
       ReactDOM.render(
         <Provider store={configureDashboardStore(args)}>
-          <InternalIotDashboard />
+          <DndProvider
+            debugMode={true}
+            backend={TouchBackend}
+            options={{
+              enableMouseEvents: true,
+              enableKeyboardEvents: true,
+            }}
+          >
+            <InternalDashboard />
+          </DndProvider>
         </Provider>,
         container
       );

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -1,5 +1,11 @@
-import React from 'react';
-import { useDispatch } from 'react-redux';
+import React, { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import last from 'lodash/last';
+import sortBy from 'lodash/sortBy';
+
+import { MockWidgetFactory } from '../../../testing/mocks';
+import { useKeyPress } from '../../hooks/useKeyPress';
 
 /**
  * For developing purposes only.
@@ -8,34 +14,266 @@ import { useDispatch } from 'react-redux';
  */
 // import { DEMO_TURBINE_ASSET_1, DEMO_TURBINE_ASSET_1_PROPERTY_4, query } from '../../../testing/siteWiseQueries';
 
-import { onCreateWidgetsAction } from '../../store/actions';
-// import { DashboardState } from '../../store/state';
+import {
+  onChangeDashboardHeightAction,
+  onChangeDashboardWidthAction,
+  onCreateWidgetsAction,
+  onSelectWidgetsAction,
+} from '../../store/actions';
+import { onMoveWidgetsAction } from '../../store/actions/moveWidgets';
+import { DashboardState } from '../../store/state';
+import { Position, Rect, Widget } from '../../types';
+import { getSelectedWidgets } from '../../util/select';
+import Grid, { DragEvent, GridProps, PointClickEvent } from '../grid';
+import UserSelection, { UserSelectionProps } from '../userSelection';
+import Widgets, { WidgetsProps } from '../widgets/list';
 
 import './index.css';
+import { determineTargetGestures } from './determineTargetGestures';
 
-const InternalIotDashboard = () => {
+type Gesture = 'move' | 'resize' | 'select' | undefined;
+
+type Selection = {
+  start: Position;
+  end: Position;
+};
+
+const selectedRect = (selection: Selection | undefined): Rect | undefined => {
+  if (!selection) {
+    return undefined;
+  }
+  return {
+    x: Math.min(selection.start.x, selection.end.x),
+    y: Math.min(selection.start.y, selection.end.y),
+    width: Math.abs(selection.start.x - selection.end.x),
+    height: Math.abs(selection.start.y - selection.end.y),
+  };
+};
+
+const InternalDashboard = () => {
+  /**
+   * Store variables
+   */
+  const dashboardConfiguration = useSelector((state: DashboardState) => state.dashboardConfiguration);
+  const grid = useSelector((state: DashboardState) => state.grid);
+  const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
+  // console.log(selectedWidgets);
+
   const dispatch = useDispatch();
-
-  // const widgets = useSelector((state: DashboardState) => state.dashboardConfiguration.widgets);
-
   const createWidgets = () =>
     dispatch(
       onCreateWidgetsAction({
-        widgets: [],
+        widgets: [MockWidgetFactory.getKpiWidget()],
       })
     );
+
+  const selectWidgets = (widgets: Widget[], union: boolean) => {
+    dispatch(
+      onSelectWidgetsAction({
+        widgets,
+        union,
+      })
+    );
+  };
+
+  const moveWidgets = (vector: Position, complete?: boolean) => {
+    dispatch(
+      onMoveWidgetsAction({
+        widgets: selectedWidgets,
+        vector: {
+          x: vector.x / grid.cellSize, // transform to grid units
+          y: vector.y / grid.cellSize,
+        },
+        complete,
+      })
+    );
+  };
+
+  const changeWidth = (e: React.ChangeEvent<HTMLInputElement>) =>
+    dispatch(
+      onChangeDashboardWidthAction({
+        width: parseInt(e.target.value),
+      })
+    );
+
+  const changeHeight = (e: React.ChangeEvent<HTMLInputElement>) =>
+    dispatch(
+      onChangeDashboardHeightAction({
+        height: parseInt(e.target.value),
+      })
+    );
+
+  /**
+   * Local variables
+   */
+  const [userSelection, setUserSelection] = useState<Selection | undefined>(undefined);
+  const [activeGesture, setActiveGesture] = useState<Gesture | undefined>(undefined);
+
+  const escape = useKeyPress((e) => e.key === 'Escape');
+  useEffect(() => {
+    if (escape) {
+      onClearSelection();
+    }
+  }, [escape]);
+
+  /**
+   * Selection handlers
+   */
+  const onClearSelection = () => {
+    selectWidgets([], false);
+  };
+  const onPointSelect = ({ position, union }: { position: Position; union: boolean }) => {
+    /**
+     * TODO Can refactor this to be less lines
+     */
+    const { x, y } = position;
+    const intersectedWidgets = getSelectedWidgets({
+      selectedRect: { x, y, width: 1, height: 1 },
+      dashboardConfiguration,
+      cellSize: grid.cellSize,
+    });
+    const selectingAlreadySelectedWidget = intersectedWidgets
+      .map((widget) => widget.id)
+      .some((widgetId) => selectedWidgets.map((w) => w.id).includes(widgetId));
+
+    if (selectedWidgets.length === 0 || !selectingAlreadySelectedWidget) {
+      const sortableWidgets = intersectedWidgets.map((widget, index) => ({ id: widget.id, z: widget.z, index }));
+      const topMostWidgetId = last(sortBy(sortableWidgets, ['z', 'index']).map((widget) => widget.id));
+      const widgetIds = topMostWidgetId ? [topMostWidgetId] : [];
+      const widgets = dashboardConfiguration.widgets.filter((w) => widgetIds.includes(w.id));
+
+      selectWidgets(widgets, union);
+    }
+  };
+  const onSelectionStart = (dragEvent: DragEvent) => {
+    setActiveGesture('select');
+    setUserSelection({
+      start: dragEvent.start,
+      end: dragEvent.end,
+    });
+  };
+
+  const onSelectionUpdate = (dragEvent: DragEvent) => {
+    const updatedSelection = {
+      start: dragEvent.start,
+      end: dragEvent.end,
+    };
+    setUserSelection(updatedSelection);
+
+    const union = dragEvent.union;
+
+    const intersectedWidgets = getSelectedWidgets({
+      selectedRect: selectedRect(updatedSelection),
+      dashboardConfiguration,
+      cellSize: grid.cellSize,
+    });
+
+    selectWidgets(intersectedWidgets, union);
+  };
+  const onSelectionEnd = () => {
+    setUserSelection(undefined);
+  };
+
+  /**
+   * Move handlers
+   */
+  const onMoveStart = () => {
+    setActiveGesture('move');
+  };
+  const onMoveUpdate = (dragEvent: DragEvent) => {
+    moveWidgets(dragEvent.vector, false);
+  };
+  const onMoveEnd = (dragEvent: DragEvent) => {
+    moveWidgets(dragEvent.vector, true);
+  };
+
+  /**
+   * Gesture handlers
+   */
+  const onPointClick = (pointClickEvent: PointClickEvent) => {
+    onPointSelect(pointClickEvent);
+  };
+  const onGestureStart = (dragEvent: DragEvent) => {
+    const { isOnResizeHandle, isOnSelection, isOnWidget } = determineTargetGestures(dragEvent);
+    const isUnion = dragEvent.union;
+
+    const isMoveGesture = !isUnion && (isOnWidget || isOnSelection);
+
+    if (isOnWidget && !isOnSelection) {
+      onPointSelect({ position: dragEvent.start, union: dragEvent.union });
+    }
+
+    if (isOnResizeHandle) {
+      // handle resize
+    } else if (isMoveGesture) {
+      onMoveStart();
+    } else {
+      onSelectionStart(dragEvent);
+    }
+  };
+  const onGestureUpdate = (dragEvent: DragEvent) => {
+    if (activeGesture === 'select') {
+      onSelectionUpdate(dragEvent);
+    } else if (activeGesture === 'move') {
+      onMoveUpdate(dragEvent);
+    }
+  };
+  const onGestureEnd = (dragEvent: DragEvent) => {
+    if (activeGesture === 'select') {
+      onSelectionEnd();
+    } else if (activeGesture === 'move') {
+      onMoveEnd(dragEvent);
+    }
+
+    setActiveGesture(undefined);
+  };
+
+  /**
+   *
+   * Child component props configuration
+   */
+  const gridProps: GridProps = {
+    grid,
+    click: onPointClick,
+    dragStart: onGestureStart,
+    drag: onGestureUpdate,
+    dragEnd: onGestureEnd,
+  };
+
+  const widgetsProps: WidgetsProps = {
+    dashboardConfiguration,
+    selectedWidgets,
+    cellSize: grid.cellSize,
+  };
+
+  const selectionProps: UserSelectionProps = {
+    rect: selectedRect(userSelection),
+  };
 
   return (
     <div className="iot-dashboard">
       <div className="iot-dashboard-toolbar">
         toolbar
         <button onClick={createWidgets}>Add widget</button>
+        <label>
+          width:
+          <input type="number" defaultValue={grid.width} onChange={changeWidth} />
+        </label>
+        <label>
+          height:
+          <input type="number" defaultValue={grid.height} onChange={changeHeight} />
+        </label>
       </div>
       <div className="iot-resizable-panel iot-resizable-panel-left">left panel</div>
-      <div className="iot-dashboard-grid">grid</div>
+      <div className="iot-dashboard-grid">
+        <Grid {...gridProps}>
+          <Widgets {...widgetsProps} />
+          {activeGesture === 'select' && <UserSelection {...selectionProps} />}
+        </Grid>
+      </div>
       <div className="iot-resizable-panel iot-resizable-panel-right">right panel</div>
     </div>
   );
 };
 
-export default InternalIotDashboard;
+export default InternalDashboard;

--- a/packages/dashboard/src/components/userSelection/index.css
+++ b/packages/dashboard/src/components/userSelection/index.css
@@ -1,0 +1,7 @@
+@import "../../styles/variables.css";
+
+.select-rect {
+  border: var(--selection-border-width) solid var(--selection-color);
+  position: absolute;
+  z-index: var(--stack-order-selection-box);
+}

--- a/packages/dashboard/src/components/userSelection/index.tsx
+++ b/packages/dashboard/src/components/userSelection/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { Rect } from '../../types';
+
+import './index.css';
+
+export type UserSelectionProps = {
+  rect: Rect | undefined;
+};
+
+const UserSelection: React.FC<UserSelectionProps> = ({ rect }) => {
+  return rect ? (
+    <div
+      className="select-rect"
+      style={{
+        left: `${rect.x}px`,
+        top: `${rect.y}px`,
+        width: `${rect.width}px`,
+        height: `${rect.height}px`,
+      }}
+    ></div>
+  ) : null;
+};
+
+export default UserSelection;

--- a/packages/dashboard/src/components/widgets/list.css
+++ b/packages/dashboard/src/components/widgets/list.css
@@ -1,0 +1,4 @@
+.widgets {
+  /* margin: -0.5em; */
+  position: absolute;
+}

--- a/packages/dashboard/src/components/widgets/list.tsx
+++ b/packages/dashboard/src/components/widgets/list.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import map from 'lodash/map';
+import includes from 'lodash/includes';
+
+import { DashboardConfiguration, Widget } from '../../types';
+
+import './list.css';
+import WidgetComponent from './widget';
+import SelectionBox from './selectionBox';
+
+export type WidgetsProps = {
+  dashboardConfiguration: DashboardConfiguration;
+  selectedWidgets: Widget[];
+  cellSize: number;
+};
+
+const Widgets: React.FC<WidgetsProps> = ({ dashboardConfiguration, selectedWidgets, cellSize }) => {
+  const { widgets, viewport } = dashboardConfiguration;
+  const isSelected = (id: string) =>
+    includes(
+      map(selectedWidgets, (sw) => sw.id),
+      id
+    );
+  return (
+    <div
+      className="widgets"
+      style={{
+        margin: `${cellSize / 2}px`,
+      }}
+    >
+      <SelectionBox {...{ dashboardConfiguration, selectedWidgets, cellSize }} />
+      {widgets.map((widget) => (
+        <WidgetComponent
+          isSelected={isSelected(widget.id)}
+          key={widget.id}
+          cellSize={cellSize}
+          widget={widget}
+          viewport={viewport}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default Widgets;

--- a/packages/dashboard/src/components/widgets/selectionBox.css
+++ b/packages/dashboard/src/components/widgets/selectionBox.css
@@ -1,0 +1,12 @@
+@import "../../styles/variables.css";
+
+.selection-box {
+  position: relative;
+  z-index: 9999999999999;
+  border: var(--selection-border-width) solid var(--selection-color);
+  border-radius: var(--selection-radius);
+  font-weight: bold;
+  height: 100%;
+  user-select: none;
+  box-sizing: border-box;
+}

--- a/packages/dashboard/src/components/widgets/selectionBox.tsx
+++ b/packages/dashboard/src/components/widgets/selectionBox.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { DashboardConfiguration, Rect, Widget } from '../../types';
+import { isDefined } from '../../util/isDefined';
+import SelectionBoxAnchor from './selectionBoxAnchor';
+
+import './selectionBox.css';
+import { gestureable } from '../internalDashboard/determineTargetGestures';
+
+// Returns the smallest rectangle which can contain all the selected widgets
+export const getSelectionBox = ({
+  selectedWidgetIds,
+  dashboardConfiguration,
+}: {
+  selectedWidgetIds: string[];
+  dashboardConfiguration: DashboardConfiguration;
+}): Rect | null => {
+  const widgets = selectedWidgetIds
+    .map((widgetId) => dashboardConfiguration.widgets.find((widget) => widget.id === widgetId))
+    .filter(isDefined);
+
+  if (widgets.length === 0) {
+    return null;
+  }
+
+  const minX = Math.min(...widgets.map((widget) => widget.x));
+  const maxX = Math.max(...widgets.map((widget) => widget.x + widget.width));
+  const minY = Math.min(...widgets.map((widget) => widget.y));
+  const maxY = Math.max(...widgets.map((widget) => widget.y + widget.height));
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+};
+
+export type SelectionBoxProps = {
+  dashboardConfiguration: DashboardConfiguration;
+  selectedWidgets: Widget[];
+  cellSize: number;
+};
+
+const SelectionBox: React.FC<SelectionBoxProps> = ({ dashboardConfiguration, selectedWidgets, cellSize }) => {
+  const rect = getSelectionBox({ selectedWidgetIds: selectedWidgets.map((w) => w.id), dashboardConfiguration });
+  if (!rect) return null;
+
+  const { x, y, height, width } = rect;
+
+  return (
+    <div
+      {...gestureable('selection')}
+      className="selection-box"
+      style={{
+        top: `${cellSize * y}px`,
+        left: `${cellSize * x}px`,
+        width: `${cellSize * (width - 1)}px`,
+        height: `${cellSize * (height - 1)}px`,
+      }}
+    >
+      <SelectionBoxAnchor anchor="top" />
+      <SelectionBoxAnchor anchor="bottom" />
+      <SelectionBoxAnchor anchor="right" />
+      <SelectionBoxAnchor anchor="left" />
+      <SelectionBoxAnchor anchor="top-right" />
+      <SelectionBoxAnchor anchor="top-left" />
+      <SelectionBoxAnchor anchor="bottom-right" />
+      <SelectionBoxAnchor anchor="bottom-left" />
+    </div>
+  );
+};
+
+export default SelectionBox;

--- a/packages/dashboard/src/components/widgets/selectionBoxAnchor.css
+++ b/packages/dashboard/src/components/widgets/selectionBoxAnchor.css
@@ -1,0 +1,74 @@
+@import "../../styles/variables.css";
+
+/**
+ * Draggable corners for the selection box
+ */
+
+.selection-box-corner {
+  position: absolute;
+  width: var(--selection-box-size);
+  height: var(--selection-box-size);
+  border: var(--selection-border-width) solid var(--selection-color);
+  background: var(--selection-bg-color);
+  border-radius: var(--selection-radius-small);
+}
+
+.selection-box-corner-top-right {
+  cursor: nesw-resize;
+  right: calc(-1 * var(--selection-box-size) / 2);
+  top: calc(-1 * var(--selection-box-size) / 2);
+}
+
+.selection-box-corner-top-left {
+  cursor: nwse-resize;
+  top: calc(-1 * var(--selection-box-size) / 2);
+  left: calc(-1 * var(--selection-box-size) / 2);
+}
+
+.selection-box-corner-bottom-right {
+  cursor: nwse-resize;
+  bottom: calc(-1 * var(--selection-box-size) / 2);
+  right: calc(-1 * var(--selection-box-size) / 2);
+}
+
+.selection-box-corner-bottom-left {
+  cursor: nesw-resize;
+  bottom: calc(-1 * var(--selection-box-size) / 2);
+  left: calc(-1 * var(--selection-box-size) / 2);
+}
+
+/**
+ * Draggable sides for the selection box
+ */
+
+.selection-box-side {
+  position: absolute;
+}
+
+.selection-box-side-top {
+  cursor: ns-resize;
+  height: var(--selection-border-touch-width);
+  width: 100%;
+  top: calc(-1 / 2 * var(--selection-border-touch-width));
+}
+
+.selection-box-side-bottom {
+  cursor: ns-resize;
+  height: var(--selection-border-touch-width);
+  width: 100%;
+  bottom: calc(-1 / 2 * var(--selection-border-touch-width));
+}
+
+.selection-box-side-right {
+  cursor: ew-resize;
+  width: var(--selection-border-touch-width);
+  height: 100%;
+  right: calc(-1 / 2 * var(--selection-border-touch-width));
+}
+
+.selection-box-side-left {
+  cursor: ew-resize;
+  width: var(--selection-border-touch-width);
+  height: 100%;
+  left: calc(-1 / 2 * var(--selection-border-touch-width));
+}

--- a/packages/dashboard/src/components/widgets/selectionBoxAnchor.tsx
+++ b/packages/dashboard/src/components/widgets/selectionBoxAnchor.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { gestureable } from '../internalDashboard/determineTargetGestures';
+
+import './selectionBoxAnchor.css';
+
+export type Anchor = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left' | 'left' | 'right' | 'top' | 'bottom';
+
+const CORNERS: Anchor[] = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+const SIDES: Anchor[] = ['top', 'right', 'bottom', 'left'];
+
+export type SelectionBoxAnchorProps = {
+  anchor: Anchor;
+};
+
+const SelectionBoxAnchor: React.FC<SelectionBoxAnchorProps> = ({ anchor }) => {
+  const isCorner = CORNERS.includes(anchor);
+  const isSide = SIDES.includes(anchor);
+  const cornerClass = isCorner ? `selection-box-corner selection-box-corner-${anchor}` : '';
+  const sideClass = isSide ? `selection-box-side selection-box-side-${anchor}` : '';
+  const anchorClass = `${cornerClass} ${sideClass}`;
+
+  return <div {...gestureable('resize')} className={anchorClass} />;
+};
+
+export default SelectionBoxAnchor;

--- a/packages/dashboard/src/components/widgets/widget.css
+++ b/packages/dashboard/src/components/widgets/widget.css
@@ -1,0 +1,32 @@
+@import "../../styles/variables.css";
+
+.widget {
+  position: absolute;
+  background-color: var(--selection-bg-color);
+  font-weight: bold;
+  height: 100%;
+  user-select: none;
+  box-sizing: border-box;
+  border: var(--selection-border-width) solid var(--selection-bg-color);
+}
+
+.widget:hover {
+  border: var(--selection-border-width) solid var(--selection-color-secondary);
+  cursor: all-scroll;
+  border-radius: var(--selection-radius-small);
+}
+
+.widget-selected {
+  border: var(--selection-border-width) solid var(--selection-color-secondary);
+  border-radius: var(--selection-radius);
+}
+
+.widget-content {
+  display: flex;
+  font-weight: bold;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+}

--- a/packages/dashboard/src/components/widgets/widget.tsx
+++ b/packages/dashboard/src/components/widgets/widget.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { DashboardConfiguration, Widget } from '../../types';
+import { gestureable } from '../internalDashboard/determineTargetGestures';
+
+import './widget.css';
+
+export type WidgetProps = {
+  isSelected: boolean;
+  cellSize: number;
+  widget: Widget;
+  viewport: DashboardConfiguration['viewport'];
+};
+
+const WidgetComponent: React.FC<WidgetProps> = ({ cellSize, widget }) => {
+  const { x, y, z, width, height, componentTag } = widget;
+
+  return (
+    <div
+      {...gestureable('widget')}
+      className="widget"
+      style={{
+        zIndex: z.toString(),
+        top: `${cellSize * y}px`,
+        left: `${cellSize * x}px`,
+        width: `${cellSize * (width - 1)}px`,
+        height: `${cellSize * (height - 1)}px`,
+      }}
+    >
+      <div>{componentTag}</div>
+    </div>
+  );
+};
+
+export default WidgetComponent;

--- a/packages/dashboard/src/hooks/useKeyPress.ts
+++ b/packages/dashboard/src/hooks/useKeyPress.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+export const useKeyPress = (selector: (event: KeyboardEvent) => boolean) => {
+  const [keyPressed, setKeyPressed] = useState<boolean>(false);
+  const onKeyDown = (e: KeyboardEvent) => setKeyPressed(selector(e));
+  const onKeyUp = (e: KeyboardEvent) => setKeyPressed(selector(e));
+
+  useEffect(() => {
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+  }, []);
+
+  return keyPressed;
+};

--- a/packages/dashboard/src/store/actions/changeDashboardSize/changeHeight.spec.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardSize/changeHeight.spec.ts
@@ -1,0 +1,24 @@
+import { changeDashboardHeight, onChangeDashboardHeightAction } from './changeHeight';
+import { initialState } from '../../state';
+
+it('can change the height of the dashboard', () => {
+  expect(
+    changeDashboardHeight(
+      initialState,
+      onChangeDashboardHeightAction({
+        height: 10,
+      })
+    ).grid.height
+  ).toEqual(10);
+});
+
+it('does not allow negative heights', () => {
+  expect(
+    changeDashboardHeight(
+      initialState,
+      onChangeDashboardHeightAction({
+        height: -10,
+      })
+    ).grid.height
+  ).toEqual(0);
+});

--- a/packages/dashboard/src/store/actions/changeDashboardSize/changeHeight.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardSize/changeHeight.ts
@@ -1,0 +1,22 @@
+import { Action } from 'redux';
+
+import { DashboardState } from '../../state';
+import { changeGridProperty } from './updateGrid';
+
+type ChangeDashboardHeightActionPayload = {
+  height: number;
+};
+export interface ChangeDashboardHeightAction extends Action {
+  type: 'CHANGE_HEIGHT';
+  payload: ChangeDashboardHeightActionPayload;
+}
+
+export const onChangeDashboardHeightAction = (
+  payload: ChangeDashboardHeightActionPayload
+): ChangeDashboardHeightAction => ({
+  type: 'CHANGE_HEIGHT',
+  payload,
+});
+
+export const changeDashboardHeight = (state: DashboardState, action: ChangeDashboardHeightAction): DashboardState =>
+  changeGridProperty(state, 'height', Math.max(0, action.payload.height));

--- a/packages/dashboard/src/store/actions/changeDashboardSize/changeWidth.spec.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardSize/changeWidth.spec.ts
@@ -1,0 +1,24 @@
+import { changeDashboardWidth, onChangeDashboardWidthAction } from './changeWidth';
+import { initialState } from '../../state';
+
+it('can change the width of the dashboard', () => {
+  expect(
+    changeDashboardWidth(
+      initialState,
+      onChangeDashboardWidthAction({
+        width: 10,
+      })
+    ).grid.width
+  ).toEqual(10);
+});
+
+it('does not allow negative widths', () => {
+  expect(
+    changeDashboardWidth(
+      initialState,
+      onChangeDashboardWidthAction({
+        width: -10,
+      })
+    ).grid.width
+  ).toEqual(0);
+});

--- a/packages/dashboard/src/store/actions/changeDashboardSize/changeWidth.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardSize/changeWidth.ts
@@ -1,0 +1,22 @@
+import { Action } from 'redux';
+
+import { DashboardState } from '../../state';
+import { changeGridProperty } from './updateGrid';
+
+type ChangeDashboardWidthActionPayload = {
+  width: number;
+};
+export interface ChangeDashboardWidthAction extends Action {
+  type: 'CHANGE_WIDTH';
+  payload: ChangeDashboardWidthActionPayload;
+}
+
+export const onChangeDashboardWidthAction = (
+  payload: ChangeDashboardWidthActionPayload
+): ChangeDashboardWidthAction => ({
+  type: 'CHANGE_WIDTH',
+  payload,
+});
+
+export const changeDashboardWidth = (state: DashboardState, action: ChangeDashboardWidthAction): DashboardState =>
+  changeGridProperty(state, 'width', Math.max(0, action.payload.width));

--- a/packages/dashboard/src/store/actions/changeDashboardSize/index.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardSize/index.ts
@@ -1,0 +1,2 @@
+export * from './changeHeight';
+export * from './changeWidth';

--- a/packages/dashboard/src/store/actions/changeDashboardSize/updateGrid.spec.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardSize/updateGrid.spec.ts
@@ -1,0 +1,12 @@
+import { changeGridProperty } from './updateGrid';
+import { initialState } from '../../state';
+
+it('can change a grid property', () => {
+  expect(changeGridProperty(initialState, 'cellSize', 20).grid.cellSize).toEqual(20);
+
+  expect(changeGridProperty(initialState, 'width', 10).grid.width).toEqual(10);
+
+  expect(changeGridProperty(initialState, 'height', 10).grid.height).toEqual(10);
+
+  expect(changeGridProperty(initialState, 'stretchToFit', true).grid.stretchToFit).toEqual(true);
+});

--- a/packages/dashboard/src/store/actions/changeDashboardSize/updateGrid.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardSize/updateGrid.ts
@@ -1,0 +1,28 @@
+import { constrainWidgetPositionToGrid } from '../../../util/constrainWidgetPositionToGrid';
+import { DashboardState } from '../../state';
+
+type GridProperties = keyof DashboardState['grid'];
+type GridValues = DashboardState['grid'][GridProperties];
+
+export const changeGridProperty = (
+  state: DashboardState,
+  property: GridProperties,
+  value: GridValues
+): DashboardState => {
+  const grid = {
+    ...state.grid,
+    [property]: value,
+  };
+  const widgets = state.dashboardConfiguration.widgets.map((w) => {
+    return constrainWidgetPositionToGrid({ x: 0, y: 0, width: grid.width, height: grid.height }, w);
+  });
+
+  return {
+    ...state,
+    dashboardConfiguration: {
+      ...state.dashboardConfiguration,
+      widgets,
+    },
+    grid,
+  };
+};

--- a/packages/dashboard/src/store/actions/index.ts
+++ b/packages/dashboard/src/store/actions/index.ts
@@ -1,5 +1,16 @@
 import { CreateWidgetsAction } from './createWidget';
+import { SelectWidgetsAction } from './selectWidgets';
+import { MoveWidgetsAction } from './moveWidgets';
+import { ChangeDashboardWidthAction, ChangeDashboardHeightAction } from './changeDashboardSize';
 
 export * from './createWidget';
+export * from './selectWidgets';
+export * from './moveWidgets';
+export * from './changeDashboardSize';
 
-export type DashboardAction = CreateWidgetsAction;
+export type DashboardAction =
+  | CreateWidgetsAction
+  | SelectWidgetsAction
+  | MoveWidgetsAction
+  | ChangeDashboardWidthAction
+  | ChangeDashboardHeightAction;

--- a/packages/dashboard/src/store/actions/moveWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/moveWidgets/index.spec.ts
@@ -1,0 +1,175 @@
+import { moveWidgets, onMoveWidgetsAction } from './index';
+import { DashboardState, initialState } from '../../state';
+
+import { MockWidgetFactory, MOCK_KPI_WIDGET } from '../../../../testing/mocks';
+import { Widget } from '../../../types';
+
+const setupDashboardState = (widgets: Widget[] = []): DashboardState => ({
+  ...initialState,
+  grid: {
+    ...initialState.grid,
+    width: 100,
+    height: 100,
+  },
+  dashboardConfiguration: {
+    ...initialState.dashboardConfiguration,
+    widgets,
+  },
+});
+
+describe('move', () => {
+  it('does nothing if given an empty list of widgets', () => {
+    expect(
+      moveWidgets(
+        setupDashboardState([MOCK_KPI_WIDGET]),
+        onMoveWidgetsAction({
+          widgets: [],
+          vector: { x: 1, y: 0 },
+        })
+      ).dashboardConfiguration.widgets
+    ).toEqual([MOCK_KPI_WIDGET]);
+  });
+
+  it('shifts a single selected widget by a fractional amount when position changes slightly', () => {
+    const widget = MockWidgetFactory.getKpiWidget({ x: 1, y: 1, width: 5, height: 5 });
+
+    expect(
+      moveWidgets(
+        setupDashboardState([widget]),
+        onMoveWidgetsAction({
+          widgets: [widget],
+          vector: { x: 0.1, y: 0.1 },
+        })
+      ).dashboardConfiguration.widgets
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          x: 1.1,
+          y: 1.1,
+        }),
+      ])
+    );
+  });
+
+  it('does not shift off of the grid', () => {
+    const widget = MockWidgetFactory.getKpiWidget({ x: 0, y: 0, width: 5, height: 5 });
+    const dashboardState = setupDashboardState([widget]);
+
+    expect(
+      moveWidgets(
+        dashboardState,
+        onMoveWidgetsAction({
+          widgets: [widget],
+          vector: { x: dashboardState.grid.width, y: 0 },
+        })
+      ).dashboardConfiguration.widgets
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          x: dashboardState.grid.width - widget.width,
+          y: 0,
+        }),
+      ])
+    );
+  });
+
+  it('does not shift widget that is not selected', () => {
+    const widget1 = MockWidgetFactory.getKpiWidget({ x: 0, y: 0, width: 5, height: 5 });
+    const widget2 = MockWidgetFactory.getKpiWidget({ x: 6, y: 6, width: 5, height: 5 });
+
+    expect(
+      moveWidgets(
+        setupDashboardState([widget1, widget2]),
+        onMoveWidgetsAction({
+          widgets: [widget1],
+          vector: { x: 1, y: 1 },
+        })
+      ).dashboardConfiguration.widgets
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          x: 1,
+          y: 1,
+        }),
+        expect.objectContaining({
+          x: 6,
+          y: 6,
+        }),
+      ])
+    );
+  });
+
+  it('does not shift widget when the vector is 0, 0', () => {
+    const widget = MockWidgetFactory.getKpiWidget({ x: 0, y: 0, width: 5, height: 5 });
+
+    expect(
+      moveWidgets(
+        setupDashboardState([widget]),
+        onMoveWidgetsAction({
+          widgets: [widget],
+          vector: { x: 0, y: 0 },
+        })
+      ).dashboardConfiguration.widgets
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          x: 0,
+          y: 0,
+        }),
+      ])
+    );
+  });
+
+  it('shifts only selected widgets when multiple widgets are on the dashboard', () => {
+    const widget1 = MockWidgetFactory.getKpiWidget({ x: 0, y: 0, width: 5, height: 5 });
+    const widget2 = MockWidgetFactory.getKpiWidget({ x: 6, y: 6, width: 5, height: 5 });
+    const widget3 = MockWidgetFactory.getKpiWidget({ x: 14, y: 14, width: 5, height: 5 });
+
+    expect(
+      moveWidgets(
+        setupDashboardState([widget1, widget2, widget3]),
+        onMoveWidgetsAction({
+          widgets: [widget1, widget2],
+          vector: { x: 1, y: 1 },
+        })
+      ).dashboardConfiguration.widgets
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          x: 1,
+          y: 1,
+        }),
+        expect.objectContaining({
+          x: 7,
+          y: 7,
+        }),
+        expect.objectContaining({
+          x: 14,
+          y: 14,
+        }),
+      ])
+    );
+  });
+
+  it('snaps widgets to the grid when the move action is complete', () => {
+    const widget1 = MockWidgetFactory.getKpiWidget({ x: 0, y: 0, width: 5, height: 5 });
+
+    expect(
+      moveWidgets(
+        setupDashboardState([widget1]),
+        onMoveWidgetsAction({
+          widgets: [widget1],
+          vector: { x: 1.1, y: 1.1 },
+          complete: true,
+        })
+      ).dashboardConfiguration.widgets
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          x: 1,
+          y: 1,
+        }),
+      ])
+    );
+  });
+});

--- a/packages/dashboard/src/store/actions/moveWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/moveWidgets/index.ts
@@ -1,0 +1,47 @@
+import { Action } from 'redux';
+
+import { Position, Widget } from '../../../types';
+import { constrainWidgetPositionToGrid } from '../../../util/constrainWidgetPositionToGrid';
+import { trimWidgetPosition } from '../../../util/trimWidgetPosition';
+import { DashboardState } from '../../state';
+
+type MoveWidgetsActionPayload = {
+  widgets: Widget[];
+  vector: Position;
+  complete?: boolean;
+};
+export interface MoveWidgetsAction extends Action {
+  type: 'MOVE_WIDGETS';
+  payload: MoveWidgetsActionPayload;
+}
+
+export const onMoveWidgetsAction = (payload: MoveWidgetsActionPayload): MoveWidgetsAction => ({
+  type: 'MOVE_WIDGETS',
+  payload,
+});
+
+export const moveWidgets = (state: DashboardState, action: MoveWidgetsAction): DashboardState => {
+  const vector = action.payload.vector;
+  const widgets = state.dashboardConfiguration.widgets;
+  const selectedWidgetIds = action.payload.widgets.map((w) => w.id);
+  const movedWidgets = widgets.map((w) => {
+    if (!selectedWidgetIds.includes(w.id)) {
+      return w;
+    }
+
+    const widget = { ...w, x: w.x + vector.x, y: w.y + vector.y };
+    const constrainedWidget = constrainWidgetPositionToGrid(
+      { x: 0, y: 0, width: state.grid.width, height: state.grid.height },
+      widget
+    );
+    return action.payload.complete ? trimWidgetPosition(constrainedWidget) : constrainedWidget;
+  });
+
+  return {
+    ...state,
+    dashboardConfiguration: {
+      ...state.dashboardConfiguration,
+      widgets: movedWidgets,
+    },
+  };
+};

--- a/packages/dashboard/src/store/actions/selectWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/selectWidgets/index.spec.ts
@@ -1,0 +1,88 @@
+import { selectWidgets, onSelectWidgetsAction } from '.';
+import { DashboardState, initialState } from '../../state';
+
+import { MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET, MOCK_SCATTER_CHART_WIDGET } from '../../../../testing/mocks';
+
+const dashboardState: DashboardState = {
+  ...initialState,
+  dashboardConfiguration: {
+    ...initialState.dashboardConfiguration,
+    widgets: [MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET, MOCK_SCATTER_CHART_WIDGET],
+  },
+};
+
+it('does nothing if no widgets are provided', () => {
+  expect(
+    selectWidgets(
+      dashboardState,
+      onSelectWidgetsAction({
+        widgets: [],
+        union: false,
+      })
+    ).selectedWidgets
+  ).toEqual([]);
+});
+
+it('selects a single widget', () => {
+  expect(
+    selectWidgets(
+      dashboardState,
+      onSelectWidgetsAction({
+        widgets: [MOCK_KPI_WIDGET],
+        union: false,
+      })
+    ).selectedWidgets
+  ).toEqual([MOCK_KPI_WIDGET]);
+});
+
+it('selects multiple widget', () => {
+  expect(
+    selectWidgets(
+      dashboardState,
+      onSelectWidgetsAction({
+        widgets: [MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET],
+        union: false,
+      })
+    ).selectedWidgets
+  ).toEqual([MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET]);
+});
+
+it('adds a single widget to a selection', () => {
+  const state = selectWidgets(
+    dashboardState,
+    onSelectWidgetsAction({
+      widgets: [MOCK_KPI_WIDGET],
+      union: false,
+    })
+  );
+
+  expect(
+    selectWidgets(
+      state,
+      onSelectWidgetsAction({
+        widgets: [MOCK_LINE_CHART_WIDGET],
+        union: true,
+      })
+    ).selectedWidgets
+  ).toEqual([MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET]);
+});
+
+it('adds multiple widgets to a selection', () => {
+  const state = selectWidgets(
+    dashboardState,
+    onSelectWidgetsAction({
+      widgets: [MOCK_KPI_WIDGET],
+      union: false,
+    })
+  );
+
+  expect(
+    selectWidgets(
+      state,
+      onSelectWidgetsAction({
+        widgets: [MOCK_LINE_CHART_WIDGET, MOCK_SCATTER_CHART_WIDGET],
+        union: true,
+      })
+    ).selectedWidgets
+  ).toEqual([MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET, MOCK_SCATTER_CHART_WIDGET]);
+});

--- a/packages/dashboard/src/store/actions/selectWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/selectWidgets/index.ts
@@ -1,0 +1,26 @@
+import { Action } from 'redux';
+import uniqBy from 'lodash/uniqBy';
+
+import { Widget } from '../../../types';
+import { DashboardState } from '../../state';
+
+type SelectWidgetsActionPayload = {
+  widgets: Widget[];
+  union: boolean;
+};
+export interface SelectWidgetsAction extends Action {
+  type: 'SELECT_WIDGETS';
+  payload: SelectWidgetsActionPayload;
+}
+
+export const onSelectWidgetsAction = (payload: SelectWidgetsActionPayload): SelectWidgetsAction => ({
+  type: 'SELECT_WIDGETS',
+  payload,
+});
+
+export const selectWidgets = (state: DashboardState, action: SelectWidgetsAction): DashboardState => ({
+  ...state,
+  selectedWidgets: action.payload.union
+    ? uniqBy([...state.selectedWidgets, ...action.payload.widgets], 'id')
+    : action.payload.widgets,
+});

--- a/packages/dashboard/src/store/index.ts
+++ b/packages/dashboard/src/store/index.ts
@@ -1,14 +1,16 @@
 import { Store } from 'redux';
 import { configureStore } from '@reduxjs/toolkit';
 
+import merge from 'lodash/merge';
+
 import { DashboardAction } from './actions';
-import { DashboardState } from './state';
+import { DashboardState, initialState } from './state';
 import { dashboardReducer } from './reducer';
 
 export type DashboardStore = Store<DashboardState, DashboardAction>;
 
-export const configureDashboardStore = (preloadedState?: DashboardState) =>
+export const configureDashboardStore = (preloadedState?: Partial<DashboardState>) =>
   configureStore({
     reducer: dashboardReducer,
-    preloadedState,
+    preloadedState: merge(initialState, preloadedState),
   });

--- a/packages/dashboard/src/store/reducer.ts
+++ b/packages/dashboard/src/store/reducer.ts
@@ -1,7 +1,7 @@
 import { Reducer } from 'redux';
 
 import { DashboardState, initialState } from './state';
-import { DashboardAction } from './actions';
+import { DashboardAction, changeDashboardHeight, changeDashboardWidth, moveWidgets, selectWidgets } from './actions';
 
 import { createWidgets } from './actions/createWidget';
 
@@ -10,8 +10,25 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
   action: DashboardAction
 ): DashboardState => {
   switch (action.type) {
-    case 'CREATE_WIDGETS':
+    case 'CREATE_WIDGETS': {
       return createWidgets(state, action);
+    }
+
+    case 'SELECT_WIDGETS': {
+      return selectWidgets(state, action);
+    }
+
+    case 'CHANGE_WIDTH': {
+      return changeDashboardWidth(state, action);
+    }
+
+    case 'CHANGE_HEIGHT': {
+      return changeDashboardHeight(state, action);
+    }
+
+    case 'MOVE_WIDGETS': {
+      return moveWidgets(state, action);
+    }
 
     default:
       return state;

--- a/packages/dashboard/src/store/state.ts
+++ b/packages/dashboard/src/store/state.ts
@@ -1,10 +1,24 @@
-import { DashboardConfiguration } from '../types';
+import { DashboardConfiguration, Widget } from '../types';
 
 export type DashboardState = {
+  grid: {
+    width: number;
+    height: number;
+    cellSize: number;
+    stretchToFit: boolean;
+  };
+  selectedWidgets: Widget[];
   dashboardConfiguration: DashboardConfiguration;
 };
 
 export const initialState: DashboardState = {
+  grid: {
+    width: 100,
+    height: 100,
+    cellSize: 10,
+    stretchToFit: false,
+  },
+  selectedWidgets: [],
   dashboardConfiguration: {
     viewport: { duration: '5m' },
     widgets: [],

--- a/packages/dashboard/src/styles/variables.css
+++ b/packages/dashboard/src/styles/variables.css
@@ -1,0 +1,23 @@
+:root {
+  --selection-color: #0d99ff;
+  --selection-color-secondary: #9cccef;
+  --selection-bg-color: white;
+  --selection-box-size: 12px;
+  --selection-radius: 8px;
+  --selection-border-width: 2px;
+  --selection-border-touch-width: 8px;
+  --selection-radius-small: 4px;
+  --stack-order-grid-image: -999999999;
+  --stack-order-selection-box: 9999999999999;
+  --stack-order-context-menu: 9999999999999;
+  --colors-blue: #0073bb;
+  --colors-dark-grey: rgb(27 27 27);
+  --colors-grey: rgb(116 116 116);
+  --colors-light-grey: rgb(170 170 170);
+  --font-size-context-menu: 12px;
+  --font-weight-context-menu: 400;
+  --spacing-context-menu-option: 0.5rem 1rem;
+  --spacing-context-menu-section: 0.5rem 0;
+  --border-width-context-menu-section: 0.5px;
+  --size-context-menu-min-width: 200px;
+}

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -19,3 +19,6 @@ export type DashboardConfiguration = {
   widgets: Widget[];
   viewport: MinimalViewPortConfig;
 };
+
+export type Position = { x: number; y: number };
+export type Rect = { x: number; y: number; width: number; height: number };

--- a/packages/dashboard/src/util/constrainWidgetPositionToGrid.spec.ts
+++ b/packages/dashboard/src/util/constrainWidgetPositionToGrid.spec.ts
@@ -1,0 +1,126 @@
+import { MockWidgetFactory } from '../../testing/mocks';
+import { constrainWidgetPositionToGrid } from './constrainWidgetPositionToGrid';
+
+it('prevents a widget from overflowing the sides', () => {
+  expect(
+    constrainWidgetPositionToGrid(
+      {
+        x: 0,
+        y: 0,
+        height: 20,
+        width: 20,
+      },
+      MockWidgetFactory.getKpiWidget({
+        x: 15,
+        y: 10,
+        width: 10,
+        height: 5,
+      })
+    )
+  ).toEqual(
+    expect.objectContaining({
+      x: 10,
+      y: 10,
+      width: 10,
+      height: 5,
+    })
+  );
+
+  expect(
+    constrainWidgetPositionToGrid(
+      {
+        x: 0,
+        y: 0,
+        height: 20,
+        width: 20,
+      },
+      MockWidgetFactory.getKpiWidget({
+        x: -5,
+        y: 10,
+        width: 10,
+        height: 5,
+      })
+    )
+  ).toEqual(
+    expect.objectContaining({
+      x: 0,
+      y: 10,
+      width: 10,
+      height: 5,
+    })
+  );
+
+  expect(
+    constrainWidgetPositionToGrid(
+      {
+        x: 0,
+        y: 0,
+        height: 20,
+        width: 20,
+      },
+      MockWidgetFactory.getKpiWidget({
+        x: 10,
+        y: -5,
+        width: 5,
+        height: 10,
+      })
+    )
+  ).toEqual(
+    expect.objectContaining({
+      x: 10,
+      y: 0,
+      width: 5,
+      height: 10,
+    })
+  );
+
+  expect(
+    constrainWidgetPositionToGrid(
+      {
+        x: 0,
+        y: 0,
+        height: 20,
+        width: 20,
+      },
+      MockWidgetFactory.getKpiWidget({
+        x: 10,
+        y: 15,
+        width: 5,
+        height: 10,
+      })
+    )
+  ).toEqual(
+    expect.objectContaining({
+      x: 10,
+      y: 10,
+      width: 5,
+      height: 10,
+    })
+  );
+});
+
+it('prevents a widget from being placed completely outside the grid', () => {
+  expect(
+    constrainWidgetPositionToGrid(
+      {
+        x: 0,
+        y: 0,
+        height: 20,
+        width: 20,
+      },
+      MockWidgetFactory.getKpiWidget({
+        x: 30,
+        y: 30,
+        width: 5,
+        height: 5,
+      })
+    )
+  ).toEqual(
+    expect.objectContaining({
+      x: 15,
+      y: 15,
+      width: 5,
+      height: 5,
+    })
+  );
+});

--- a/packages/dashboard/src/util/constrainWidgetPositionToGrid.ts
+++ b/packages/dashboard/src/util/constrainWidgetPositionToGrid.ts
@@ -1,0 +1,7 @@
+import { Rect, Widget } from '../types';
+
+export const constrainWidgetPositionToGrid = (gridRect: Rect, widget: Widget): Widget => ({
+  ...widget,
+  x: Math.min(gridRect.width - widget.width, Math.max(gridRect.x, widget.x)),
+  y: Math.min(gridRect.height - widget.height, Math.max(gridRect.y, widget.y)),
+});

--- a/packages/dashboard/src/util/isContained.spec.ts
+++ b/packages/dashboard/src/util/isContained.spec.ts
@@ -1,0 +1,27 @@
+import { isContained } from './isContained';
+
+// Note: A degenerate rectangle is one with a side of length 0.
+
+it('two degenerate rectangles contained on the same point are contained', () => {
+  expect(isContained({ width: 0, height: 0, x: 0, y: 0 }, { width: 0, height: 0, x: 0, y: 0 })).toBe(true);
+});
+
+it('two degenerate rectangles contained on different points are not contained', () => {
+  expect(isContained({ width: 0, height: 0, x: 0, y: 0 }, { width: 0, height: 0, x: 1, y: 1 })).toBe(false);
+});
+
+it('two degenerate rectangles contained on different points are not contained', () => {
+  expect(isContained({ width: 0, height: 0, x: 0, y: 0 }, { width: 0, height: 0, x: 1, y: 1 })).toBe(false);
+});
+
+it('two rectangles have no overlap, then it is not contained', () => {
+  expect(isContained({ width: 1, height: 1, x: 0, y: 0 }, { width: 2, height: 2, x: 3, y: 3 })).toBe(false);
+});
+
+it('two rectangles have overlap at the border, then it is contained', () => {
+  expect(isContained({ width: 1, height: 1, x: 0, y: 0 }, { width: 2, height: 2, x: 1, y: 1 })).toBe(true);
+});
+
+it('two rectangles have overlap within the area contained in the rectangles, then it is contained', () => {
+  expect(isContained({ width: 2, height: 2, x: 0, y: 0 }, { width: 2, height: 2, x: 1, y: 1 })).toBe(true);
+});

--- a/packages/dashboard/src/util/isContained.ts
+++ b/packages/dashboard/src/util/isContained.ts
@@ -1,0 +1,11 @@
+import { Rect } from '../types';
+import intersect from 'box-intersect';
+
+export const isContained = (a: Rect, b: Rect): boolean => {
+  const contained = intersect([
+    [a.x, a.y, a.x + a.width, a.y + a.height],
+    [b.x, b.y, b.x + b.width, b.y + b.height],
+  ]);
+
+  return contained.length != 0;
+};

--- a/packages/dashboard/src/util/isDefined.ts
+++ b/packages/dashboard/src/util/isDefined.ts
@@ -1,0 +1,28 @@
+/**
+ * Predicate Utilities
+ *
+ * A place for generic predicates. Useful when needing predicates which play nicely
+ * with typescript, or other non-trivial predicate logic.
+ *
+ * Providing smart predicates with built in type guards can give us stronger typing in our business logic.
+ * https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types
+ *
+ * Example:
+ *
+ * Without Type Guards (to be avoided):
+ * ```
+ * const maybeItems : (Item | null)[] = SOME_MAYBE_ITEMS;
+ * const items: Item[] = maybeItems.filter(x => x != null) as Item[];
+ * ```
+ *
+ * With Type Guards:
+ * ```
+ * const maybeItems : (Item | null)[] = SOME_MAYBE_ITEMS;
+ * const items: Item[] = maybeItems.filter(isDefined);
+ * ```
+ *
+ * No type casting necessary :-) all you have to do is trust that the shared predicate properly
+ * type guards.
+ *
+ */
+export const isDefined = <T>(value: T | null | undefined): value is T => value != null;

--- a/packages/dashboard/src/util/select.spec.ts
+++ b/packages/dashboard/src/util/select.spec.ts
@@ -1,0 +1,65 @@
+import { MockDashboardFactory, MockWidgetFactory, MOCK_EMPTY_DASHBOARD } from '../../testing/mocks';
+import { getSelectedWidgetIds } from './select';
+
+describe('getSelectedIds', () => {
+  it('returns no ids when dashboard has no widgets', () => {
+    expect(
+      getSelectedWidgetIds({
+        dashboardConfiguration: MOCK_EMPTY_DASHBOARD,
+        cellSize: 10,
+        selectedRect: { x: 0, y: 0, width: 1000, height: 1000 },
+      })
+    ).toEqual([]);
+  });
+
+  it('returns id of widget that is contained within the selected rectangle', () => {
+    expect(
+      getSelectedWidgetIds({
+        dashboardConfiguration: MockDashboardFactory.get({
+          widgets: [MockWidgetFactory.getLineChartWidget({ x: 5, y: 5, width: 1, height: 1, id: 'some-id' })],
+        }),
+        cellSize: 10,
+        selectedRect: { x: 0, y: 0, width: 100, height: 100 },
+      })
+    ).toEqual(['some-id']);
+  });
+
+  it('returns id of widget that overlaps the selected rectangle', () => {
+    expect(
+      getSelectedWidgetIds({
+        dashboardConfiguration: MockDashboardFactory.get({
+          widgets: [MockWidgetFactory.getLineChartWidget({ x: 1, y: 1, width: 1, height: 1, id: 'some-id' })],
+        }),
+        cellSize: 10,
+        selectedRect: { x: 10, y: 10, width: 10, height: 10 },
+      })
+    ).toEqual(['some-id']);
+  });
+
+  it('returns no ids when the widgets are not overlapping the selected rectangle', () => {
+    expect(
+      getSelectedWidgetIds({
+        dashboardConfiguration: MockDashboardFactory.get({
+          widgets: [MockWidgetFactory.getLineChartWidget({ x: 1, y: 1, width: 1, height: 1, id: 'some-id' })],
+        }),
+        cellSize: 5,
+        selectedRect: { x: 10, y: 10, width: 10, height: 10 },
+      })
+    ).toEqual([]);
+  });
+
+  it('returns only ids of overlapping widgets when multiple widgets provided', () => {
+    expect(
+      getSelectedWidgetIds({
+        dashboardConfiguration: MockDashboardFactory.get({
+          widgets: [
+            MockWidgetFactory.getLineChartWidget({ x: 1, y: 1, width: 1, height: 1, id: 'some-id' }),
+            MockWidgetFactory.getLineChartWidget({ x: 50, y: 50, width: 1, height: 1, id: 'some-id-2' }),
+          ],
+        }),
+        cellSize: 10,
+        selectedRect: { x: 10, y: 10, width: 10, height: 10 },
+      })
+    ).toEqual(['some-id']);
+  });
+});

--- a/packages/dashboard/src/util/select.ts
+++ b/packages/dashboard/src/util/select.ts
@@ -1,0 +1,41 @@
+import { DashboardConfiguration, Rect } from '../types';
+import { isContained } from './isContained';
+
+export const getSelectedWidgets = ({
+  selectedRect,
+  cellSize,
+  dashboardConfiguration,
+}: {
+  selectedRect: Rect | undefined;
+  cellSize: number;
+  dashboardConfiguration: DashboardConfiguration;
+}) => {
+  const isSelected = (rect: Rect): boolean =>
+    selectedRect
+      ? isContained(
+          {
+            x: (rect.x - 1) * cellSize,
+            y: (rect.y - 1) * cellSize,
+            width: rect.width * cellSize,
+            height: rect.height * cellSize,
+          },
+          selectedRect
+        )
+      : false;
+  return dashboardConfiguration.widgets.filter(isSelected);
+};
+
+/**
+ * Returns all widget id's of the widgets which intersect the given selection.
+ *
+ * This is utilized to determine what widgets are selected upon making a selection gesture.
+ */
+export const getSelectedWidgetIds = ({
+  selectedRect,
+  cellSize,
+  dashboardConfiguration,
+}: {
+  selectedRect: Rect | undefined;
+  cellSize: number;
+  dashboardConfiguration: DashboardConfiguration;
+}) => getSelectedWidgets({ selectedRect, cellSize, dashboardConfiguration }).map((widget) => widget.id);

--- a/packages/dashboard/src/util/trimWidgetPosition.spec.ts
+++ b/packages/dashboard/src/util/trimWidgetPosition.spec.ts
@@ -1,0 +1,61 @@
+import { MockWidgetFactory } from '../../testing/mocks';
+import { trimWidgetPosition } from './trimWidgetPosition';
+
+it('rounds the position to the nearest decimal', () => {
+  expect(
+    trimWidgetPosition(
+      MockWidgetFactory.getKpiWidget({
+        x: 1.01,
+        y: 1.99,
+        width: 10,
+        height: 20,
+        id: 'some-id',
+      })
+    )
+  ).toEqual(
+    expect.objectContaining({
+      x: 1,
+      y: 2,
+    })
+  );
+});
+
+it('rounds the width and height to the nearest decimal', () => {
+  expect(
+    trimWidgetPosition(
+      MockWidgetFactory.getKpiWidget({
+        x: 1,
+        y: 2,
+        width: 10.49,
+        height: 20.59,
+        id: 'some-id',
+      })
+    )
+  ).toEqual(
+    expect.objectContaining({
+      width: 10,
+      height: 21,
+    })
+  );
+});
+
+it('does nothing to widgets with integer based position and dimensions', () => {
+  expect(
+    trimWidgetPosition(
+      MockWidgetFactory.getKpiWidget({
+        x: 1,
+        y: 2,
+        width: 10,
+        height: 20,
+        id: 'some-id',
+      })
+    )
+  ).toEqual(
+    expect.objectContaining({
+      width: 10,
+      height: 20,
+      x: 1,
+      y: 2,
+    })
+  );
+});

--- a/packages/dashboard/src/util/trimWidgetPosition.ts
+++ b/packages/dashboard/src/util/trimWidgetPosition.ts
@@ -1,0 +1,11 @@
+import { Widget } from '../types';
+
+export const trimWidgetPosition = (widget: Widget): Widget => {
+  return {
+    ...widget,
+    x: Math.round(widget.x),
+    y: Math.round(widget.y),
+    width: Math.round(widget.width),
+    height: Math.round(widget.height),
+  };
+};

--- a/packages/dashboard/testing/mocks.ts
+++ b/packages/dashboard/testing/mocks.ts
@@ -23,8 +23,8 @@ export const createMockWidget =
 export const MOCK_KPI_WIDGET: Widget = {
   id: 'mock-kpi-widget',
   componentTag: 'iot-kpi',
-  x: 2,
-  y: 2,
+  x: 0,
+  y: 0,
   z: 1,
   width: 8,
   height: 5,

--- a/packages/dashboard/testing/siteWiseQueries.ts
+++ b/packages/dashboard/testing/siteWiseQueries.ts
@@ -19,8 +19,6 @@ export const DEMO_TURBINE_ASSET_1_PROPERTY_2 = process.env.DEMO_TURBINE_ASSET_1_
 export const DEMO_TURBINE_ASSET_1_PROPERTY_3 = process.env.DEMO_TURBINE_ASSET_1_PROPERTY_3 || '';
 export const DEMO_TURBINE_ASSET_1_PROPERTY_4 = process.env.DEMO_TURBINE_ASSET_1_PROPERTY_4 || '';
 
-console.log(DEMO_TURBINE_ASSET_1);
-
 export const ASSET_DETAILS_QUERY = {
   assetId: STRING_ASSET_ID,
 };


### PR DESCRIPTION
## Overview
Select and Move widget functionality. Gestures are handled in the InternalDashboard component and driven off drag and drop events defined in the Grid component. Drag and Drop is implemented using the [React dnd](https://react-dnd.github.io/react-dnd/docs/overview) library.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
