### PR TITLE
fix(composer): entityId data binding not rendered

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -157,7 +157,7 @@
         "lines": 77.23,
         "statements": 76.33,
         "functions": 76.64,
-        "branches": 62.91,
+        "branches": 62.8,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/components/panels/scene-components/ValueDataBindingBuilder.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/ValueDataBindingBuilder.tsx
@@ -77,7 +77,7 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
     // Initiate the provider
     const state = valueDataBindingStore.setBinding(componentRef, binding, dataBindingConfig);
     setBuilderState(state);
-    setAutoSuggestValue(builderState.selectedOptions[ENTITY_ID_INDEX]?.value || '');
+    setAutoSuggestValue(state.selectedOptions[ENTITY_ID_INDEX]?.value || '');
   }, [componentRef, binding, valueDataBindingProvider, dataBindingConfig]);
 
   return (


### PR DESCRIPTION
## Overview
entityId data binding not rendered because the `builderState` is not updated right after `setBuilderState` call

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
