### PR TITLE
feat(dashboard): resource explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "fix:stylelint": "stylelint '**/*.css' --fix",
     "test": "npm-run-all -p test:unit test:eslint test:stylelint test:git",
     "test:integration": "npm run test:integration -ws --if-present",
-    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=39",
+    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=43",
     "test:stylelint": "stylelint '**/*.css' --max-warnings 0",
     "test:unit": "npm run test -ws --if-present",
     "test:git": "git diff --exit-code",

--- a/packages/dashboard/jest.config.ts
+++ b/packages/dashboard/jest.config.ts
@@ -19,5 +19,5 @@ export default {
   //   '^.+\\.tsx?$': 'ts-jest',
   //   '^.+\\.(js|jsx)$': 'babel-jest',
   // },
-  // transformIgnorePatterns: ['node_modules/(?!@awsui/components-react)/'],
+  transformIgnorePatterns: ['node_modules/(?!@awsui/components-react)/'],
 };

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -7,12 +7,14 @@ import sortBy from 'lodash/sortBy';
 import { MockWidgetFactory } from '../../../testing/mocks';
 import { useKeyPress } from '../../hooks/useKeyPress';
 import { ResizablePanes } from '../resizablePanes';
+import { IotResourceExplorer } from '../resourceExplorer';
+
 /**
  * For developing purposes only.
  * Will be removed once component palette
  * and asset explorer are implemented.
  */
-// import { DEMO_TURBINE_ASSET_1, DEMO_TURBINE_ASSET_1_PROPERTY_4, query } from '../../../testing/siteWiseQueries';
+import { /* DEMO_TURBINE_ASSET_1, DEMO_TURBINE_ASSET_1_PROPERTY_4,*/ query } from '../../../testing/siteWiseQueries';
 
 import {
   Anchor,
@@ -304,7 +306,11 @@ const InternalDashboard = () => {
       </div>
       <div className="iot-dashboard-panes-area">
         <ResizablePanes
-          leftPane={<div className="dummy-content">Resource explorer pane</div>}
+          leftPane={
+            <div className="iot-resource-explorer-pane">
+              <IotResourceExplorer query={query.assetTree.fromRoot()} />
+            </div>
+          }
           centerPane={
             <div className="iot-dashboard-grid">
               <Grid {...gridProps}>

--- a/packages/dashboard/src/components/resourceExplorer/index.spec.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/index.spec.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { createMockSiteWiseSDK, createMockIoTEventsSDK, initialize } from '@iot-app-kit/source-iotsitewise';
+import { IotResourceExplorer, IotResourceExplorerProps } from './index';
+import { mocklistAssetsResponse } from './mocks';
+import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { act } from 'react-dom/test-utils';
+
+const createDefaultClient = () =>
+  createMockSiteWiseSDK({
+    listAssets: () => Promise.resolve(mocklistAssetsResponse),
+  });
+
+// (input: ListAssetsCommandInput) => Promise<ListAssetsResponse>
+
+const elSelector = '.iot-resource-explorer';
+
+const createTestContext = async (
+  propOverrides: Partial<IotResourceExplorerProps>,
+  iotSiteWiseClient: IoTSiteWiseClient = createDefaultClient()
+) => {
+  const { query } = initialize({
+    iotSiteWiseClient: iotSiteWiseClient,
+    iotEventsClient: createMockIoTEventsSDK(),
+  });
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  act(() => {
+    ReactDOM.render(
+      <div>
+        <IotResourceExplorer query={query.assetTree.fromRoot()} {...propOverrides} />
+      </div>,
+      container
+    );
+  });
+
+  return document;
+};
+
+describe('IotResourceExplorer', () => {
+  it('should render', async () => {
+    const document = await createTestContext({});
+    const elements = document.querySelectorAll(elSelector);
+    expect(elements.length).toBe(1);
+  });
+});
+
+it('renders with custom loadingText', async () => {
+  const emptyText = 'Loading...';
+  const document = await createTestContext({ loadingText: emptyText });
+  const element = document.querySelector(elSelector);
+  expect(element!.getAttribute('loadingText')).toBe(emptyText);
+});
+
+it('renders without filter', async () => {
+  const document = await createTestContext({ filterEnabled: false });
+  const element = document.querySelector(elSelector);
+  expect(element!.getAttribute('filterEnabled')).toBe(null);
+});
+
+it('renders without sorting', async () => {
+  const document = await createTestContext({ sortingEnabled: false });
+  const element = document.querySelector(elSelector);
+  expect(element!.getAttribute('sortingEnabled')).toBe(null);
+});
+
+it('renders without pagination', async () => {
+  const document = await createTestContext({ paginationEnabled: false });
+  const element = document.querySelector(elSelector);
+  expect(element!.getAttribute('paginationEnabled')).toBe(null);
+});

--- a/packages/dashboard/src/components/resourceExplorer/index.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/index.tsx
@@ -1,0 +1,186 @@
+import React, { useState, useEffect } from 'react';
+import { ErrorDetails, TreeProvider, TreeQuery } from '@iot-app-kit/core';
+import { BranchReference, SiteWiseAssetTreeNode } from '@iot-app-kit/source-iotsitewise';
+import { SiteWiseAssetResource, FilterTexts, ColumnDefinition } from './types';
+import { parseSitewiseAssetTree } from './utils';
+import {
+  EmptyStateProps,
+  RelatedTable,
+  withUseTreeCollection,
+  UseTreeCollection,
+  ITreeNode,
+} from '@iot-app-kit/related-table';
+import { TableProps } from '@awsui/components-react/table';
+import { NonCancelableCustomEvent } from '@awsui/components-react';
+import { v4 as uuidv4 } from 'uuid';
+
+const DEFAULT_COLUMNS: ColumnDefinition<SiteWiseAssetResource>[] = [
+  {
+    sortingField: 'name',
+    id: 'name',
+    header: 'Asset Name',
+    cell: ({ name }: SiteWiseAssetResource) => name,
+  },
+  {
+    sortingField: 'status',
+    id: 'status',
+    header: 'Status',
+    cell: ({ status }: SiteWiseAssetResource) => status?.state,
+  },
+  {
+    sortingField: 'creationDate',
+    id: 'creationDate',
+    header: 'Created',
+    cell: ({ creationDate }: SiteWiseAssetResource) => creationDate?.toUTCString(),
+  },
+  {
+    sortingField: 'lastUpdateDate',
+    id: 'lastUpdateDate',
+    header: 'Updated',
+    cell: ({ lastUpdateDate }: SiteWiseAssetResource) => lastUpdateDate?.toUTCString(),
+  },
+];
+
+const defaults = {
+  selectionType: 'single' as TableProps.SelectionType,
+  loadingText: 'loading...',
+  filterText: {
+    placeholder: 'Filter by name',
+    empty: 'No assets found.',
+    noMatch: `We can't find a match.`,
+  },
+  empty: {
+    header: 'No assets',
+    description: `You don't have any assets.`,
+  },
+};
+
+export interface IotResourceExplorerProps {
+  query: TreeQuery<SiteWiseAssetTreeNode[], BranchReference>;
+  columnDefinitions?: ColumnDefinition<any>[];
+  filterTexts?: FilterTexts;
+  selectionType?: TableProps.SelectionType;
+  loadingText?: string;
+  empty?: EmptyStateProps;
+  filterEnabled?: boolean;
+  sortingEnabled?: boolean;
+  paginationEnabled?: boolean;
+  wrapLines?: boolean;
+  widgetId?: string;
+  onSelectionChange?: (event: NonCancelableCustomEvent<TableProps.SelectionChangeDetail<unknown>>) => void;
+  expanded?: boolean;
+}
+
+type ProviderStateValue = TreeProvider<SiteWiseAssetTreeNode[], BranchReference>;
+
+const RelatedTableWithCollectionHooks = withUseTreeCollection(RelatedTable);
+
+const makeExpandNodeFunction = (provider: any) => {
+  return (node: ITreeNode<SiteWiseAssetResource>) => {
+    node.hierarchies?.forEach((hierarchy: any) => {
+      provider.expand(new BranchReference(node.id, hierarchy.id as string));
+    });
+  };
+};
+
+export const IotResourceExplorer = ({
+  query,
+  columnDefinitions = DEFAULT_COLUMNS,
+  filterTexts,
+  selectionType,
+  loadingText,
+  empty,
+  filterEnabled = true,
+  sortingEnabled = true,
+  paginationEnabled = true,
+  wrapLines = false,
+  widgetId = uuidv4(),
+  onSelectionChange,
+  expanded = false,
+}: IotResourceExplorerProps) => {
+  const [provider, setProvider] = useState<ProviderStateValue | undefined>(undefined);
+  const [items, setItems] = useState<SiteWiseAssetResource[]>([]);
+  const [expandedItems, setExpandedItems] = useState<{ [id: string]: boolean }>({});
+  const [errors, setErrors] = useState<ErrorDetails[]>([]);
+
+  useEffect(() => {
+    const nextProvider = query.build(widgetId);
+    nextProvider.subscribe({
+      next: (data: SiteWiseAssetTreeNode[]) => {
+        setItems(parseSitewiseAssetTree(data));
+      },
+      error: (err: ErrorDetails[]) => {
+        setErrors(err);
+      },
+    });
+
+    setProvider(nextProvider);
+
+    return () => {
+      nextProvider.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!provider || !expanded) return;
+    const newExpandedItems: { [id: string]: boolean } = {};
+
+    items.forEach(({ id, hierarchies, hasChildren }) => {
+      if (id && !expandedItems[id] && hasChildren) {
+        hierarchies?.forEach((hierarchy: any) => {
+          provider.expand(new BranchReference(id, hierarchy.id as string));
+        });
+
+        newExpandedItems[id] = true;
+      }
+    });
+
+    setExpandedItems({ ...expandedItems, ...newExpandedItems });
+  }, [items]);
+
+  const filtering = filterEnabled ? filterTexts || defaults.filterText : undefined;
+
+  const collectionOptions: UseTreeCollection<unknown> = {
+    columnDefinitions: columnDefinitions,
+    keyPropertyName: 'id',
+    parentKeyPropertyName: 'parentId',
+    selection: {
+      keepSelection: true,
+    },
+    sorting: {
+      defaultState: {
+        sortingColumn: {
+          sortingField: 'name',
+        },
+        isDescending: true,
+      },
+    },
+    filtering,
+  };
+
+  if (paginationEnabled) {
+    collectionOptions.pagination = { pageSize: 20 };
+  }
+
+  const emptyContent =
+    errors.length > 0 ? { header: 'Error', description: errors[errors.length - 1]?.msg } : empty || defaults.empty;
+
+  return (
+    <div className="iot-resource-explorer">
+      <RelatedTableWithCollectionHooks
+        items={items}
+        collectionOptions={collectionOptions}
+        columnDefinitions={columnDefinitions}
+        selectionType={selectionType || defaults.selectionType}
+        loadingText={loadingText || defaults.loadingText}
+        filterPlaceholder={filtering?.placeholder}
+        expandChildren={makeExpandNodeFunction(provider)}
+        onSelectionChange={onSelectionChange}
+        empty={emptyContent}
+        sortingDisabled={!sortingEnabled}
+        wrapLines={wrapLines}
+        expanded={expanded}
+      />
+    </div>
+  );
+};

--- a/packages/dashboard/src/components/resourceExplorer/mocks.ts
+++ b/packages/dashboard/src/components/resourceExplorer/mocks.ts
@@ -1,0 +1,43 @@
+import { ListAssetsResponse } from '@aws-sdk/client-iotsitewise';
+// import { NetworkAssetSummary, Modify } from './types';
+
+// type NetworkListAssetsResponse = Modify<
+//   ListAssetsResponse,
+//   {
+//     assetSummaries: NetworkAssetSummary[];
+//   }
+// >;
+
+export const mocklistAssetsResponse: ListAssetsResponse = {
+  assetSummaries: [
+    {
+      arn: 'arn:aws:iotsitewise:us-east-1:650249681718:asset/1aafd293-0d67-4306-a849-2a325247d9c0',
+      assetModelId: 'bc1375df-c0fc-4dfa-a267-a3946715e87a',
+      creationDate: new Date(1629327591123),
+      hierarchies: [
+        {
+          id: '4044d48a-3f81-4509-af06-75529de975f7',
+          name: 'Engine',
+        },
+      ],
+      id: '1aafd293-0d67-4306-a849-2a325247d9c0',
+      lastUpdateDate: new Date(1629327592123),
+      name: 'Turbine 1',
+      status: {
+        state: 'ACTIVE',
+      },
+    },
+    {
+      arn: 'arn:aws:iotsitewise:us-east-1:650249681718:asset/5a87ad39-9eae-406b-8772-b5c2e2395234',
+      assetModelId: 'b59bbc06-5efb-4bbb-8999-94eaf0162b2a',
+      creationDate: new Date(1629327593123),
+      hierarchies: [],
+      id: '5a87ad39-9eae-406b-8772-b5c2e2395234',
+      lastUpdateDate: new Date(1629327594123),
+      name: 'Wing 1',
+      status: {
+        state: 'ACTIVE',
+      },
+    },
+  ],
+};

--- a/packages/dashboard/src/components/resourceExplorer/types.ts
+++ b/packages/dashboard/src/components/resourceExplorer/types.ts
@@ -1,0 +1,28 @@
+import { AssetSummary } from '@aws-sdk/client-iotsitewise';
+import { TableProps } from '@awsui/components-react';
+
+export type Modify<T, R> = Omit<T, keyof R> & R;
+
+export type NetworkAssetSummary = Modify<
+  AssetSummary,
+  {
+    creationDate: number;
+    lastUpdateDate: number;
+  }
+>;
+
+export interface FilterTexts {
+  placeholder: string;
+  empty: string;
+  noMatch: string;
+}
+
+export interface ColumnDefinition<T> extends TableProps.ColumnDefinition<T> {
+  header: string;
+  cell: (item: T) => string | undefined;
+}
+
+export interface SiteWiseAssetResource extends AssetSummary {
+  hasChildren: boolean;
+  parentId?: string;
+}

--- a/packages/dashboard/src/components/resourceExplorer/utils.ts
+++ b/packages/dashboard/src/components/resourceExplorer/utils.ts
@@ -1,0 +1,25 @@
+import { SiteWiseAssetTreeNode, HierarchyGroup } from '@iot-app-kit/source-iotsitewise';
+import { SiteWiseAssetResource } from './types';
+
+const recursiveParseSitewiseAssetTree = (
+  flattenTree: SiteWiseAssetResource[],
+  subTree: SiteWiseAssetTreeNode[],
+  parentId?: string
+) => {
+  subTree.forEach((node) => {
+    flattenTree.push({
+      ...node.asset,
+      hasChildren: node.hierarchies.size > 0,
+      parentId,
+    });
+    node.hierarchies.forEach((hierarchy: HierarchyGroup) => {
+      recursiveParseSitewiseAssetTree(flattenTree, hierarchy.children, node.asset.id);
+    });
+  });
+};
+
+export const parseSitewiseAssetTree = (tree: SiteWiseAssetTreeNode[]) => {
+  const flattenTree: SiteWiseAssetResource[] = [];
+  recursiveParseSitewiseAssetTree(flattenTree, tree);
+  return flattenTree;
+};


### PR DESCRIPTION
## Overview
Initial implementation of React resource explorer in left sidebar based on Stencil component.

Uncommented test query in internalDashboard so we'd have something valid to feed as query prop.

Deferring advanced functionality like dragging resources onto widgets until the grid is ready.

![Screen Shot 2022-11-15 at 11 04 06 AM](https://user-images.githubusercontent.com/15032398/202005130-e120c4a2-7bed-4483-8a90-6e191e9606db.png)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
