### PR TITLE
fix(composer): reorder to same parent duplicates child

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyDataProvider.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyDataProvider.tsx
@@ -109,7 +109,7 @@ const sortNodes = (a, b) => {
 };
 
 const SceneHierarchyDataProvider: FC<SceneHierarchyDataProviderProps> = ({ selectionMode, children }) => {
-  useLifecycleLogging('SceneHierarchyDataProvider');
+  const log = useLifecycleLogging('SceneHierarchyDataProvider');
   const sceneComposerId = useSceneComposerId();
   const { document, removeSceneNode } = useStore(sceneComposerId)((state) => state);
   const { isEditing } = useStore(sceneComposerId)((state) => state);
@@ -192,52 +192,43 @@ const SceneHierarchyDataProvider: FC<SceneHierarchyDataProviderProps> = ({ selec
     (objectRef: string, newParentRef?: string) => {
       const originalObject = getSceneNodeByRef(objectRef);
       const originalObject3D = getObject3DBySceneNodeRef(objectRef);
-      if (newParentRef) {
-        const objectToMoveRef = originalObject?.ref as string;
-        const oldParentRef = originalObject?.parentRef as string;
-        const newParent = getSceneNodeByRef(newParentRef);
-        const oldParent = getSceneNodeByRef(oldParentRef);
-        const oldParentChildren = oldParent?.childRefs.filter((child) => child !== objectToMoveRef);
-        const newParentObject = getObject3DBySceneNodeRef(newParentRef);
-        let maintainedTransform: any = null;
-        if (originalObject3D) {
-          const worldPosition = originalObject3D.getWorldPosition(new Vector3());
-          const worldRotation = new Euler().setFromQuaternion(originalObject3D.getWorldQuaternion(new Quaternion()));
-          const worldScale = originalObject3D.getWorldScale(new Vector3());
-          maintainedTransform = getFinalTransform(
-            {
-              position: worldPosition,
-              rotation: worldRotation,
-              scale: worldScale,
-            },
-            newParentObject,
-          );
-        }
-        // remove child ref from parent
-        if (!oldParentRef) {
-          const newRoots = document.rootNodeRefs.filter((ref) => ref !== objectRef);
-          updateDocumentInternal({ rootNodeRefs: newRoots });
-        } else {
-          updateSceneNodeInternal(oldParentRef, { childRefs: oldParentChildren });
-        }
-        // Create updates to the moving object
-        const partial: RecursivePartial<ISceneNodeInternal> = { parentRef: newParentRef };
-        if (maintainedTransform) {
-          // Update the node position to remain in its world space
-          partial.transform = {
-            position: maintainedTransform.position.toArray(),
-            rotation: maintainedTransform.rotation.toVector3().toArray(),
-            scale: maintainedTransform.scale.toArray(),
-          };
-        }
-        // update new parent to have new child
-        updateSceneNodeInternal(newParentRef, { childRefs: [...newParent!.childRefs, objectRef] });
-        // update node to have new parent
-        updateSceneNodeInternal(objectToMoveRef, partial);
-        // TODO: create single call to handle this
+      const oldParentRef = originalObject?.parentRef as string;
+
+      if (oldParentRef === newParentRef) {
+        log?.verbose('Parent ref unchanged. Do nothing.');
+        return;
       }
+
+      const newParentObject = getObject3DBySceneNodeRef(newParentRef);
+      let maintainedTransform: any = null;
+      if (originalObject3D) {
+        const worldPosition = originalObject3D.getWorldPosition(new Vector3());
+        const worldRotation = new Euler().setFromQuaternion(originalObject3D.getWorldQuaternion(new Quaternion()));
+        const worldScale = originalObject3D.getWorldScale(new Vector3());
+        maintainedTransform = getFinalTransform(
+          {
+            position: worldPosition,
+            rotation: worldRotation,
+            scale: worldScale,
+          },
+          newParentObject,
+        );
+      }
+
+      // Create updates to the moving object
+      const partial: RecursivePartial<ISceneNodeInternal> = { parentRef: newParentRef };
+      if (maintainedTransform) {
+        // Update the node position to remain in its world space
+        partial.transform = {
+          position: maintainedTransform.position.toArray(),
+          rotation: maintainedTransform.rotation.toVector3().toArray(),
+          scale: maintainedTransform.scale.toArray(),
+        };
+      }
+
+      updateSceneNodeInternal(objectRef, partial);
     },
-    [updateSceneNodeInternal, updateDocumentInternal, getSceneNodeByRef, nodeMap, document],
+    [updateSceneNodeInternal, getSceneNodeByRef, nodeMap, document],
   );
 
   const show = useCallback(

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
@@ -81,7 +81,7 @@ const SceneHierarchyTreeItem: FC<SceneHierarchyTreeItemProps> = ({
       labelText={<SceneNodeLabel objectRef={key} labelText={labelText} componentTypes={componentTypes} />}
       onExpand={onExpandNode}
       expanded={expanded}
-      expandable={node && node.childRefs.length > 0 && !isSearching}
+      expandable={node && (node.childRefs.length > 0 || !!showSubModel) && !isSearching}
       selected={selected === key}
       selectionMode={selectionMode}
       onSelected={isViewing() ? onActivated : onToggle}

--- a/packages/scene-composer/src/store/slices/EditorStateSlice.ts
+++ b/packages/scene-composer/src/store/slices/EditorStateSlice.ts
@@ -298,6 +298,10 @@ export const createEditStateSlice = (set: SetState<RootState>, get: GetState<Roo
     },
 
     setCursorVisible(isVisible: boolean) {
+      if (get().cursorVisible === isVisible) {
+        return;
+      }
+
       set((draft) => {
         draft.cursorVisible = isVisible;
         draft.lastOperation = 'setCursorVisible';
@@ -305,6 +309,10 @@ export const createEditStateSlice = (set: SetState<RootState>, get: GetState<Roo
     },
 
     setCursorStyle(style: CursorStyle) {
+      if (get().cursorStyle === style) {
+        return;
+      }
+
       set((draft) => {
         draft.cursorStyle = style;
         draft.lastOperation = 'setCursorStyle';

--- a/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
+++ b/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
@@ -37,7 +37,7 @@ export interface ISceneDocumentSlice {
   getSceneNodesByRefs(refs: (string | undefined)[]): (ISceneNodeInternal | undefined)[];
   appendSceneNodeInternal(node: ISceneNodeInternal, parentRef?: string): void;
   updateSceneNodeInternal(ref: string, partial: RecursivePartial<ISceneNodeInternal>, isTransient?: boolean): void;
-  updateDocumentInternal(partial: RecursivePartial<Pick<ISceneDocumentInternal, 'unit' | 'rootNodeRefs'>>): void;
+  updateDocumentInternal(partial: RecursivePartial<Pick<ISceneDocumentInternal, 'unit'>>): void;
   listSceneRuleMapIds(): string[];
   getSceneRuleMapById(id?: string): Readonly<IRuleBasedMapInternal> | undefined;
   updateSceneRuleMapById(id: string, ruleMap: IRuleBasedMapInternal): void;
@@ -158,8 +158,36 @@ export const createSceneDocumentSlice = (
     },
 
     updateSceneNodeInternal: (ref, partial, isTransient) => {
+      const document = get().document;
+
       set((draft) => {
+        // update target node
         mergeDeep(draft.document.nodeMap[ref], partial);
+
+        // Reorder logics
+        if ('parentRef' in partial) {
+          const nodeToMove = document.nodeMap[ref];
+
+          const oldParentRef = nodeToMove?.parentRef;
+          const oldParent = document.nodeMap[oldParentRef || ''];
+
+          const newParentRef = partial.parentRef;
+
+          // remove target node from old parent
+          if (!oldParentRef) {
+            draft.document.rootNodeRefs = document.rootNodeRefs.filter((root) => root !== ref);
+          } else {
+            draft.document.nodeMap[oldParentRef].childRefs = oldParent.childRefs.filter((child) => child !== ref);
+          }
+
+          // update new parent to have target node as child
+          if (!newParentRef) {
+            draft.document.rootNodeRefs.push(ref);
+          } else {
+            draft.document.nodeMap[newParentRef].childRefs.push(ref);
+          }
+        }
+
         draft.lastOperation = isTransient ? 'updateSceneNodeInternalTransient' : 'updateSceneNodeInternal';
       });
     },

--- a/packages/scene-composer/tests/store/slices/EditorStateSlice.spec.tsx
+++ b/packages/scene-composer/tests/store/slices/EditorStateSlice.spec.tsx
@@ -350,7 +350,7 @@ describe('createEditStateSlice', () => {
     // Arrange
     const cursorVisible = true;
     const draft = { lastOperation: undefined, cursorVisible };
-    const get = jest.fn();
+    const get = jest.fn().mockReturnValue({});
     const set = jest.fn(((callback) => callback(draft)) as any);
 
     // Act
@@ -366,7 +366,7 @@ describe('createEditStateSlice', () => {
     // Arrange
     const cursorStyle = 'edit';
     const draft = { lastOperation: undefined, cursorStyle };
-    const get = jest.fn();
+    const get = jest.fn().mockReturnValue({});
     const set = jest.fn(((callback) => callback(draft)) as any);
 
     // Act


### PR DESCRIPTION
## Overview
Refactor `move` code to fix
- multiple update node actions cause multiple undo/redo states
- drop to same parent will have duplicate child
- drop to and from root node (still need https://github.com/awslabs/iot-app-kit/pull/390/files#diff-fff361d200b3777ce4c1ecd27e04425c2c1e3203ef65799e4217d182366cf7e0 to be able to drop to root from tree)

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
