### PR TITLE
fix(composer): One instance of sub models allowed per instance of the model

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
@@ -14,9 +14,7 @@ Array [
     ],
     "name": "RootObject",
     "parentRef": "112",
-    "properties": Object {
-      "subModelId": "RootObject",
-    },
+    "properties": Object {},
     "ref": "112#undefined",
     "transform": Object {
       "position": Array [


### PR DESCRIPTION
## Overview
It was my misunderstanding that we needed to limit multiple instances of the sub models on a per ModelRef basis. This fixes that and also removes the unnecessary property

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
