### PR TITLE
feat(dashboard): add thresholds editing section

### DIFF
--- a/packages/dashboard/src/components/sidePanel/index.css
+++ b/packages/dashboard/src/components/sidePanel/index.css
@@ -1,3 +1,5 @@
 .iot-side-panel {
   height: 100%;
+  max-height: 100vh;
+  overflow-y: scroll;
 }

--- a/packages/dashboard/src/components/sidePanel/sections/chartSettings.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/chartSettings.tsx
@@ -18,7 +18,7 @@ import { BaseChangeDetail } from '@cloudscape-design/components/input/interfaces
 const ChartTitleSetting = () => {
   const [title, updateTitle] = useInput<string>('title');
   return (
-    <SettingTile title={'Widget title'} gridDefinition={[{ colspan: 12 }]}>
+    <SettingTile label={'Widget title'} gridDefinition={[{ colspan: 12 }]}>
       <div className="section-item-content">
         <Input value={title} onChange={({ detail: { value } }) => updateTitle(value)} />
       </div>
@@ -34,7 +34,7 @@ const SizeSettings = () => {
   const onHeightChange: NonCancelableEventHandler<BaseChangeDetail> = ({ detail: { value } }) =>
     updateHeight(parseInt(value));
   return (
-    <SettingTile title={'Size'} gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+    <SettingTile label={'Size'} gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
       <div className="section-item-content">
         <div className="section-item-label">Width</div>
         <Input value={`${width}`} type="number" onChange={onWidthChange} />
@@ -53,7 +53,7 @@ const PositionSettings = () => {
   const onXChange: NonCancelableEventHandler<BaseChangeDetail> = ({ detail: { value } }) => updateX(parseInt(value));
   const onYChange: NonCancelableEventHandler<BaseChangeDetail> = ({ detail: { value } }) => updateY(parseInt(value));
   return (
-    <SettingTile title={'Position'} gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+    <SettingTile label={'Position'} gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
       <div className="section-item-content">
         <div className="section-item-label">X</div>
         <Input value={`${x}`} type="number" onChange={onXChange} />
@@ -74,7 +74,7 @@ const YAxisSettings = () => {
     updateShowAxis(checked);
   };
   return (
-    <SettingTile title={'Y-axis'} gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
+    <SettingTile label={'Y-axis'} gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
       <div className="section-item-content">
         <div className="section-item-label">Title</div>
         <Input value={title} onChange={onTitleChange} />
@@ -97,7 +97,7 @@ const LegendSettings = () => {
     updatePosition(selectedOption.value as LEGEND_POSITION);
   };
   return (
-    <SettingTile title="Legend" gridDefinition={[{ colspan: 6 }, { colspan: 6 }, { colspan: 6 }]}>
+    <SettingTile label="Legend" gridDefinition={[{ colspan: 6 }, { colspan: 6 }, { colspan: 6 }]}>
       <div className="section-item-content">
         <div className="section-item-label">Width</div>
         <Input value={`${width}`} onChange={onWidthChange} />

--- a/packages/dashboard/src/components/sidePanel/sections/index.css
+++ b/packages/dashboard/src/components/sidePanel/sections/index.css
@@ -1,0 +1,30 @@
+.threshold-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.threshold-container > div {
+  flex-grow: 1;
+}
+
+.threshold-container > div > div {
+  display: flex;
+  align-items: center;
+}
+
+.threshold-content-color-picker {
+  width: 2.28rem;
+  height: 1.57rem;
+  border-radius: 0.57rem;
+}
+
+.threshold-container > div > div:last-child {
+  flex-grow: 1;
+  justify-content: end;
+}
+
+/* force labels of select options to have same width */
+.threshold-container > div > div:nth-child(2) button > span:first-child {
+  width: 1.5rem;
+}

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection.tsx
@@ -1,14 +1,128 @@
-import React from 'react';
-import { ExpandableSection } from '@cloudscape-design/components';
+import React, { FC, MouseEventHandler } from 'react';
+import {
+  Button,
+  Checkbox,
+  CheckboxProps,
+  ExpandableSection,
+  Input,
+  InputProps,
+  Select,
+  SelectProps,
+  SpaceBetween,
+} from '@cloudscape-design/components';
 import ExpandableSectionHeader from '../shared/expandableSectionHeader';
+import { useInput } from '../utils';
+import { COMPARISON_OPERATOR, ThresholdValue } from '@synchro-charts/core';
+import { YAnnotation } from '@synchro-charts/core/dist/types/components/charts/common/types';
+import './index.css';
+import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
+import SettingTile from '../shared/settingTile';
+
+const ComparisonOperatorOptions: { label: string; value: COMPARISON_OPERATOR }[] = [
+  { label: '>', value: COMPARISON_OPERATOR.GREATER_THAN },
+  { label: '<', value: COMPARISON_OPERATOR.LESS_THAN },
+  { label: '=', value: COMPARISON_OPERATOR.EQUAL },
+  { label: '>=', value: COMPARISON_OPERATOR.GREATER_THAN_EQUAL },
+  { label: '<=', value: COMPARISON_OPERATOR.LESS_THAN_EQUAL },
+  // TECHDEBT: support new comparator `contains`
+];
+const DEFAULT_THRESHOLD_COLOR = '#000000';
+const getRandomColor = () => `#` + Math.floor(Math.random() * 16777215).toString(16);
+
+const ThresholdComponent: FC<{ path: string; deleteSelf: () => void }> = ({ path, deleteSelf }) => {
+  const [color = DEFAULT_THRESHOLD_COLOR, updateThresholdColor] = useInput<string>(path + '.color');
+  const [comparisonOperator, updateComparator] = useInput<string>(path + '.comparisonOperator');
+  const [value = '', updateValue] = useInput<ThresholdValue>(path + '.value');
+  const [description] = useInput(path + '.description');
+  const [id = ''] = useInput(path + '.id');
+  const selectedOption =
+    ComparisonOperatorOptions.find(({ value }) => value === comparisonOperator) || ComparisonOperatorOptions[0];
+
+  const onUpdateComparator: NonCancelableEventHandler<SelectProps.ChangeDetail> = ({ detail }) => {
+    updateComparator(detail.selectedOption.value || comparisonOperator);
+  };
+
+  const onUpdateThresholdValue: NonCancelableEventHandler<InputProps.ChangeDetail> = ({ detail }) => {
+    updateValue(detail.value);
+  };
+
+  const onUpdateThresholdColor = () => {
+    // TODO: add color picker
+    updateThresholdColor(getRandomColor());
+  };
+
+  return (
+    <SettingTile label={`Threshold ${id}`} description={description}>
+      <div className="threshold-container">
+        <SpaceBetween size="xs" direction={'horizontal'}>
+          if
+          <Select
+            className="threshold-content-select-label"
+            options={ComparisonOperatorOptions}
+            selectedOption={selectedOption}
+            onChange={onUpdateComparator}
+          />
+          <Input value={`${value}`} placeholder="Threshold value" onChange={onUpdateThresholdValue} />
+          <div
+            className="threshold-content-color-picker"
+            style={{ backgroundColor: color }}
+            onClick={onUpdateThresholdColor}
+          ></div>
+          <div>
+            <Button iconName="close" variant="icon" onClick={deleteSelf} />
+          </div>
+        </SpaceBetween>
+      </div>
+    </SettingTile>
+  );
+};
 
 const ThresholdsSection = () => {
+  const [thresholdList = [], updateThresholdList] = useInput<YAnnotation[]>('annotations.y');
+  const [colorDataAcrossThresholds, updateColorDataAcrossThresholds] =
+    useInput<boolean>('annotations.thresholdOptions');
+  const [showThresholds, updateShowThresholds] = useInput<boolean>('annotations.show');
+  const onCheckShowThresholds: NonCancelableEventHandler<CheckboxProps.ChangeDetail> = ({ detail: { checked } }) => {
+    updateShowThresholds(checked);
+  };
+  const addNewThreshold: MouseEventHandler = (e) => {
+    e.stopPropagation();
+    const newThreshold: YAnnotation = {
+      color: DEFAULT_THRESHOLD_COLOR,
+      comparisonOperator: COMPARISON_OPERATOR.EQUAL,
+      value: 10,
+    };
+    updateThresholdList([...thresholdList, newThreshold]);
+  };
+  const onCheckColorData: NonCancelableEventHandler<CheckboxProps.ChangeDetail> = ({ detail: { checked } }) => {
+    updateColorDataAcrossThresholds(checked);
+  };
+
+  const deleteThresholdWithIndex = (index: number) => {
+    updateThresholdList([...thresholdList.slice(0, index), ...thresholdList.slice(index + 1)]);
+  };
+
+  const thresholdComponents = thresholdList.map((threshold, index) => {
+    return (
+      <ThresholdComponent
+        path={`annotations.y.${index}`}
+        key={threshold.id || index}
+        deleteSelf={() => deleteThresholdWithIndex(index)}
+      />
+    );
+  });
   return (
     <ExpandableSection
-      headerText={<ExpandableSectionHeader onClickButton={() => {}}>Thresholds</ExpandableSectionHeader>}
+      headerText={<ExpandableSectionHeader onClickButton={addNewThreshold}>Thresholds</ExpandableSectionHeader>}
       defaultExpanded
     >
-      --
+      {thresholdComponents}
+      <Checkbox checked={colorDataAcrossThresholds} onChange={onCheckColorData}>
+        Color Data Across Thresholds
+      </Checkbox>
+      <Checkbox checked={showThresholds} onChange={onCheckShowThresholds}>
+        Show Thresholds
+      </Checkbox>
     </ExpandableSection>
   );
 };

--- a/packages/dashboard/src/components/sidePanel/shared/expandableSectionHeader.tsx
+++ b/packages/dashboard/src/components/sidePanel/shared/expandableSectionHeader.tsx
@@ -1,10 +1,10 @@
-import React, { FC, PropsWithChildren } from 'react';
+import React, { FC, MouseEventHandler, PropsWithChildren } from 'react';
 import { Icon, IconProps } from '@cloudscape-design/components';
 import './styles.css';
 
 type ExpandableSectionHeaderProps = {
   variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
-  onClickButton?: (e: Event) => void;
+  onClickButton?: MouseEventHandler;
   iconName?: IconProps.Name;
 };
 const ExpandableSectionHeader: FC<PropsWithChildren<ExpandableSectionHeaderProps>> = (props) => {
@@ -14,7 +14,9 @@ const ExpandableSectionHeader: FC<PropsWithChildren<ExpandableSectionHeaderProps
       {children}
       {onClickButton && (
         <span className="expandable-section-header-icon">
-          <Icon name={iconName} />
+          <div onClick={onClickButton}>
+            <Icon name={iconName} />
+          </div>
         </span>
       )}
     </>

--- a/packages/dashboard/src/components/sidePanel/shared/settingTile.tsx
+++ b/packages/dashboard/src/components/sidePanel/shared/settingTile.tsx
@@ -1,11 +1,11 @@
 import React, { FC, PropsWithChildren } from 'react';
-import { FormField, Grid, GridProps } from '@cloudscape-design/components';
+import { FormField, FormFieldProps, Grid, GridProps } from '@cloudscape-design/components';
 import './styles.css';
 
-type SettingTileProps = GridProps & { title: string };
-const SettingTile: FC<PropsWithChildren<SettingTileProps>> = ({ gridDefinition, title, children }) => {
+type SettingTileProps = GridProps & FormFieldProps;
+const SettingTile: FC<PropsWithChildren<SettingTileProps>> = ({ gridDefinition, label, description, children }) => {
   return (
-    <FormField label={title}>
+    <FormField label={label} description={description}>
       <Grid gridDefinition={gridDefinition}>{children}</Grid>
     </FormField>
   );


### PR DESCRIPTION
## Overview
Add threshold editing section. 
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/11740421/207940971-56f89b3b-47e4-4c0a-9076-6a8bf360dd88.png">

## Todos
- add color picker
- support to add `XThreshold` 

## Known issues
- new added thresholds will not be displayed/updated with latest value. This is because currently we didn't dispatch action to update the real dashboard definitions. Each threshold can't get real data. This will be fixed once we add support of updating dashboard definitions.


## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
