### PR TITLE
fix(composer): SubModel child fix

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
@@ -36,7 +36,7 @@ Array [
       ],
     },
     "transformConstraint": Object {
-      "snapToFloor": true,
+      "snapToFloor": false,
     },
   },
 ]

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/index.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/index.tsx
@@ -82,7 +82,7 @@ const SubModelTree: FC<SubModelTreeProps> = ({
         rotation: [object3D.rotation.x, object3D.rotation.y, object3D.rotation.z],
       },
       transformConstraint: {
-        snapToFloor: true,
+        snapToFloor: false,
       },
       childRefs: [],
       properties: {

--- a/packages/scene-composer/src/interfaces/feature.ts
+++ b/packages/scene-composer/src/interfaces/feature.ts
@@ -12,6 +12,7 @@ export enum COMPOSER_FEATURES {
   EnvironmentModel = 'EnvironmentModel',
   TagResize = 'TagResize',
   SubModelMovement = 'SubModelMovement',
+  SubModelChildren = 'SubModelChildren',
 }
 
 export type FeatureConfig = Partial<Record<COMPOSER_FEATURES, boolean>>;


### PR DESCRIPTION
### Overview
Forces all sub model children to be physically parented to it's parent. This makes it so that children don't move with the sub model but the render correctly. There is a feature flag to maintain previous implementations so that we can fix later

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
