### PR TITLE
fix(dashboard): fix storybook props

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -77,7 +77,7 @@
     "@iot-app-kit/source-iotsitewise": "^2.4.2",
     "@iot-app-kit/react-components": "2.5.1",
     "@popperjs/core": "^2.11.6",
-    "@synchro-charts/core": "^4.0.0",
+    "@synchro-charts/core": "^6.0.4",
     "box-intersect": "^1.0.2",
     "is-hotkey": "^0.2.0",
     "react-dnd": "^15.1.2",

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -11,8 +11,7 @@ import InternalDashboard from '../internalDashboard';
 import { configureDashboardStore } from '../../store';
 import { DashboardState } from '../../store/state';
 import { RecursivePartial } from '../../types';
-import { TreeQuery } from '@iot-app-kit/core';
-import { BranchReference, SiteWiseAssetTreeNode } from '@iot-app-kit/source-iotsitewise';
+import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 import { DashboardMessages, DefaultDashboardMessages } from '../../messages';
 
 import '@cloudscape-design/global-styles/index.css';
@@ -20,7 +19,7 @@ import '../../styles/variables.css';
 
 export type IotDashboardProps = {
   messageOverrides?: RecursivePartial<DashboardMessages>;
-  query: TreeQuery<SiteWiseAssetTreeNode[], BranchReference> | undefined;
+  query?: SiteWiseQuery;
 } & Pick<DashboardState, 'dashboardConfiguration'>;
 
 const Dashboard: React.FC<IotDashboardProps> = ({ dashboardConfiguration, messageOverrides, query }) => (

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -45,6 +45,7 @@ import { onDeleteWidgetsAction } from '../../store/actions/deleteWidgets';
 import { widgetCreator } from '../../store/actions/createWidget/presets';
 
 import './index.css';
+import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 
 type Gesture = 'move' | 'resize' | 'select' | undefined;
 
@@ -72,7 +73,7 @@ const toGridPosition = (position: Position, cellSize: number): Position => ({
 
 type InternalDashboardProps = {
   messageOverrides: DashboardMessages;
-  query: any;
+  query?: SiteWiseQuery;
 };
 
 const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides, query }) => {

--- a/packages/dashboard/stories/IotDashboard/IotDashboard.stories.tsx
+++ b/packages/dashboard/stories/IotDashboard/IotDashboard.stories.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { createMockSiteWiseSDK, createMockIoTEventsSDK, initialize } from '@iot-app-kit/source-iotsitewise';
-import IotDashboard from '../../src/components/dashboard';
-import { mockListAssets, mockListAssociatedAssets } from './mockData';
+
+import IotDashboard, { IotDashboardProps } from '../../src/components/dashboard';
+import { query } from '../../testing/siteWiseQueries';
 
 export default {
   title: 'IotDashboard',
@@ -12,30 +12,12 @@ export default {
   },
 } as ComponentMeta<typeof IotDashboard>;
 
-const iotSiteWiseClient = createMockSiteWiseSDK({
-  listAssets: mockListAssets as any,
-  listAssociatedAssets: mockListAssociatedAssets as any,
-});
+const args = {
+  dashboardConfiguration: {
+    widgets: [],
+    viewport: { duration: '5m' },
+  },
+  query: query,
+} as IotDashboardProps;
 
-export const Main: ComponentStory<typeof IotDashboard> = () => {
-  const [query, setQuery] = useState(undefined as any);
-
-  useEffect(() => {
-    const { query } = initialize({
-      iotSiteWiseClient,
-      iotEventsClient: createMockIoTEventsSDK(),
-    });
-    if (!query) return;
-    setQuery(query);
-  }, []);
-
-  return (
-    <IotDashboard
-      query={query}
-      dashboardConfiguration={{
-        widgets: [],
-        viewport: { duration: '5m' },
-      }}
-    />
-  );
-};
+export const Main: ComponentStory<typeof IotDashboard> = () => <IotDashboard {...args} />;


### PR DESCRIPTION
## Overview
Duplicate initialization / usage of sitewise query objects were causing the charts not to render in the dashboard.
