### PR TITLE
fix(composer): Fix to persist drag/drop actions after refresh

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -155,7 +155,7 @@
     "coverageThreshold": {
       "global": {
         "lines": 77.51,
-        "statements": 76.6,
+        "statements": 76.61,
         "functions": 76.76,
         "branches": 63.17,
         "branchesTrue": 100

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyDataProvider.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyDataProvider.tsx
@@ -5,7 +5,7 @@ import { isEmpty } from 'lodash';
 
 import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
 import { findComponentByType, isEnvironmentNode } from '../../../utils/nodeUtils';
-import { ISceneNodeInternal, useNodeErrorState, useStore } from '../../../store';
+import { ISceneNodeInternal, useNodeErrorState, useSceneDocument, useStore } from '../../../store';
 import useLifecycleLogging from '../../../logger/react-logger/hooks/useLifecycleLogging';
 import { KnownComponentType } from '../../../interfaces';
 
@@ -104,7 +104,8 @@ const SceneHierarchyDataProvider: FC<SceneHierarchyDataProviderProps> = ({ selec
   useLifecycleLogging('SceneHierarchyDataProvider');
   const sceneComposerId = useSceneComposerId();
   const { document, removeSceneNode } = useStore(sceneComposerId)((state) => state);
-  const { updateSceneNodeInternal, isEditing } = useStore(sceneComposerId)((state) => state);
+  const { isEditing } = useStore(sceneComposerId)((state) => state);
+  const { updateSceneNodeInternal } = useSceneDocument(sceneComposerId);
   const selectedSceneNodeRef = useStore(sceneComposerId)((state) => state.selectedSceneNodeRef);
   const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
   const getObject3DBySceneNodeRef = useStore(sceneComposerId)((state) => state.getObject3DBySceneNodeRef);


### PR DESCRIPTION
## Overview
Updating import for `updateSceneNodeInternal` to come from `useSceneDocument` to achieve persist on refresh. 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
