### PR TITLE
Set the types/node to a necessary version we need

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -42,7 +42,7 @@
     "@storybook/testing-library": "^0.0.13",
     "@types/box-intersect": "^1.0.0",
     "@types/lodash": "^4.14.186",
-    "@types/node": "^18.11.4",
+    "@types/node": "^18.11.8",
     "@types/react": "^17.0.38",
     "babel-loader": "^8.2.5",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
## Overview
Due to some internal build issues changing the version of the package @types/node from 18.11.4 to 18.11.8

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
