### PR TITLE
Prevent Sub-Models from being moved without a feature flag

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -154,10 +154,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 77.00,
-        "statements": 76.00,
-        "functions": 77.0,
-        "branches": 63.0,
+        "lines": 77.55,
+        "statements": 76.71,
+        "functions": 77.15,
+        "branches": 63.49,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
@@ -87,7 +87,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
     [selectedSceneNode],
   );
 
-  const showForSubModel = !isSubModelComponent || subModelMovementEnabled;
+  const transformVisible = !isSubModelComponent || subModelMovementEnabled;
 
   const shouldShowScale = !((isTagComponent && !tagResizeEnabled) || isCameraComponent);
 
@@ -141,7 +141,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
             <TextInput value={selectedSceneNode.name} setValue={(e) => handleInputChanges({ name: e?.toString() })} />
           </FormField>
         </ExpandableInfoSection>
-        {!isEnvironmentNode(selectedSceneNode) && showForSubModel && (
+        {!isEnvironmentNode(selectedSceneNode) && transformVisible && (
           <ExpandableInfoSection
             title={intl.formatMessage({ defaultMessage: 'Transform', description: 'Expandable section title' })}
             defaultExpanded

--- a/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
@@ -29,6 +29,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
   const intl = useIntl();
 
   const tagResizeEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagResize];
+  const subModelMovementEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.SubModelMovement];
 
   const i18nKnownComponentTypesStrings = defineMessages({
     [KnownComponentType.ModelRef]: {
@@ -80,6 +81,13 @@ export const SceneNodeInspectorPanel: React.FC = () => {
     () => !!findComponentByType(selectedSceneNode, KnownComponentType.Tag),
     [selectedSceneNode],
   );
+
+  const isSubModelComponent = useMemo(
+    () => !!findComponentByType(selectedSceneNode, KnownComponentType.SubModelRef),
+    [selectedSceneNode],
+  );
+
+  const showForSubModel = !isSubModelComponent || subModelMovementEnabled;
 
   const shouldShowScale = !((isTagComponent && !tagResizeEnabled) || isCameraComponent);
 
@@ -133,7 +141,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
             <TextInput value={selectedSceneNode.name} setValue={(e) => handleInputChanges({ name: e?.toString() })} />
           </FormField>
         </ExpandableInfoSection>
-        {!isEnvironmentNode(selectedSceneNode) && (
+        {!isEnvironmentNode(selectedSceneNode) && showForSubModel && (
           <ExpandableInfoSection
             title={intl.formatMessage({ defaultMessage: 'Transform', description: 'Expandable section title' })}
             defaultExpanded

--- a/packages/scene-composer/src/components/three-fiber/EditorTransformControls.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EditorTransformControls.tsx
@@ -27,11 +27,19 @@ export function EditorTransformControls() {
 
   const [transformControls] = useState(() => new TransformControlsImpl(camera, domElement));
   const tagResizeEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagResize];
+  const subModelMovementEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.SubModelMovement];
 
   const isTagComponent = useMemo(
     () => !!findComponentByType(selectedSceneNode, KnownComponentType.Tag),
     [selectedSceneNode],
   );
+
+  const isSubModelComponent = useMemo(
+    () => !!findComponentByType(selectedSceneNode, KnownComponentType.SubModelRef),
+    [selectedSceneNode],
+  );
+
+  const showForSubModel = !isSubModelComponent || subModelMovementEnabled;
 
   // Set transform controls' camera
   useEffect(() => {
@@ -68,7 +76,7 @@ export function EditorTransformControls() {
 
   // Update transform controls' attached object
   useEffect(() => {
-    if (selectedSceneNodeRef && !isEnvironmentNode(selectedSceneNode)) {
+    if (selectedSceneNodeRef && !isEnvironmentNode(selectedSceneNode) && showForSubModel) {
       const object3d = getObject3DBySceneNodeRef(selectedSceneNodeRef);
       if (object3d) {
         log?.verbose('attach transform controls to', object3d);

--- a/packages/scene-composer/src/components/three-fiber/EditorTransformControls.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EditorTransformControls.tsx
@@ -39,7 +39,7 @@ export function EditorTransformControls() {
     [selectedSceneNode],
   );
 
-  const showForSubModel = !isSubModelComponent || subModelMovementEnabled;
+  const transformVisible = !isSubModelComponent || subModelMovementEnabled;
 
   // Set transform controls' camera
   useEffect(() => {
@@ -76,7 +76,7 @@ export function EditorTransformControls() {
 
   // Update transform controls' attached object
   useEffect(() => {
-    if (selectedSceneNodeRef && !isEnvironmentNode(selectedSceneNode) && showForSubModel) {
+    if (selectedSceneNodeRef && !isEnvironmentNode(selectedSceneNode) && transformVisible) {
       const object3d = getObject3DBySceneNodeRef(selectedSceneNodeRef);
       if (object3d) {
         log?.verbose('attach transform controls to', object3d);

--- a/packages/scene-composer/src/interfaces/feature.ts
+++ b/packages/scene-composer/src/interfaces/feature.ts
@@ -11,6 +11,7 @@ export enum COMPOSER_FEATURES {
   CameraView = 'CameraView',
   EnvironmentModel = 'EnvironmentModel',
   TagResize = 'TagResize',
+  SubModelMovement = 'SubModelMovement',
 }
 
 export type FeatureConfig = Partial<Record<COMPOSER_FEATURES, boolean>>;

--- a/packages/scene-composer/stories/SceneComposer.stories.tsx
+++ b/packages/scene-composer/stories/SceneComposer.stories.tsx
@@ -152,6 +152,7 @@ const knobsConfigurationDecorator = [
         [COMPOSER_FEATURES.CameraView]: true,
         [COMPOSER_FEATURES.EnvironmentModel]: false,
         [COMPOSER_FEATURES.TagResize]: true,
+        [COMPOSER_FEATURES.SubModelMovement]: false,
         ...args.config.featureConfig,
       },
       ...args.config,


### PR DESCRIPTION
## Overview
Due to issues with Multiple World spaces and/or coordinates for Sub Models preventing the ability to adjust the sub-model position ensures that child objects will continue to work. We hide the ability to edit a Sub-model's position behind a new feature flag `SubModelMovement`

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
