### PR TITLE
docs: fix initialize param casing

### DIFF
--- a/docs/AWSIoTSiteWiseSource.md
+++ b/docs/AWSIoTSiteWiseSource.md
@@ -18,9 +18,9 @@ Queries are available upon initialization of the AWS IoT SiteWise source.
 
 ```
 import { initialize } from '@iot-app-kit/source-iotsitewise
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 ```
 
 **Query construction example**
@@ -152,12 +152,12 @@ const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
 import { initialize } from '@iot-app-kit/source-iotsitewise';
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
 
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
 defineCustomElements();
 
 // initialize source-iotsitewise
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <iot-line-chart
@@ -256,9 +256,9 @@ import { initialize } from '@iot-app-kit/source-iotsitewise';
 
 const { IoTSiteWiseClient } = require("@aws-sdk/client-iotsitewise");
 
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient, settings: { batchDuration: 100 } });
+const { query } = initialize({ iotSiteWiseClient, settings: { batchDuration: 100 } });
 ```
 
 `batchDuration`

--- a/docs/BarChart.md
+++ b/docs/BarChart.md
@@ -16,9 +16,9 @@ The line chart utilizes WebGL. You need to create an instance of the WebGL conte
 import { initialize } from '@iot-app-kit/source-iotsitewise';
 import { BarChart } from '@iot-app-kit/react-components';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <BarChart
@@ -43,9 +43,9 @@ const { IoTSiteWiseClient } = require("@aws-sdk/client-iotsitewise");
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
 
 defineCustomElements();
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <iot-bar-chart

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -17,9 +17,9 @@ Use the step-by-step tutorial in this section to learn how to set up IoT Applica
 
     const { IoTSiteWiseClient } = require("@aws-sdk/client-iotsitewise");
 
-    const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+    const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-    const { query } = initialize({ iotsitewiseClient });
+    const { query } = initialize({ iotSiteWiseClient });
     ```
 
     2. To initialize an instance of [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers), use the following sample code, but replace the credential provider with the one you wish to utilize: 
@@ -44,8 +44,8 @@ import { initialize } from '@iot-app-kit/source-iotsitewise';
 import { LineChart, WebglContext } from '@iot-app-kit/react-components';
 const { IoTSiteWiseClient } = require("@aws-sdk/client-iotsitewise");
 
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
-const { query } = initialize({ iotsitewiseClient });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const { query } = initialize({ iotSiteWiseClient });
 
 // React component example
 <LineChart

--- a/docs/KPI.md
+++ b/docs/KPI.md
@@ -14,9 +14,9 @@ To view and interact with a KPI example, visit [KPI](https://synchrocharts.com/#
 import { initialize } from '@iot-app-kit/source-iotsitewise';
 import { KPI } from '@iot-app-kit/react-components';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <KPI
@@ -41,9 +41,9 @@ const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
 
 defineCustomElements();
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <iot-kpi

--- a/docs/LineChart.md
+++ b/docs/LineChart.md
@@ -16,9 +16,9 @@ The line chart utilizes WebGL. You need to create an instance of the WebGL conte
 import { initialize } from '@iot-app-kit/source-iotsitewise';
 import { LineChart } from '@iot-app-kit/react-components';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <LineChart
@@ -43,9 +43,9 @@ const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
 
 defineCustomElements();
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <iot-line-chart

--- a/docs/ResourceExplorer.md
+++ b/docs/ResourceExplorer.md
@@ -11,9 +11,9 @@ The resource explorer allows you to navigate and select AWS IoT SiteWise assets 
 import { initialize } from '@iot-app-kit/source-iotsitewise';
 import { ResourceExplorer } from '@iot-app-kit/react-components';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <ResourceExplorer
@@ -30,9 +30,9 @@ const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
 
 defineCustomElements();
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 
 // jsx

--- a/docs/ScatterChart.md
+++ b/docs/ScatterChart.md
@@ -16,9 +16,9 @@ The scatter chart utilizes WebGL. You need to create an instance of the WebGL co
 import { initialize } from '@iot-app-kit/source-iotsitewise';
 import { ScatterChart } from '@iot-app-kit/react-components';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <ScatterChart
@@ -42,9 +42,9 @@ import { initialize } from '@iot-app-kit/source-iotsitewise';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
 defineCustomElements();
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <iot-scatter-chart

--- a/docs/StatusGrid.md
+++ b/docs/StatusGrid.md
@@ -14,9 +14,9 @@ To view and interact with a status grid example, visit [StatusGrid](https://sync
 import { initialize } from '@iot-app-kit/source-iotsitewise';
 import { StatusGrid } from '@iot-app-kit/react-components';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <StatusGrid
@@ -40,9 +40,9 @@ import { initialize } from '@iot-app-kit/source-iotsitewise';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
 defineCustomElements();
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <iot-status-grid

--- a/docs/StatusTimeline.md
+++ b/docs/StatusTimeline.md
@@ -18,9 +18,9 @@ The status timeline utilizes WebGL. You need to create an instance of the WebGL 
 import { initialize } from '@iot-app-kit/source-iotsitewise';
 import { StatusTimeline } from '@iot-app-kit/react-components';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <StatusTimeline
@@ -56,9 +56,9 @@ import { initialize } from '@iot-app-kit/source-iotsitewise';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
 defineCustomElements();
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <iot-status-timeline

--- a/docs/Table.md
+++ b/docs/Table.md
@@ -14,9 +14,9 @@ Current version (v2.0.0), `iot-table` component does **NOT** support viewport gr
 import { initialize, toId } from '@iot-app-kit/source-iotsitewise';
 import { Table } from '@iot-app-kit/react-components';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <Table
@@ -94,9 +94,9 @@ import { initialize, toId } from '@iot-app-kit/source-iotsitewise';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
 defineCustomElements();
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 
 // jsx
 <iot-table
@@ -388,9 +388,9 @@ and `columnDefinitions` defines how table maps `items` to columns. For more deta
 import { initialize, toId } from '@iot-app-kit/source-iotsitewise';
 import { Table } from '@iot-app-kit/react-components';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 <Table
   viewport={{ duration: '5m' }}
   tableColumns={[
@@ -434,9 +434,9 @@ const { query } = initialize({ iotsitewiseClient });
 import { initialize, toId } from '@iot-app-kit/source-iotsitewise';
 import { Table } from '@iot-app-kit/react-components';
 const { IoTSiteWiseClient } = require('@aws-sdk/client-iotsitewise');
-const iotsitewiseClient = new IoTSiteWiseClient({ region: "REGION" });
+const iotSiteWiseClient = new IoTSiteWiseClient({ region: "REGION" });
 
-const { query } = initialize({ iotsitewiseClient });
+const { query } = initialize({ iotSiteWiseClient });
 <Table
   viewport={{ duration: '5m' }}
   items={[


### PR DESCRIPTION
## Overview
Many code blocks in our docs have an incorrect param for `initialize`, resulting in errors and the TS complaint `Object literal may only specify known properties, but 'iotsitewiseClient' does not exist in type 'SiteWiseDataSourceInitInputs'. Did you mean to write 'iotSiteWiseClient'?`. The correct casing is [here](https://github.com/awslabs/iot-app-kit/blob/main/packages/source-iotsitewise/src/initialize.ts#L25). This PR fixes all instances of this issue.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
