### PR TITLE
Opacity filter zero

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/index.tsx
@@ -45,12 +45,14 @@ const ColorOverlayComponent: React.FC<IColorOverlayComponentProps> = ({
     /* istanbul ignore next */ (obj) => {
       if (obj instanceof Mesh && ruleColor) {
         if ('color' in obj.material) {
-          if (ruleColor?.color) {
-            obj.material.color = ruleColor.color.clone().convertSRGBToLinear();
-          }
-          if (ruleColor?.alpha && ruleColor?.alpha !== 1) {
-            obj.material.transparent = true;
-            obj.material.opacity = ruleColor.alpha;
+          if (ruleColor) {
+            if (ruleColor.color) {
+              obj.material.color = ruleColor.color.clone().convertSRGBToLinear();
+            }
+            if ((ruleColor.alpha || ruleColor.alpha === 0) && ruleColor?.alpha !== 1) {
+              obj.material.transparent = true;
+              obj.material.opacity = ruleColor.alpha;
+            }
           }
         }
       }


### PR DESCRIPTION
## Overview
Opacity filter was incorrectly showing objects when opacity was set to 0. This was a bug in the boolean logic to check if it should apply alpha or not.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
