### PR TITLE
feat(dashboard): add chart setting section

### DIFF
--- a/packages/dashboard/src/components/sidePanel/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/index.tsx
@@ -5,8 +5,14 @@ import ThresholdsSection from './sections/thresholdsSection';
 import ChartSettings from './sections/chartSettings';
 import DataSettings from './sections/dataSettings';
 import './index.css';
+import { useSelector } from 'react-redux';
+import { DashboardState } from '../../store/state';
 
 const SidePanel = () => {
+  const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
+  if (selectedWidgets.length !== 1) {
+    return <div>Currently we only support changing setting for one widget only.</div>;
+  }
   return (
     <Container header={<Header variant="h3">Configurations</Header>} className={'iot-side-panel'}>
       <PropertiesAlarmsSection />

--- a/packages/dashboard/src/components/sidePanel/sections/chartSettings.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/chartSettings.tsx
@@ -1,11 +1,142 @@
 import React from 'react';
-import { ExpandableSection } from '@cloudscape-design/components';
+import {
+  Checkbox,
+  CheckboxProps,
+  ExpandableSection,
+  Input,
+  Select,
+  SelectProps,
+  SpaceBetween,
+} from '@cloudscape-design/components';
 import ExpandableSectionHeader from '../shared/expandableSectionHeader';
+import { capitalizeFirstLetter, useInput } from '../utils';
+import SettingTile from '../shared/settingTile';
+import { LEGEND_POSITION } from '@synchro-charts/core';
+import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
+import { BaseChangeDetail } from '@cloudscape-design/components/input/interfaces';
+
+const ChartTitleSetting = () => {
+  const [title, updateTitle] = useInput<string>('title');
+  return (
+    <SettingTile title={'Widget title'} gridDefinition={[{ colspan: 12 }]}>
+      <div className="section-item-content">
+        <Input value={title} onChange={({ detail: { value } }) => updateTitle(value)} />
+      </div>
+    </SettingTile>
+  );
+};
+
+const SizeSettings = () => {
+  const [width, updateWidth] = useInput<number>('width');
+  const [height, updateHeight] = useInput<number>('height');
+  const onWidthChange: NonCancelableEventHandler<BaseChangeDetail> = ({ detail: { value } }) =>
+    updateWidth(parseInt(value));
+  const onHeightChange: NonCancelableEventHandler<BaseChangeDetail> = ({ detail: { value } }) =>
+    updateHeight(parseInt(value));
+  return (
+    <SettingTile title={'Size'} gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+      <div className="section-item-content">
+        <div className="section-item-label">Width</div>
+        <Input value={`${width}`} type="number" onChange={onWidthChange} />
+      </div>
+      <div className="section-item-content">
+        <div className="section-item-label">Height</div>
+        <Input value={`${height}`} type="number" onChange={onHeightChange} />
+      </div>
+    </SettingTile>
+  );
+};
+
+const PositionSettings = () => {
+  const [x, updateX] = useInput<number>('x');
+  const [y, updateY] = useInput<number>('y');
+  const onXChange: NonCancelableEventHandler<BaseChangeDetail> = ({ detail: { value } }) => updateX(parseInt(value));
+  const onYChange: NonCancelableEventHandler<BaseChangeDetail> = ({ detail: { value } }) => updateY(parseInt(value));
+  return (
+    <SettingTile title={'Position'} gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+      <div className="section-item-content">
+        <div className="section-item-label">X</div>
+        <Input value={`${x}`} type="number" onChange={onXChange} />
+      </div>
+      <div className="section-item-content">
+        <div className="section-item-label">Y</div>
+        <Input value={`${y}`} type="number" onChange={onYChange} />
+      </div>
+    </SettingTile>
+  );
+};
+
+const YAxisSettings = () => {
+  const [title, updateTitle] = useInput<string>('properties.axis.labels.yAxis.content');
+  const [showAxis = false, updateShowAxis] = useInput<boolean>('properties.axis.showY');
+  const onTitleChange: NonCancelableEventHandler<BaseChangeDetail> = ({ detail: { value } }) => updateTitle(value);
+  const onToggleShowAxis: NonCancelableEventHandler<CheckboxProps.ChangeDetail> = ({ detail: { checked } }) => {
+    updateShowAxis(checked);
+  };
+  return (
+    <SettingTile title={'Y-axis'} gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
+      <div className="section-item-content">
+        <div className="section-item-label">Title</div>
+        <Input value={title} onChange={onTitleChange} />
+      </div>
+      <div className="section-item-content">
+        <div className="section-item-label">Show</div>
+        <Checkbox checked={showAxis} onChange={onToggleShowAxis} />
+      </div>
+    </SettingTile>
+  );
+};
+const LegendSettings = () => {
+  const [width = 0, updateWidth] = useInput<number>('properties.legend.width');
+  const [position = 'Right', updatePosition] = useInput<LEGEND_POSITION>('properties.legend.position');
+  const [title = '', updateTitle] = useInput<string>('properties.legend.legendLabels.title');
+  const onWidthChange: NonCancelableEventHandler<BaseChangeDetail> = ({ detail: { value } }) =>
+    updateWidth(parseInt(value));
+  const onTitleChange: NonCancelableEventHandler<BaseChangeDetail> = ({ detail: { value } }) => updateTitle(value);
+  const onPositionChange: NonCancelableEventHandler<SelectProps.ChangeDetail> = ({ detail: { selectedOption } }) => {
+    updatePosition(selectedOption.value as LEGEND_POSITION);
+  };
+  return (
+    <SettingTile title="Legend" gridDefinition={[{ colspan: 6 }, { colspan: 6 }, { colspan: 6 }]}>
+      <div className="section-item-content">
+        <div className="section-item-label">Width</div>
+        <Input value={`${width}`} onChange={onWidthChange} />
+      </div>
+      <div className="section-item-content">
+        <div className="section-item-label">Title</div>
+        <Input value={title} onChange={onTitleChange} />
+      </div>
+      <div className="section-item-content">
+        <div className="section-item-label">Position</div>
+        <Select
+          selectedOption={{ label: capitalizeFirstLetter(position), value: position }}
+          onChange={onPositionChange}
+          options={[
+            {
+              label: 'Right',
+              value: LEGEND_POSITION.RIGHT,
+            },
+            {
+              label: 'Bottom',
+              value: LEGEND_POSITION.BOTTOM,
+            },
+          ]}
+        />
+      </div>
+    </SettingTile>
+  );
+};
 
 const ChartSettings = () => {
   return (
     <ExpandableSection headerText={<ExpandableSectionHeader>Chart Setting</ExpandableSectionHeader>} defaultExpanded>
-      --
+      <SpaceBetween size="l" direction="vertical">
+        <SizeSettings />
+        <PositionSettings />
+        <ChartTitleSetting />
+        <YAxisSettings />
+        <LegendSettings />
+      </SpaceBetween>
     </ExpandableSection>
   );
 };

--- a/packages/dashboard/src/components/sidePanel/shared/expandableSectionHeader.tsx
+++ b/packages/dashboard/src/components/sidePanel/shared/expandableSectionHeader.tsx
@@ -1,4 +1,4 @@
-import React, { createElement, FC, PropsWithChildren } from 'react';
+import React, { FC, PropsWithChildren } from 'react';
 import { Icon, IconProps } from '@cloudscape-design/components';
 import './styles.css';
 
@@ -8,11 +8,10 @@ type ExpandableSectionHeaderProps = {
   iconName?: IconProps.Name;
 };
 const ExpandableSectionHeader: FC<PropsWithChildren<ExpandableSectionHeaderProps>> = (props) => {
-  const { children, onClickButton, iconName = 'add-plus', variant = 'h5' } = props;
-  const element = createElement(variant, { className: 'expandable-section-header-text' }, children);
+  const { children, onClickButton, iconName = 'add-plus' } = props;
   return (
     <>
-      {element}
+      {children}
       {onClickButton && (
         <span className="expandable-section-header-icon">
           <Icon name={iconName} />

--- a/packages/dashboard/src/components/sidePanel/shared/settingTile.tsx
+++ b/packages/dashboard/src/components/sidePanel/shared/settingTile.tsx
@@ -1,0 +1,14 @@
+import React, { FC, PropsWithChildren } from 'react';
+import { FormField, Grid, GridProps } from '@cloudscape-design/components';
+import './styles.css';
+
+type SettingTileProps = GridProps & { title: string };
+const SettingTile: FC<PropsWithChildren<SettingTileProps>> = ({ gridDefinition, title, children }) => {
+  return (
+    <FormField label={title}>
+      <Grid gridDefinition={gridDefinition}>{children}</Grid>
+    </FormField>
+  );
+};
+
+export default SettingTile;

--- a/packages/dashboard/src/components/sidePanel/shared/styles.css
+++ b/packages/dashboard/src/components/sidePanel/shared/styles.css
@@ -2,6 +2,15 @@
   margin-left: auto;
 }
 
-.expandable-section-header-text {
-  margin: 0;
+.section-item-content {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  height: 100%;
+}
+
+.section-item-label {
+  min-width: fit-content;
+  align-items: center;
+  display: flex;
 }

--- a/packages/dashboard/src/components/sidePanel/utils/index.ts
+++ b/packages/dashboard/src/components/sidePanel/utils/index.ts
@@ -1,18 +1,34 @@
-import { useEffect, Dispatch, useState } from 'react';
+import { Dispatch, useEffect, useState } from 'react';
 // import { useDispatch } from 'react-redux';
-import { get, set, cloneDeep } from 'lodash';
+import { get } from 'lodash';
+import { useSelector } from 'react-redux';
+import { DashboardState } from '../../../store/state';
 
 export const useInput: <T>(path: string) => [T, Dispatch<T>] = (path) => {
-  const selectedWidget = {}; // TODO: get selected widget from state manager or context
-  const [value, updateValue] = useState(get(selectedWidget, path));
-  // const dispatch = useDispatch();
-  useEffect(() => {
-    if (selectedWidget && get(selectedWidget, path) !== value) {
-      const deepClone = cloneDeep(selectedWidget);
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const newWidget = set(deepClone, path, value);
-      // TODO: dispatch(onUpdateSelectedWidgetAction(newWidget))
+  // TECHDEBT: only support viewing and updating the first selected widget.
+  const [selectedWidget] = useSelector((state: DashboardState) => state.dashboardConfiguration.widgets);
+  const [inputValue, updateInputValue] = useState(get(selectedWidget, path));
+
+  const onSelectedWidgetChange = () => {
+    const currentWidgetState = get(selectedWidget, path);
+    if (inputValue !== currentWidgetState) {
+      updateInputValue(currentWidgetState);
     }
-  }, [value]);
-  return [value, updateValue];
+  };
+  useEffect(onSelectedWidgetChange, [selectedWidget]);
+
+  const onInputValueChange = () => {
+    const currentWidgetState = get(selectedWidget, path);
+    if (inputValue !== currentWidgetState) {
+      // TODO: dispatch an action to update widget
+    }
+  };
+  useEffect(onInputValueChange, [inputValue]);
+
+  return [inputValue, updateInputValue];
 };
+
+export function capitalizeFirstLetter(string: string) {
+  const lowerCase = string.toLowerCase();
+  return lowerCase.charAt(0).toUpperCase() + lowerCase.slice(1);
+}


### PR DESCRIPTION
## Overview
Sub task of #401 

- add chart setting section 
- update useInput hook. now it reads changes from widget states.

## Preview
- When one widget is selected
![image](https://user-images.githubusercontent.com/11740421/205725870-dd3d0f99-d4c7-452a-8af1-8704c792c4ed.png)
- When multiple widgets are selected
![image](https://user-images.githubusercontent.com/11740421/205726084-741d3670-366a-45e9-a42c-8754c4a7defa.png)
- When no widget is selected
![image](https://user-images.githubusercontent.com/11740421/205726151-0518fd14-7f07-42f2-bf5f-effdc5eea149.png)



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
