### PR TITLE
fix(composer): scene change is sometimes not saved

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -156,8 +156,8 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 77.23,
-        "statements": 76.33,
+        "lines": 77.2,
+        "statements": 76.3,
         "functions": 76.64,
         "branches": 62.8,
         "branchesTrue": 100

--- a/packages/scene-composer/src/utils/sceneDocumentSnapshotCreator.ts
+++ b/packages/scene-composer/src/utils/sceneDocumentSnapshotCreator.ts
@@ -11,7 +11,7 @@ import serializationHelpers from '../store/helpers/serializationHelpers';
 class SceneDocumentSnapshotImpl implements ISceneDocumentSnapshot {
   private readonly document: ISceneDocumentInternal;
 
-  constructor(state: RootState) {
+  constructor(state: Pick<RootState, 'document'>) {
     this.document = state.document;
   }
 
@@ -21,7 +21,7 @@ class SceneDocumentSnapshotImpl implements ISceneDocumentSnapshot {
 }
 
 export default {
-  create(state: RootState): ISceneDocumentSnapshot {
+  create(state: Pick<RootState, 'document'>): ISceneDocumentSnapshot {
     return new SceneDocumentSnapshotImpl(state);
   },
 };


### PR DESCRIPTION
## Overview
Checking if document is changed to determine if onSceneUpdated should be triggered, because of issues:
- SnapToFloor doesn't save position change as it's transient operation
- In weird case when multiple actions happening at the same time, the store update seems to be batched/lost which could cause the UPDATE_DOCUMENT operation to be missed. 

The console side is debouncing the save scene function in onSceneUpdated callback, so there won't be extra save scene API call.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
