### PR TITLE
fix(SubModelHidingChildren): Unnamed children should be skipped not omitted

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
@@ -46,6 +46,7 @@ const SceneHierarchyTreeItem: FC<SceneHierarchyTreeItemProps> = ({
   const { getSceneNodeByRef } = useSceneDocument(sceneComposerId);
   const node = getSceneNodeByRef(key);
   const isSubModel = !!findComponentByType(node, KnownComponentType.SubModelRef);
+  const componentRef = findComponentByType(node, KnownComponentType.ModelRef)?.ref;
   const { searchTerms } = useSceneHierarchyData();
   const isSearching = searchTerms !== '';
 
@@ -101,7 +102,7 @@ const SceneHierarchyTreeItem: FC<SceneHierarchyTreeItemProps> = ({
             </React.Fragment>
           ))}
           {showSubModel && !isSearching && (
-            <SubModelTree parentRef={key} expanded={false} object3D={model!} selectable />
+            <SubModelTree parentRef={key} expanded={false} object3D={model!} componentRef={componentRef!} selectable />
           )}
         </EnhancedTree>
       )}

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/SubModelTree.spec.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/SubModelTree.spec.tsx
@@ -43,6 +43,8 @@ const defaultObject = {
       node(3, 'Node 3', [], false),
       node(4),
       node(5, 'Node 5', [node(6, 'Child 1'), node(7, 'Child 2'), node(8, 'Child 3')]),
+      node(9, '', [node(10, 'Child 4'), node(11, 'Child 5'), node(12, 'Child 6')]),
+      node(13, 'Composer Added', [node(14, 'Child 7'), node(15, 'Child 8'), node(16, 'Child 9')], false),
     ] as unknown as Object3D<Event>[],
   } as unknown as Object3D<Event>,
   parentRef: '112',
@@ -61,7 +63,7 @@ describe('SubModelTree', () => {
 
     const objectNullName = {
       ...defaultObject,
-      name: null,
+      name: undefined,
     };
 
     const { container } = render(<SubModelTree {...objectNullName} />);

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
@@ -167,6 +167,96 @@ exports[`SubModelTree should not render a SubModel Tree if isOriginal flag is fa
           </li>
         </ol>
       </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 4
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 5
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 6
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 7
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 8
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 9
+          </div>
+        </label>
+      </li>
     </ol>
   </li>
 </div>
@@ -299,6 +389,96 @@ exports[`SubModelTree should not render a SubModel Tree if name is null 1`] = `
           </li>
         </ol>
       </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 4
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 5
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 6
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 7
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 8
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 9
+          </div>
+        </label>
+      </li>
     </ol>
   </li>
 </div>
@@ -430,6 +610,96 @@ exports[`SubModelTree should render appropriately based on the object 1`] = `
             </label>
           </li>
         </ol>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 4
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 5
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 6
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 7
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 8
+          </div>
+        </label>
+      </li>
+      <li
+        class="tm-tree-item tm-sub-model"
+        role="treeitem"
+      >
+        <label
+          aria-selected="false"
+          class="tm-tree-item-inner"
+        >
+          <div
+            data-mocked="SubModelTreeItemLabel"
+          >
+            Child 9
+          </div>
+        </label>
       </li>
     </ol>
   </li>

--- a/packages/scene-composer/src/components/three-fiber/ModelRefComponent/GLTFModelComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ModelRefComponent/GLTFModelComponent.tsx
@@ -30,6 +30,7 @@ function processObject(component: IModelRefComponentInternal, obj: THREE.Object3
   acceleratedRaycasting(obj);
   enableShadow(component, obj, options.maxAnisotropy);
   obj.userData.isOriginal = true; // This is important to the SubModelSelection tool, it's used to filter out geomtry we've added with our
+  obj.userData.componentRef = component.ref;
 }
 
 interface GLTFModelProps {


### PR DESCRIPTION
Named objects under unnamed parents were not showing up in the SubModel Tree.

## Overview
Previously, we were making some assumptions that named items would have named parents up to the root node, but in some cases this isn't true.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
