### PR TITLE
fix(composer): boolean data always converted to false

### DIFF
--- a/packages/scene-composer/src/utils/dataStreamUtils.spec.ts
+++ b/packages/scene-composer/src/utils/dataStreamUtils.spec.ts
@@ -1,7 +1,8 @@
 import { TimeSeriesData } from '@iot-app-kit/core';
 
 import {
-  booleanStream,
+  booleanStream1,
+  booleanStream2,
   end,
   labels,
   numberStream,
@@ -64,12 +65,24 @@ describe('convertDataStreamsToDataInput', () => {
             },
           ],
         },
+        {
+          dataFrameId: streamId,
+          fields: [
+            timeField,
+            {
+              name: 'test',
+              valueType: 'boolean',
+              labels,
+              values: [true, false],
+            },
+          ],
+        },
       ],
     };
 
-    expect(convertDataStreamsToDataInput([numberStream, stringStream, booleanStream], viewport)).toEqual(
-      expectedDataInput,
-    );
+    expect(
+      convertDataStreamsToDataInput([numberStream, stringStream, booleanStream1, booleanStream2], viewport),
+    ).toEqual(expectedDataInput);
   });
 });
 
@@ -79,19 +92,23 @@ describe('combineTimeSeriesData', () => {
       {
         dataStreams: [numberStream],
         viewport: { start, end: start },
+        annotations: {},
       },
       {
-        dataStreams: [booleanStream],
+        dataStreams: [booleanStream1],
         viewport: { start: end, end },
+        annotations: {},
       },
       {
         dataStreams: [stringStream],
         viewport,
+        annotations: {},
       },
     ];
     const expected: TimeSeriesData = {
-      dataStreams: [numberStream, booleanStream, stringStream],
+      dataStreams: [numberStream, booleanStream1, stringStream],
       viewport,
+      annotations: {},
     };
 
     expect(combineTimeSeriesData(input)).toEqual(expected);

--- a/packages/scene-composer/src/utils/dataStreamUtils.ts
+++ b/packages/scene-composer/src/utils/dataStreamUtils.ts
@@ -32,7 +32,9 @@ export const convertDataStreamsToDataInput = (streams: DataStream[], viewport: V
         name: labels[DataBindingLabelKeys.propertyName],
         valueType: toValueType(stream.dataType),
         labels,
-        values: stream.data.map(({ y }) => (stream.dataType === 'BOOLEAN' ? y === 'true' : y)),
+        // the boolean value y will be a string 'true' or 'false' when data is coming from app kit data source,
+        // but can be actual boolean when from other source
+        values: stream.data.map(({ y }) => (stream.dataType === 'BOOLEAN' ? y === 'true' || (y as any) === true : y)),
       },
     ];
 

--- a/packages/scene-composer/tests/data/mockDataStreams.ts
+++ b/packages/scene-composer/tests/data/mockDataStreams.ts
@@ -26,11 +26,21 @@ export const stringStream: DataStream = {
   resolution: 0,
   meta: labels,
 };
-export const booleanStream: DataStream = {
+export const booleanStream1: DataStream = {
   id: streamId,
   data: [
     { x: start.getTime(), y: 'true' },
     { x: end.getTime(), y: 'false' },
+  ],
+  dataType: 'BOOLEAN',
+  resolution: 0,
+  meta: labels,
+};
+export const booleanStream2: DataStream = {
+  id: streamId,
+  data: [
+    { x: start.getTime(), y: true as any },
+    { x: end.getTime(), y: false as any },
   ],
   dataType: 'BOOLEAN',
   resolution: 0,


### PR DESCRIPTION
## Overview
fix the issue when the boolean data in the dataStream is an actual boolean (instead of string 'true' / 'false'), the data will always be converted to false

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
