### PR TITLE
fix(composer): Fixes the light helper delete 

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -154,10 +154,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 77.57,
-        "statements": 76.73,
-        "functions": 77.19,
-        "branches": 63.54,
+        "lines": 77.49,
+        "statements": 76.63,
+        "functions": 77.08,
+        "branches": 63.36,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/hooks/useEditorHelper.ts
+++ b/packages/scene-composer/src/hooks/useEditorHelper.ts
@@ -1,9 +1,8 @@
 import * as THREE from 'three';
 import { MutableRefObject, useEffect, useRef } from 'react';
-import { useFrame } from '@react-three/fiber';
+import { useThree, useFrame } from '@react-three/fiber';
 
 import { useStore } from '../store';
-import { getFinalTransform } from '../utils/nodeUtils';
 
 type Helper = THREE.Object3D & {
   update: () => void;
@@ -29,34 +28,24 @@ export function useEditorHelper<T>(
 ) {
   const helper = useRef<Helper>();
 
+  const scene = useThree((state) => state.scene);
+
   useEffect(() => {
     if (isEditing) {
       if (proto && object3D.current) {
         helper.current = new (proto as any)(object3D.current, ...args);
-
         if (helper.current) {
-          const helperTransform = {
-            position: helper.current.position.clone(),
-            rotation: helper.current.rotation.clone(),
-            scale: helper.current.scale.clone(),
-          };
-          const finalTransform = getFinalTransform(helperTransform, object3D.current);
-          const group = new THREE.Group();
-          group.add(helper.current);
-          group.position.copy(finalTransform.position);
-          group.rotation.copy(finalTransform.rotation);
-          group.scale.copy(finalTransform.scale);
-          object3D.current.add(group);
+          scene.add(helper.current);
         }
       }
     }
 
     return () => {
-      if (helper.current?.parent) {
-        object3D.current?.remove(helper.current.parent);
+      if (helper.current) {
+        scene.remove(helper.current);
       }
     };
-  }, [isEditing, proto, object3D, args]);
+  }, [isEditing, scene, proto, object3D, args]);
 
   useStore(sceneComposerId).subscribe((state) => {
     if (helper.current) {
@@ -67,6 +56,11 @@ export function useEditorHelper<T>(
   useFrame(() => {
     if (helper.current) {
       helper.current.update();
+      if (object3D.current) {
+        let isVisible = true;
+        object3D.current?.traverseAncestors((ancestor) => (isVisible = isVisible && ancestor.visible));
+        helper.current.visible = isVisible;
+      }
     }
   });
 

--- a/packages/scene-composer/tests/hooks/useEditorHelper.spec.tsx
+++ b/packages/scene-composer/tests/hooks/useEditorHelper.spec.tsx
@@ -8,18 +8,23 @@ import { useStore } from '../../src/store';
 
 let container = null;
 let helper = null;
+let scene = null;
 
 jest.mock('@react-three/fiber', () => {
   const originalModule = jest.requireActual('@react-three/fiber');
   return {
     __esModule: true,
     ...originalModule,
+    useThree: jest.fn(() => scene),
     useFrame: jest.fn(),
   };
 });
 
 beforeEach(() => {
-  jest.clearAllMocks();
+  scene = {
+    add: jest.fn(),
+    remove: jest.fn(),
+  } as any;
   container = document.createElement('div') as any;
   document.body.appendChild(container as any);
 });
@@ -31,13 +36,11 @@ afterEach(() => {
 });
 
 const object3D = new Object3D();
-object3D.add = jest.fn();
-object3D.remove = jest.fn();
 const mutableRefObj = {
   current: object3D,
 };
 
-class HelperType extends Object3D {}
+class HelperType {}
 
 interface TestComponentPros {
   isEditing: boolean;
@@ -54,13 +57,14 @@ describe('return correct editor helper.', () => {
     act(() => {
       render(<TestComponent isEditing={true} sceneComposerId='sceneComposerId' />, container);
     });
-    expect(object3D.add).toBeCalledTimes(1);
+    expect((scene as any).add).toBeCalledTimes(1);
 
     act(() => {
       unmountComponentAtNode(container as any);
     });
 
-    expect(object3D.remove).toBeCalledTimes(1);
+    expect((scene as any).remove).toBeCalledTimes(1);
+    expect((helper as any).current.visible).toBe(undefined);
     useStore('sceneComposerId').setState({});
     expect((helper as any).current.visible).toBe(true);
   });
@@ -69,9 +73,9 @@ describe('return correct editor helper.', () => {
     act(() => {
       render(<TestComponent isEditing={false} sceneComposerId='sceneComposerId' />, container);
     });
-    expect(object3D.add).toBeCalledTimes(0);
+    expect((scene as any).add).toBeCalledTimes(0);
     unmountComponentAtNode(container as any);
-    expect(object3D.remove).toBeCalledTimes(0);
+    expect((scene as any).remove).toBeCalledTimes(0);
     expect((helper as any).current).toBe(undefined);
     useStore('sceneComposerId').setState({});
     expect((helper as any).current).toBe(undefined);


### PR DESCRIPTION
## Overview
1. Reverts the previous change to parent to an dobject as this causes an error on delete thanks to React Three Fiber based removal
2. Helper checks each frame whether or not it should remain visible based on the ancestry of the light

`useFrame` gets a bad wrap as the boogeyman but this look up the ancestor tree should not cause performance issues but maintains a simplicity and code cleanliness to get around this issue. Typically only a complex set of calculations would be problematic but most 3D software performs operations every frame. Should we see performance issues we can revisit the implementation

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
