### PR TITLE
fix(composer): submodel and hierarchy search fix

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -154,10 +154,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 77.56,
-        "statements": 76.73,
-        "functions": 77.62,
-        "branches": 63.67,
+        "lines": 77.58,
+        "statements": 76.75,
+        "functions": 77.58,
+        "branches": 63.72,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
@@ -5,9 +5,10 @@ import ISceneHierarchyNode from '../../model/ISceneHierarchyNode';
 import { useSceneHierarchyData } from '../../SceneHierarchyDataProvider';
 import { DropHandler } from '../../../../../hooks/useDropMonitor';
 import SubModelTree from '../SubModelTree';
-import { KnownComponentType } from '../../../../../interfaces';
+import { COMPOSER_FEATURES, KnownComponentType } from '../../../../../interfaces';
 import { IModelRefComponentInternal } from '../../../../../store';
 import { ModelType } from '../../../../../models/SceneModels';
+import useFeature from '../../../../../hooks/useFeature';
 
 import SceneNodeLabel from './SceneNodeLabel';
 import { AcceptableDropTypes, EnhancedTree, EnhancedTreeItem } from './constants';
@@ -47,7 +48,8 @@ const SceneHierarchyTreeItem: FC<SceneHierarchyTreeItemProps> = ({
       (type as unknown as IModelRefComponentInternal)?.modelType !== ModelType.Environment,
   );
 
-  const showSubModel = isValidModelRef && !!model && !isViewing();
+  const [{ variation: subModelSelectionEnabled }] = useFeature(COMPOSER_FEATURES[COMPOSER_FEATURES.SubModelSelection]);
+  const showSubModel = subModelSelectionEnabled === 'T1' && isValidModelRef && !!model && !isViewing();
 
   const onExpandNode = useCallback((expanded) => {
     setExpanded(expanded);
@@ -97,11 +99,9 @@ const SceneHierarchyTreeItem: FC<SceneHierarchyTreeItemProps> = ({
             getChildNodes(key).map((node, index) => (
               <React.Fragment key={index}>
                 <SceneHierarchyTreeItem key={node.objectRef} enableDragAndDrop={enableDragAndDrop} {...node} />
-                {showSubModel && node?.componentTypes?.includes(KnownComponentType.SubModelRef) && (
-                  <SubModelTree parentRef={key} expanded={false} object3D={model!} selectable />
-                )}
               </React.Fragment>
             ))}
+          {showSubModel && <SubModelTree parentRef={key} expanded={false} object3D={model!} selectable />}
         </EnhancedTree>
       )}
     </EnhancedTreeItem>


### PR DESCRIPTION
## Overview
- fix the issue where only root nodes can be searched
- only show the matching nodes in a flat list, not their children
- gate sub-model feature with flag
- show SubModelTree for ModelRef component and fix duplicated trees when sub model is promoted to a node

search issue:

https://user-images.githubusercontent.com/9315598/199861938-7d02f86d-83d8-4029-a0f8-80f2d30256e4.mov

search fix:

https://user-images.githubusercontent.com/9315598/199862110-74d44955-e29c-4945-80eb-0519a830c8e4.mov

sub-model issue:

https://user-images.githubusercontent.com/9315598/199862147-eb260182-0119-4aa0-9c38-20eb6cbf4ba3.mov

sub-model fix:

https://user-images.githubusercontent.com/9315598/199862174-4c73a1c3-f544-435a-a673-688a84b6a7b3.mov

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
