### PR TITLE
feat(dashboard): set up basic layout for side panel

### DIFF
--- a/packages/dashboard/jest.config.ts
+++ b/packages/dashboard/jest.config.ts
@@ -9,12 +9,28 @@ export default {
   // collectCoverage: true,
   // coverageDirectory: 'coverage',
   // coverageProvider: 'v8',
+  moduleFileExtensions: ['js', 'ts', 'jsx', 'tsx'],
   moduleNameMapper: {
     '\\.(svg|css|less)$': '<rootDir>/testing/styleMock.js',
   },
   testEnvironment: 'jsdom',
-  // setupFilesAfterEnv: ['mutationobserver-shim'],
-  // transform: {
+  transform: {
+    '.*\\.(tsx?|jsx?)$': [
+      '@swc/jest',
+      {
+        jsc: {
+          transform: {
+            react: {
+              runtime: 'automatic',
+            },
+          },
+        },
+      },
+    ],
+  },
+  transformIgnorePatterns: [],
+  setupFilesAfterEnv: ['mutationobserver-shim'],
+  //transform: {
   //   '.+\\.ts$': 'ts-jest',
   //   '^.+\\.tsx?$': 'ts-jest',
   //   '^.+\\.(js|jsx)$': 'babel-jest',

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -43,6 +43,8 @@
     "@types/box-intersect": "^1.0.0",
     "@types/lodash": "^4.14.186",
     "@types/is-hotkey": "^0.1.7",
+    "@swc/core": "^1.3.20",
+    "@swc/jest": "^0.2.23",
     "@types/node": "^18.11.4",
     "@types/react": "^17.0.38",
     "babel-loader": "^8.2.5",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -67,6 +67,8 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
+    "@cloudscape-design/components": "^3.0.126",
+    "@cloudscape-design/global-styles": "^1.0.5",
     "@iot-app-kit/core": "^2.4.2",
     "@iot-app-kit/source-iotsitewise": "^2.4.2",
     "@synchro-charts/core": "^4.0.0",

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -7,6 +7,7 @@ import InternalDashboard from '../internalDashboard';
 
 import { configureDashboardStore } from '../../store';
 import { DashboardState } from '../../store/state';
+import '@cloudscape-design/global-styles/index.css';
 
 import '../../styles/variables.css';
 

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -52,6 +52,7 @@ const selectedRect = (selection: Selection | undefined): Rect | undefined => {
     height: Math.abs(selection.start.y - selection.end.y),
   };
 };
+import SidePanel from '../side-panel';
 
 const InternalDashboard = () => {
   /**
@@ -320,7 +321,7 @@ const InternalDashboard = () => {
               </Grid>
             </div>
           }
-          rightPane={<div className="dummy-content">Component pane</div>}
+          rightPane={<SidePanel />}
         />
       </div>
     </div>

--- a/packages/dashboard/src/components/side-panel/index.css
+++ b/packages/dashboard/src/components/side-panel/index.css
@@ -1,0 +1,3 @@
+.iot-side-panel {
+  height: 100%;
+}

--- a/packages/dashboard/src/components/side-panel/index.tsx
+++ b/packages/dashboard/src/components/side-panel/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Container, Header } from '@cloudscape-design/components';
+import PropertiesAlarmsSection from './sub-components/properties-alarms-section';
+import ThresholdsSection from './sub-components/thresholds-section';
+import ChartSettings from './sub-components/chart-settings';
+import DataSettings from './sub-components/data-settings';
+import './index.css';
+
+const IoTSidePanel = () => {
+  return (
+    <Container header={<Header variant="h3">Configurations</Header>} className={'iot-side-panel'}>
+      <PropertiesAlarmsSection />
+      <ThresholdsSection />
+      <ChartSettings />
+      <DataSettings />
+    </Container>
+  );
+};
+
+export default IoTSidePanel;

--- a/packages/dashboard/src/components/side-panel/shared/expandableSectionHeader.tsx
+++ b/packages/dashboard/src/components/side-panel/shared/expandableSectionHeader.tsx
@@ -1,0 +1,25 @@
+import React, { createElement, FC, PropsWithChildren } from 'react';
+import { Icon, IconProps } from '@cloudscape-design/components';
+import './styles.css';
+
+type ExpandableSectionHeaderProps = {
+  variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
+  onClickButton?: (e: Event) => void;
+  iconName?: IconProps.Name;
+};
+const ExpandableSectionHeader: FC<PropsWithChildren<ExpandableSectionHeaderProps>> = (props) => {
+  const { children, onClickButton, iconName = 'add-plus', variant = 'h5' } = props;
+  const element = createElement(variant, { className: 'expandable-section-header-text' }, children);
+  return (
+    <>
+      {element}
+      {onClickButton && (
+        <span className="expandable-section-header-icon">
+          <Icon name={iconName} />
+        </span>
+      )}
+    </>
+  );
+};
+
+export default ExpandableSectionHeader;

--- a/packages/dashboard/src/components/side-panel/shared/styles.css
+++ b/packages/dashboard/src/components/side-panel/shared/styles.css
@@ -1,0 +1,7 @@
+.expandable-section-header-icon {
+  margin-left: auto;
+}
+
+.expandable-section-header-text {
+  margin: 0;
+}

--- a/packages/dashboard/src/components/side-panel/sub-components/chart-settings.tsx
+++ b/packages/dashboard/src/components/side-panel/sub-components/chart-settings.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { ExpandableSection } from '@cloudscape-design/components';
+import ExpandableSectionHeader from '../shared/expandableSectionHeader';
+
+const ChartSettings = () => {
+  return (
+    <ExpandableSection headerText={<ExpandableSectionHeader>Chart Setting</ExpandableSectionHeader>} defaultExpanded>
+      --
+    </ExpandableSection>
+  );
+};
+
+export default ChartSettings;

--- a/packages/dashboard/src/components/side-panel/sub-components/data-settings.tsx
+++ b/packages/dashboard/src/components/side-panel/sub-components/data-settings.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { ExpandableSection } from '@cloudscape-design/components';
+import ExpandableSectionHeader from '../shared/expandableSectionHeader';
+
+const DataSettings = () => {
+  return (
+    <ExpandableSection headerText={<ExpandableSectionHeader>Data Settings</ExpandableSectionHeader>} defaultExpanded>
+      --
+    </ExpandableSection>
+  );
+};
+
+export default DataSettings;

--- a/packages/dashboard/src/components/side-panel/sub-components/properties-alarms-section.tsx
+++ b/packages/dashboard/src/components/side-panel/sub-components/properties-alarms-section.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ExpandableSection } from '@cloudscape-design/components';
+import ExpandableSectionHeader from '../shared/expandableSectionHeader';
+
+const PropertiesAlarmsSection = () => {
+  return (
+    <ExpandableSection
+      headerText={<ExpandableSectionHeader onClickButton={() => {}}>Properties & Alarms</ExpandableSectionHeader>}
+      defaultExpanded
+    >
+      --
+    </ExpandableSection>
+  );
+};
+
+export default PropertiesAlarmsSection;

--- a/packages/dashboard/src/components/side-panel/sub-components/thresholds-section.tsx
+++ b/packages/dashboard/src/components/side-panel/sub-components/thresholds-section.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ExpandableSection } from '@cloudscape-design/components';
+import ExpandableSectionHeader from '../shared/expandableSectionHeader';
+
+const ThresholdsSection = () => {
+  return (
+    <ExpandableSection
+      headerText={<ExpandableSectionHeader onClickButton={() => {}}>Thresholds</ExpandableSectionHeader>}
+      defaultExpanded
+    >
+      --
+    </ExpandableSection>
+  );
+};
+
+export default ThresholdsSection;


### PR DESCRIPTION
## Overview
- import @cloudscape-design/components
- set up expandable section 
- add a shared components `ExpandableSectionHeader` to allow use to handle actions that targets to the whole section. Eg. add a new threshold.
- fix jest transforms with @swc/jest

## Preview
![image](https://user-images.githubusercontent.com/11740421/204841392-27eda906-6e00-4dcd-bc47-d83248fb5fb8.png)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
