### PR TITLE
chore: specify node version to 16

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 'lts/*'
+          node-version: '16.x'
 
       - name: Install and Build
         run: |


### PR DESCRIPTION
## Overview
Specify node version to 16 to fix the following issue during GH auto test workflow.

```
Run yarn install --frozen-lockfile
yarn install v1.22.19
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
error @achrinza/node-ipc@9.2.2: The engine "node" is incompatible with this module. Expected version "8 || 10 || 12 || 14 || 1[6](https://github.com/awslabs/iot-app-kit/actions/runs/3516513445/jobs/5893168217#step:4:7) || 1[7](https://github.com/awslabs/iot-app-kit/actions/runs/3516513445/jobs/5893168217#step:4:8)". Got "1[8](https://github.com/awslabs/iot-app-kit/actions/runs/3516513445/jobs/5893168217#step:4:9).12.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
