### PR TITLE
fix: fix syntax not supported in all circumstances for package.json override

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@types/react-dom": "^17.0.2"
   },
   "overrides": {
-    "d3-color": "d3-color-1-fix",
+    "d3-color": "npm:d3-color-1-fix@^1.4.2",
     "nth-check": "^2.1.1"
   }
 }


### PR DESCRIPTION
## Overview
Yet another override fix. There are several different ways to reference overrides: nested objects, various string formats, etc. Apparently they are not all equivalent - the `"package": "other-package"` syntax is supported in some but not all circumstances; as it will successfully apply the override if you clone and install but not if you clone and delete package-lock and then install. Switching to `"package": "npm:other-package@^1.0.0"` fixes this issue.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
