### PR TITLE
fix(dashboard): remove package for rolling up types

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -56,7 +56,6 @@
     "redux": "^4.2.0",
     "rimraf": "^3.0.2",
     "rollup": "2.76.0",
-    "rollup-plugin-dts": "^4.2.2",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-polyfill-node": "^0.11.0",
     "rollup-plugin-postcss": "^4.0.2",

--- a/packages/dashboard/rollup.config.js
+++ b/packages/dashboard/rollup.config.js
@@ -1,7 +1,6 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
-import dts from 'rollup-plugin-dts';
 import { terser } from 'rollup-plugin-terser';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import postcss from 'rollup-plugin-postcss';
@@ -48,11 +47,5 @@ export default [
       terser(),
     ],
     external: ['react', 'react-dom'],
-  },
-  {
-    input: 'dist/esm/dashboard/src/index.d.ts',
-    output: [{ file: 'dist/index.d.ts', format: 'esm' }],
-    external: [/\.css$/],
-    plugins: [dts()],
   },
 ];


### PR DESCRIPTION
## Overview
Removes the rollup-dts-plugin from the build.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
