### PR TITLE
feat(dashboard): refactor appkit widget to store asset query definitions instead of time series data queries

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.1",
   "description": "A dashboard widget for IoT App Kit components",
   "homepage": "https://github.com/awslabs/iot-app-kit#readme",
   "license": "Apache-2.0",

--- a/packages/dashboard/src/components/dragLayer/components/widget.tsx
+++ b/packages/dashboard/src/components/dragLayer/components/widget.tsx
@@ -32,7 +32,7 @@ const DragLayerWidget: React.FC<DragLayerWidgetProps> = ({ componentTag }) => {
       <DynamicWidgetComponent
         componentTag={componentTag}
         widgetId={nanoid()}
-        queries={[]}
+        assets={[]}
         viewport={viewport}
         invalidTagErrorHeader={''}
         invalidTagErrorSubheader={''}

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Box from '@cloudscape-design/components/box';
+import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 
 import last from 'lodash/last';
 import sortBy from 'lodash/sortBy';
@@ -45,7 +46,6 @@ import { onDeleteWidgetsAction } from '../../store/actions/deleteWidgets';
 import { widgetCreator } from '../../store/actions/createWidget/presets';
 
 import './index.css';
-import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 
 type Gesture = 'move' | 'resize' | 'select' | undefined;
 
@@ -325,7 +325,7 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
       x: Math.floor(x),
       y: Math.floor(y),
       z: 0,
-      queries: [],
+      assets: [],
     };
     createWidgets([widget]);
   };
@@ -354,6 +354,7 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
   };
 
   const widgetsProps: WidgetsProps = {
+    query,
     dashboardConfiguration,
     selectedWidgets,
     messageOverrides,

--- a/packages/dashboard/src/components/widgets/dynamicWidget.tsx
+++ b/packages/dashboard/src/components/widgets/dynamicWidget.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TimeQuery, TimeSeriesData, TimeSeriesDataRequest } from '@iot-app-kit/core';
+import { AssetQuery } from '@iot-app-kit/core';
 import {
   Annotations,
   LabelsConfig,
@@ -27,6 +27,7 @@ import {
 
 import './dynamicWidget.css';
 import { ComponentTag } from '../../types';
+import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 
 // eslint-disable-next-line
 const IconX = require('./iconx.svg') as string;
@@ -45,7 +46,8 @@ export const ComponentMap: { [key in ComponentTag]: any } = {
 export type DynamicWidgetProps = {
   componentTag: ComponentTag;
   widgetId: string;
-  queries: TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>[];
+  query?: SiteWiseQuery;
+  assets: AssetQuery[];
   viewport: MinimalViewPortConfig;
   movement?: MovementConfig;
   scale?: ScaleConfig;
@@ -68,7 +70,8 @@ export type DynamicWidgetProps = {
 const DynamicWidgetComponent: React.FC<DynamicWidgetProps> = ({
   componentTag,
   widgetId,
-  queries,
+  query,
+  assets,
   viewport,
   movement,
   scale,
@@ -90,10 +93,12 @@ const DynamicWidgetComponent: React.FC<DynamicWidgetProps> = ({
   const Component = ComponentMap[componentTag];
   const componentIsRegistered = typeof Component !== 'undefined';
 
+  const queries = query !== undefined ? [query.timeSeriesData({ assets })] : [];
+
   // eslint-disable-next-line
   const props: any = {
     widgetId: widgetId,
-    queries: queries,
+    queries,
     viewport: viewport,
     movement: movement,
     scale: scale,

--- a/packages/dashboard/src/components/widgets/list.tsx
+++ b/packages/dashboard/src/components/widgets/list.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import map from 'lodash/map';
 import includes from 'lodash/includes';
+import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 
 import { DashboardConfiguration, Widget } from '../../types';
 
@@ -11,13 +12,20 @@ import SelectionBox from './selectionBox';
 import { DashboardMessages } from '../../messages';
 
 export type WidgetsProps = {
+  query?: SiteWiseQuery;
   dashboardConfiguration: DashboardConfiguration;
   selectedWidgets: Widget[];
   cellSize: number;
   messageOverrides: DashboardMessages;
 };
 
-const Widgets: React.FC<WidgetsProps> = ({ dashboardConfiguration, selectedWidgets, cellSize, messageOverrides }) => {
+const Widgets: React.FC<WidgetsProps> = ({
+  dashboardConfiguration,
+  selectedWidgets,
+  cellSize,
+  messageOverrides,
+  query,
+}) => {
   const { widgets, viewport } = dashboardConfiguration;
   const isSelected = (id: string) =>
     includes(
@@ -34,6 +42,7 @@ const Widgets: React.FC<WidgetsProps> = ({ dashboardConfiguration, selectedWidge
       <SelectionBox {...{ selectedWidgets, cellSize }} />
       {widgets.map((widget) => (
         <WidgetComponent
+          query={query}
           messageOverrides={messageOverrides}
           isSelected={isSelected(widget.id)}
           key={widget.id}

--- a/packages/dashboard/src/components/widgets/widget.tsx
+++ b/packages/dashboard/src/components/widgets/widget.tsx
@@ -1,3 +1,4 @@
+import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 import React from 'react';
 import { DashboardMessages } from '../../messages';
 
@@ -8,6 +9,7 @@ import DynamicWidgetComponent from './dynamicWidget';
 import './widget.css';
 
 export type WidgetProps = {
+  query?: SiteWiseQuery;
   isSelected: boolean;
   cellSize: number;
   widget: Widget;
@@ -15,7 +17,7 @@ export type WidgetProps = {
   messageOverrides: DashboardMessages;
 };
 
-const WidgetComponent: React.FC<WidgetProps> = ({ cellSize, widget, viewport, messageOverrides }) => {
+const WidgetComponent: React.FC<WidgetProps> = ({ cellSize, widget, viewport, messageOverrides, query }) => {
   const { id, x, y, z, width, height } = widget;
 
   const { invalidTagHeader, invalidTagSubheader } = messageOverrides.widgets;
@@ -33,6 +35,7 @@ const WidgetComponent: React.FC<WidgetProps> = ({ cellSize, widget, viewport, me
       }}
     >
       <DynamicWidgetComponent
+        query={query}
         widgetId={id}
         viewport={viewport}
         invalidTagErrorHeader={invalidTagHeader}

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -1,4 +1,4 @@
-import { TimeQuery, TimeSeriesData, TimeSeriesDataRequest } from '@iot-app-kit/core';
+import { AssetQuery } from '@iot-app-kit/core';
 import { Annotations, ChartConfig, MinimalViewPortConfig } from '@synchro-charts/core';
 
 export type ComponentTag =
@@ -19,7 +19,7 @@ export type Widget = {
   z: number;
   height: number;
   width: number;
-  queries: TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>[];
+  assets: AssetQuery[];
   properties?: ChartConfig;
   annotations?: Annotations;
 };

--- a/packages/dashboard/testing/mocks.ts
+++ b/packages/dashboard/testing/mocks.ts
@@ -10,7 +10,6 @@ import {
   DEMO_TURBINE_ASSET_1_PROPERTY_2,
   DEMO_TURBINE_ASSET_1_PROPERTY_3,
   DEMO_TURBINE_ASSET_1_PROPERTY_4,
-  query,
 } from './siteWiseQueries';
 
 export const createMockWidget =
@@ -29,15 +28,11 @@ export const MOCK_KPI_WIDGET: Widget = {
   z: 1,
   width: 8,
   height: 5,
-  queries: [
-    query.timeSeriesData({
-      assets: [
-        {
-          assetId: DEMO_TURBINE_ASSET_1,
-          properties: [{ resolution: '0', propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_4 }],
-        },
-      ],
-    }),
+  assets: [
+    {
+      assetId: DEMO_TURBINE_ASSET_1,
+      properties: [{ resolution: '0', propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_4 }],
+    },
   ],
 };
 
@@ -49,15 +44,11 @@ export const MOCK_SCATTER_CHART_WIDGET: Widget = {
   z: 1,
   width: 8,
   height: 5,
-  queries: [
-    query.timeSeriesData({
-      assets: [
-        {
-          assetId: DEMO_TURBINE_ASSET_1,
-          properties: [{ resolution: '0', propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_3 }],
-        },
-      ],
-    }),
+  assets: [
+    {
+      assetId: DEMO_TURBINE_ASSET_1,
+      properties: [{ resolution: '0', propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_3 }],
+    },
   ],
 };
 
@@ -69,18 +60,11 @@ export const MOCK_LINE_CHART_WIDGET: Widget = {
   z: 1,
   width: 8,
   height: 5,
-  queries: [
-    query.timeSeriesData({
-      assets: [
-        {
-          assetId: DEMO_TURBINE_ASSET_1,
-          properties: [
-            { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_2 },
-            { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_1 },
-          ],
-        },
-      ],
-    }),
+  assets: [
+    {
+      assetId: DEMO_TURBINE_ASSET_1,
+      properties: [{ propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_2 }, { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_1 }],
+    },
   ],
 };
 
@@ -92,18 +76,11 @@ export const MOCK_STATUS_TIMELINE_WIDGET: Widget = {
   z: 1,
   width: 8,
   height: 5,
-  queries: [
-    query.timeSeriesData({
-      assets: [
-        {
-          assetId: DEMO_TURBINE_ASSET_1,
-          properties: [
-            { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_2 },
-            { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_1 },
-          ],
-        },
-      ],
-    }),
+  assets: [
+    {
+      assetId: DEMO_TURBINE_ASSET_1,
+      properties: [{ propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_2 }, { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_1 }],
+    },
   ],
 };
 


### PR DESCRIPTION
## Overview
Changing the way we define queries for a widget. Now we are going to store a list of asset queries instead of the time query returned from the timeSeriesData function. Asset queries are serializable so they work better in redux, and will also be easier to work with from the resource explorer / properties panel.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
