### PR TITLE
fix(composer): Fix for useEffect error

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyDataProvider.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyDataProvider.tsx
@@ -79,12 +79,18 @@ export const useChildNodes = (parentRef: string) => {
   const [childNodes, setChildNodes] = useState([] as ISceneHierarchyNode[]);
 
   useEffect(() => {
+    let mounted = true;
     (async () => {
       setLoading(true);
       const results = await getChildNodes(parentRef);
-      setChildNodes(results);
-      setLoading(false);
+      if (mounted) {
+        setChildNodes(results);
+        setLoading(false);
+      }
     })();
+    return () => {
+      mounted = false;
+    };
   }, [getChildNodes]);
 
   return [childNodes, loading] as [ISceneHierarchyNode[], boolean];


### PR DESCRIPTION
## Overview
Fix to unsubscribe in `useEffect` that was triggering error on drag/drop. Includes fix for type safety in `move` function.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
