### PR TITLE
fix(video-player): use static timestamps in tests

### DIFF
--- a/packages/react-components/src/video-player/customVideoProgressBar.spec.tsx
+++ b/packages/react-components/src/video-player/customVideoProgressBar.spec.tsx
@@ -8,29 +8,29 @@ it('should return custom video progress bar html', () => {
   // TimezoneOffset is included to make sure that output is calucalted as expected result without timezone issue during test
   const timerangesWithSource = [
     {
-      start: 1630005300000 + new Date().getTimezoneOffset() * 60000,
-      end: 1630005400000 + new Date().getTimezoneOffset() * 60000,
+      start: 1630005300000 + new Date(1630005300000).getTimezoneOffset() * 60000,
+      end: 1630005400000 + new Date(1630005400000).getTimezoneOffset() * 60000,
       src: 'mockOnDemandURL-1',
     },
     {
-      start: 1630005400000 + new Date().getTimezoneOffset() * 60000,
-      end: 1630005500000 + new Date().getTimezoneOffset() * 60000,
+      start: 1630005400000 + new Date(1630005400000).getTimezoneOffset() * 60000,
+      end: 1630005500000 + new Date(1630005500000).getTimezoneOffset() * 60000,
       src: 'mockOnDemandURL-2',
     },
     {
-      start: 1630005800000 + new Date().getTimezoneOffset() * 60000,
-      end: 1630005850000 + new Date().getTimezoneOffset() * 60000,
+      start: 1630005800000 + new Date(1630005800000).getTimezoneOffset() * 60000,
+      end: 1630005850000 + new Date(1630005850000).getTimezoneOffset() * 60000,
       src: 'mockOnDemandURL-3',
     },
   ];
   const timerangesForVideoOnEdge = [
     {
-      start: 1630005400000 + new Date().getTimezoneOffset() * 60000,
-      end: 1630005600000 + new Date().getTimezoneOffset() * 60000,
+      start: 1630005400000 + new Date(1630005400000).getTimezoneOffset() * 60000,
+      end: 1630005600000 + new Date(1630005600000).getTimezoneOffset() * 60000,
     },
     {
-      start: 1630005800000 + new Date().getTimezoneOffset() * 60000,
-      end: 1630005900000 + new Date().getTimezoneOffset() * 60000,
+      start: 1630005800000 + new Date(1630005800000).getTimezoneOffset() * 60000,
+      end: 1630005900000 + new Date(1630005900000).getTimezoneOffset() * 60000,
     },
   ];
   expect(
@@ -40,8 +40,8 @@ it('should return custom video progress bar html', () => {
       playProgressId: 'playProgressId',
       timerangesWithSource,
       timerangesForVideoOnEdge,
-      startTimestamp: 1630005300000 + new Date().getTimezoneOffset() * 60000,
-      endTimestamp: 1630005900000 + new Date().getTimezoneOffset() * 60000,
+      startTimestamp: 1630005300000 + new Date(1630005300000).getTimezoneOffset() * 60000,
+      endTimestamp: 1630005900000 + new Date(1630005900000).getTimezoneOffset() * 60000,
     })
   ).toEqual(expectedResult);
 });

--- a/packages/react-components/src/video-player/utils/dateRangeUtils.spec.tsx
+++ b/packages/react-components/src/video-player/utils/dateRangeUtils.spec.tsx
@@ -19,7 +19,7 @@ it('should return start and end time for relative range in seconds', () => {
     unit: 'second',
     type: 'relative',
   };
-  const currentDateTimeForRelativeValue = new Date();
+  const currentDateTimeForRelativeValue = new Date(1665583620000);
   const actualResult = getStartAndEndTimeFromRange(newDateRange, currentDateTimeForRelativeValue);
 
   const endTime = currentDateTimeForRelativeValue.getTime().toString();
@@ -37,7 +37,7 @@ it('should return start and end time for relative range in minutes', () => {
     unit: 'minute',
     type: 'relative',
   };
-  const currentDateTimeForRelativeValue = new Date();
+  const currentDateTimeForRelativeValue = new Date(1665583620000);
   const actualResult = getStartAndEndTimeFromRange(newDateRange, currentDateTimeForRelativeValue);
 
   const endTime = currentDateTimeForRelativeValue.getTime().toString();
@@ -55,7 +55,7 @@ it('should return start and end time for relative range in hours', () => {
     unit: 'hour',
     type: 'relative',
   };
-  const currentDateTimeForRelativeValue = new Date();
+  const currentDateTimeForRelativeValue = new Date(1665583620000);
   const actualResult = getStartAndEndTimeFromRange(newDateRange, currentDateTimeForRelativeValue);
 
   const endTime = currentDateTimeForRelativeValue.getTime().toString();
@@ -73,7 +73,7 @@ it('should return start and end time for relative range in days', () => {
     unit: 'day',
     type: 'relative',
   };
-  const currentDateTimeForRelativeValue = new Date();
+  const currentDateTimeForRelativeValue = new Date(1665583620000);
   const actualResult = getStartAndEndTimeFromRange(newDateRange, currentDateTimeForRelativeValue);
 
   const endTime = currentDateTimeForRelativeValue.getTime().toString();
@@ -91,7 +91,7 @@ it('should return start and end time for relative range in week', () => {
     unit: 'week',
     type: 'relative',
   };
-  const currentDateTimeForRelativeValue = new Date();
+  const currentDateTimeForRelativeValue = new Date(1665583620000);
   const actualResult = getStartAndEndTimeFromRange(newDateRange, currentDateTimeForRelativeValue);
 
   const endTime = currentDateTimeForRelativeValue.getTime().toString();
@@ -109,7 +109,7 @@ it('should return start and end time for relative range in month', () => {
     unit: 'month',
     type: 'relative',
   };
-  const currentDateTimeForRelativeValue = new Date();
+  const currentDateTimeForRelativeValue = new Date(1665583620000);
   const actualResult = getStartAndEndTimeFromRange(newDateRange, currentDateTimeForRelativeValue);
 
   const endTime = currentDateTimeForRelativeValue.getTime().toString();
@@ -127,7 +127,7 @@ it('should return start and end time for relative range in year', () => {
     unit: 'year',
     type: 'relative',
   };
-  const currentDateTimeForRelativeValue = new Date();
+  const currentDateTimeForRelativeValue = new Date(1665583620000);
   const actualResult = getStartAndEndTimeFromRange(newDateRange, currentDateTimeForRelativeValue);
 
   const endTime = currentDateTimeForRelativeValue.getTime().toString();

--- a/packages/react-components/src/video-player/utils/videoProgressUtils.spec.tsx
+++ b/packages/react-components/src/video-player/utils/videoProgressUtils.spec.tsx
@@ -10,8 +10,8 @@ it('should return video seek time according to percentage', () => {
 
 // TimezoneOffset is included to make sure that output is calucalted as expected result without timezone issue during test
 it('should set valid tooltip on video progress', () => {
-  const seekTime = 1665583620000 + new Date().getTimezoneOffset() * 60000;
-  const startTime = 1665583520000 + new Date().getTimezoneOffset() * 60000;
+  const seekTime = 1665583620000 + new Date(1665583620000).getTimezoneOffset() * 60000;
+  const startTime = 1665583520000 + new Date(1665583520000).getTimezoneOffset() * 60000;
   expect(getVideoProgressTooltip(seekTime, startTime)).toEqual(`10/12\n14:07:00`);
 });
 


### PR DESCRIPTION
## Overview
Create new `Date` object at runtime could lead to inconsistent values in test. For example :
```
packages/react-components/src/video-player/utils/dateTimeUtils.spec.tsx
---
it('should format the Date to DateTime value', () => {
  const rawDate = new Date(1665583620000 + new Date().getTimezoneOffset() * 60000);
  expect(getFormattedDateTime(rawDate)).toEqual(`10/12\n14:07:00`);
});
---
Error: expect(received).toEqual(expected) // deep equality

- Expected  - 1
+ Received  + 1

  10/12
- 14:07:00
+ 15:07:00
```

The issue is related to Daylight saving. The hard coded value 1665583620000 is `Wed Oct 12 2022 10:07:00 GMT-0400` (Eastern Daylight Time) but currently we are in standard time.
```
new Date().getTimezoneOffset() // -> 300
new Date(1665583620000).getTimezoneOffset() //-> 240 
```

This change would help we have more confidence running our tests.
 
## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
