### PR TITLE
fix: require npm >=8.7.0 to fix yarn.lock issue with d3-color-1-fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "git@github.com:awslabs/iot-app-kit.git",
   "engines": {
     "node": ">=16.0.0",
-    "npm": ">=8.5.0"
+    "npm": ">=8.7.0"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
## Overview
@sheilaXu identified an issue where `"d3-color-1-fix"` is sometimes not properly referenced in package-lock.json. I tested with different versions of npm and verified that this is an issue with versions below 8.7, likely due to [this npm bug](https://github.com/npm/cli/issues/4687) with setting overrides in package-lock.

Here I am bumping the minimum version of npm for the package to 8.7, which ensures consistent package-lock generation.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
