### PR TITLE
feat(dashboard): add context menu, send to back, bring to front, copy, paste

### DIFF
--- a/packages/dashboard/.babelrc
+++ b/packages/dashboard/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"],
-  "plugins": []
-}

--- a/packages/dashboard/babel.config.js
+++ b/packages/dashboard/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
+  plugins: [],
+};

--- a/packages/dashboard/jest.config.ts
+++ b/packages/dashboard/jest.config.ts
@@ -28,12 +28,11 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: [],
   setupFilesAfterEnv: ['mutationobserver-shim'],
   //transform: {
   //   '.+\\.ts$': 'ts-jest',
   //   '^.+\\.tsx?$': 'ts-jest',
   //   '^.+\\.(js|jsx)$': 'babel-jest',
   // },
-  // transformIgnorePatterns: ['node_modules/(?!@awsui/components-react)/'],
+  transformIgnorePatterns: [],
 };

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -41,10 +41,10 @@
     "@storybook/react": "^6.5.12",
     "@storybook/testing-library": "^0.0.13",
     "@types/box-intersect": "^1.0.0",
-    "@types/lodash": "^4.14.186",
     "@types/is-hotkey": "^0.1.7",
     "@swc/core": "^1.3.20",
     "@swc/jest": "^0.2.23",
+    "@types/lodash": "^4.14.186",
     "@types/node": "^18.11.4",
     "@types/react": "^17.0.38",
     "babel-loader": "^8.2.5",
@@ -73,11 +73,13 @@
     "@cloudscape-design/global-styles": "^1.0.5",
     "@iot-app-kit/core": "^2.4.2",
     "@iot-app-kit/source-iotsitewise": "^2.4.2",
+    "@popperjs/core": "^2.11.6",
     "@synchro-charts/core": "^4.0.0",
     "box-intersect": "^1.0.2",
     "is-hotkey": "^0.2.0",
     "react-dnd": "^15.1.2",
-    "react-dnd-touch-backend": "^15.1.2"
+    "react-dnd-touch-backend": "^15.1.2",
+    "react-popper": "^2.3.0"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/dashboard/src/components/contextMenu/contextMenuOptions.ts
+++ b/packages/dashboard/src/components/contextMenu/contextMenuOptions.ts
@@ -1,0 +1,113 @@
+import { ContextMenuMessages, keyboardShortcuts } from '../../messages';
+
+type ContextMenuOptionConfiguration = {
+  id: string;
+  action: () => void;
+  text: string;
+  disabled: boolean;
+  hotkey?: string;
+};
+
+type ContextMenuSectionConfiguration = {
+  id: string;
+  options: ContextMenuOptionConfiguration[];
+};
+
+export type ContextMenuConfiguration = ContextMenuSectionConfiguration[];
+
+export type ContextMenuConfigurationProps = {
+  messages: ContextMenuMessages;
+  actions: {
+    copyAction: () => void;
+    pasteAction: () => void;
+    deleteAction: () => void;
+    bringToFrontAction: () => void;
+    sendToBackAction: () => void;
+  };
+  state: {
+    hasSelectedWidgets: boolean;
+    hasCopiedWidgets: boolean;
+  };
+};
+
+type OptionCreator = (props: ContextMenuConfigurationProps) => ContextMenuOptionConfiguration;
+
+type ContextMenuConfigurationCreator = {
+  id: string;
+  options: OptionCreator[];
+};
+
+const createCopyOption: OptionCreator = (props: ContextMenuConfigurationProps): ContextMenuOptionConfiguration => {
+  const { actions, messages, state } = props;
+  return {
+    id: 'copy',
+    text: messages.copyText,
+    hotkey: keyboardShortcuts.copy,
+    disabled: !state.hasSelectedWidgets,
+    action: actions.copyAction,
+  };
+};
+
+const createPasteOption: OptionCreator = (props: ContextMenuConfigurationProps): ContextMenuOptionConfiguration => {
+  const { actions, messages, state } = props;
+  return {
+    id: 'paste',
+    text: messages.pasteText,
+    hotkey: keyboardShortcuts.paste,
+    disabled: !state.hasCopiedWidgets,
+    action: actions.pasteAction,
+  };
+};
+
+const createDeleteOption: OptionCreator = (props: ContextMenuConfigurationProps): ContextMenuOptionConfiguration => {
+  const { actions, messages, state } = props;
+  return {
+    id: 'delete',
+    text: messages.deleteText,
+    disabled: !state.hasSelectedWidgets,
+    action: actions.deleteAction,
+  };
+};
+
+const createBringToFrontOption: OptionCreator = (
+  props: ContextMenuConfigurationProps
+): ContextMenuOptionConfiguration => {
+  const { actions, messages, state } = props;
+  return {
+    id: 'bringToFront',
+    text: messages.bringToFrontText,
+    hotkey: keyboardShortcuts.bringToFront,
+    disabled: !state.hasSelectedWidgets,
+    action: actions.bringToFrontAction,
+  };
+};
+
+const createSendToBackOption: OptionCreator = (
+  props: ContextMenuConfigurationProps
+): ContextMenuOptionConfiguration => {
+  const { actions, messages, state } = props;
+  return {
+    id: 'sendToBack',
+    text: messages.sendToBackText,
+    hotkey: keyboardShortcuts.sendToBack,
+    disabled: !state.hasSelectedWidgets,
+    action: actions.sendToBackAction,
+  };
+};
+
+const configuration: ContextMenuConfigurationCreator[] = [
+  {
+    id: 'section1',
+    options: [createCopyOption, createPasteOption, createDeleteOption],
+  },
+  {
+    id: 'section2',
+    options: [createBringToFrontOption, createSendToBackOption],
+  },
+];
+
+export const createContextMenuOptions = (props: ContextMenuConfigurationProps): ContextMenuConfiguration =>
+  configuration.map((section) => ({
+    ...section,
+    options: section.options.map((createOption) => createOption(props)),
+  }));

--- a/packages/dashboard/src/components/contextMenu/index.tsx
+++ b/packages/dashboard/src/components/contextMenu/index.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+import { Position } from '../../types';
+
+import './index.css';
+import Menu from './menu';
+import ContextMenuSection from './section';
+import ContextMenuOption from './option';
+import { DASHBOARD_CONTAINER_ID, getDashboardPosition } from '../grid/getDashboardPosition';
+import { useKeyPress } from '../../hooks/useKeyPress';
+import { createContextMenuOptions } from './contextMenuOptions';
+import { DashboardMessages } from '../../messages';
+
+export type ContextMenuProps = {
+  copyWidgets: () => void;
+  pasteWidgets: (position: Position) => void;
+  deleteWidgets: () => void;
+  bringWidgetsToFront: () => void;
+  sendWidgetsToBack: () => void;
+  messageOverrides: DashboardMessages;
+  hasCopiedWidgets: boolean;
+  hasSelectedWidgets: boolean;
+};
+
+const ContextMenu: React.FC<ContextMenuProps> = ({
+  messageOverrides,
+  hasCopiedWidgets,
+  hasSelectedWidgets,
+  copyWidgets,
+  pasteWidgets,
+  deleteWidgets,
+  bringWidgetsToFront,
+  sendWidgetsToBack,
+}) => {
+  const [contextMenuOpen, setContextMenuOpen] = useState<boolean>(false);
+  const [contextMenuPosition, setContextMenuPosition] = useState<Position | null>(null);
+
+  const toggleContextMenu = (position?: Position) => {
+    if (position) {
+      setContextMenuOpen(true);
+      setContextMenuPosition(position);
+    } else {
+      setContextMenuOpen(false);
+      setContextMenuPosition(null);
+    }
+  };
+
+  useKeyPress('esc', () => toggleContextMenu());
+
+  const onContextMenu = (e: MouseEvent) => {
+    e.preventDefault();
+    toggleContextMenu(getDashboardPosition(e));
+  };
+
+  const onClickOutside = () => {
+    toggleContextMenu();
+  };
+
+  useEffect(() => {
+    const dashboardContainer = document.getElementById(DASHBOARD_CONTAINER_ID);
+    if (!dashboardContainer) return;
+
+    dashboardContainer.addEventListener('contextmenu', onContextMenu);
+
+    return () => {
+      dashboardContainer.removeEventListener('contextmenu', onContextMenu);
+    };
+  }, []);
+
+  const withClose = (action: () => void) => () => {
+    action();
+    toggleContextMenu();
+  };
+
+  const copyAction = withClose(() => copyWidgets());
+  const pasteAction = withClose(() => pasteWidgets(contextMenuPosition || { x: 0, y: 0 }));
+  const deleteAction = withClose(() => deleteWidgets());
+  const bringToFrontAction = withClose(() => bringWidgetsToFront());
+  const sendToBackAction = withClose(() => sendWidgetsToBack());
+
+  const configuration = createContextMenuOptions({
+    messages: messageOverrides.contextMenu,
+    actions: {
+      copyAction,
+      pasteAction,
+      deleteAction,
+      bringToFrontAction,
+      sendToBackAction,
+    },
+    state: {
+      hasCopiedWidgets: hasCopiedWidgets,
+      hasSelectedWidgets: hasSelectedWidgets,
+    },
+  });
+
+  return contextMenuOpen && contextMenuPosition ? (
+    <Menu clickOutside={onClickOutside} position={contextMenuPosition}>
+      {configuration.map(({ id: sectionId, options }) => (
+        <ContextMenuSection key={sectionId}>
+          {options.map(({ id: optionId, text, action, hotkey, disabled }) => (
+            <ContextMenuOption key={optionId} text={text} action={action} hotkey={hotkey} disabled={disabled} />
+          ))}
+        </ContextMenuSection>
+      ))}
+    </Menu>
+  ) : null;
+};
+
+export default ContextMenu;

--- a/packages/dashboard/src/components/contextMenu/menu.css
+++ b/packages/dashboard/src/components/contextMenu/menu.css
@@ -1,0 +1,12 @@
+@import "../../styles/variables.css";
+
+.iot-context-menu-placement {
+  position: absolute;
+}
+
+.iot-context-menu {
+  min-width: var(--size-context-menu-min-width);
+  border-radius: var(--radius-context-menu);
+  background-color: var(--colors-dark-grey);
+  z-index: var(--stack-order-context-menu);
+}

--- a/packages/dashboard/src/components/contextMenu/menu.tsx
+++ b/packages/dashboard/src/components/contextMenu/menu.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { usePopper } from 'react-popper';
+import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow.js';
+import flip from '@popperjs/core/lib/modifiers/flip.js';
+
+import { Position } from '../../types';
+
+import './menu.css';
+
+export type MenuProps = {
+  position: Position;
+  clickOutside?: (event: MouseEvent) => void;
+};
+
+const Menu: React.FC<MenuProps> = ({ position, clickOutside, children }) => {
+  const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
+
+  const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    placement: 'right-start',
+    modifiers: [
+      flip,
+      preventOverflow,
+      {
+        name: 'offset',
+        options: {
+          offset: [0, 10],
+        },
+      },
+    ],
+  });
+
+  useEffect(() => {
+    if (!clickOutside) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (popperElement && event.target && event.target instanceof Node && !popperElement.contains(event.target)) {
+        clickOutside(event);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [popperElement]);
+
+  return (
+    <>
+      <div
+        className="iot-context-menu-placement"
+        style={{
+          left: `${position.x}px`,
+          top: `${position.y}px`,
+        }}
+        ref={setReferenceElement}
+      />
+
+      <div
+        className="iot-context-menu"
+        ref={setPopperElement}
+        style={styles.popper}
+        {...attributes.popper}
+        onPointerDown={(e) => {
+          e.stopPropagation();
+          // prevent the grid from handling click events
+        }}
+        onPointerUp={(e) => {
+          e.stopPropagation();
+          // prevent the grid from handling click events
+        }}
+      >
+        {children}
+      </div>
+    </>
+  );
+};
+
+export default Menu;

--- a/packages/dashboard/src/components/contextMenu/option.css
+++ b/packages/dashboard/src/components/contextMenu/option.css
@@ -1,0 +1,19 @@
+.iot-context-menu-option {
+  color: white;
+  background-color: rgb(27 27 27);
+  font-weight: 400;
+  font-size: 12px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+}
+
+.iot-context-menu-option:hover {
+  background-color: #0073bb;
+}
+
+.iot-context-menu-option-disabled {
+  color: rgb(170 170 170);
+  cursor: not-allowed;
+}

--- a/packages/dashboard/src/components/contextMenu/option.tsx
+++ b/packages/dashboard/src/components/contextMenu/option.tsx
@@ -1,0 +1,33 @@
+import isHotkey from 'is-hotkey';
+import React from 'react';
+
+import './option.css';
+
+export type ContextMenuOptionProps = {
+  disabled: boolean;
+  text: string;
+  hotkey?: string;
+  action: () => void;
+};
+
+const ContextMenuOption: React.FC<ContextMenuOptionProps> = ({ disabled, text, hotkey, action }) => {
+  return (
+    <li
+      onKeyDown={(e) => {
+        if (disabled || !isHotkey('enter', e)) return;
+        action();
+      }}
+      tabIndex={0}
+      onClick={() => {
+        if (disabled) return;
+        action();
+      }}
+      className={`iot-context-menu-option ${disabled && 'iot-context-menu-option-disabled'}`}
+    >
+      <div>{text}</div>
+      <div>{hotkey}</div>
+    </li>
+  );
+};
+
+export default ContextMenuOption;

--- a/packages/dashboard/src/components/contextMenu/section.css
+++ b/packages/dashboard/src/components/contextMenu/section.css
@@ -1,0 +1,5 @@
+.iot-context-menu-section {
+  padding: 0.5rem 0;
+  border-bottom: 0.5px solid rgb(116 116 116);
+  margin: 0;
+}

--- a/packages/dashboard/src/components/contextMenu/section.tsx
+++ b/packages/dashboard/src/components/contextMenu/section.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import './section.css';
+
+const ContextMenuSection: React.FC = ({ children }) => {
+  return <ul className="iot-context-menu-section">{children}</ul>;
+};
+
+export default ContextMenuSection;

--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import * as ReactDOM from 'react-dom';
 
-import Dashboard from './index';
+import Dashboard, { IotDashboardProps } from './index';
 
 describe('Dashboard', () => {
   it('should render', function () {
     const container = document.createElement('div');
     document.body.appendChild(container);
 
-    const args = {
+    const args: IotDashboardProps = {
       dashboardConfiguration: {
         widgets: [],
         viewport: { duration: '5m' },

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -2,19 +2,24 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { DndProvider } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
+import { merge } from 'lodash';
 
 import InternalDashboard from '../internalDashboard';
 
 import { configureDashboardStore } from '../../store';
 import { DashboardState } from '../../store/state';
-import '@cloudscape-design/global-styles/index.css';
+import { RecursivePartial } from '../../types';
+import { DashboardMessages, DefaultDashboardMessages } from '../../messages';
 
+import '@cloudscape-design/global-styles/index.css';
 import '../../styles/variables.css';
 
-export type IotDashboardProps = Pick<DashboardState, 'dashboardConfiguration'>;
+export type IotDashboardProps = {
+  messageOverrides?: RecursivePartial<DashboardMessages>;
+} & Pick<DashboardState, 'dashboardConfiguration'>;
 
-const Dashboard = (props: IotDashboardProps) => (
-  <Provider store={configureDashboardStore(props)}>
+const Dashboard: React.FC<IotDashboardProps> = ({ dashboardConfiguration, messageOverrides }) => (
+  <Provider store={configureDashboardStore({ dashboardConfiguration })}>
     <DndProvider
       backend={TouchBackend}
       options={{
@@ -22,7 +27,7 @@ const Dashboard = (props: IotDashboardProps) => (
         enableKeyboardEvents: true,
       }}
     >
-      <InternalDashboard />
+      <InternalDashboard messageOverrides={merge(messageOverrides, DefaultDashboardMessages)} />
     </DndProvider>
   </Provider>
 );

--- a/packages/dashboard/src/components/grid/getDashboardPosition.ts
+++ b/packages/dashboard/src/components/grid/getDashboardPosition.ts
@@ -1,10 +1,13 @@
+import React from 'react';
 import { Position } from '../../types';
 
 export const DASHBOARD_CONTAINER_ID = 'container';
 
-const getOffsets = (event: React.MouseEvent | React.TouchEvent | React.PointerEvent) => {
-  if ((event as React.TouchEvent).touches) {
-    const ev = (event as React.TouchEvent).touches[0];
+const getOffsets = (
+  event: React.MouseEvent | React.TouchEvent | React.PointerEvent | MouseEvent | TouchEvent | PointerEvent
+) => {
+  if (event instanceof TouchEvent || (event as React.TouchEvent).touches) {
+    const ev = (event as TouchEvent).touches[0];
 
     const rect = (ev.target as HTMLElement).getBoundingClientRect();
     const offsetX = ev.clientX - rect.x;
@@ -16,11 +19,7 @@ const getOffsets = (event: React.MouseEvent | React.TouchEvent | React.PointerEv
     };
   }
 
-  // return {
-  //   offsetX: event.offsetX,
-  //   offsetY: event.offsetY,
-  // };
-  const ev = event as React.MouseEvent;
+  const ev = event as MouseEvent;
   const rect = (ev.target as HTMLElement).getBoundingClientRect();
   const offsetX = ev.clientX - rect.x;
   const offsetY = ev.clientY - rect.y;
@@ -31,7 +30,9 @@ const getOffsets = (event: React.MouseEvent | React.TouchEvent | React.PointerEv
   };
 };
 
-export const getDashboardPosition = (event: React.MouseEvent | React.TouchEvent | React.PointerEvent): Position => {
+export const getDashboardPosition = (
+  event: React.MouseEvent | React.TouchEvent | React.PointerEvent | MouseEvent | TouchEvent | PointerEvent
+): Position => {
   const { offsetX, offsetY } = getOffsets(event);
   let totalOffsetX = offsetX;
   let totalOffsetY = offsetY;

--- a/packages/dashboard/src/components/grid/index.tsx
+++ b/packages/dashboard/src/components/grid/index.tsx
@@ -2,7 +2,7 @@ import React, { PointerEventHandler, useEffect, useState } from 'react';
 import { useDrag } from 'react-dnd';
 import { useKeyPress } from '../../hooks/useKeyPress';
 import { DashboardState } from '../../store/state';
-import { Position } from '../../types';
+import { MouseClick, Position } from '../../types';
 import { gestureable } from '../internalDashboard/determineTargetGestures';
 import { DASHBOARD_CONTAINER_ID, getDashboardPosition } from './getDashboardPosition';
 
@@ -113,7 +113,9 @@ const Grid: React.FC<GridProps> = ({ grid, click, dragStart, drag, dragEnd, chil
   };
 
   const onPointerUp: PointerEventHandler = (e) => {
-    if (!cancelClick) {
+    if (cancelClick) return;
+
+    if (e.button === MouseClick.Left) {
       click({
         position: getDashboardPosition(e),
         union,

--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -8,6 +8,7 @@ import { act } from 'react-dom/test-utils';
 
 import InternalDashboard from './index';
 import { configureDashboardStore } from '../../store';
+import { DefaultDashboardMessages } from '../../messages';
 
 describe('InternalDashboard', () => {
   it('should render', function () {
@@ -31,7 +32,7 @@ describe('InternalDashboard', () => {
               enableKeyboardEvents: true,
             }}
           >
-            <InternalDashboard />
+            <InternalDashboard messageOverrides={DefaultDashboardMessages} />
           </DndProvider>
         </Provider>,
         container

--- a/packages/dashboard/src/components/widgets/selectionBox.css
+++ b/packages/dashboard/src/components/widgets/selectionBox.css
@@ -2,7 +2,7 @@
 
 .selection-box {
   position: relative;
-  z-index: 9999999999999;
+  z-index: var(--stack-order-selection-box);
   border: var(--selection-border-width) solid var(--selection-color);
   border-radius: var(--selection-radius);
   font-weight: bold;

--- a/packages/dashboard/src/messages.ts
+++ b/packages/dashboard/src/messages.ts
@@ -1,0 +1,42 @@
+import { isMacLike } from './util/browser';
+
+export type ContextMenuMessages = {
+  copyText: string;
+  pasteText: string;
+  deleteText: string;
+  bringToFrontText: string;
+  sendToBackText: string;
+};
+
+export type WidgetsMessages = {
+  invalidTagHeader: string;
+  invalidTagSubheader: string;
+};
+
+export type DashboardMessages = {
+  widgets: WidgetsMessages;
+  contextMenu: ContextMenuMessages;
+};
+
+export const DefaultDashboardMessages: DashboardMessages = {
+  widgets: {
+    invalidTagHeader: 'Widget failed to load',
+    invalidTagSubheader: 'Please try again later or contact an admin for help.',
+  },
+  contextMenu: {
+    copyText: 'Copy',
+    pasteText: 'Paste',
+    deleteText: 'Delete',
+    bringToFrontText: 'Bring to Front',
+    sendToBackText: 'Send to Back',
+  },
+};
+
+const mod = isMacLike ? '⌘' : 'Ctrl';
+export const keyboardShortcuts = {
+  mod,
+  copy: `${mod}C`,
+  paste: `${mod}V`,
+  bringToFront: ']',
+  sendToBack: '[',
+};

--- a/packages/dashboard/src/store/actions/bringToFront/index.spec.ts
+++ b/packages/dashboard/src/store/actions/bringToFront/index.spec.ts
@@ -1,0 +1,72 @@
+import { bringWidgetsToFront } from '.';
+import { DashboardState, initialState } from '../../state';
+
+import { MockWidgetFactory, MOCK_KPI_WIDGET } from '../../../../testing/mocks';
+import { Widget } from '../../../types';
+
+const setupDashboardState = (widgets: Widget[] = [], selectedWidgets: Widget[] = []): DashboardState => ({
+  ...initialState,
+  dashboardConfiguration: {
+    ...initialState.dashboardConfiguration,
+    widgets,
+  },
+  selectedWidgets,
+});
+
+it('does nothing if there are no widgets selected', () => {
+  expect(bringWidgetsToFront(setupDashboardState([MOCK_KPI_WIDGET])).dashboardConfiguration.widgets).toEqual([
+    MOCK_KPI_WIDGET,
+  ]);
+});
+
+it('moves selected widget to front', () => {
+  const MOCK_WIDGET = MockWidgetFactory.getKpiWidget({
+    id: 'widget-1',
+  });
+  const MOCK_WIDGET_2 = MockWidgetFactory.getKpiWidget({
+    id: 'widget-2',
+    z: MOCK_WIDGET.z - 1, // A z-index lower than `MOCK_WIDGET`'s z-index
+  });
+
+  expect(
+    bringWidgetsToFront(setupDashboardState([MOCK_WIDGET, MOCK_WIDGET_2], [MOCK_WIDGET_2])).dashboardConfiguration
+      .widgets
+  ).toEqual(
+    expect.arrayContaining([
+      MOCK_WIDGET,
+      expect.objectContaining({
+        z: MOCK_WIDGET.z + 1,
+      }),
+    ])
+  );
+});
+
+it('moves group of widgets and retains their relative order', () => {
+  const MOCK_WIDGET = MockWidgetFactory.getKpiWidget({
+    id: 'widget-1',
+  });
+  const MOCK_WIDGET_2 = MockWidgetFactory.getKpiWidget({
+    id: 'widget-2',
+    z: MOCK_WIDGET.z - 1, // A z-index lower than `MOCK_WIDGET`'s z-index
+  });
+  const MOCK_WIDGET_3 = MockWidgetFactory.getKpiWidget({
+    id: 'widget-3',
+    z: MOCK_WIDGET_2.z - 1, // A z-index lower than `MOCK_WIDGET_2`'s z-index
+  });
+
+  expect(
+    bringWidgetsToFront(
+      setupDashboardState([MOCK_WIDGET, MOCK_WIDGET_2, MOCK_WIDGET_3], [MOCK_WIDGET_2, MOCK_WIDGET_3])
+    ).dashboardConfiguration.widgets
+  ).toEqual(
+    expect.arrayContaining([
+      MOCK_WIDGET,
+      expect.objectContaining({
+        z: MOCK_WIDGET.z + 2,
+      }),
+      expect.objectContaining({
+        z: MOCK_WIDGET.z + 1,
+      }),
+    ])
+  );
+});

--- a/packages/dashboard/src/store/actions/bringToFront/index.ts
+++ b/packages/dashboard/src/store/actions/bringToFront/index.ts
@@ -1,0 +1,41 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
+import maxBy from 'lodash/maxBy';
+import minBy from 'lodash/minBy';
+
+import { DashboardState } from '../../state';
+
+export interface BringWidgetsToFrontAction extends PayloadAction<null> {
+  type: 'BRING_WIDGETS_TO_FRONT';
+}
+
+export const onBringWidgetsToFrontAction = (): BringWidgetsToFrontAction => ({
+  type: 'BRING_WIDGETS_TO_FRONT',
+  payload: null,
+});
+
+export const bringWidgetsToFront = (state: DashboardState): DashboardState => {
+  const widgets = state.dashboardConfiguration.widgets;
+  const slectedWidgets = state.selectedWidgets;
+  const selectedWidgetsIds = slectedWidgets.map(({ id }) => id);
+  const topZIndex = maxBy(widgets, 'z')?.z ?? 0;
+  const minSelectedZ = minBy(slectedWidgets, 'z')?.z ?? 0;
+
+  const zOffset = topZIndex + 1 - minSelectedZ;
+
+  const translatedWidgets = widgets.map((widget) => ({
+    ...widget,
+    z: selectedWidgetsIds.includes(widget.id) ? widget.z + zOffset : widget.z,
+  }));
+
+  const translatedSelectedWidgets = translatedWidgets.filter((widget) => selectedWidgetsIds.includes(widget.id));
+
+  return {
+    ...state,
+    dashboardConfiguration: {
+      ...state.dashboardConfiguration,
+      widgets: translatedWidgets,
+    },
+    selectedWidgets: translatedSelectedWidgets,
+  };
+};

--- a/packages/dashboard/src/store/actions/copyWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/copyWidgets/index.spec.ts
@@ -1,0 +1,69 @@
+import { copyWidgets, onCopyWidgetsAction } from '.';
+import { DashboardState, initialState } from '../../state';
+
+import { MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET, MOCK_SCATTER_CHART_WIDGET } from '../../../../testing/mocks';
+import { Widget } from '../../../types';
+
+const setupDashboardState = (widgets: Widget[] = [], pasteCounter = 0): DashboardState => ({
+  ...initialState,
+  dashboardConfiguration: {
+    ...initialState.dashboardConfiguration,
+    widgets,
+  },
+  pasteCounter,
+});
+
+it('does nothing if no widgets are provided', () => {
+  expect(
+    copyWidgets(
+      setupDashboardState(),
+      onCopyWidgetsAction({
+        widgets: [],
+      })
+    ).copiedWidgets
+  ).toEqual([]);
+});
+
+it('adds one widget to the copy group', () => {
+  expect(
+    copyWidgets(
+      setupDashboardState([MOCK_KPI_WIDGET]),
+      onCopyWidgetsAction({
+        widgets: [MOCK_KPI_WIDGET],
+      })
+    ).copiedWidgets
+  ).toEqual([MOCK_KPI_WIDGET]);
+});
+
+it('adds many widgets to the copy group', () => {
+  expect(
+    copyWidgets(
+      setupDashboardState([MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET]),
+      onCopyWidgetsAction({
+        widgets: [MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET],
+      })
+    ).copiedWidgets
+  ).toEqual([MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET]);
+});
+
+it('does not add a widget to the copy group that is not in the configuration', () => {
+  expect(
+    copyWidgets(
+      setupDashboardState([MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET]),
+      onCopyWidgetsAction({
+        widgets: [MOCK_SCATTER_CHART_WIDGET],
+      })
+    ).copiedWidgets
+  ).toEqual([]);
+});
+
+it('resets paste counter', () => {
+  expect(
+    copyWidgets(
+      setupDashboardState([MOCK_KPI_WIDGET], 10),
+      onCopyWidgetsAction({
+        widgets: [MOCK_KPI_WIDGET],
+      })
+    ).pasteCounter
+  ).toEqual(0);
+});

--- a/packages/dashboard/src/store/actions/copyWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/copyWidgets/index.ts
@@ -1,0 +1,29 @@
+import { Action } from 'redux';
+
+import intersectionBy from 'lodash/intersectionBy';
+
+import { Widget } from '../../../types';
+import { DashboardState } from '../../state';
+
+type CopyWidgetsActionPayload = {
+  widgets: Widget[];
+};
+export interface CopyWidgetsAction extends Action {
+  type: 'COPY_WIDGETS';
+  payload: CopyWidgetsActionPayload;
+}
+
+export const onCopyWidgetsAction = (payload: CopyWidgetsActionPayload): CopyWidgetsAction => ({
+  type: 'COPY_WIDGETS',
+  payload,
+});
+
+export const copyWidgets = (state: DashboardState, action: CopyWidgetsAction): DashboardState => {
+  const copiedWidgets = intersectionBy(state.dashboardConfiguration.widgets, action.payload.widgets, 'id');
+
+  return {
+    ...state,
+    copiedWidgets,
+    pasteCounter: 0,
+  };
+};

--- a/packages/dashboard/src/store/actions/index.ts
+++ b/packages/dashboard/src/store/actions/index.ts
@@ -4,11 +4,19 @@ import { MoveWidgetsAction } from './moveWidgets';
 import { ResizeWidgetsAction } from './resizeWidgets';
 import { ChangeDashboardWidthAction, ChangeDashboardHeightAction } from './changeDashboardSize';
 import { DeleteWidgetsAction } from './deleteWidgets';
+import { CopyWidgetsAction } from './copyWidgets';
+import { PasteWidgetsAction } from './pasteWidgets';
+import { BringWidgetsToFrontAction } from './bringToFront';
+import { SendWidgetsToBackAction } from './sendToBack';
 
 export * from './createWidget';
 export * from './deleteWidgets';
 export * from './selectWidgets';
+export * from './copyWidgets';
+export * from './pasteWidgets';
 export * from './moveWidgets';
+export * from './bringToFront';
+export * from './sendToBack';
 export * from './resizeWidgets';
 export * from './changeDashboardSize';
 
@@ -16,7 +24,11 @@ export type DashboardAction =
   | CreateWidgetsAction
   | DeleteWidgetsAction
   | SelectWidgetsAction
+  | CopyWidgetsAction
+  | PasteWidgetsAction
   | MoveWidgetsAction
+  | BringWidgetsToFrontAction
+  | SendWidgetsToBackAction
   | ResizeWidgetsAction
   | ChangeDashboardWidthAction
   | ChangeDashboardHeightAction;

--- a/packages/dashboard/src/store/actions/pasteWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/pasteWidgets/index.spec.ts
@@ -1,0 +1,152 @@
+import { pasteWidgets, onPasteWidgetsAction } from '.';
+import { DashboardState, initialState } from '../../state';
+
+import { MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET } from '../../../../testing/mocks';
+import { Widget } from '../../../types';
+
+const setupDashboardState = (widgets: Widget[] = [], copiedWidgets: Widget[] = []): DashboardState => ({
+  ...initialState,
+  dashboardConfiguration: {
+    ...initialState.dashboardConfiguration,
+    widgets,
+  },
+  copiedWidgets,
+});
+
+it('does nothing when pasting with nothing in the copy group', () => {
+  expect(pasteWidgets(setupDashboardState(), onPasteWidgetsAction({})).dashboardConfiguration.widgets).toEqual([]);
+});
+
+it('paste single widget', () => {
+  expect(
+    pasteWidgets(setupDashboardState([MOCK_KPI_WIDGET], [MOCK_KPI_WIDGET]), onPasteWidgetsAction({}))
+      .dashboardConfiguration.widgets
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: MOCK_KPI_WIDGET.x,
+        y: MOCK_KPI_WIDGET.y,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: MOCK_KPI_WIDGET.x + 1,
+        y: MOCK_KPI_WIDGET.y + 1,
+      }),
+    ])
+  );
+});
+
+it('paste single widget a second time, shifts the position down', () => {
+  const state = pasteWidgets(setupDashboardState([MOCK_KPI_WIDGET], [MOCK_KPI_WIDGET]), onPasteWidgetsAction({}));
+
+  expect(pasteWidgets(state, onPasteWidgetsAction({})).dashboardConfiguration.widgets).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: MOCK_KPI_WIDGET.x,
+        y: MOCK_KPI_WIDGET.y,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: MOCK_KPI_WIDGET.x + 1,
+        y: MOCK_KPI_WIDGET.y + 1,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: MOCK_KPI_WIDGET.x + 2,
+        y: MOCK_KPI_WIDGET.y + 2,
+      }),
+    ])
+  );
+});
+
+it('paste multiple widgets', () => {
+  expect(
+    pasteWidgets(
+      setupDashboardState([MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET], [MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET]),
+      onPasteWidgetsAction({})
+    ).dashboardConfiguration.widgets
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: MOCK_KPI_WIDGET.x,
+        y: MOCK_KPI_WIDGET.y,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_LINE_CHART_WIDGET.componentTag,
+        x: MOCK_LINE_CHART_WIDGET.x,
+        y: MOCK_LINE_CHART_WIDGET.y,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: MOCK_KPI_WIDGET.x + 1,
+        y: MOCK_KPI_WIDGET.y + 1,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_LINE_CHART_WIDGET.componentTag,
+        x: MOCK_LINE_CHART_WIDGET.x + 1,
+        y: MOCK_LINE_CHART_WIDGET.y + 1,
+      }),
+    ])
+  );
+});
+
+it('pastes a widget at a specific location', () => {
+  expect(
+    pasteWidgets(
+      setupDashboardState([MOCK_KPI_WIDGET], [MOCK_KPI_WIDGET]),
+      onPasteWidgetsAction({
+        position: { x: 100, y: 100 },
+      })
+    ).dashboardConfiguration.widgets
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: MOCK_KPI_WIDGET.x,
+        y: MOCK_KPI_WIDGET.y,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: 10,
+        y: 10,
+      }),
+    ])
+  );
+});
+
+it('pastes multiple widgets at a specific location', () => {
+  expect(
+    pasteWidgets(
+      setupDashboardState([MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET], [MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET]),
+      onPasteWidgetsAction({
+        position: { x: 100, y: 100 },
+      })
+    ).dashboardConfiguration.widgets
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: MOCK_KPI_WIDGET.x,
+        y: MOCK_KPI_WIDGET.y,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_LINE_CHART_WIDGET.componentTag,
+        x: MOCK_LINE_CHART_WIDGET.x,
+        y: MOCK_LINE_CHART_WIDGET.y,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: 10,
+        y: 10,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_LINE_CHART_WIDGET.componentTag,
+        x: 10,
+        y: 10,
+      }),
+    ])
+  );
+});

--- a/packages/dashboard/src/store/actions/pasteWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/pasteWidgets/index.ts
@@ -1,0 +1,64 @@
+import { Action } from 'redux';
+
+import first from 'lodash/first';
+import sortBy from 'lodash/sortBy';
+
+import { Position } from '../../../types';
+import { DashboardState } from '../../state';
+import { v4 } from 'uuid';
+
+type PasteWidgetsActionPayload = {
+  position?: Position;
+};
+export interface PasteWidgetsAction extends Action {
+  type: 'PASTE_WIDGETS';
+  payload: PasteWidgetsActionPayload;
+}
+
+export const onPasteWidgetsAction = (payload: PasteWidgetsActionPayload): PasteWidgetsAction => ({
+  type: 'PASTE_WIDGETS',
+  payload,
+});
+
+export const pasteWidgets = (state: DashboardState, action: PasteWidgetsAction): DashboardState => {
+  const { position } = action.payload;
+
+  const cellSize = state.grid.cellSize;
+  const copyGroup = state.copiedWidgets;
+  let pasteCounter = state.pasteCounter + 1;
+
+  let offset: Position = {
+    x: 0,
+    y: 0,
+  };
+  if (position !== undefined) {
+    pasteCounter = 0;
+
+    const cellPosition: Position = {
+      x: position && Math.floor(position.x / cellSize),
+      y: position && Math.floor(position.y / cellSize),
+    };
+
+    const widgetToCompare = first(sortBy(copyGroup, ['x', 'y']));
+    offset = {
+      x: cellPosition.x - (widgetToCompare?.x ?? 0),
+      y: cellPosition.y - (widgetToCompare?.y ?? 0),
+    };
+  }
+
+  const widgetsToPaste = copyGroup.map((widget) => ({
+    ...widget,
+    id: v4(),
+    x: offset.x + widget.x + pasteCounter,
+    y: offset.y + widget.y + pasteCounter,
+  }));
+
+  return {
+    ...state,
+    dashboardConfiguration: {
+      ...state.dashboardConfiguration,
+      widgets: [...state.dashboardConfiguration.widgets, ...widgetsToPaste],
+    },
+    pasteCounter: position !== undefined ? 0 : pasteCounter,
+  };
+};

--- a/packages/dashboard/src/store/actions/sendToBack/index.spec.ts
+++ b/packages/dashboard/src/store/actions/sendToBack/index.spec.ts
@@ -1,0 +1,69 @@
+import { sendWidgetsToBack } from '.';
+import { MockWidgetFactory, MOCK_KPI_WIDGET } from '../../../../testing/mocks';
+import { Widget } from '../../../types';
+import { DashboardState, initialState } from '../../state';
+
+const setupDashboardState = (widgets: Widget[] = [], selectedWidgets: Widget[] = []): DashboardState => ({
+  ...initialState,
+  dashboardConfiguration: {
+    ...initialState.dashboardConfiguration,
+    widgets,
+  },
+  selectedWidgets,
+});
+
+it('does nothing if there are no widgets selected', () => {
+  expect(sendWidgetsToBack(setupDashboardState([MOCK_KPI_WIDGET])).dashboardConfiguration.widgets).toEqual([
+    MOCK_KPI_WIDGET,
+  ]);
+});
+
+it('moves selected widget to back', () => {
+  const MOCK_WIDGET = MockWidgetFactory.getKpiWidget({
+    id: 'widget-1',
+  });
+  const MOCK_WIDGET_2 = MockWidgetFactory.getKpiWidget({
+    id: 'widget-2',
+    z: MOCK_WIDGET.z - 1, // A z-index lower than `MOCK_WIDGET`'s z-index
+  });
+
+  expect(
+    sendWidgetsToBack(setupDashboardState([MOCK_WIDGET, MOCK_WIDGET_2], [MOCK_WIDGET])).dashboardConfiguration.widgets
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        z: MOCK_WIDGET.z - 2,
+      }),
+      MOCK_WIDGET_2,
+    ])
+  );
+});
+
+it('moves group of widgets and retains their relative order', () => {
+  const MOCK_WIDGET = MockWidgetFactory.getKpiWidget({
+    id: 'widget-1',
+  });
+  const MOCK_WIDGET_2 = MockWidgetFactory.getKpiWidget({
+    id: 'widget-2',
+    z: MOCK_WIDGET.z - 1, // A z-index lower than `MOCK_WIDGET`'s z-index
+  });
+  const MOCK_WIDGET_3 = MockWidgetFactory.getKpiWidget({
+    id: 'widget-3',
+    z: MOCK_WIDGET_2.z - 1, // A z-index lower than `MOCK_WIDGET_2`'s z-index
+  });
+
+  expect(
+    sendWidgetsToBack(setupDashboardState([MOCK_WIDGET, MOCK_WIDGET_2, MOCK_WIDGET_3], [MOCK_WIDGET, MOCK_WIDGET_2]))
+      .dashboardConfiguration.widgets
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        z: MOCK_WIDGET_3.z - 1,
+      }),
+      expect.objectContaining({
+        z: MOCK_WIDGET_3.z - 2,
+      }),
+      MOCK_WIDGET_3,
+    ])
+  );
+});

--- a/packages/dashboard/src/store/actions/sendToBack/index.ts
+++ b/packages/dashboard/src/store/actions/sendToBack/index.ts
@@ -1,0 +1,41 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
+import maxBy from 'lodash/maxBy';
+import minBy from 'lodash/minBy';
+
+import { DashboardState } from '../../state';
+
+export interface SendWidgetsToBackAction extends PayloadAction<null> {
+  type: 'SEND_WIDGETS_TO_BACK';
+}
+
+export const onSendWidgetsToBackAction = (): SendWidgetsToBackAction => ({
+  type: 'SEND_WIDGETS_TO_BACK',
+  payload: null,
+});
+
+export const sendWidgetsToBack = (state: DashboardState): DashboardState => {
+  const widgets = state.dashboardConfiguration.widgets;
+  const slectedWidgets = state.selectedWidgets;
+  const selectedWidgetsIds = slectedWidgets.map(({ id }) => id);
+  const bottomZIndex = minBy(widgets, 'z')?.z ?? 0;
+  const maxSelectedZ = maxBy(slectedWidgets, 'z')?.z ?? 0;
+
+  const zOffset = bottomZIndex - 1 - maxSelectedZ;
+
+  const translatedWidgets = widgets.map((widget) => ({
+    ...widget,
+    z: selectedWidgetsIds.includes(widget.id) ? widget.z + zOffset : widget.z,
+  }));
+
+  const translatedSelectedWidgets = translatedWidgets.filter((widget) => selectedWidgetsIds.includes(widget.id));
+
+  return {
+    ...state,
+    dashboardConfiguration: {
+      ...state.dashboardConfiguration,
+      widgets: translatedWidgets,
+    },
+    selectedWidgets: translatedSelectedWidgets,
+  };
+};

--- a/packages/dashboard/src/store/reducer.ts
+++ b/packages/dashboard/src/store/reducer.ts
@@ -9,6 +9,10 @@ import {
   selectWidgets,
   resizeWidgets,
   deleteWidgets,
+  copyWidgets,
+  pasteWidgets,
+  sendWidgetsToBack,
+  bringWidgetsToFront,
 } from './actions';
 
 import { createWidgets } from './actions/createWidget';
@@ -38,8 +42,24 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
       return selectWidgets(state, action);
     }
 
+    case 'COPY_WIDGETS': {
+      return copyWidgets(state, action);
+    }
+
+    case 'PASTE_WIDGETS': {
+      return pasteWidgets(state, action);
+    }
+
     case 'MOVE_WIDGETS': {
       return moveWidgets(state, action);
+    }
+
+    case 'BRING_WIDGETS_TO_FRONT': {
+      return bringWidgetsToFront(state);
+    }
+
+    case 'SEND_WIDGETS_TO_BACK': {
+      return sendWidgetsToBack(state);
     }
 
     case 'RESIZE_WIDGETS': {

--- a/packages/dashboard/src/store/state.ts
+++ b/packages/dashboard/src/store/state.ts
@@ -8,6 +8,8 @@ export type DashboardState = {
     stretchToFit: boolean;
   };
   selectedWidgets: Widget[];
+  copiedWidgets: Widget[];
+  pasteCounter: number;
   dashboardConfiguration: DashboardConfiguration;
 };
 
@@ -19,6 +21,8 @@ export const initialState: DashboardState = {
     stretchToFit: false,
   },
   selectedWidgets: [],
+  copiedWidgets: [],
+  pasteCounter: 0,
   dashboardConfiguration: {
     viewport: { duration: '5m' },
     widgets: [],

--- a/packages/dashboard/src/styles/variables.css
+++ b/packages/dashboard/src/styles/variables.css
@@ -8,8 +8,8 @@
   --selection-border-touch-width: 8px;
   --selection-radius-small: 4px;
   --stack-order-grid-image: -999999999;
-  --stack-order-selection-box: 9999999999999;
-  --stack-order-context-menu: 9999999999999;
+  --stack-order-selection-box: 2;
+  --stack-order-context-menu: 3;
   --colors-blue: #0073bb;
   --colors-dark-grey: rgb(27 27 27);
   --colors-grey: rgb(116 116 116);
@@ -20,4 +20,5 @@
   --spacing-context-menu-section: 0.5rem 0;
   --border-width-context-menu-section: 0.5px;
   --size-context-menu-min-width: 200px;
+  --radius-context-menu: 3px;
 }

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -22,3 +22,16 @@ export type DashboardConfiguration = {
 
 export type Position = { x: number; y: number };
 export type Rect = { x: number; y: number; width: number; height: number };
+
+export enum MouseClick {
+  Left = 0,
+  Right = 2,
+}
+
+export type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : T[P] extends object
+    ? RecursivePartial<T[P]>
+    : T[P];
+};

--- a/packages/dashboard/src/util/browser.ts
+++ b/packages/dashboard/src/util/browser.ts
@@ -1,0 +1,5 @@
+/**
+ * navigator.platform is deprecated see - https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform
+ * For usecases like displaying the proper key for copy / paste shortcuts, documentation suggets this is fine.
+ *  */
+export const isMacLike = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);

--- a/packages/dashboard/src/util/select.spec.ts
+++ b/packages/dashboard/src/util/select.spec.ts
@@ -40,7 +40,7 @@ describe('getSelectedIds', () => {
     expect(
       getSelectedWidgetIds({
         dashboardConfiguration: MockDashboardFactory.get({
-          widgets: [MockWidgetFactory.getLineChartWidget({ x: 1, y: 1, width: 1, height: 1, id: 'some-id' })],
+          widgets: [MockWidgetFactory.getLineChartWidget({ x: 0, y: 0, width: 1, height: 1, id: 'some-id' })],
         }),
         cellSize: 5,
         selectedRect: { x: 10, y: 10, width: 10, height: 10 },

--- a/packages/dashboard/src/util/select.ts
+++ b/packages/dashboard/src/util/select.ts
@@ -14,8 +14,8 @@ export const getSelectedWidgets = ({
     selectedRect
       ? isContained(
           {
-            x: (rect.x - 1) * cellSize,
-            y: (rect.y - 1) * cellSize,
+            x: rect.x * cellSize,
+            y: rect.y * cellSize,
             width: rect.width * cellSize,
             height: rect.height * cellSize,
           },


### PR DESCRIPTION
## Overview
Adds a right click / long press context menu with the actions: copy, paste, delete, send to back, bring to front.

Adds implementation for copy, paste,  send to back, bring to front.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
