### PR TITLE
Fix Failing Date Utils Test

### DIFF
--- a/packages/react-components/src/video-player/utils/dateTimeUtils.spec.tsx
+++ b/packages/react-components/src/video-player/utils/dateTimeUtils.spec.tsx
@@ -3,9 +3,10 @@ import { PLAYBACKMODE_LIVE, PLAYBACKMODE_ON_DEMAND } from '../constants';
 import { getFormattedDateTime, getNewSeekTime, getStartAndEndTimeForVideo } from './dateTimeUtils';
 
 // TimezoneOffset is included to make sure that output is calucalted as expected result without timezone issue during test
+// TimezoneOffset changes in year due to daylight savings time, we check for one or the other expected values to compensate
 it('should format the Date to DateTime value', () => {
   const rawDate = new Date(1665583620000 + new Date().getTimezoneOffset() * 60000);
-  expect(getFormattedDateTime(rawDate)).toEqual(`10/12\n14:07:00`);
+  expect([`10/12\n14:07:00`, `10/12\n15:07:00`]).toContain(getFormattedDateTime(rawDate));
 });
 
 it('should return correct seek time', () => {

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -157,10 +157,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 77.2,
-        "statements": 76.3,
-        "functions": 76.64,
-        "branches": 62.8,
+        "lines": 77.35,
+        "statements": 76.47,
+        "functions": 76.8,
+        "branches": 63.1,
         "branchesTrue": 100
       }
     }


### PR DESCRIPTION
## Overview
A test for the `react-components` package was failing. The test uses `Date.prototype.getTimezoneOffset` which returns a different value depending on Daylight Savings Time.

This now expects one of two values to be returned from the function being tested - either a non-DST or a DST value.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
