### PR TITLE
feat: remove unsupported data requests from subscriptions

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { DataType, Provider, StyleSettingsMap, TimeQuery, TimeSeriesData, TimeSeriesDataRequest, TimeSeriesDataRequestSettings, TreeQuery, Viewport } from "@iot-app-kit/core";
+import { DataType, ProviderWithViewport, StyleSettingsMap, TimeQuery, TimeSeriesData, TimeSeriesDataRequest, TimeSeriesDataRequestSettings, TreeQuery, Viewport } from "@iot-app-kit/core";
 import { AlarmsConfig, Annotations, Axis, LabelsConfig, LayoutConfig, LegendConfig, MessageOverrides, MinimalSizeConfig, MovementConfig, ScaleConfig, TableColumn, Trend } from "@synchro-charts/core";
 import { Item, RecursivePartial, TableItem, TableMessages, TableProps } from "@iot-app-kit/table";
 import { BranchReference, SiteWiseAssetTreeNode } from "@iot-app-kit/source-iotsitewise";
@@ -152,7 +152,7 @@ export namespace Components {
         "annotations": Annotations;
         "assignDefaultColors": boolean | undefined;
         "initialViewport": Viewport;
-        "provider": Provider<TimeSeriesData[]>;
+        "provider": ProviderWithViewport<TimeSeriesData[]>;
         "renderFunc": (data: TimeSeriesData) => void;
         "styleSettings": StyleSettingsMap | undefined;
         "supportedDataTypes": DataType[];
@@ -438,7 +438,7 @@ declare namespace LocalJSX {
         "annotations"?: Annotations;
         "assignDefaultColors"?: boolean | undefined;
         "initialViewport"?: Viewport;
-        "provider"?: Provider<TimeSeriesData[]>;
+        "provider"?: ProviderWithViewport<TimeSeriesData[]>;
         "renderFunc"?: (data: TimeSeriesData) => void;
         "styleSettings"?: StyleSettingsMap | undefined;
         "supportedDataTypes"?: DataType[];

--- a/packages/components/src/components/iot-time-series-connector/iot-time-series-connector.tsx
+++ b/packages/components/src/components/iot-time-series-connector/iot-time-series-connector.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, State, Watch } from '@stencil/core';
-import { Provider, StyleSettingsMap, TimeSeriesData, Viewport, DataType } from '@iot-app-kit/core';
+import { ProviderWithViewport, StyleSettingsMap, TimeSeriesData, Viewport, DataType } from '@iot-app-kit/core';
 import { bindStylesToDataStreams } from '../common/bindStylesToDataStreams';
 import { combineAnnotations } from '../common/combineAnnotations';
 import { Annotations } from '@synchro-charts/core';
@@ -29,7 +29,7 @@ const combineTimeSeriesData = (timeSeresDataResults: TimeSeriesData[]): TimeSeri
 export class IotTimeSeriesConnector {
   @Prop() annotations: Annotations;
 
-  @Prop() provider: Provider<TimeSeriesData[]>;
+  @Prop() provider: ProviderWithViewport<TimeSeriesData[]>;
 
   @Prop() renderFunc: (data: TimeSeriesData) => void;
 
@@ -80,6 +80,9 @@ export class IotTimeSeriesConnector {
       assignDefaultColors: this.assignDefaultColors || false,
     }).filter((stream) => {
       if (!stream.dataType || stream.streamType === 'ALARM') return true;
+      if (!this.supportedDataTypes.includes(stream.dataType)) {
+        this.provider.unsubscribeFromDataStream(stream.id);
+      }
       return this.supportedDataTypes.includes(stream.dataType);
     });
 

--- a/packages/components/src/testing/testing-ground/siteWiseQueries.ts
+++ b/packages/components/src/testing/testing-ground/siteWiseQueries.ts
@@ -1,43 +1,43 @@
 const STRING_ASSET_ID = 'fa94ab3e-d02f-4c50-88e1-f017c9069c4d';
 
-export const DEMO_ASSET = 'f1f2cfd5-6590-44af-b5d9-38992738342d';
-export const DEMO_PROPERTY = '22162993-7b4a-4eff-afdc-0bd429372578';
-export const DEMO_ALARM_PROPERTY = 'a728d514-b6e4-49c2-843f-c91cdbb7827b';
-export const DEMO_TURBINE_ASSET_1_PROPERTY_3 = '18faca18-a8e5-4e48-9153-462c54980869';
-export const DEMO_TURBINE_ASSET_1_PROPERTY_4 = '95648016-38d0-45e7-8f53-872404b9b471';
+export const DEMO_ASSET = '98c18897-661f-4ec4-bb7b-e8bfd44cee8b';
+export const DEMO_PROPERTY = '24fe8142-82c9-4feb-93b2-8aa2f346c9c4';
+export const DEMO_ALARM_PROPERTY = '66c892d3-1aca-4f16-b891-5d5d352c07a1';
+export const DEMO_TURBINE_ASSET_1_PROPERTY_3 = '54e31d3d-9865-4d3a-855a-b56cf2eb08ee';
+export const DEMO_TURBINE_ASSET_1_PROPERTY_4 = '7e84e40c-2842-4e88-af85-73fb7f72b11d';
 
-export const DEMO_TURBINE_ASSET_2 = 'e6fb533c-4919-4981-a71f-7764ccc10867';
-export const DEMO_TURBINE_ASSET_2_PROPERTY_1 = 'f63861af-251e-4d0b-a32e-4d2089d35b1c';
-export const DEMO_TURBINE_ASSET_2_PROPERTY_2 = 'ea55054e-55d0-4eda-8359-2cbc19d52a3d';
-export const DEMO_TURBINE_ASSET_2_PROPERTY_3 = '18faca18-a8e5-4e48-9153-462c54980869';
-export const DEMO_TURBINE_ASSET_2_PROPERTY_4 = '95648016-38d0-45e7-8f53-872404b9b471';
+export const DEMO_TURBINE_ASSET_2 = '98c18897-661f-4ec4-bb7b-e8bfd44cee8b';
+export const DEMO_TURBINE_ASSET_2_PROPERTY_1 = '24fe8142-82c9-4feb-93b2-8aa2f346c9c4';
+export const DEMO_TURBINE_ASSET_2_PROPERTY_2 = '3bca5bbc-faba-4f04-bc61-39c5c5f7c623';
+export const DEMO_TURBINE_ASSET_2_PROPERTY_3 = '54e31d3d-9865-4d3a-855a-b56cf2eb08ee';
+export const DEMO_TURBINE_ASSET_2_PROPERTY_4 = '7e84e40c-2842-4e88-af85-73fb7f72b11d';
 
-export const DEMO_TURBINE_ASSET_3 = 'bc86bf78-c506-460c-8602-0c534356892a';
-export const DEMO_TURBINE_ASSET_3_PROPERTY_1 = 'f63861af-251e-4d0b-a32e-4d2089d35b1c';
-export const DEMO_TURBINE_ASSET_3_PROPERTY_2 = 'ea55054e-55d0-4eda-8359-2cbc19d52a3d';
-export const DEMO_TURBINE_ASSET_3_PROPERTY_3 = '18faca18-a8e5-4e48-9153-462c54980869';
-export const DEMO_TURBINE_ASSET_3_PROPERTY_4 = '95648016-38d0-45e7-8f53-872404b9b471';
+export const DEMO_TURBINE_ASSET_3 = '98c18897-661f-4ec4-bb7b-e8bfd44cee8b';
+export const DEMO_TURBINE_ASSET_3_PROPERTY_1 = '24fe8142-82c9-4feb-93b2-8aa2f346c9c4';
+export const DEMO_TURBINE_ASSET_3_PROPERTY_2 = '3bca5bbc-faba-4f04-bc61-39c5c5f7c623';
+export const DEMO_TURBINE_ASSET_3_PROPERTY_3 = '54e31d3d-9865-4d3a-855a-b56cf2eb08ee';
+export const DEMO_TURBINE_ASSET_3_PROPERTY_4 = '7e84e40c-2842-4e88-af85-73fb7f72b11d';
 export const MISSING_PROPERTY = 'missing_property';
 
 export const ASSET_DETAILS_QUERY = {
   assetId: STRING_ASSET_ID,
 };
 
-const AGGREGATED_DATA_ASSET = STRING_ASSET_ID;
-const AGGREGATED_DATA_PROPERTY = 'b1616ab4-7526-4c0a-85e2-a137cf57d668';
-const AGGREGATED_DATA_PROPERTY_2 = '729479fb-8720-4a70-bd55-2a9f9eaaa32e4';
+// const AGGREGATED_DATA_ASSET = STRING_ASSET_ID;
+// const AGGREGATED_DATA_PROPERTY = 'b1616ab4-7526-4c0a-85e2-a137cf57d668';
+// const AGGREGATED_DATA_PROPERTY_2 = '729479fb-8720-4a70-bd55-2a9f9eaaa32e4';
 
-export const AGGREGATED_DATA_QUERY = {
-  assets: [
-    {
-      assetId: AGGREGATED_DATA_ASSET,
-      properties: [
-        { propertyId: AGGREGATED_DATA_PROPERTY, resolution: '0', refId: 'testing' },
-        { propertyId: AGGREGATED_DATA_PROPERTY_2 },
-      ],
-    },
-  ],
-};
+// export const AGGREGATED_DATA_QUERY = {
+//   assets: [
+//     {
+//       assetId: AGGREGATED_DATA_ASSET,
+//       properties: [
+//         { propertyId: AGGREGATED_DATA_PROPERTY, resolution: '0', refId: 'testing' },
+//         { propertyId: AGGREGATED_DATA_PROPERTY_2 },
+//       ],
+//     },
+//   ],
+// };
 
 // From demo turbine asset, found at https://p-rlvy2rj8.app.iotsitewise.aws/
 // These resources will eventually expire and need to be manually updated,

--- a/packages/components/src/testing/testing-ground/testing-ground.tsx
+++ b/packages/components/src/testing/testing-ground/testing-ground.tsx
@@ -87,12 +87,12 @@ const items: Item[] = [
         resolution: 0,
       },
     },
-    torque: {
-      $cellRef: {
-        id: toId({ assetId: DEMO_TURBINE_ASSET_3, propertyId: MISSING_PROPERTY }),
-        resolution: 0,
-      },
-    },
+    // torque: {
+    //   $cellRef: {
+    //     id: toId({ assetId: DEMO_TURBINE_ASSET_3, propertyId: MISSING_PROPERTY }),
+    //     resolution: 0,
+    //   },
+    // },
     // missing myLabel property
   },
   // a pure hard coded object.
@@ -117,7 +117,7 @@ const columnDefinitions: TableProps['columnDefinitions'] = [
   {
     key: 'torque',
     header: 'Torque (Newton Meter)',
-    formatter: (data) => `${Math.round((data as number) * 100) / 100} kN/M`,
+    formatter: (data: any) => `${Math.round((data as number) * 100) / 100} kN/M`,
     sortingField: 'torque',
     maxWidth: 200,
   },
@@ -196,7 +196,7 @@ export class TestingGround {
     return (
       <div>
         <div style={{ width: '800px' }}>
-          <iot-table
+          {/* <iot-table
             viewport={this.viewport}
             items={items}
             columnDefinitions={columnDefinitions}
@@ -221,22 +221,22 @@ export class TestingGround {
                       { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_3 },
                     ],
                   },
-                  {
-                    assetId: DEMO_TURBINE_ASSET_3,
-                    properties: [
-                      { propertyId: DEMO_PROPERTY },
-                      { propertyId: DEMO_ALARM_PROPERTY },
-                      { propertyId: MISSING_PROPERTY },
-                    ],
-                  },
+                  // {
+                  //   assetId: DEMO_TURBINE_ASSET_3,
+                  //   properties: [
+                  //     { propertyId: DEMO_PROPERTY },
+                  //     { propertyId: DEMO_ALARM_PROPERTY },
+                  //     { propertyId: MISSING_PROPERTY },
+                  //   ],
+                  // },
                 ],
               }),
-            ]}
-          />
+            ]} 
+          />*/}
           <br />
           <br />
           <br />
-          <div style={{ width: '400px', height: '500px' }}>
+          {/* <div style={{ width: '400px', height: '500px' }}>
             <iot-line-chart
               widgetId="kpi-1"
               viewport={{ duration: '5m' }}
@@ -347,9 +347,9 @@ export class TestingGround {
                 }),
               ]}
             />
-          </div>
-          <div style={{ width: '400px', height: '500px' }}>
-            <iot-status-grid
+          </div> */}
+          <div style={{ width: '400px', height: '1500px' }}>
+            {/* <iot-status-grid
               widgetId="status-grid"
               viewport={{ duration: '10m' }}
               queries={[
@@ -362,8 +362,8 @@ export class TestingGround {
                   ],
                 }),
               ]}
-            />
-            <div style={{ height: '200px' }}>
+            /> */}
+            {/* <div style={{ height: '200px' }}>
               <iot-status-timeline
                 widgetId="status-timeline"
                 viewport={{ duration: '10m' }}
@@ -371,14 +371,14 @@ export class TestingGround {
                   this.query.timeSeriesData({
                     assets: [
                       {
-                        assetId: DEMO_ASSET,
-                        properties: [{ propertyId: DEMO_ALARM_PROPERTY }],
+                        assetId: DEMO_TURBINE_ASSET_3,
+                        properties: [{ propertyId: DEMO_TURBINE_ASSET_3_PROPERTY_3 }],
                       },
                     ],
                   }),
                 ]}
               />
-            </div>
+            </div> */}
             <iot-line-chart
               widgetId="line-chart"
               viewport={{ duration: '10m' }}
@@ -389,10 +389,21 @@ export class TestingGround {
                       assetId: DEMO_ASSET,
                       properties: [
                         {
-                          propertyId: DEMO_PROPERTY,
+                          propertyId: DEMO_TURBINE_ASSET_3_PROPERTY_3,
                         },
                         {
-                          propertyId: DEMO_ALARM_PROPERTY,
+                          propertyId: DEMO_TURBINE_ASSET_3_PROPERTY_3,
+                        },
+                      ],
+                    },
+                    {
+                      assetId: DEMO_TURBINE_ASSET_3,
+                      properties: [
+                        {
+                          propertyId: DEMO_TURBINE_ASSET_3_PROPERTY_1,
+                        },
+                        {
+                          propertyId: DEMO_TURBINE_ASSET_3_PROPERTY_2,
                         },
                       ],
                     },

--- a/packages/core/src/common/combineProviders.ts
+++ b/packages/core/src/common/combineProviders.ts
@@ -7,6 +7,7 @@ import { MinimalViewPortConfig } from '@synchro-charts/core';
 export const combineProviders = <Result>(
   providers: ProviderWithViewport<Result[]>[]
 ): ProviderWithViewport<Result[]> => {
+
   if (providers.length === 0) {
     throw new Error(`composeSiteWiseProviders must be called with at least one provider`);
   }
@@ -20,6 +21,11 @@ export const combineProviders = <Result>(
       providers.forEach((provider) => {
         provider.updateViewport(viewport);
       });
+    },
+    unsubscribeFromDataStream(dataStreamId: string) {
+      providers.forEach((provider) => {
+        provider.unsubscribeFromDataStream(dataStreamId);
+      })
     },
     subscribe(observer: ProviderObserver<Result[]>) {
       const results: { [index: number]: Result[] } = {};

--- a/packages/core/src/common/types.ts
+++ b/packages/core/src/common/types.ts
@@ -14,6 +14,7 @@ export interface Provider<Result> {
 
 export interface ProviderWithViewport<Result> extends Provider<Result> {
   updateViewport(viewport: MinimalViewPortConfig): void;
+  unsubscribeFromDataStream: (dataStreamId: string) => void;
 }
 
 export interface Query<Result, Params = void> {

--- a/packages/core/src/data-module/TimeSeriesDataModule.ts
+++ b/packages/core/src/data-module/TimeSeriesDataModule.ts
@@ -152,9 +152,13 @@ export class TimeSeriesDataModule<Query extends DataStreamQuery> {
       this.unsubscribe(subscriptionId);
     };
 
+    const unsubscribeFromDataStream = (dataStreamId: string) => {
+      this.unsubscribeFromDataStream(dataStreamId)
+    }
+
     const update = (subscriptionUpdate: SubscriptionUpdate<Query>) => this.update(subscriptionId, subscriptionUpdate);
 
-    return { unsubscribe, update };
+    return { unsubscribe, update, unsubscribeFromDataStream };
   };
 
   private update = async (subscriptionId: string, subscriptionUpdate: SubscriptionUpdate<Query>): Promise<void> => {
@@ -204,4 +208,10 @@ export class TimeSeriesDataModule<Query extends DataStreamQuery> {
   private unsubscribe = (subscriptionId: string): void => {
     this.subscriptions.removeSubscription(subscriptionId);
   };
+
+  private unsubscribeFromDataStream = (dataStreamId: string): void => {
+    const subscriptionIds = this.subscriptions.getIdsForDataStreamId(dataStreamId)
+    console.log("### bad sub ids", subscriptionIds)
+    subscriptionIds.forEach(subId => this.unsubscribe(subId))
+  }
 }

--- a/packages/core/src/data-module/types.ts
+++ b/packages/core/src/data-module/types.ts
@@ -128,6 +128,7 @@ export type SubscriptionResponse<Query extends DataStreamQuery> = {
 
   /** Update the subscription. This will immediately evaluate if a new query must be requested */
   update: (subscriptionUpdate: SubscriptionUpdate<Query>) => Promise<void>;
+  unsubscribeFromDataStream: (dataStreamId: string) => void;
 };
 
 // SiteWise specific types - eventually remove these from here

--- a/packages/source-iotsitewise/src/time-series-data/provider.ts
+++ b/packages/source-iotsitewise/src/time-series-data/provider.ts
@@ -21,6 +21,8 @@ export class SiteWiseTimeSeriesDataProvider implements Provider<TimeSeriesData[]
 
   public input: DataModuleSubscription<SiteWiseDataStreamQuery>;
 
+  public unsubscribeFromDataStream: (dataStreamId: string) => void;
+
   constructor(session: SiteWiseComponentSession, input: DataModuleSubscription<SiteWiseDataStreamQuery>) {
     this.session = session;
     this.input = input;
@@ -29,13 +31,14 @@ export class SiteWiseTimeSeriesDataProvider implements Provider<TimeSeriesData[]
   subscribe(observer: ProviderObserver<TimeSeriesData[]>) {
     const { session } = this;
 
-    const { update, unsubscribe } = subscribeToTimeSeriesData(
-      timeSeriesDataSession(session),
+    const { update, unsubscribe, unsubscribeFromDataStream } = subscribeToTimeSeriesData(
+      timeSeriesDataSession(session), // LUCI NOTE this contains subscriptions object, which has unsubscribe function we can use
       assetSession(session),
       alarmsSession(session)
     )(this.input, (timeSeriesData: TimeSeriesData) => observer.next([timeSeriesData]));
 
     this.update = update;
+    this.unsubscribeFromDataStream = unsubscribeFromDataStream;
 
     /** @todo move into datamodule namespace when sessions are supported on time series module */
     this.session.attachDataModuleSession({

--- a/packages/source-iotsitewise/src/time-series-data/subscribeToTimeSeriesData.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/subscribeToTimeSeriesData.spec.ts
@@ -64,6 +64,7 @@ it('unsubscribes', () => {
   const unsubscribeSpy = jest.fn();
   jest.spyOn(dataModule, 'subscribeToDataStreams').mockImplementation(() => ({
     unsubscribe: unsubscribeSpy,
+    unsubscribeFromDataStream: async () => {},
     update: async () => {},
   }));
 

--- a/packages/source-iotsitewise/src/time-series-data/subscribeToTimeSeriesData.ts
+++ b/packages/source-iotsitewise/src/time-series-data/subscribeToTimeSeriesData.ts
@@ -24,7 +24,7 @@ export const subscribeToTimeSeriesData =
       callback,
     });
 
-    const { update, unsubscribe } = dataModule.subscribeToDataStreams({ queries, request }, (data) => {
+    const { update, unsubscribe, unsubscribeFromDataStream } = dataModule.subscribeToDataStreams({ queries, request }, (data) => {
       store.appendTimeSeriesData({
         dataStreams: data.dataStreams,
         viewport: data.viewport,
@@ -61,6 +61,9 @@ export const subscribeToTimeSeriesData =
     return {
       unsubscribe: () => {
         unsubscribe();
+      },
+      unsubscribeFromDataStream: (dataStreamId: string) => {
+        unsubscribeFromDataStream(dataStreamId);
       },
       update: (subscriptionUpdate: SubscriptionUpdate<SiteWiseDataStreamQuery>) => {
         update(subscriptionUpdate);

--- a/packages/source-iottwinmaker/src/time-series-data/provider.ts
+++ b/packages/source-iottwinmaker/src/time-series-data/provider.ts
@@ -23,6 +23,7 @@ export class TwinMakerTimeSeriesDataProvider implements Provider<TimeSeriesData[
   public input: DataModuleSubscription<TwinMakerDataStreamQuery>;
 
   private _unsubscribes: (() => void)[] = [];
+  private _unsubscribeFromDataStream: ((id: string) => void)[] = [];
 
   constructor(
     metadataModule: TwinMakerMetadataModule,
@@ -35,13 +36,14 @@ export class TwinMakerTimeSeriesDataProvider implements Provider<TimeSeriesData[
   }
 
   subscribe = (observer: ProviderObserver<TimeSeriesData[]>) => {
-    const { update, unsubscribe } = subscribeToTimeSeriesData(this.metadataModule, this.dataModule)(
+    const { update, unsubscribe, unsubscribeFromDataStream } = subscribeToTimeSeriesData(this.metadataModule, this.dataModule)(
       this.input,
       (timeSeriesData: TimeSeriesData) => observer.next([timeSeriesData])
     );
 
     this.update = update;
     this._unsubscribes.push(unsubscribe);
+    this._unsubscribeFromDataStream.push(unsubscribeFromDataStream);
   };
 
   updateSubscription = (subscriptionUpdate: SubscriptionUpdate<TwinMakerDataStreamQuery>) => {
@@ -51,6 +53,10 @@ export class TwinMakerTimeSeriesDataProvider implements Provider<TimeSeriesData[
   unsubscribe = () => {
     this._unsubscribes.forEach((unsub) => unsub());
   };
+
+  unsubscribeFromDataStream = (id: string) => {
+    this._unsubscribeFromDataStream.forEach((unsub) => unsub(id))
+  }
 
   updateViewport = (viewport: MinimalViewPortConfig) => {
     this.update({

--- a/packages/source-iottwinmaker/src/time-series-data/subscribeToTimeSeriesData.spec.ts
+++ b/packages/source-iottwinmaker/src/time-series-data/subscribeToTimeSeriesData.spec.ts
@@ -11,6 +11,7 @@ describe('subscribeToTimeSeriesData', () => {
   const dataModule = new TimeSeriesDataModule(createDataSource(metadataModule, tmClient));
   const mockUpdate = jest.fn();
   const mockUnsubscribe = jest.fn();
+  const mockUnsubscribeFromDataStream = jest.fn();
 
   const query = {
     workspaceId: 'ws-1',
@@ -23,7 +24,7 @@ describe('subscribeToTimeSeriesData', () => {
     jest.clearAllMocks();
     jest.spyOn(dataModule, 'subscribeToDataStreams').mockImplementation((input, cb) => {
       cb({ dataStreams: [], viewport: { duration: '5m' }, annotations: {} });
-      return { update: mockUpdate, unsubscribe: mockUnsubscribe };
+      return { update: mockUpdate, unsubscribe: mockUnsubscribe, unsubscribeFromDataStream: mockUnsubscribeFromDataStream };
     });
     jest.spyOn(metadataModule, 'fetchEntity').mockResolvedValue({ entityId: 'entity-1' } as GetEntityResponse);
   });

--- a/packages/source-iottwinmaker/src/time-series-data/subscribeToTimeSeriesData.ts
+++ b/packages/source-iottwinmaker/src/time-series-data/subscribeToTimeSeriesData.ts
@@ -34,7 +34,7 @@ export const subscribeToTimeSeriesData =
       });
     };
 
-    const { update, unsubscribe } = dataModule.subscribeToDataStreams({ queries, request }, (data: TimeSeriesData) => {
+    const { update, unsubscribe, unsubscribeFromDataStream } = dataModule.subscribeToDataStreams({ queries, request }, (data: TimeSeriesData) => {
       dataStreams = data.dataStreams;
       viewport = data.viewport;
       emit();
@@ -70,6 +70,9 @@ export const subscribeToTimeSeriesData =
     return {
       unsubscribe: () => {
         unsubscribe();
+      },
+      unsubscribeFromDataStream: (dataStreamId: string) => {
+        unsubscribeFromDataStream(dataStreamId)
       },
       update: (subscriptionUpdate: SubscriptionUpdate<TwinMakerDataStreamQuery>) => {
         update(subscriptionUpdate);


### PR DESCRIPTION
## Overview
after a data request is made, if the data is of an unsupported type then the subscription is removed

<img width="534" alt="Screen Shot 2022-12-27 at 16 20 42" src="https://user-images.githubusercontent.com/28601414/209713043-1c2455d9-7191-4e10-a9e5-0c5ddbc24ce9.png">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
