### PR TITLE
fix(composer): reorder doesn't persist after reloading

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyDataProvider.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyDataProvider.tsx
@@ -202,10 +202,10 @@ const SceneHierarchyDataProvider: FC<SceneHierarchyDataProviderProps> = ({ selec
         } else {
           updateSceneNodeInternal(oldParentRef, { childRefs: oldParentChildren });
         }
-        // update node to have new parent
-        updateSceneNodeInternal(objectToMoveRef, { parentRef: newParentRef });
         // update new parent to have new child
         updateSceneNodeInternal(newParentRef, { childRefs: [...newParent!.childRefs, objectRef] });
+        // update node to have new parent
+        updateSceneNodeInternal(objectToMoveRef, { parentRef: newParentRef });
         // TODO: create single call to handle this
       }
     },


### PR DESCRIPTION
## Overview
the multiple `updateSceneNodeInternal` calls seem to have conflicts and cause state update event to be missed. since `childRefs` is used during serialization, it's more important. so update it first. 
The long term solution should be combining them to single call.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
