### PR TITLE
docs(SceneComposer): Cleaning up stories and adding Scene Composer wr…

### DIFF
--- a/packages/scene-composer/.storybook/preview.js
+++ b/packages/scene-composer/.storybook/preview.js
@@ -7,3 +7,28 @@ export const parameters = {
     },
   },
 };
+
+export const globalTypes = {
+  locale: {
+    name: 'Locale',
+    description: 'Internationalization locale',
+    defaultValue: 'en-US',
+    toolbar: {
+      icon: 'globe',
+      items: [
+        { value: 'de-DE', right: '🇩🇪', title: 'Germany (DE)' },
+        { value: 'en-UK', right: '🇬🇧', title: 'English (UK)' },
+        { value: 'en-US', right: '🇺🇸', title: 'English (US)' },
+        { value: 'es-ES', right: '🇪🇸', title: 'Spanish (ES)' },
+        { value: 'fr-FR', right: '🇫🇷', title: 'French (FR)' },
+        { value: 'id-ID', right: '🇮🇩', title: 'Indonesian (ID)' },
+        { value: 'it-IT', right: '🇮🇹', title: 'Italian (IT)' },
+        { value: 'ja-JP', right: '🇯🇵', title: 'Japanese (JP)' },
+        { value: 'ko-KR', right: '🇰🇷', title: 'Korean (KR)' },
+        { value: 'pt-BR', right: '🇵🇹', title: 'Portuguese (BR)' },
+        { value: 'zh-CN', right: '🇨🇳', title: 'Chinese (CN)' },
+        { value: 'zh-TW', right: '🇹🇼', title: 'Taiwanese (CN)' },
+      ]
+    }
+  }
+}

--- a/packages/scene-composer/src/components/IntlProvider/index.tsx
+++ b/packages/scene-composer/src/components/IntlProvider/index.tsx
@@ -17,7 +17,7 @@ const Provider = ({ locale, children }) => {
   useEffect(() => {
     log?.verbose('i18nFeature is enabled! Detected locale: ', locale);
     setLoc(locale || DEFAULT_LOCALE);
-  }, []);
+  }, [locale]);
 
   useEffect(() => {
     if (loc !== '') {

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/index.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/index.tsx
@@ -48,8 +48,6 @@ const SubModelTree: FC<SubModelTreeProps> = ({
   const [visible, setVisible] = useState(defaultVisible);
 
   const hoverColor = new Color(0x00ff00);
-  console.log('ModelRef', componentRef, object3D.userData);
-
   const skipNode = !object3D.name || !object3D.userData?.isOriginal || object3D.userData?.componentRef !== componentRef;
 
   const { name } = object3D;

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -39,7 +39,7 @@ export interface ISceneDocumentSnapshot {
    *
    * @param specVersion - version of the document format
    */
-  serialize(specVersion: string): string;
+  serialize(specVersion: string, ...stringifyArgs): string;
 }
 
 export interface ISceneDocument {

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -672,7 +672,7 @@ function convertRules(ruleMap: Record<string, IRuleBasedMapInternal>) {
   );
 }
 
-function serializeDocument(document: ISceneDocumentInternal, specVersion: string): string {
+function serializeDocument(document: ISceneDocumentInternal, specVersion: string, ...stringifyArgs): string {
   if (specVersion !== CURRENT_VERSION) {
     throw new Error(`Unsupported specVersion: ${specVersion}`);
   }
@@ -707,7 +707,7 @@ function serializeDocument(document: ISceneDocumentInternal, specVersion: string
     defaultCameraIndex: indexedObjectCollector[KnownComponentType.Camera] ? 0 : undefined,
   };
 
-  return JSON.stringify(exportedScene);
+  return JSON.stringify(exportedScene, ...stringifyArgs);
 }
 
 export default {

--- a/packages/scene-composer/src/utils/sceneDocumentSnapshotCreator.ts
+++ b/packages/scene-composer/src/utils/sceneDocumentSnapshotCreator.ts
@@ -15,8 +15,8 @@ class SceneDocumentSnapshotImpl implements ISceneDocumentSnapshot {
     this.document = state.document;
   }
 
-  serialize(specVersion: string): string {
-    return serializationHelpers.document.serialize(this.document, specVersion);
+  serialize(specVersion: string, ...stringifyArgs): string {
+    return serializationHelpers.document.serialize(this.document, specVersion, ...stringifyArgs);
   }
 }
 

--- a/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
@@ -1,0 +1,50 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+
+import SceneComposer, { argTypes } from '../components/scene-composer';
+import { testScenes } from '../../tests/testData';
+import { COMPOSER_FEATURES } from '../../src/interfaces/feature';
+
+<Meta title="Developer/Scene Composer" component={SceneComposer} argTypes={argTypes} />
+
+export const defaultArgs = {
+  source: 'local',
+  scene: 'scene1',
+  theme: 'dark',
+  mode: 'Editing',
+  density: 'comfortable',
+  features: [
+    COMPOSER_FEATURES.SceneHierarchyRedesign,
+    COMPOSER_FEATURES.SceneHierarchyReorder,
+    COMPOSER_FEATURES.SceneHierarchySearch,
+    COMPOSER_FEATURES.SubModelSelection,
+    COMPOSER_FEATURES.ENHANCED_EDITING,
+    COMPOSER_FEATURES.CameraView,
+    COMPOSER_FEATURES.OpacityRule,
+  ]
+}
+
+export const Template = (args) => {
+  return <SceneComposer {...defaultArgs} {...args} />
+}
+
+# Scene Composer
+
+The scene composer allows you to edit and manipulate the scene, configure data bindings, place elements, and all sorts of other useful features.
+
+<Canvas>
+  <Story name='Local Scene'
+    parameters={{ layout: 'fullscreen' }}
+    args={{ ...defaultArgs }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+Enter your AWS Credentials to load a scene from AWS
+
+<Canvas>
+  <Story name='AWS Scene'
+    height='100vh'
+    args={{ ...defaultArgs, source: 'aws' }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
@@ -1,0 +1,49 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+
+import SceneViewer, { argTypes } from '../components/scene-viewer';
+import { testScenes } from '../../tests/testData';
+import { COMPOSER_FEATURES } from '../../src/interfaces/feature';
+
+<Meta title="Developer/Scene Viewer" component={SceneViewer} argTypes={argTypes} />
+
+export const defaultArgs = {
+  source: 'local',
+  scene: 'scene1',
+  theme: 'dark',
+  density: 'comfortable',
+  features: [
+    COMPOSER_FEATURES.SceneHierarchyRedesign,
+    COMPOSER_FEATURES.SceneHierarchyReorder,
+    COMPOSER_FEATURES.SceneHierarchySearch,
+    COMPOSER_FEATURES.SubModelSelection,
+    COMPOSER_FEATURES.ENHANCED_EDITING,
+    COMPOSER_FEATURES.CameraView,
+    COMPOSER_FEATURES.OpacityRule,
+  ]
+}
+
+export const Template = (args, { globals: { locale }}) => {
+  return <SceneViewer {...defaultArgs} locale={locale} {...args} />
+}
+
+# Scene Viewer
+
+This viewer is loading local scene files:
+
+<Canvas>
+  <Story name='Local Scene'
+    height='500px'
+    args={{ ...defaultArgs }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+Enter your AWS Credentials to load a scene from AWS
+
+<Canvas>
+  <Story name='AWS Scene'
+    height='500px'
+    args={{ ...defaultArgs, source: 'aws' }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/packages/scene-composer/stories/SceneComposer.stories.tsx
+++ b/packages/scene-composer/stories/SceneComposer.stories.tsx
@@ -245,7 +245,7 @@ const knobsConfigurationDecorator = [
 ];
 
 export default {
-  title: 'Components/SceneComposer',
+  title: 'Components/Scene Composer',
   component: SceneComposerInternal,
   parameters: {
     layout: 'fullscreen',

--- a/packages/scene-composer/stories/SceneViewer.stories.mdx
+++ b/packages/scene-composer/stories/SceneViewer.stories.mdx
@@ -28,22 +28,17 @@ export const Template = (args) => {
 
 # Scene Viewer
 
-This viewer is loading local scene files:
+## Opacity Filter
+
+With the opacity filter feature, you can make objects transparent based on rule data.
 
 <Canvas>
-  <Story name='Local Scene'
+  <Story name='Opacity Filter'
     height='500px'
-    args={{ ...defaultArgs, sceneId: 'scene1' }}>
+    parameters={{ controls: { include: ['onSelectionChanged', 'onWidgetClick'], hideNoControlsWarning: true }}}
+    args={{ ...defaultArgs, scene: 'waterTank' }}>
     {Template.bind({})}
   </Story>
 </Canvas>
 
-Enter your AWS Credentials to load a scene from AWS
-
-<Canvas>
-  <Story name='AWS Scene'
-    height='500px'
-    args={{ ...defaultArgs, source: 'aws' }}>
-    {Template.bind({})}
-  </Story>
-</Canvas>
+## Sub Model Selection

--- a/packages/scene-composer/stories/SceneViewer.stories.tsx
+++ b/packages/scene-composer/stories/SceneViewer.stories.tsx
@@ -1,0 +1,199 @@
+import React, { useMemo, useRef } from 'react';
+import { useToolbarActions } from 'storybook-addon-toolbar-actions';
+import { boolean, text, withKnobs } from '@storybook/addon-knobs';
+import { ComponentStory, ComponentMeta, forceReRender } from '@storybook/react';
+import { initialize, SceneLoader } from '@iot-app-kit/source-iottwinmaker';
+import { useCallback, useState } from '@storybook/addons';
+import str2ab from 'string-to-arraybuffer';
+import { Viewport } from '@iot-app-kit/core';
+
+import { useSceneComposerApi } from '../src/components/SceneComposerInternal';
+import { GetSceneObjectFunction, ISelectionChangedEvent, SceneViewerProps } from '../src/interfaces';
+import { setDebugMode } from '../src/common/GlobalSettings';
+import { convertDataInputToDataStreams, getTestDataInputContinuous, testScenes } from '../tests/testData';
+import { SceneViewer } from '../src';
+
+import '@awsui/global-styles/index.css';
+import '@awsui/global-styles/dark-mode-utils.css';
+
+const region = 'us-east-1';
+const rociEndpoint = 'https://iottwinmaker.us-east-1.amazonaws.com';
+
+// 'Cookie_Factory_Warehouse_Building_No_Site.glb'
+let localModelToLoad = 'PALLET_JACK.glb';
+
+const sampleSceneContentUrl1 = './sampleScene1';
+const sampleSceneContentUrl2 = './sampleScene2';
+function createGetSceneObjectFunction(sceneContent: string): GetSceneObjectFunction {
+  return (uri: string) => {
+    if (uri !== sampleSceneContentUrl1 && uri !== sampleSceneContentUrl2) {
+      return null;
+    } else {
+      return Promise.resolve(str2ab(sceneContent));
+    }
+  };
+}
+
+const commonLoaders = [
+  async () => ({
+    configurations: await (async () => {
+      const awsAccessKeyId = text('awsAccessKeyId', process.env.STORYBOOK_ACCESS_KEY_ID || '');
+      const awsSecretAccessKey = text('awsSecretAccessKey', process.env.STORYBOOK_SECRET_ACCESS_KEY || '');
+      const awsSessionToken = text('awsSessionToken', process.env.STORYBOOK_SESSION_TOKEN || '');
+      const workspaceId = text('workspaceId', '');
+      const sceneId = text('sceneId', '');
+      const loadFromAws = boolean('Load from AWS', false);
+      localModelToLoad = text('local glb model', 'PALLET_JACK.glb');
+
+      let sceneLoader: SceneLoader;
+
+      const loadFromAwsFn = async () => {
+        const credentials = {
+          accessKeyId: awsAccessKeyId,
+          secretAccessKey: awsSecretAccessKey,
+          sessionToken: awsSessionToken,
+        };
+
+        const init = initialize(workspaceId, {
+          awsCredentials: credentials,
+          awsRegion: region,
+          tmEndpoint: rociEndpoint,
+        });
+        const sceneLoader = init.s3SceneLoader(sceneId);
+
+        return [sceneLoader];
+      };
+
+      const loadFromLocalFn = () => {
+        const _getSceneObjectFunction: GetSceneObjectFunction = createGetSceneObjectFunction(testScenes.scene2);
+        const _sceneLoader = {
+          getSceneUri: () => Promise.resolve(sampleSceneContentUrl2),
+          getSceneObject: _getSceneObjectFunction,
+        };
+        return [_sceneLoader];
+      };
+
+      if (loadFromAws) {
+        try {
+          [sceneLoader] = await loadFromAwsFn();
+        } catch (error) {
+          console.error('Error: failed to load from aws, loading a default local scene instead', error);
+
+          [sceneLoader] = loadFromLocalFn();
+        }
+      } else {
+        [sceneLoader] = loadFromLocalFn();
+      }
+
+      setDebugMode();
+
+      return {
+        loadFromAws,
+        sceneLoader,
+        sceneId,
+      };
+    })(),
+  }),
+];
+
+const knobsConfigurationDecorator = [
+  withKnobs({ escapeHTML: false }),
+  (story, { parameters, loaded: { configurations }, args }) => {
+    const { sceneLoader, sceneId } = configurations;
+
+    const cameraTarget = text('camera target ref', '');
+    const anchorRef = text('anchor ref', '');
+
+    args.config = args.config || {};
+    args.config.dracoDecoder = {
+      enable: true,
+    };
+    args.sceneLoader = sceneLoader;
+    args.sceneId = sceneId;
+
+    const sceneComposerApi = useSceneComposerApi('scene1');
+
+    useToolbarActions('refresh', <div>Refresh</div>, {
+      onClick: () => {
+        forceReRender();
+      },
+    });
+
+    useToolbarActions('camera', <div>Move Camera</div>, {
+      onClick: () => {
+        sceneComposerApi.setCameraTarget(cameraTarget, 'transition');
+      },
+    });
+
+    useToolbarActions('find label', <div>Find {'&'} Move Camera</div>, {
+      onClick: () => {
+        const dataFrameLabel = sceneComposerApi.findSceneNodeRefBy('/room1/temperatureSensor1:temperature');
+        sceneComposerApi.setCameraTarget(dataFrameLabel[0], 'transition');
+      },
+    });
+
+    useToolbarActions('anchor', <div>Select Anchor</div>, {
+      onClick: () => {
+        sceneComposerApi.setSelectedSceneNodeRef(anchorRef);
+      },
+    });
+
+    return story();
+  },
+];
+
+export default {
+  title: 'Components/Scene Viewer',
+  component: SceneViewer,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof SceneViewer>;
+
+export const Default: ComponentStory<typeof SceneViewer> = (args: SceneViewerProps & { sceneId?: string }) => {
+  const [selected, setSelected] = useState<any>({ entityId: 'room1', componentName: 'temperatureSensor2' });
+  const loader = useMemo(() => {
+    return args.sceneLoader;
+  }, [args.sceneId]);
+
+  const viewport = useRef<Viewport>({
+    start: new Date(getTestDataInputContinuous().timeRange.from),
+    end: new Date(getTestDataInputContinuous().timeRange.to),
+  });
+
+  const onSelectionChanged = useCallback((e: ISelectionChangedEvent) => {
+    const dataBindingContext = e.additionalComponentData?.[0].dataBindingContext;
+    console.log('onSelectionChanged', dataBindingContext);
+
+    setSelected(
+      dataBindingContext
+        ? {
+            entityId: (dataBindingContext as any)?.entityId,
+            componentName: (dataBindingContext as any)?.componentName,
+          }
+        : undefined,
+    );
+  }, []);
+
+  return (
+    <SceneViewer
+      sceneComposerId='scene1'
+      {...args}
+      sceneLoader={loader}
+      onSelectionChanged={onSelectionChanged}
+      selectedDataBinding={selected}
+      dataStreams={convertDataInputToDataStreams(getTestDataInputContinuous())}
+      viewport={viewport.current}
+    />
+  );
+};
+Default.parameters = {};
+Default.decorators = knobsConfigurationDecorator;
+Default.args = {
+  dataBindingTemplate: {
+    sel_entity: 'room1',
+    sel_comp: 'temperatureSensor2',
+  },
+};
+// @ts-ignore
+Default.loaders = commonLoaders;

--- a/packages/scene-composer/stories/components/argTypes.ts
+++ b/packages/scene-composer/stories/components/argTypes.ts
@@ -1,0 +1,68 @@
+import { Density, Mode } from '@awsui/global-styles';
+
+import { COMPOSER_FEATURES } from '../../src';
+import { testScenes } from '../../tests/testData';
+
+export const viewerArgs = {
+  source: {
+    options: ['local', 'aws'],
+    control: 'inline-radio',
+    table: { category: 'Scene' },
+  },
+  // if local scene
+  scene: {
+    options: Object.keys(testScenes),
+    control: 'select',
+    table: { category: 'Scene' },
+    if: { arg: 'source', eq: 'local' },
+  },
+  // if aws scene
+  awsAccessKeyId: {
+    if: { arg: 'source', eq: 'aws' },
+    table: { category: 'Scene' },
+    control: 'text',
+  },
+  awsSecretAccessKey: {
+    if: { arg: 'source', eq: 'aws' },
+    table: { category: 'Scene' },
+    control: 'text',
+  },
+  awsSessionToken: {
+    if: { arg: 'source', eq: 'aws' },
+    table: { category: 'Scene' },
+    control: 'text',
+  },
+  workspaceId: {
+    if: { arg: 'source', eq: 'aws' },
+    table: { category: 'Scene' },
+    control: 'text',
+  },
+  sceneId: {
+    if: { arg: 'source', eq: 'aws' },
+    table: { category: 'Scene' },
+    control: 'text',
+  },
+  theme: {
+    options: Object.values(Mode),
+    control: 'inline-radio',
+    table: { category: 'Theme' },
+  },
+  density: {
+    options: Object.values(Density),
+    control: 'inline-radio',
+    table: { category: 'Theme' },
+  },
+  features: {
+    options: Object.values(COMPOSER_FEATURES),
+    control: 'check',
+    table: { category: 'Advanced' },
+  },
+  onSelectionChanged: {
+    action: 'selection-changed',
+    table: { category: 'Events' },
+  },
+  onWidgetClick: {
+    action: 'widget-clicked',
+    table: { category: 'Events' },
+  },
+};

--- a/packages/scene-composer/stories/components/hooks/useLoader.ts
+++ b/packages/scene-composer/stories/components/hooks/useLoader.ts
@@ -1,0 +1,57 @@
+import { SceneLoader, initialize } from '@iot-app-kit/source-iottwinmaker';
+import { useCallback, useMemo } from 'react';
+import str2ab from 'string-to-arraybuffer';
+
+import { testScenes } from '../../../tests/testData';
+
+const region = 'us-east-1';
+const rociEndpoint = 'https://iottwinmaker.us-east-1.amazonaws.com';
+
+const useLoader = (source, scene, credentials, workspaceId, sceneId) => {
+  const { awsAccessKeyId, awsSecretAccessKey, awsSessionToken } = credentials;
+  const sceneContent = useMemo(() => testScenes[scene], [scene]);
+
+  const getSceneObject = useCallback(
+    (uri: string) => {
+      if (!Object.keys(testScenes).includes(uri)) {
+        return null;
+      } else {
+        return Promise.resolve(str2ab(sceneContent));
+      }
+    },
+    [sceneContent],
+  );
+
+  const localLoader = useMemo(
+    () =>
+      ({
+        getSceneUri: () => Promise.resolve(scene),
+        getSceneObject,
+      } as SceneLoader),
+    [scene],
+  );
+
+  const awsLoader = useMemo(() => {
+    const init = initialize(workspaceId!, {
+      awsCredentials: credentials,
+      awsRegion: region,
+      tmEndpoint: rociEndpoint,
+    });
+    const loader = init.s3SceneLoader(sceneId!);
+
+    return loader as SceneLoader;
+  }, [awsAccessKeyId, awsSecretAccessKey, awsSessionToken, workspaceId, sceneId]);
+
+  const loader = useMemo(() => {
+    switch (source) {
+      case 'aws':
+        return awsAccessKeyId && awsSecretAccessKey && awsSessionToken && workspaceId && sceneId ? awsLoader : null;
+      default:
+        return scene ? localLoader : null;
+    }
+  }, [scene, credentials, workspaceId, sceneId, source]);
+
+  return loader;
+};
+
+export default useLoader;

--- a/packages/scene-composer/stories/components/scene-composer.tsx
+++ b/packages/scene-composer/stories/components/scene-composer.tsx
@@ -1,0 +1,142 @@
+import React, { FC, useCallback, useRef } from 'react';
+import { Mode, Density } from '@awsui/global-styles';
+import styled from 'styled-components';
+
+import {
+  ISceneDocumentSnapshot,
+  OnSceneUpdateCallback,
+  OperationMode,
+  SceneComposerInternal,
+  SceneViewerPropsShared,
+  useSceneComposerApi,
+} from '../../src';
+import { useMockedValueDataBindingProvider } from '../useMockedValueDataBindingProvider';
+
+import ThemeManager, { ThemeManagerProps } from './theme-manager';
+import useLoader from './hooks/useLoader';
+import { mapFeatures } from './utils';
+import { viewerArgs } from './argTypes';
+import EditingToolbar from './toolbars/EditingToolbar';
+
+const SceneComposerContainer = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+
+  canvas {
+    outline: none;
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0); /* mobile webkit */
+  }
+`;
+
+interface SceneComposerWrapperProps extends SceneViewerPropsShared, ThemeManagerProps {
+  source: 'local' | 'aws';
+  scene?: string;
+  sceneId?: string;
+  awsAccessKeyId?: string;
+  awsSecretAccessKey?: string;
+  awsSessionToken?: string;
+  workspaceId?: string;
+  features?: string[];
+  mode?: OperationMode;
+  onSceneUpdated?: OnSceneUpdateCallback;
+}
+
+const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
+  source = 'local',
+  scene: localScene,
+  theme = Mode.Dark,
+  density = Density.Comfortable,
+  mode = 'Editing',
+  awsAccessKeyId,
+  awsSecretAccessKey,
+  awsSessionToken,
+  workspaceId,
+  sceneId,
+  features = [],
+  sceneLoader: ignoredLoader,
+  onSceneUpdated = () => {},
+  ...props
+}: SceneComposerWrapperProps) => {
+  const stagedScene = useRef<ISceneDocumentSnapshot | undefined>(undefined);
+  const scene = sceneId || localScene || 'scene1';
+  const loader = useLoader(
+    source,
+    scene,
+    {
+      accessKeyId: awsAccessKeyId!,
+      secretAccessKey: awsSecretAccessKey!,
+      sessionToken: awsSessionToken!,
+    },
+    workspaceId,
+    sceneId,
+  );
+
+  const config = {
+    dracoDecoder: {
+      enable: true,
+    },
+    mode,
+    colorTheme: theme,
+    featureConfig: mapFeatures(features),
+  };
+
+  const valueDataBindingProvider = useMockedValueDataBindingProvider();
+  const sceneComposerApi = useSceneComposerApi(scene);
+
+  const handleSceneUpdated = useCallback((sceneSnapshot) => {
+    stagedScene.current = sceneSnapshot;
+    onSceneUpdated(sceneSnapshot);
+  }, []);
+
+  if (loader) {
+    return (
+      <ThemeManager theme={theme} density={density}>
+        <SceneComposerContainer data-testid={'webgl-root'} className='sceneViewer'>
+          {mode === 'Editing' && (
+            <EditingToolbar getScene={() => stagedScene.current} sceneComposerApi={sceneComposerApi} />
+          )}
+          <SceneComposerInternal
+            sceneLoader={loader}
+            config={config as any}
+            valueDataBindingProvider={valueDataBindingProvider}
+            onSceneUpdated={handleSceneUpdated}
+            {...props}
+          />
+        </SceneComposerContainer>
+      </ThemeManager>
+    );
+  }
+
+  return <div>Configure your AWS Credentials in the control panel, or switch to local scene to render</div>;
+};
+
+export default SceneComposerWrapper;
+
+export const argTypes = {
+  ...viewerArgs,
+  mode: {
+    label: 'Operation Mode',
+    options: ['Editing', 'Viewing'],
+    control: 'inline-radio',
+    table: { category: 'Advanced' },
+  },
+  onSceneUpdated: {
+    action: 'scene-updated',
+    table: { category: 'Events' },
+  },
+  onSceneLoaded: {
+    action: 'scene-loaded',
+    table: { category: 'Events' },
+  },
+  onError: {
+    action: 'error',
+    table: { category: 'Events' },
+  },
+  showAssetBrowserCallback: {
+    action: 'show-asset-browser',
+    table: { category: 'Events' },
+  },
+};

--- a/packages/scene-composer/stories/components/scene-viewer.tsx
+++ b/packages/scene-composer/stories/components/scene-viewer.tsx
@@ -1,17 +1,12 @@
-import { initialize, SceneLoader } from '@iot-app-kit/source-iottwinmaker';
-import React, { FC, useEffect, useMemo } from 'react';
-import str2ab from 'string-to-arraybuffer';
-import { Mode, applyDensity, Density } from '@awsui/global-styles';
+import React, { FC } from 'react';
 
-import { SceneViewer, SceneViewerPropsShared } from '../../src';
-import { testScenes } from '../../tests/testData';
-import { setDebugMode } from '../../src/common/GlobalSettings';
-import { COMPOSER_FEATURES } from '../../src/interfaces/feature';
+import { SceneViewerPropsShared } from '../../src';
 
-const region = 'us-east-1';
-const rociEndpoint = 'https://iottwinmaker.us-east-1.amazonaws.com';
+import { ThemeManagerProps } from './theme-manager';
+import SceneComposerWrapper from './scene-composer';
+import { viewerArgs } from './argTypes';
 
-interface StorybookSceneViewerProps extends SceneViewerPropsShared {
+interface StorybookSceneViewerProps extends SceneViewerPropsShared, ThemeManagerProps {
   source: 'local' | 'aws';
   scene?: string;
   sceneId?: string;
@@ -19,141 +14,14 @@ interface StorybookSceneViewerProps extends SceneViewerPropsShared {
   awsSecretAccessKey?: string;
   awsSessionToken?: string;
   workspaceId?: string;
-  mode?: string;
-  density?: string;
   features?: string[];
+  locale: string;
 }
 
-const SceneViewerWrapper: FC<StorybookSceneViewerProps> = ({
-  source = 'local',
-  scene,
-  mode = Mode.Dark,
-  density = Density.Comfortable,
-  awsAccessKeyId,
-  awsSecretAccessKey,
-  awsSessionToken,
-  workspaceId,
-  sceneId,
-  features = [],
-  sceneLoader: ignoredLoader,
-  ...props
-}: StorybookSceneViewerProps) => {
-  const localLoader = useMemo(() => {
-    return {
-      getSceneUri: () => Promise.resolve(scene),
-      getSceneObject: () => Promise.resolve<ArrayBuffer>(str2ab(testScenes[scene!])),
-    } as SceneLoader;
-  }, [scene]);
-
-  const awsLoader = useMemo(() => {
-    const credentials = {
-      accessKeyId: awsAccessKeyId!,
-      secretAccessKey: awsSecretAccessKey!,
-      sessionToken: awsSessionToken!,
-    };
-
-    const init = initialize(workspaceId!, {
-      awsCredentials: credentials,
-      awsRegion: region,
-      tmEndpoint: rociEndpoint,
-    });
-    const loader = init.s3SceneLoader(sceneId!);
-
-    return loader as SceneLoader;
-  }, [awsAccessKeyId, awsSecretAccessKey, awsSessionToken, workspaceId, sceneId]);
-
-  useEffect(() => {
-    applyDensity(density as Density);
-  }, [density]);
-
-  useEffect(() => {
-    setDebugMode();
-  }, []);
-
-  const config = {
-    dracoDecoder: {
-      enable: true,
-    },
-    colorTheme: mode,
-    featureConfig: Object.values(COMPOSER_FEATURES).reduce((acc, feature) => {
-      acc[feature] = features.includes(feature);
-      return acc;
-    }, {}),
-  };
-
-  if (source === 'local') {
-    return <SceneViewer sceneLoader={localLoader} config={config} {...props} />;
-  } else {
-    if (!!awsAccessKeyId && !!awsSecretAccessKey && !!awsSessionToken && !!workspaceId && !!sceneId) {
-      return <SceneViewer sceneLoader={awsLoader} config={config} {...props} />;
-    }
-  }
-
-  return <div>Configure your AWS Credentials in the control panel, or switch to local scene to render</div>;
+const SceneViewerWrapper: FC<StorybookSceneViewerProps> = ({ ...props }: StorybookSceneViewerProps) => {
+  return <SceneComposerWrapper mode='Viewing' {...props} />;
 };
 
 export default SceneViewerWrapper;
 
-export const argTypes = {
-  source: {
-    options: ['local', 'aws'],
-    control: 'inline-radio',
-    table: { category: 'Scene' },
-  },
-  // if local scene
-  scene: {
-    options: Object.keys(testScenes),
-    control: 'select',
-    table: { category: 'Scene' },
-    if: { arg: 'source', eq: 'local' },
-  },
-  // if aws scene
-  awsAccessKeyId: {
-    if: { arg: 'source', eq: 'aws' },
-    table: { category: 'Scene' },
-    control: 'text',
-  },
-  awsSecretAccessKey: {
-    if: { arg: 'source', eq: 'aws' },
-    table: { category: 'Scene' },
-    control: 'text',
-  },
-  awsSessionToken: {
-    if: { arg: 'source', eq: 'aws' },
-    table: { category: 'Scene' },
-    control: 'text',
-  },
-  workspaceId: {
-    if: { arg: 'source', eq: 'aws' },
-    table: { category: 'Scene' },
-    control: 'text',
-  },
-  sceneId: {
-    if: { arg: 'source', eq: 'aws' },
-    table: { category: 'Scene' },
-    control: 'text',
-  },
-  mode: {
-    options: Object.values(Mode),
-    control: 'inline-radio',
-    table: { category: 'Theme' },
-  },
-  density: {
-    options: Object.values(Density),
-    control: 'inline-radio',
-    table: { category: 'Theme' },
-  },
-  features: {
-    options: Object.values(COMPOSER_FEATURES),
-    control: 'check',
-    table: { category: 'Advanced' },
-  },
-  onSelectionChanged: {
-    action: 'selection-changed',
-    table: { category: 'Events' },
-  },
-  onWidgetClick: {
-    action: 'widget-clicked',
-    table: { category: 'Events' },
-  },
-};
+export const argTypes = viewerArgs;

--- a/packages/scene-composer/stories/components/theme-manager.tsx
+++ b/packages/scene-composer/stories/components/theme-manager.tsx
@@ -1,0 +1,27 @@
+import { Mode, Density, applyDensity, applyMode } from '@awsui/global-styles';
+import React, { FC, useEffect } from 'react';
+
+import { setDebugMode } from '../../src';
+
+export interface ThemeManagerProps {
+  theme?: 'light' | 'dark';
+  density?: string;
+}
+
+const ThemeManager: FC<ThemeManagerProps> = ({ theme = Mode.Dark, density = Density.Comfortable, children }) => {
+  useEffect(() => {
+    applyDensity(density as Density);
+  }, [density]);
+
+  useEffect(() => {
+    applyMode(theme as Mode);
+  }, [theme]);
+
+  useEffect(() => {
+    setDebugMode();
+  }, []);
+
+  return <>{children}</>;
+};
+
+export default ThemeManager;

--- a/packages/scene-composer/stories/components/toolbars/EditingToolbar.tsx
+++ b/packages/scene-composer/stories/components/toolbars/EditingToolbar.tsx
@@ -1,0 +1,36 @@
+import { forceReRender } from '@storybook/react';
+import React, { FC } from 'react';
+import { useToolbarActions } from 'storybook-addon-toolbar-actions/dist';
+
+import { ISceneDocumentSnapshot, SceneComposerApi } from '../../../src';
+
+interface EditingToolbarProps {
+  sceneComposerApi: SceneComposerApi;
+  getScene(): ISceneDocumentSnapshot | undefined;
+}
+
+const EditingToolbar: FC<EditingToolbarProps> = ({ getScene, sceneComposerApi }) => {
+  useToolbarActions('save', <div>Save Scene</div>, {
+    onClick: () => {
+      const scene = getScene();
+      if (scene) {
+        const data = scene.serialize('1.0', null, '\t');
+        const file = new Blob([data], { type: 'application/json' });
+        const a = document.createElement('a');
+        const url = URL.createObjectURL(file);
+        a.href = url;
+        a.download = 'scene.json';
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(function () {
+          document.body.removeChild(a);
+          window.URL.revokeObjectURL(url);
+        }, 0);
+      }
+    },
+  });
+
+  return null;
+};
+
+export default EditingToolbar;

--- a/packages/scene-composer/stories/components/utils.ts
+++ b/packages/scene-composer/stories/components/utils.ts
@@ -1,0 +1,8 @@
+import { COMPOSER_FEATURES } from '../../src/interfaces';
+
+export const mapFeatures = (features) => {
+  return Object.values(COMPOSER_FEATURES).reduce((acc, feature) => {
+    acc[feature] = features.includes(feature);
+    return acc;
+  }, {});
+};


### PR DESCRIPTION
…apper/i18n

## Overview
Adds locale changer to global stories, refactors new SceneViewer Stories, and introduces new MDX driven Scene Composer Stores.

Still have outstanding issue with loading models, so you should use the work around of loading the old stories first, and then play with the new ones while I investigate the issue.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
