### PR TITLE
fix(composer): Fixes the duplication of sub models

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -154,10 +154,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 77.49,
-        "statements": 76.63,
-        "functions": 77.01,
-        "branches": 63.2,
+        "lines": 77.51,
+        "statements": 76.64,
+        "functions": 77.1,
+        "branches": 63.32,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
@@ -14,7 +14,9 @@ Array [
     ],
     "name": "RootObject",
     "parentRef": "112",
-    "properties": Array [],
+    "properties": Object {
+      "subModelId": "RootObject",
+    },
     "ref": "112#undefined",
     "transform": Object {
       "position": Array [

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/index.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/index.tsx
@@ -27,7 +27,7 @@ const SubModelTree: FC<SubModelTreeProps> = ({
   visible: defaultVisible = true,
 }) => {
   const sceneComposerId = useSceneComposerId();
-  const { appendSceneNodeInternal } = useSceneDocument(sceneComposerId);
+  const { appendSceneNodeInternal, document } = useSceneDocument(sceneComposerId);
   const { setSceneNodeObject3DMapping } = useEditorState(sceneComposerId);
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [visible, setVisible] = useState(defaultVisible);
@@ -54,6 +54,15 @@ const SubModelTree: FC<SubModelTreeProps> = ({
   }, []);
 
   const onCreate = useCallback(() => {
+    // Prevent duplicates
+    const duplicates = Object.entries(document.nodeMap).filter(
+      ([name, node]) => node.properties?.subModelId === object3D.name,
+    );
+
+    if (duplicates.length > 0) {
+      return;
+    }
+
     const nodeRef = `${parentRef}#${object3D.id}`;
     const subModelComponent: ISubModelRefComponent = {
       type: KnownComponentType.SubModelRef,
@@ -76,12 +85,14 @@ const SubModelTree: FC<SubModelTreeProps> = ({
         snapToFloor: true,
       },
       childRefs: [],
-      properties: [],
+      properties: {
+        subModelId: object3D.name,
+      },
     } as ISceneNodeInternal;
 
     appendSceneNodeInternal(node);
     setSceneNodeObject3DMapping(nodeRef, object3D); // Cache Reference
-  }, [object3D]);
+  }, [object3D, document.nodeMap]);
 
   const onHover = useCallback((e) => {
     e.preventDefault();

--- a/packages/scene-composer/tests/scenes/scene_1.json
+++ b/packages/scene-composer/tests/scenes/scene_1.json
@@ -250,7 +250,7 @@
         }
       ],
       "properties": {
-
+        "subModelId": "Scene491"
       }
     },
     {


### PR DESCRIPTION
## Overview
Sub Models previously relied on `appendSceneNodeInternal` preventing.a duplicate based purely on the reference Id and the Object3D.id of the original sub model. The problem is both ThreeJS and our Ids are not persisted by design. 

The solution was to add a property specifically to sub models that reference the "ID" of the sub model object. The only persisted case here is the name and changing that within the model in something like Blender is still a way to mess this up however I do believe unless you specifically name objects the most 3D applications will provide a new name. We then check all nodes in the scene for the property matching the name. If we find it we do not add the sub model to the scene as was occurring when within the same session.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
