### PR TITLE
fix(DragHandleIcon): Drag Handle icon not showing up without special webpack config

### DIFF
--- a/packages/scene-composer/src/enhancers/draggable.scss
+++ b/packages/scene-composer/src/enhancers/draggable.scss
@@ -2,7 +2,7 @@
   cursor: grab;
 
   &::before {
-    content: url('../assets/icons/draghandle.svg');
+    content: url("data:image/svg+xml,%3Csvg width='4' height='19' viewBox='0 0 4 19' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cline x1='0.5' y1='0.5' x2='0.499999' y2='18.5' stroke='%23879596'/%3E%3Cline x1='2.96094' y1='0.5' x2='2.96094' y2='18.5' stroke='%23879596'/%3E%3C/svg%3E");
     position: absolute;
     left: 0;
     margin: 1.9rem 1rem 1rem 0.75rem;


### PR DESCRIPTION
Just inlines the icon for now, but we may need to look at a better way of handling SVGs in CSS.

## Overview
Provide an explanation of what the change is

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
