### PR TITLE
chore(PublishStorybook): Publish Storybook Site to build artifacts

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -1,0 +1,32 @@
+name: Publish Storybook
+on:
+  pull_request:
+    paths:
+    - 'packages/scene-composer/**'
+
+jobs:
+  publish-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install and Build
+        run: |
+          npm ci
+          npm run build
+          npm run build-storybook -w packages/scene-composer
+
+      # store storybook site
+      - name: Upload Storybook Assets
+        uses: actions/upload-artifact@v1
+        if: success()
+        with:
+          name: scene-composer-${{ github.sha }}
+          path: packages/scene-composer/storybook-static
+

--- a/packages/scene-composer/README.md
+++ b/packages/scene-composer/README.md
@@ -45,3 +45,4 @@ localStorage.debug = '*'; // by default gives you all logging output
 localStorage.debug = '*,-verbose:*'; // don't show verbose logging
 localStorage.debug = 'ruleEvaluator*'; // only show messages related to the ruleEvaluator component
 ```
+


### PR DESCRIPTION
## Overview
Adds a github action workflow that allows a reviewer to download the prebuilt Storybook site for Scene composer at the current revision.

You can download these artifacts from the workflow, and using a local static site tool like `httpserver` run the storybook website and play with new features before approving the CR, without having to check it out and run it locally.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
