### PR TITLE
chore: upgrade video.js to remove xmldom

### DIFF
--- a/examples/react-app/package-lock.json
+++ b/examples/react-app/package-lock.json
@@ -5046,8 +5046,7 @@
         "@iot-app-kit/core": "^2.2.0",
         "@iot-app-kit/source-iottwinmaker": "^2.2.0",
         "dompurify": "2.3.4",
-        "uuid": "^8.3.2",
-        "video.js": "7.14.3"
+        "uuid": "^8.3.2"
       },
       "peerDependencies": {
         "react": "^17.0.2",
@@ -7443,52 +7442,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@videojs/http-streaming": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-2.9.2.tgz",
-      "integrity": "sha512-2ZsxJn4/nZZ6k6jIhic2l9ynGmKwprtuI5b3+M6JgqOSLvQQ/ah+heVs/0g2Ze7qJxodqR+aSY948JwJIz1gCw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.2",
-        "aes-decrypter": "3.1.2",
-        "global": "^4.4.0",
-        "m3u8-parser": "4.7.0",
-        "mpd-parser": "0.17.0",
-        "mux.js": "5.12.2",
-        "video.js": "^6 || ^7"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "video.js": "^6 || ^7"
-      }
-    },
-    "node_modules/@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
-    "node_modules/@videojs/xhr": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.5.1.tgz",
-      "integrity": "sha512-wV9nGESHseSK+S9ePEru2+OJZ1jq/ZbbzniGQ4weAmTIepuBMSYPx5zrxxQA0E786T5ykpO8ts+LayV+3/oI2w==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "global": "~4.4.0",
-        "is-function": "^1.0.1"
-      }
-    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -7785,17 +7738,6 @@
       },
       "engines": {
         "node": ">=8.9"
-      }
-    },
-    "node_modules/aes-decrypter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-3.1.2.tgz",
-      "integrity": "sha512-42nRwfQuPRj9R1zqZBdoxnaAmnIFyDi0MNyTVhjdFOd8fifXKKRfwIHIZ6AMn1or4x5WONzjwRTbTWcsIQ0O4A==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.0",
-        "global": "^4.4.0",
-        "pkcs7": "^1.0.4"
       }
     },
     "node_modules/agent-base": {
@@ -10351,11 +10293,6 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
-    "node_modules/dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
     "node_modules/domain-browser": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
@@ -12111,15 +12048,6 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
-    "node_modules/global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "node_modules/global-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -12730,11 +12658,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/individual": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
-      "integrity": "sha512-pWt8hBCqJsUWI/HtcfWod7+N9SgAqyPEaF7JQjwzjn5vGrpg6aQ5qeAFQ7dx//UH4J1O+7xqew+gCeeFt6xN/g=="
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -12938,11 +12861,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
@@ -14383,11 +14301,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/keycode": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
-      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -14611,16 +14524,6 @@
         "lz-string": "bin/bin.js"
       }
     },
-    "node_modules/m3u8-parser": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.7.0.tgz",
-      "integrity": "sha512-48l/OwRyjBm+QhNNigEEcRcgbRvnUjL7rxs597HmW9QSNbyNvt+RcZ9T/d9vxi9A9z7EZrB1POtZYhdRlwYQkQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.0",
-        "global": "^4.4.0"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -14799,14 +14702,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
-      "dependencies": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -14936,20 +14831,6 @@
         "node": ">=12.13.0"
       }
     },
-    "node_modules/mpd-parser": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.17.0.tgz",
-      "integrity": "sha512-oKS5G0jCcHHJ3sHYlcLeM9Xcbuixl08eAx7QW0Th7ChlZiI0YvLtGaHE/L0aKUBJFNvtkeksIr8XgJgSBBsS4g==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.2",
-        "global": "^4.4.0",
-        "xmldom": "^0.5.0"
-      },
-      "bin": {
-        "mpd-to-m3u8-json": "bin/parse.js"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -14971,21 +14852,6 @@
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/mutationobserver-shim/-/mutationobserver-shim-0.3.7.tgz",
       "integrity": "sha512-oRIDTyZQU96nAiz2AQyngwx1e89iApl2hN5AOYwyxLUB47UYsU3Wv9lJWqH5y/QdiYkc5HQLi23ZNB3fELdHcQ=="
-    },
-    "node_modules/mux.js": {
-      "version": "5.12.2",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.12.2.tgz",
-      "integrity": "sha512-9OY1lrFIo7FxMeIC6aLUftiNv97AztufDfi30N7qDll1Pcy7bCxlHztyHp1Ce0KQwy2XqchGeENPS4v1NJngHQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2"
-      },
-      "bin": {
-        "muxjs-transmux": "bin/transmux.js"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -15709,17 +15575,6 @@
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pkcs7": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz",
-      "integrity": "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5"
-      },
-      "bin": {
-        "pkcs7": "bin/cli.js"
       }
     },
     "node_modules/pkg-dir": {
@@ -17061,6 +16916,7 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -18190,14 +18046,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rust-result": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rust-result/-/rust-result-1.0.0.tgz",
-      "integrity": "sha512-6cJzSBU+J/RJCF063onnQf0cDUOHs9uZI1oroSGnHOph+CQTIJ5Pp2hK5kEQq1+7yE/EEWfulSNXAQ2jikPthA==",
-      "dependencies": {
-        "individual": "^2.0.0"
-      }
-    },
     "node_modules/rxjs": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
@@ -18210,14 +18058,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/safe-json-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
-      "integrity": "sha512-RjZPPHugjK0TOzFrLZ8inw44s9bKox99/0AZW9o/BEQVrJfhI+fIHMErnPyRa89/yRXUUr93q+tiN6zhoVV4wQ==",
-      "dependencies": {
-        "rust-result": "^1.0.0"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -19886,11 +19726,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/url-toolkit": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
-      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg=="
-    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -20038,39 +19873,6 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/video.js": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.14.3.tgz",
-      "integrity": "sha512-6avCdSIfn5ss5NOgoQfY/xEfPNcz9DXSw+ZN80NwPguCdRd4VL4y40b/d7osYJwyCdF+YkvhqAW7dw4s0vBigg==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "2.9.2",
-        "@videojs/vhs-utils": "^3.0.2",
-        "@videojs/xhr": "2.5.1",
-        "aes-decrypter": "3.1.2",
-        "global": "^4.4.0",
-        "keycode": "^2.2.0",
-        "m3u8-parser": "4.7.0",
-        "mpd-parser": "0.17.0",
-        "mux.js": "5.12.2",
-        "safe-json-parse": "4.0.0",
-        "videojs-font": "3.2.0",
-        "videojs-vtt.js": "^0.15.3"
-      }
-    },
-    "node_modules/videojs-font": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.2.0.tgz",
-      "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA=="
-    },
-    "node_modules/videojs-vtt.js": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.4.tgz",
-      "integrity": "sha512-r6IhM325fcLb1D6pgsMkTQT1PpFdUdYZa1iqk7wJEu+QlibBwATPfPc9Bg8Jiym0GE5yP1AG2rMLu+QMVWkYtA==",
-      "dependencies": {
-        "global": "^4.3.1"
       }
     },
     "node_modules/vm-browserify": {
@@ -20932,14 +20734,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-    },
-    "node_modules/xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -23107,7 +22901,8 @@
     "@awsui/collection-hooks": {
       "version": "1.0.39",
       "resolved": "https://registry.npmjs.org/@awsui/collection-hooks/-/collection-hooks-1.0.39.tgz",
-      "integrity": "sha512-VIOh91oWzONtBNTM8tIveJ28r0RmUpe+yRrSQHn7rVrWQpeRbpF0FpipWQQ3D49bVbqI+S/tZGFwA2IfGIbGqA=="
+      "integrity": "sha512-VIOh91oWzONtBNTM8tIveJ28r0RmUpe+yRrSQHn7rVrWQpeRbpF0FpipWQQ3D49bVbqI+S/tZGFwA2IfGIbGqA==",
+      "requires": {}
     },
     "@awsui/components-react": {
       "version": "3.0.613",
@@ -24569,12 +24364,14 @@
     "@csstools/postcss-unset-value": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.2.tgz",
-      "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g=="
+      "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==",
+      "requires": {}
     },
     "@csstools/selector-specificity": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
-      "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg=="
+      "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
+      "requires": {}
     },
     "@emotion/hash": {
       "version": "0.8.0",
@@ -24754,7 +24551,8 @@
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+      "requires": {}
     },
     "@iot-app-kit/components": {
       "version": "2.4.2",
@@ -24820,8 +24618,7 @@
         "@iot-app-kit/core": "^2.2.0",
         "@iot-app-kit/source-iottwinmaker": "^2.2.0",
         "dompurify": "2.3.4",
-        "uuid": "^8.3.2",
-        "video.js": "7.14.3"
+        "uuid": "^8.3.2"
       }
     },
     "@iot-app-kit/related-table": {
@@ -25433,7 +25230,8 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+      "requires": {}
     },
     "@material-ui/utils": {
       "version": "4.11.3",
@@ -25553,7 +25351,8 @@
         "three-mesh-bvh": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.4.3.tgz",
-          "integrity": "sha512-4CO1dU73hQRwGgeOL05CnsKkIa0LgNCH6S8t66D9nvSiyK9wDzrSqzGVd8e+eUytFoliYHc/lwoW0uamrmXo5w=="
+          "integrity": "sha512-4CO1dU73hQRwGgeOL05CnsKkIa0LgNCH6S8t66D9nvSiyK9wDzrSqzGVd8e+eUytFoliYHc/lwoW0uamrmXo5w==",
+          "requires": {}
         }
       }
     },
@@ -25586,7 +25385,8 @@
     "@react-three/test-renderer": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@react-three/test-renderer/-/test-renderer-7.0.6.tgz",
-      "integrity": "sha512-MDROOyPbei+qE+LkLZJitJHas4RFr9m1vjmR8Bwa7qSbPbwZQW+4U1G77drOxuhU/PnEOxTsqE7phukbPrHLuQ=="
+      "integrity": "sha512-MDROOyPbei+qE+LkLZJitJHas4RFr9m1vjmR8Bwa7qSbPbwZQW+4U1G77drOxuhU/PnEOxTsqE7phukbPrHLuQ==",
+      "requires": {}
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -25679,7 +25479,8 @@
     "@stencil/redux": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@stencil/redux/-/redux-0.1.2.tgz",
-      "integrity": "sha512-HLASGyE7BJX/hJUatXBKjeHxH8EGh9M5U6FpCUiIkxWuBXdEVL2oQOwOgm7QPe3yRgN6i8dEKVXD5Vv4ZnNZ1Q=="
+      "integrity": "sha512-HLASGyE7BJX/hJUatXBKjeHxH8EGh9M5U6FpCUiIkxWuBXdEVL2oQOwOgm7QPe3yRgN6i8dEKVXD5Vv4ZnNZ1Q==",
+      "requires": {}
     },
     "@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -26656,41 +26457,6 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
-    "@videojs/http-streaming": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-2.9.2.tgz",
-      "integrity": "sha512-2ZsxJn4/nZZ6k6jIhic2l9ynGmKwprtuI5b3+M6JgqOSLvQQ/ah+heVs/0g2Ze7qJxodqR+aSY948JwJIz1gCw==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.2",
-        "aes-decrypter": "3.1.2",
-        "global": "^4.4.0",
-        "m3u8-parser": "4.7.0",
-        "mpd-parser": "0.17.0",
-        "mux.js": "5.12.2",
-        "video.js": "^6 || ^7"
-      }
-    },
-    "@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
-      }
-    },
-    "@videojs/xhr": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.5.1.tgz",
-      "integrity": "sha512-wV9nGESHseSK+S9ePEru2+OJZ1jq/ZbbzniGQ4weAmTIepuBMSYPx5zrxxQA0E786T5ykpO8ts+LayV+3/oI2w==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "global": "~4.4.0",
-        "is-function": "^1.0.1"
-      }
-    },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -26908,12 +26674,14 @@
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -26949,17 +26717,6 @@
       "requires": {
         "loader-utils": "^2.0.0",
         "regex-parser": "^2.2.11"
-      }
-    },
-    "aes-decrypter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-3.1.2.tgz",
-      "integrity": "sha512-42nRwfQuPRj9R1zqZBdoxnaAmnIFyDi0MNyTVhjdFOd8fifXKKRfwIHIZ6AMn1or4x5WONzjwRTbTWcsIQ0O4A==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.0",
-        "global": "^4.4.0",
-        "pkcs7": "^1.0.4"
       }
     },
     "agent-base": {
@@ -27010,7 +26767,8 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -27299,7 +27057,8 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q=="
+      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
+      "requires": {}
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.3",
@@ -28224,7 +27983,8 @@
     "css-declaration-sorter": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
-      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w=="
+      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+      "requires": {}
     },
     "css-has-pseudo": {
       "version": "3.0.4",
@@ -28307,7 +28067,8 @@
     "css-prefers-color-scheme": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA=="
+      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
+      "requires": {}
     },
     "css-select": {
       "version": "4.3.0",
@@ -28439,7 +28200,8 @@
     "cssnano-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -28924,11 +28686,6 @@
         "domhandler": "^4.2.0",
         "entities": "^2.0.0"
       }
-    },
-    "dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "domain-browser": {
       "version": "4.22.0",
@@ -29505,7 +29262,8 @@
     "eslint-plugin-react-hooks": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g=="
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "5.6.4",
@@ -30212,15 +29970,6 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
-    "global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "global-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -30584,7 +30333,8 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "requires": {}
     },
     "idb": {
       "version": "7.0.2",
@@ -30660,11 +30410,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
-    },
-    "individual": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
-      "integrity": "sha512-pWt8hBCqJsUWI/HtcfWod7+N9SgAqyPEaF7JQjwzjn5vGrpg6aQ5qeAFQ7dx//UH4J1O+7xqew+gCeeFt6xN/g=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -30809,11 +30554,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    },
-    "is-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -31306,7 +31046,8 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -31905,11 +31646,6 @@
         "object.assign": "^4.1.3"
       }
     },
-    "keycode": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
-      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
-    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -32094,16 +31830,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
       "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ=="
     },
-    "m3u8-parser": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.7.0.tgz",
-      "integrity": "sha512-48l/OwRyjBm+QhNNigEEcRcgbRvnUjL7rxs597HmW9QSNbyNvt+RcZ9T/d9vxi9A9z7EZrB1POtZYhdRlwYQkQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.0",
-        "global": "^4.4.0"
-      }
-    },
     "magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -32244,14 +31970,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -32347,17 +32065,6 @@
         "@babel/runtime": "^7.8.0"
       }
     },
-    "mpd-parser": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.17.0.tgz",
-      "integrity": "sha512-oKS5G0jCcHHJ3sHYlcLeM9Xcbuixl08eAx7QW0Th7ChlZiI0YvLtGaHE/L0aKUBJFNvtkeksIr8XgJgSBBsS4g==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.2",
-        "global": "^4.4.0",
-        "xmldom": "^0.5.0"
-      }
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -32376,14 +32083,6 @@
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/mutationobserver-shim/-/mutationobserver-shim-0.3.7.tgz",
       "integrity": "sha512-oRIDTyZQU96nAiz2AQyngwx1e89iApl2hN5AOYwyxLUB47UYsU3Wv9lJWqH5y/QdiYkc5HQLi23ZNB3fELdHcQ=="
-    },
-    "mux.js": {
-      "version": "5.12.2",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.12.2.tgz",
-      "integrity": "sha512-9OY1lrFIo7FxMeIC6aLUftiNv97AztufDfi30N7qDll1Pcy7bCxlHztyHp1Ce0KQwy2XqchGeENPS4v1NJngHQ==",
-      "requires": {
-        "@babel/runtime": "^7.11.2"
-      }
     },
     "nanoid": {
       "version": "3.3.4",
@@ -32911,14 +32610,6 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ=="
     },
-    "pkcs7": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz",
-      "integrity": "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==",
-      "requires": {
-        "@babel/runtime": "^7.5.5"
-      }
-    },
     "pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -33036,7 +32727,8 @@
     "postcss-browser-comments": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
-      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg=="
+      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
+      "requires": {}
     },
     "postcss-calc": {
       "version": "8.2.4",
@@ -33134,22 +32826,26 @@
     "postcss-discard-comments": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ=="
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+      "requires": {}
     },
     "postcss-double-position-gradients": {
       "version": "3.1.2",
@@ -33171,7 +32867,8 @@
     "postcss-flexbugs-fixes": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
+      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
+      "requires": {}
     },
     "postcss-focus-visible": {
       "version": "6.0.4",
@@ -33192,12 +32889,14 @@
     "postcss-font-variant": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
+      "requires": {}
     },
     "postcss-gap-properties": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.5.tgz",
-      "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg=="
+      "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==",
+      "requires": {}
     },
     "postcss-image-set-function": {
       "version": "4.0.7",
@@ -33220,7 +32919,8 @@
     "postcss-initial": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
+      "requires": {}
     },
     "postcss-js": {
       "version": "4.0.0",
@@ -33252,12 +32952,14 @@
     "postcss-logical": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g=="
+      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
+      "requires": {}
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ=="
+      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
+      "requires": {}
     },
     "postcss-merge-longhand": {
       "version": "5.1.6",
@@ -33318,7 +33020,8 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -33376,7 +33079,8 @@
     "postcss-normalize-charset": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -33469,7 +33173,8 @@
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
+      "requires": {}
     },
     "postcss-place": {
       "version": "7.0.5",
@@ -33563,7 +33268,8 @@
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
+      "requires": {}
     },
     "postcss-selector-not": {
       "version": "6.0.1",
@@ -33647,7 +33353,8 @@
     "postprocessing": {
       "version": "6.23.2",
       "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.23.2.tgz",
-      "integrity": "sha512-DnkWnZzVPXMl3/fhqWDDRZ2BnD08OCxqNpOx2xaj04sg5ShjMj4Gq1pNfUJZqzoUzr3IVJJD7UZP9DWGFp6jyw=="
+      "integrity": "sha512-DnkWnZzVPXMl3/fhqWDDRZ2BnD08OCxqNpOx2xaj04sg5ShjMj4Gq1pNfUJZqzoUzr3IVJJD7UZP9DWGFp6jyw==",
+      "requires": {}
     },
     "potpack": {
       "version": "1.0.2",
@@ -33693,7 +33400,8 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -34531,14 +34239,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "rust-result": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rust-result/-/rust-result-1.0.0.tgz",
-      "integrity": "sha512-6cJzSBU+J/RJCF063onnQf0cDUOHs9uZI1oroSGnHOph+CQTIJ5Pp2hK5kEQq1+7yE/EEWfulSNXAQ2jikPthA==",
-      "requires": {
-        "individual": "^2.0.0"
-      }
-    },
     "rxjs": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
@@ -34551,14 +34251,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "safe-json-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
-      "integrity": "sha512-RjZPPHugjK0TOzFrLZ8inw44s9bKox99/0AZW9o/BEQVrJfhI+fIHMErnPyRa89/yRXUUr93q+tiN6zhoVV4wQ==",
-      "requires": {
-        "rust-result": "^1.0.0"
-      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -35131,7 +34823,8 @@
     "style-loader": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ=="
+      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+      "requires": {}
     },
     "styled-components": {
       "version": "5.3.6",
@@ -35456,7 +35149,8 @@
     "three-mesh-bvh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.2.tgz",
-      "integrity": "sha512-DAKWujkp8xpSBqGiIsZbZC1utxAbYBg0SShQk9LdOG/xWWl1/OLK76eXDGfov47trl3L7PUTHi0hhRvZdVro1Q=="
+      "integrity": "sha512-DAKWujkp8xpSBqGiIsZbZC1utxAbYBg0SShQk9LdOG/xWWl1/OLK76eXDGfov47trl3L7PUTHi0hhRvZdVro1Q==",
+      "requires": {}
     },
     "three-stdlib": {
       "version": "2.4.0",
@@ -35595,7 +35289,8 @@
     "troika-three-utils": {
       "version": "0.42.0",
       "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.42.0.tgz",
-      "integrity": "sha512-IimGItKTN4PxeXEL4uWSF20kHZU1J1jXHD0gYQflX3QOFSven7HBG7nEqHcWavbZkB3AeRfR6NB3294GIt3uGA=="
+      "integrity": "sha512-IimGItKTN4PxeXEL4uWSF20kHZU1J1jXHD0gYQflX3QOFSven7HBG7nEqHcWavbZkB3AeRfR6NB3294GIt3uGA==",
+      "requires": {}
     },
     "troika-worker-utils": {
       "version": "0.42.0",
@@ -35817,11 +35512,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "url-toolkit": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
-      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg=="
-    },
     "use-asset": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/use-asset/-/use-asset-1.0.4.tgz",
@@ -35916,39 +35606,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-    },
-    "video.js": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.14.3.tgz",
-      "integrity": "sha512-6avCdSIfn5ss5NOgoQfY/xEfPNcz9DXSw+ZN80NwPguCdRd4VL4y40b/d7osYJwyCdF+YkvhqAW7dw4s0vBigg==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "2.9.2",
-        "@videojs/vhs-utils": "^3.0.2",
-        "@videojs/xhr": "2.5.1",
-        "aes-decrypter": "3.1.2",
-        "global": "^4.4.0",
-        "keycode": "^2.2.0",
-        "m3u8-parser": "4.7.0",
-        "mpd-parser": "0.17.0",
-        "mux.js": "5.12.2",
-        "safe-json-parse": "4.0.0",
-        "videojs-font": "3.2.0",
-        "videojs-vtt.js": "^0.15.3"
-      }
-    },
-    "videojs-font": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.2.0.tgz",
-      "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA=="
-    },
-    "videojs-vtt.js": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.4.tgz",
-      "integrity": "sha512-r6IhM325fcLb1D6pgsMkTQT1PpFdUdYZa1iqk7wJEu+QlibBwATPfPc9Bg8Jiym0GE5yP1AG2rMLu+QMVWkYtA==",
-      "requires": {
-        "global": "^4.3.1"
-      }
     },
     "vm-browserify": {
       "version": "1.1.2",
@@ -36187,7 +35844,8 @@
         "ws": {
           "version": "8.8.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-          "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA=="
+          "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+          "requires": {}
         }
       }
     },
@@ -36617,7 +36275,8 @@
     "ws": {
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -36628,11 +36287,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-    },
-    "xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
     },
     "xtend": {
       "version": "4.0.2",
@@ -36686,12 +36340,14 @@
     "zundo": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/zundo/-/zundo-1.1.0.tgz",
-      "integrity": "sha512-H5pGENa5F0v5X2VVEco8cDucKXawJGIwr/X43HZkzpjP1PxdQjsA8dFXUJMPWsTNE2buGA8r6iJx4kLD8KVsMQ=="
+      "integrity": "sha512-H5pGENa5F0v5X2VVEco8cDucKXawJGIwr/X43HZkzpjP1PxdQjsA8dFXUJMPWsTNE2buGA8r6iJx4kLD8KVsMQ==",
+      "requires": {}
     },
     "zustand": {
       "version": "3.5.14",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.5.14.tgz",
-      "integrity": "sha512-Y5o/024/eBluNGLt1MYp9KTqCzbw/Cztvx8MVjtmMWHQPrgnKfOe0Wqu7j7JSl+KxfJMA0TxNz4RKSqDx0fbHQ=="
+      "integrity": "sha512-Y5o/024/eBluNGLt1MYp9KTqCzbw/Cztvx8MVjtmMWHQPrgnKfOe0Wqu7j7JSl+KxfJMA0TxNz4RKSqDx0fbHQ==",
+      "requires": {}
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1552,7 +1552,6 @@
     },
     "node_modules/@aws-sdk/credential-providers": {
       "version": "3.163.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.163.0.tgz",
       "integrity": "sha512-xOV8btU1zeeqSGapV4irUPkSgTwbDpZ8QT8MZDPZAvbCW8slYwci4TO2W1iOdbTaEH32zhXXrYqyqjU3bG476g==",
       "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.163.0",
@@ -12271,89 +12270,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@videojs/http-streaming": {
-      "version": "2.9.2",
-      "integrity": "sha512-2ZsxJn4/nZZ6k6jIhic2l9ynGmKwprtuI5b3+M6JgqOSLvQQ/ah+heVs/0g2Ze7qJxodqR+aSY948JwJIz1gCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.2",
-        "aes-decrypter": "3.1.2",
-        "global": "^4.4.0",
-        "m3u8-parser": "4.7.0",
-        "mpd-parser": "0.17.0",
-        "mux.js": "5.12.2",
-        "video.js": "^6 || ^7"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "video.js": "^6 || ^7"
-      }
-    },
-    "node_modules/@videojs/http-streaming/node_modules/@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
-    "node_modules/@videojs/http-streaming/node_modules/m3u8-parser": {
-      "version": "4.7.0",
-      "integrity": "sha512-48l/OwRyjBm+QhNNigEEcRcgbRvnUjL7rxs597HmW9QSNbyNvt+RcZ9T/d9vxi9A9z7EZrB1POtZYhdRlwYQkQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.0",
-        "global": "^4.4.0"
-      }
-    },
-    "node_modules/@videojs/http-streaming/node_modules/mpd-parser": {
-      "version": "0.17.0",
-      "integrity": "sha512-oKS5G0jCcHHJ3sHYlcLeM9Xcbuixl08eAx7QW0Th7ChlZiI0YvLtGaHE/L0aKUBJFNvtkeksIr8XgJgSBBsS4g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.2",
-        "global": "^4.4.0",
-        "xmldom": "^0.5.0"
-      },
-      "bin": {
-        "mpd-to-m3u8-json": "bin/parse.js"
-      }
-    },
-    "node_modules/@videojs/http-streaming/node_modules/mux.js": {
-      "version": "5.12.2",
-      "integrity": "sha512-9OY1lrFIo7FxMeIC6aLUftiNv97AztufDfi30N7qDll1Pcy7bCxlHztyHp1Ce0KQwy2XqchGeENPS4v1NJngHQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2"
-      },
-      "bin": {
-        "muxjs-transmux": "bin/transmux.js"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
-    "node_modules/@videojs/http-streaming/node_modules/xmldom": {
-      "version": "0.5.0",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@videojs/vhs-utils": {
       "version": "2.3.0",
       "integrity": "sha512-ThSmm91S7tuIJ757ON50K4y7S/bvKN4+B0tu303gCOxaG57PoP1UvPfMQZ90XGhxwNgngexVojOqbBHhTvXVHQ==",
@@ -12367,16 +12283,6 @@
       "engines": {
         "node": ">=8",
         "npm": ">=5"
-      }
-    },
-    "node_modules/@videojs/xhr": {
-      "version": "2.5.1",
-      "integrity": "sha512-wV9nGESHseSK+S9ePEru2+OJZ1jq/ZbbzniGQ4weAmTIepuBMSYPx5zrxxQA0E786T5ykpO8ts+LayV+3/oI2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "global": "~4.4.0",
-        "is-function": "^1.0.1"
       }
     },
     "node_modules/@vue/cli-overlay": {
@@ -14051,6 +13957,14 @@
       "version": "1.0.0",
       "integrity": "sha512-Ppxde+G1/QZbU8ShCQg+eq5VtlcL/FPkerF1dkDOLlIml0LJD1tFqnCZYR0SrHzYleIQ2siRnOx7xbFLaCpExQ=="
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.9",
+      "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
@@ -14151,31 +14065,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aes-decrypter": {
-      "version": "3.1.2",
-      "integrity": "sha512-42nRwfQuPRj9R1zqZBdoxnaAmnIFyDi0MNyTVhjdFOd8fifXKKRfwIHIZ6AMn1or4x5WONzjwRTbTWcsIQ0O4A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.0",
-        "global": "^4.4.0",
-        "pkcs7": "^1.0.4"
-      }
-    },
-    "node_modules/aes-decrypter/node_modules/@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
       }
     },
     "node_modules/agent-base": {
@@ -20543,7 +20432,6 @@
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
       "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true,
       "engines": {
@@ -33864,17 +33752,6 @@
         "lz-string": "bin/bin.js"
       }
     },
-    "node_modules/m3u8-parser": {
-      "version": "4.5.0",
-      "integrity": "sha512-RGm/1WVCX3o1bSWbJGmJUu4zTbtJy8lImtgHM4CESFvJRXYztr1j6SW/q9/ghYOrUjgH7radsIar+z1Leln0sA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@videojs/vhs-utils": "^2.2.1",
-        "global": "^4.3.2"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
@@ -34974,18 +34851,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "node_modules/mpd-parser": {
-      "version": "0.15.0",
-      "integrity": "sha512-GfspJVaEnVbWKZQASvh9nsJkvxWh3M/c5Kb2RPnN5ZXPZ7jWWfarWkNKTEuqvoaAKIT8IB/r6PFTWA1GY4fzGg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@videojs/vhs-utils": "^2.2.1",
-        "global": "^4.3.2",
-        "xmldom": "^0.1.27"
       }
     },
     "node_modules/mri": {
@@ -48135,87 +48000,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/video.js": {
-      "version": "7.14.3",
-      "integrity": "sha512-6avCdSIfn5ss5NOgoQfY/xEfPNcz9DXSw+ZN80NwPguCdRd4VL4y40b/d7osYJwyCdF+YkvhqAW7dw4s0vBigg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "2.9.2",
-        "@videojs/vhs-utils": "^3.0.2",
-        "@videojs/xhr": "2.5.1",
-        "aes-decrypter": "3.1.2",
-        "global": "^4.4.0",
-        "keycode": "^2.2.0",
-        "m3u8-parser": "4.7.0",
-        "mpd-parser": "0.17.0",
-        "mux.js": "5.12.2",
-        "safe-json-parse": "4.0.0",
-        "videojs-font": "3.2.0",
-        "videojs-vtt.js": "^0.15.3"
-      }
-    },
-    "node_modules/video.js/node_modules/@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
-    "node_modules/video.js/node_modules/m3u8-parser": {
-      "version": "4.7.0",
-      "integrity": "sha512-48l/OwRyjBm+QhNNigEEcRcgbRvnUjL7rxs597HmW9QSNbyNvt+RcZ9T/d9vxi9A9z7EZrB1POtZYhdRlwYQkQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.0",
-        "global": "^4.4.0"
-      }
-    },
-    "node_modules/video.js/node_modules/mpd-parser": {
-      "version": "0.17.0",
-      "integrity": "sha512-oKS5G0jCcHHJ3sHYlcLeM9Xcbuixl08eAx7QW0Th7ChlZiI0YvLtGaHE/L0aKUBJFNvtkeksIr8XgJgSBBsS4g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.2",
-        "global": "^4.4.0",
-        "xmldom": "^0.5.0"
-      },
-      "bin": {
-        "mpd-to-m3u8-json": "bin/parse.js"
-      }
-    },
-    "node_modules/video.js/node_modules/mux.js": {
-      "version": "5.12.2",
-      "integrity": "sha512-9OY1lrFIo7FxMeIC6aLUftiNv97AztufDfi30N7qDll1Pcy7bCxlHztyHp1Ce0KQwy2XqchGeENPS4v1NJngHQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2"
-      },
-      "bin": {
-        "muxjs-transmux": "bin/transmux.js"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
-    "node_modules/video.js/node_modules/xmldom": {
-      "version": "0.5.0",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/videojs-font": {
       "version": "3.2.0",
       "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA==",
@@ -50472,15 +50256,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/xmldom": {
-      "version": "0.1.31",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-      "dev": true,
-      "license": "(LGPL-2.0 or MIT)",
-      "engines": {
-        "node": ">=0.1"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
@@ -50827,7 +50602,6 @@
     },
     "packages/components/node_modules/@synchro-charts/core": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@synchro-charts/core/-/core-7.1.0.tgz",
       "integrity": "sha512-cT3RlsS2cIkRtda5BzlsqMXQb6oSfFfzJTHTlCGeVrJShgtSwTMGKLtiDrwa2JMU4W5+GbgJqBK2yyuGgcplDQ==",
       "dependencies": {
         "@stencil/redux": "^0.1.1",
@@ -50862,7 +50636,6 @@
     },
     "packages/components/node_modules/@synchro-charts/core/node_modules/uuid": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
@@ -50871,7 +50644,6 @@
     },
     "packages/components/node_modules/@types/d3": {
       "version": "5.16.4",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
       "integrity": "sha512-2u0O9iP1MubFiQ+AhR1id4Egs+07BLtvRATG6IL2Gs9+KzdrfaxCKNq5hxEyw1kxwsqB/lCgr108XuHcKtb/5w==",
       "dependencies": {
         "@types/d3-array": "^1",
@@ -50909,12 +50681,10 @@
     },
     "packages/components/node_modules/@types/d3-array": {
       "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.9.tgz",
       "integrity": "sha512-E/7RgPr2ylT5dWG0CswMi9NpFcjIEDqLcUSBgNHe/EMahfqYaTx4zhcggG3khqoEB/leY4Vl6nTSbwLUPjXceA=="
     },
     "packages/components/node_modules/@types/d3-axis": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.16.tgz",
       "integrity": "sha512-p7085weOmo4W+DzlRRVC/7OI/jugaKbVa6WMQGCQscaMylcbuaVEGk7abJLNyGVFLeCBNrHTdDiqRGnzvL0nXQ==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -50922,7 +50692,6 @@
     },
     "packages/components/node_modules/@types/d3-brush": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.1.5.tgz",
       "integrity": "sha512-4zGkBafJf5zCsBtLtvDj/pNMo5X9+Ii/1hUz0GvQ+wEwelUBm2AbIDAzJnp2hLDFF307o0fhxmmocHclhXC+tw==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -50930,17 +50699,14 @@
     },
     "packages/components/node_modules/@types/d3-chord": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.11.tgz",
       "integrity": "sha512-0DdfJ//bxyW3G9Nefwq/LDgazSKNN8NU0lBT3Cza6uVuInC2awMNsAcv1oKyRFLn9z7kXClH5XjwpveZjuz2eg=="
     },
     "packages/components/node_modules/@types/d3-color": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.2.tgz",
       "integrity": "sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA=="
     },
     "packages/components/node_modules/@types/d3-contour": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-1.3.3.tgz",
       "integrity": "sha512-LxwmGIfVJIc1cKs7ZFRQ1FbtXpfH7QTXYRdMIJsFP71uCMdF6jJ0XZakYDX6Hn4yZkLf+7V8FgD34yCcok+5Ww==",
       "dependencies": {
         "@types/d3-array": "^1",
@@ -50949,12 +50715,10 @@
     },
     "packages/components/node_modules/@types/d3-dispatch": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.9.tgz",
       "integrity": "sha512-zJ44YgjqALmyps+II7b1mZLhrtfV/FOxw9owT87mrweGWcg+WK5oiJX2M3SYJ0XUAExBduarysfgbR11YxzojQ=="
     },
     "packages/components/node_modules/@types/d3-drag": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.5.tgz",
       "integrity": "sha512-7NeTnfolst1Js3Vs7myctBkmJWu6DMI3k597AaHUX98saHjHWJ6vouT83UrpE+xfbSceHV+8A0JgxuwgqgmqWw==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -50962,17 +50726,14 @@
     },
     "packages/components/node_modules/@types/d3-dsv": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.1.tgz",
       "integrity": "sha512-LLmJmjiqp/fTNEdij5bIwUJ6P6TVNk5hKM9/uk5RPO2YNgEu9XvKO0dJ7Iqd3psEdmZN1m7gB1bOsjr4HmO2BA=="
     },
     "packages/components/node_modules/@types/d3-ease": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.11.tgz",
       "integrity": "sha512-wUigPL0kleGZ9u3RhzBP07lxxkMcUjL5IODP42mN/05UNL+JJCDnpEPpFbJiPvLcTeRKGIRpBBJyP/1BNwYsVA=="
     },
     "packages/components/node_modules/@types/d3-fetch": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.2.2.tgz",
       "integrity": "sha512-rtFs92GugtV/NpiJQd0WsmGLcg52tIL0uF0bKbbJg231pR9JEb6HT4AUwrtuLq3lOeKdLBhsjV14qb0pMmd0Aw==",
       "dependencies": {
         "@types/d3-dsv": "^1"
@@ -50980,17 +50741,14 @@
     },
     "packages/components/node_modules/@types/d3-force": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.4.tgz",
       "integrity": "sha512-fkorLTKvt6AQbFBQwn4aq7h9rJ4c7ZVcPMGB8X6eFFveAyMZcv7t7m6wgF4Eg93rkPgPORU7sAho1QSHNcZu6w=="
     },
     "packages/components/node_modules/@types/d3-format": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
       "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
     },
     "packages/components/node_modules/@types/d3-geo": {
       "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.12.3.tgz",
       "integrity": "sha512-yZbPb7/5DyL/pXkeOmZ7L5ySpuGr4H48t1cuALjnJy5sXQqmSSAYBiwa6Ya/XpWKX2rJqGDDubmh3nOaopOpeA==",
       "dependencies": {
         "@types/geojson": "*"
@@ -50998,12 +50756,10 @@
     },
     "packages/components/node_modules/@types/d3-hierarchy": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
       "integrity": "sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg=="
     },
     "packages/components/node_modules/@types/d3-interpolate": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.2.tgz",
       "integrity": "sha512-ylycts6llFf8yAEs1tXzx2loxxzDZHseuhPokrqKprTQSTcD3JbJI1omZP1rphsELZO3Q+of3ff0ZS7+O6yVzg==",
       "dependencies": {
         "@types/d3-color": "^1"
@@ -51011,27 +50767,22 @@
     },
     "packages/components/node_modules/@types/d3-path": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
     },
     "packages/components/node_modules/@types/d3-polygon": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.8.tgz",
       "integrity": "sha512-1TOJPXCBJC9V3+K3tGbTqD/CsqLyv/YkTXAcwdsZzxqw5cvpdnCuDl42M4Dvi8XzMxZNCT9pL4ibrK2n4VmAcw=="
     },
     "packages/components/node_modules/@types/d3-quadtree": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.9.tgz",
       "integrity": "sha512-5E0OJJn2QVavITFEc1AQlI8gLcIoDZcTKOD3feKFckQVmFV4CXhqRFt83tYNVNIN4ZzRkjlAMavJa1ldMhf5rA=="
     },
     "packages/components/node_modules/@types/d3-random": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.3.tgz",
       "integrity": "sha512-XXR+ZbFCoOd4peXSMYJzwk0/elP37WWAzS/DG+90eilzVbUSsgKhBcWqylGWe+lA2ubgr7afWAOBaBxRgMUrBQ=="
     },
     "packages/components/node_modules/@types/d3-scale": {
       "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.6.tgz",
       "integrity": "sha512-CHu34T5bGrJOeuhGxyiz9Xvaa9PlsIaQoOqjDg7zqeGj2x0rwPhGquiy03unigvcMxmvY0hEaAouT0LOFTLpIw==",
       "dependencies": {
         "@types/d3-time": "^1"
@@ -51039,17 +50790,14 @@
     },
     "packages/components/node_modules/@types/d3-scale-chromatic": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.1.tgz",
       "integrity": "sha512-7FtJYrmXTEWLykShjYhoGuDNR/Bda0+tstZMkFj4RRxUEryv16AGh3be21tqg84B6KfEwiZyEpBcTyPyU+GWjg=="
     },
     "packages/components/node_modules/@types/d3-selection": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.3.tgz",
       "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA=="
     },
     "packages/components/node_modules/@types/d3-shape": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
       "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
       "dependencies": {
         "@types/d3-path": "^1"
@@ -51057,22 +50805,18 @@
     },
     "packages/components/node_modules/@types/d3-time": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
       "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
     },
     "packages/components/node_modules/@types/d3-time-format": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
       "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
     },
     "packages/components/node_modules/@types/d3-timer": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.10.tgz",
       "integrity": "sha512-ZnAbquVqy+4ZjdW0cY6URp+qF/AzTVNda2jYyOzpR2cPT35FTXl78s15Bomph9+ckOiI1TtkljnWkwbIGAb6rg=="
     },
     "packages/components/node_modules/@types/d3-transition": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.2.tgz",
       "integrity": "sha512-J+a3SuF/E7wXbOSN19p8ZieQSFIm5hU2Egqtndbc54LXaAEOpLfDx4sBu/PKAKzHOdgKK1wkMhINKqNh4aoZAg==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -51080,7 +50824,6 @@
     },
     "packages/components/node_modules/@types/d3-zoom": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.3.tgz",
       "integrity": "sha512-3kHkL6sPiDdbfGhzlp5gIHyu3kULhtnHTTAl3UBZVtWB1PzcLL8vdmz5mTx7plLiUqOA2Y+yT2GKjt/TdA2p7Q==",
       "dependencies": {
         "@types/d3-interpolate": "^1",
@@ -51276,7 +51019,6 @@
     },
     "packages/components/node_modules/d3-format": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "engines": {
         "node": ">=12"
@@ -51284,7 +51026,6 @@
     },
     "packages/components/node_modules/d3-scale": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
       "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "dependencies": {
         "d3-array": "^2.3.0",
@@ -51296,12 +51037,10 @@
     },
     "packages/components/node_modules/d3-scale/node_modules/d3-format": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
       "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
     },
     "packages/components/node_modules/d3-time": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
       "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
       "dependencies": {
         "d3-array": "2"
@@ -51499,7 +51238,6 @@
     },
     "packages/components/node_modules/minimatch": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -51580,7 +51318,6 @@
     },
     "packages/components/node_modules/three": {
       "version": "0.125.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
       "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
     },
     "packages/components/node_modules/yallist": {
@@ -51830,7 +51567,6 @@
     },
     "packages/core/node_modules/@synchro-charts/core": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@synchro-charts/core/-/core-7.1.0.tgz",
       "integrity": "sha512-cT3RlsS2cIkRtda5BzlsqMXQb6oSfFfzJTHTlCGeVrJShgtSwTMGKLtiDrwa2JMU4W5+GbgJqBK2yyuGgcplDQ==",
       "dependencies": {
         "@stencil/redux": "^0.1.1",
@@ -51865,7 +51601,6 @@
     },
     "packages/core/node_modules/@types/d3": {
       "version": "5.16.4",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
       "integrity": "sha512-2u0O9iP1MubFiQ+AhR1id4Egs+07BLtvRATG6IL2Gs9+KzdrfaxCKNq5hxEyw1kxwsqB/lCgr108XuHcKtb/5w==",
       "dependencies": {
         "@types/d3-array": "^1",
@@ -51903,12 +51638,10 @@
     },
     "packages/core/node_modules/@types/d3-array": {
       "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.9.tgz",
       "integrity": "sha512-E/7RgPr2ylT5dWG0CswMi9NpFcjIEDqLcUSBgNHe/EMahfqYaTx4zhcggG3khqoEB/leY4Vl6nTSbwLUPjXceA=="
     },
     "packages/core/node_modules/@types/d3-axis": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.16.tgz",
       "integrity": "sha512-p7085weOmo4W+DzlRRVC/7OI/jugaKbVa6WMQGCQscaMylcbuaVEGk7abJLNyGVFLeCBNrHTdDiqRGnzvL0nXQ==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -51916,7 +51649,6 @@
     },
     "packages/core/node_modules/@types/d3-brush": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.1.5.tgz",
       "integrity": "sha512-4zGkBafJf5zCsBtLtvDj/pNMo5X9+Ii/1hUz0GvQ+wEwelUBm2AbIDAzJnp2hLDFF307o0fhxmmocHclhXC+tw==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -51924,17 +51656,14 @@
     },
     "packages/core/node_modules/@types/d3-chord": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.11.tgz",
       "integrity": "sha512-0DdfJ//bxyW3G9Nefwq/LDgazSKNN8NU0lBT3Cza6uVuInC2awMNsAcv1oKyRFLn9z7kXClH5XjwpveZjuz2eg=="
     },
     "packages/core/node_modules/@types/d3-color": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.2.tgz",
       "integrity": "sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA=="
     },
     "packages/core/node_modules/@types/d3-contour": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-1.3.3.tgz",
       "integrity": "sha512-LxwmGIfVJIc1cKs7ZFRQ1FbtXpfH7QTXYRdMIJsFP71uCMdF6jJ0XZakYDX6Hn4yZkLf+7V8FgD34yCcok+5Ww==",
       "dependencies": {
         "@types/d3-array": "^1",
@@ -51943,12 +51672,10 @@
     },
     "packages/core/node_modules/@types/d3-dispatch": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.9.tgz",
       "integrity": "sha512-zJ44YgjqALmyps+II7b1mZLhrtfV/FOxw9owT87mrweGWcg+WK5oiJX2M3SYJ0XUAExBduarysfgbR11YxzojQ=="
     },
     "packages/core/node_modules/@types/d3-drag": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.5.tgz",
       "integrity": "sha512-7NeTnfolst1Js3Vs7myctBkmJWu6DMI3k597AaHUX98saHjHWJ6vouT83UrpE+xfbSceHV+8A0JgxuwgqgmqWw==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -51956,17 +51683,14 @@
     },
     "packages/core/node_modules/@types/d3-dsv": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.1.tgz",
       "integrity": "sha512-LLmJmjiqp/fTNEdij5bIwUJ6P6TVNk5hKM9/uk5RPO2YNgEu9XvKO0dJ7Iqd3psEdmZN1m7gB1bOsjr4HmO2BA=="
     },
     "packages/core/node_modules/@types/d3-ease": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.11.tgz",
       "integrity": "sha512-wUigPL0kleGZ9u3RhzBP07lxxkMcUjL5IODP42mN/05UNL+JJCDnpEPpFbJiPvLcTeRKGIRpBBJyP/1BNwYsVA=="
     },
     "packages/core/node_modules/@types/d3-fetch": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.2.2.tgz",
       "integrity": "sha512-rtFs92GugtV/NpiJQd0WsmGLcg52tIL0uF0bKbbJg231pR9JEb6HT4AUwrtuLq3lOeKdLBhsjV14qb0pMmd0Aw==",
       "dependencies": {
         "@types/d3-dsv": "^1"
@@ -51974,17 +51698,14 @@
     },
     "packages/core/node_modules/@types/d3-force": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.4.tgz",
       "integrity": "sha512-fkorLTKvt6AQbFBQwn4aq7h9rJ4c7ZVcPMGB8X6eFFveAyMZcv7t7m6wgF4Eg93rkPgPORU7sAho1QSHNcZu6w=="
     },
     "packages/core/node_modules/@types/d3-format": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
       "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
     },
     "packages/core/node_modules/@types/d3-geo": {
       "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.12.3.tgz",
       "integrity": "sha512-yZbPb7/5DyL/pXkeOmZ7L5ySpuGr4H48t1cuALjnJy5sXQqmSSAYBiwa6Ya/XpWKX2rJqGDDubmh3nOaopOpeA==",
       "dependencies": {
         "@types/geojson": "*"
@@ -51992,12 +51713,10 @@
     },
     "packages/core/node_modules/@types/d3-hierarchy": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
       "integrity": "sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg=="
     },
     "packages/core/node_modules/@types/d3-interpolate": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.2.tgz",
       "integrity": "sha512-ylycts6llFf8yAEs1tXzx2loxxzDZHseuhPokrqKprTQSTcD3JbJI1omZP1rphsELZO3Q+of3ff0ZS7+O6yVzg==",
       "dependencies": {
         "@types/d3-color": "^1"
@@ -52005,27 +51724,22 @@
     },
     "packages/core/node_modules/@types/d3-path": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
     },
     "packages/core/node_modules/@types/d3-polygon": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.8.tgz",
       "integrity": "sha512-1TOJPXCBJC9V3+K3tGbTqD/CsqLyv/YkTXAcwdsZzxqw5cvpdnCuDl42M4Dvi8XzMxZNCT9pL4ibrK2n4VmAcw=="
     },
     "packages/core/node_modules/@types/d3-quadtree": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.9.tgz",
       "integrity": "sha512-5E0OJJn2QVavITFEc1AQlI8gLcIoDZcTKOD3feKFckQVmFV4CXhqRFt83tYNVNIN4ZzRkjlAMavJa1ldMhf5rA=="
     },
     "packages/core/node_modules/@types/d3-random": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.3.tgz",
       "integrity": "sha512-XXR+ZbFCoOd4peXSMYJzwk0/elP37WWAzS/DG+90eilzVbUSsgKhBcWqylGWe+lA2ubgr7afWAOBaBxRgMUrBQ=="
     },
     "packages/core/node_modules/@types/d3-scale": {
       "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.6.tgz",
       "integrity": "sha512-CHu34T5bGrJOeuhGxyiz9Xvaa9PlsIaQoOqjDg7zqeGj2x0rwPhGquiy03unigvcMxmvY0hEaAouT0LOFTLpIw==",
       "dependencies": {
         "@types/d3-time": "^1"
@@ -52033,17 +51747,14 @@
     },
     "packages/core/node_modules/@types/d3-scale-chromatic": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.1.tgz",
       "integrity": "sha512-7FtJYrmXTEWLykShjYhoGuDNR/Bda0+tstZMkFj4RRxUEryv16AGh3be21tqg84B6KfEwiZyEpBcTyPyU+GWjg=="
     },
     "packages/core/node_modules/@types/d3-selection": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.3.tgz",
       "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA=="
     },
     "packages/core/node_modules/@types/d3-shape": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
       "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
       "dependencies": {
         "@types/d3-path": "^1"
@@ -52051,22 +51762,18 @@
     },
     "packages/core/node_modules/@types/d3-time": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
       "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
     },
     "packages/core/node_modules/@types/d3-time-format": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
       "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
     },
     "packages/core/node_modules/@types/d3-timer": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.10.tgz",
       "integrity": "sha512-ZnAbquVqy+4ZjdW0cY6URp+qF/AzTVNda2jYyOzpR2cPT35FTXl78s15Bomph9+ckOiI1TtkljnWkwbIGAb6rg=="
     },
     "packages/core/node_modules/@types/d3-transition": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.2.tgz",
       "integrity": "sha512-J+a3SuF/E7wXbOSN19p8ZieQSFIm5hU2Egqtndbc54LXaAEOpLfDx4sBu/PKAKzHOdgKK1wkMhINKqNh4aoZAg==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -52074,7 +51781,6 @@
     },
     "packages/core/node_modules/@types/d3-zoom": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.3.tgz",
       "integrity": "sha512-3kHkL6sPiDdbfGhzlp5gIHyu3kULhtnHTTAl3UBZVtWB1PzcLL8vdmz5mTx7plLiUqOA2Y+yT2GKjt/TdA2p7Q==",
       "dependencies": {
         "@types/d3-interpolate": "^1",
@@ -52174,7 +51880,6 @@
     },
     "packages/core/node_modules/d3-format": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "engines": {
         "node": ">=12"
@@ -52182,7 +51887,6 @@
     },
     "packages/core/node_modules/d3-scale": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
       "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "dependencies": {
         "d3-array": "^2.3.0",
@@ -52194,12 +51898,10 @@
     },
     "packages/core/node_modules/d3-scale/node_modules/d3-format": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
       "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
     },
     "packages/core/node_modules/d3-time": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
       "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
       "dependencies": {
         "d3-array": "2"
@@ -52890,7 +52592,6 @@
     },
     "packages/core/node_modules/minimatch": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -52972,7 +52673,6 @@
     },
     "packages/core/node_modules/three": {
       "version": "0.125.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
       "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
     },
     "packages/core/node_modules/throat": {
@@ -53115,7 +52815,7 @@
         "@iot-app-kit/source-iottwinmaker": "^2.6.0",
         "dompurify": "2.3.4",
         "uuid": "^8.3.2",
-        "video.js": "7.14.3"
+        "video.js": "7.20.3"
       },
       "devDependencies": {
         "@babel/code-frame": "^7.18.6",
@@ -53144,8 +52844,6 @@
         "jest-dom": "^3.0.2",
         "jest-simple-dot-reporter": "^1.0.5",
         "jest-styled-components": "^7.0.0",
-        "m3u8-parser": "4.5.0",
-        "mpd-parser": "0.15.0",
         "mux.js": "5.8.0",
         "np": "^3.1.0",
         "react": "^17.0.2",
@@ -53390,6 +53088,93 @@
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
+      }
+    },
+    "packages/react-components/node_modules/@videojs/http-streaming": {
+      "version": "2.14.3",
+      "integrity": "sha512-2tFwxCaNbcEZzQugWf8EERwNMyNtspfHnvxRGRABQs09W/5SqmkWFuGWfUAm4wQKlXGfdPyAJ1338ASl459xAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "3.0.5",
+        "aes-decrypter": "3.1.3",
+        "global": "^4.4.0",
+        "m3u8-parser": "4.7.1",
+        "mpd-parser": "0.21.1",
+        "mux.js": "6.0.1",
+        "video.js": "^6 || ^7"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "video.js": "^6 || ^7"
+      }
+    },
+    "packages/react-components/node_modules/@videojs/http-streaming/node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
+    "packages/react-components/node_modules/@videojs/http-streaming/node_modules/mux.js": {
+      "version": "6.0.1",
+      "integrity": "sha512-22CHb59rH8pWGcPGW5Og7JngJ9s+z4XuSlYvnxhLuc58cA1WqGDQPzuG8I+sPm1/p0CdgpzVTaKW408k5DNn8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "muxjs-transmux": "bin/transmux.js"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
+    "packages/react-components/node_modules/@videojs/xhr": {
+      "version": "2.6.0",
+      "integrity": "sha512-7J361GiN1tXpm+gd0xz2QWr3xNWBE+rytvo8J3KuggFaLg+U37gZQ2BuPLcnkfGffy2e+ozY70RHC8jt7zjA6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "global": "~4.4.0",
+        "is-function": "^1.0.1"
+      }
+    },
+    "packages/react-components/node_modules/aes-decrypter": {
+      "version": "3.1.3",
+      "integrity": "sha512-VkG9g4BbhMBy+N5/XodDeV6F02chEk9IpgRTq/0bS80y4dzy79VH2Gtms02VXomf3HmyRe3yyJYkJ990ns+d6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0",
+        "pkcs7": "^1.0.4"
+      }
+    },
+    "packages/react-components/node_modules/aes-decrypter/node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
       }
     },
     "packages/react-components/node_modules/ansi-styles": {
@@ -54131,6 +53916,58 @@
         "node": ">=10"
       }
     },
+    "packages/react-components/node_modules/m3u8-parser": {
+      "version": "4.7.1",
+      "integrity": "sha512-pbrQwiMiq+MmI9bl7UjtPT3AK603PV9bogNlr83uC+X9IoxqL5E4k7kU7fMQ0dpRgxgeSMygqUa0IMLQNXLBNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0"
+      }
+    },
+    "packages/react-components/node_modules/m3u8-parser/node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
+    "packages/react-components/node_modules/mpd-parser": {
+      "version": "0.21.1",
+      "integrity": "sha512-BxlSXWbKE1n7eyEPBnTEkrzhS3PdmkkKdM1pgKbPnPOH0WFZIc0sPOWi7m0Uo3Wd2a4Or8Qf4ZbS7+ASqQ49fw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "@xmldom/xmldom": "^0.7.2",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "mpd-to-m3u8-json": "bin/parse.js"
+      }
+    },
+    "packages/react-components/node_modules/mpd-parser/node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
     "packages/react-components/node_modules/npm-run-path": {
       "version": "4.0.1",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
@@ -54300,6 +54137,56 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "packages/react-components/node_modules/video.js": {
+      "version": "7.20.3",
+      "integrity": "sha512-JMspxaK74LdfWcv69XWhX4rILywz/eInOVPdKefpQiZJSMD5O8xXYueqACP2Q5yqKstycgmmEKlJzZ+kVmDciw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/http-streaming": "2.14.3",
+        "@videojs/vhs-utils": "^3.0.4",
+        "@videojs/xhr": "2.6.0",
+        "aes-decrypter": "3.1.3",
+        "global": "^4.4.0",
+        "keycode": "^2.2.0",
+        "m3u8-parser": "4.7.1",
+        "mpd-parser": "0.21.1",
+        "mux.js": "6.0.1",
+        "safe-json-parse": "4.0.0",
+        "videojs-font": "3.2.0",
+        "videojs-vtt.js": "^0.15.4"
+      }
+    },
+    "packages/react-components/node_modules/video.js/node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
+    "packages/react-components/node_modules/video.js/node_modules/mux.js": {
+      "version": "6.0.1",
+      "integrity": "sha512-22CHb59rH8pWGcPGW5Og7JngJ9s+z4XuSlYvnxhLuc58cA1WqGDQPzuG8I+sPm1/p0CdgpzVTaKW408k5DNn8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "muxjs-transmux": "bin/transmux.js"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
       }
     },
     "packages/react-components/node_modules/y18n": {
@@ -54667,7 +54554,6 @@
     },
     "packages/scene-composer/node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz",
       "integrity": "sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==",
       "dev": true,
       "dependencies": {
@@ -54894,7 +54780,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-actions": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-6.5.14.tgz",
       "integrity": "sha512-fZt8bn+oCsVDv9yuZfKL4lq77V5EqW60khHpOxLRRK69hMsE+gaylK0O5l/pelVf3Jf3+TablUG+2xWTaJHGlQ==",
       "dev": true,
       "dependencies": {
@@ -54937,7 +54822,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-backgrounds": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-6.5.14.tgz",
       "integrity": "sha512-DZY8oizDTiNLsknyrCyjf6OirwyfrXB4+UCXKXT7Xp+S5PHsdHwBZUADgM6yIwLUjDXzcsL7Ok00C1zI9qERdg==",
       "dev": true,
       "dependencies": {
@@ -54974,7 +54858,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-controls": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-6.5.14.tgz",
       "integrity": "sha512-p16k/69GjwVtnpEiz0fmb1qoqp/H2d5aaSGDt7VleeXsdhs4Kh0kJyxfLpekHmlzT+5IkO08Nm/U8tJOHbw4Hw==",
       "dev": true,
       "dependencies": {
@@ -55010,7 +54893,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-docs": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.5.14.tgz",
       "integrity": "sha512-gapuzDY+dqgS4/Ap9zj5L76OSExBYtVNYej9xTiF+v0Gh4/kty9FIGlVWiqskffOmixL4nlyImpfsSH8V0JnCw==",
       "dev": true,
       "dependencies": {
@@ -55066,7 +54948,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-docs/node_modules/@jest/transform": {
       "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
       "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
       "dev": true,
       "dependencies": {
@@ -55092,7 +54973,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-docs/node_modules/@jest/types": {
       "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
       "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
       "dev": true,
       "dependencies": {
@@ -55108,7 +54988,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-docs/node_modules/@types/yargs": {
       "version": "15.0.14",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
       "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
       "dev": true,
       "dependencies": {
@@ -55117,7 +54996,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-docs/node_modules/jest-haste-map": {
       "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
       "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
       "dev": true,
       "dependencies": {
@@ -55144,7 +55022,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-docs/node_modules/jest-regex-util": {
       "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
       "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
       "dev": true,
       "engines": {
@@ -55153,7 +55030,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-docs/node_modules/jest-serializer": {
       "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
       "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
       "dev": true,
       "dependencies": {
@@ -55166,7 +55042,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-docs/node_modules/jest-util": {
       "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
       "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
       "dev": true,
       "dependencies": {
@@ -55183,7 +55058,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-docs/node_modules/jest-worker": {
       "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
       "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
       "dev": true,
       "dependencies": {
@@ -55197,7 +55071,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-essentials": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-6.5.14.tgz",
       "integrity": "sha512-6fmfDHbp1y/hF0GU0W95RLw4rzN3KGcEcpAZ8HbgTyXIF528j0hhlvkD5AjnQ5dVarlHdKAtMRZA9Y3OCEZD6A==",
       "dev": true,
       "dependencies": {
@@ -55280,7 +55153,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-links": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-6.5.14.tgz",
       "integrity": "sha512-Q4gNVFi3PqJH/YYmYJ6xX7a2VPZYs8QV97fMIjdg7/k4FLelSRj7QfsHc7jO2RGG2qQpenapO569jFoVNAW4/Q==",
       "dev": true,
       "dependencies": {
@@ -55316,7 +55188,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-measure": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-6.5.14.tgz",
       "integrity": "sha512-7JH35z7NRaNiOMYIG+tJQrQdV2fdURUK94g9x58rNBT4GCtXTclFvhWiwKHHT2CnM8xdYuKGMt3DY9U0urq3Gg==",
       "dev": true,
       "dependencies": {
@@ -55348,7 +55219,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-outline": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-6.5.14.tgz",
       "integrity": "sha512-eXkkRmSxfPIcztfcLxGO1Cj61Ohx4qKuYSjNh25CRc+HYbBjQkWyxOXZP+x4Ritx4IuQsgWiCJJO3/zdgXLRgw==",
       "dev": true,
       "dependencies": {
@@ -55382,7 +55252,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-toolbars": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-6.5.14.tgz",
       "integrity": "sha512-BZGQ9YadVRtSd5mpmrwnJta0wK1leX/vgziJX4gUKX2A5JX7VWsiswUGVukLVtE9Oa1jp3fJXE3O5Ip9moj0Ag==",
       "dev": true,
       "dependencies": {
@@ -55413,7 +55282,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addon-viewport": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-6.5.14.tgz",
       "integrity": "sha512-QtcQZe5ahWcMr4oRgfjeCIJtweTitArc8x1cDfS8maEEy965JJGjrR9xBIOLaw6IEiRtBuvrewYAWbRLLsUE+g==",
       "dev": true,
       "dependencies": {
@@ -55448,7 +55316,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/addons": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.5.14.tgz",
       "integrity": "sha512-8wVy1eDKipj+dmWpVmmPa1p2jYVqDvrkWll4IsP/KU7AYFCiyCiVAd1ZPDv9EhDnwArfYYjrdJjAl6gmP0UMag==",
       "dev": true,
       "dependencies": {
@@ -55475,7 +55342,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/api": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.5.14.tgz",
       "integrity": "sha512-RpgEWV4mxD1mNsGWkjSNq3+B/LFNIhXZc4OapEEK5u0jgCZKB7OCsRL9NJZB5WfpyN+vx8SwbUTgo8DIkes3qw==",
       "dev": true,
       "dependencies": {
@@ -55508,7 +55374,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/builder-webpack4": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack4/-/builder-webpack4-6.5.14.tgz",
       "integrity": "sha512-0pv8BlsMeiP9VYU2CbCZaa3yXDt1ssb8OeTRDbFC0uFFb3eqslsH68I7XsC8ap/dr0RZR0Edtw0OW3HhkjUXXw==",
       "dev": true,
       "dependencies": {
@@ -55576,7 +55441,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/builder-webpack4/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "dependencies": {
@@ -55590,7 +55454,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/builder-webpack4/node_modules/fork-ts-checker-webpack-plugin": {
       "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-4.1.6.tgz",
       "integrity": "sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==",
       "dev": true,
       "dependencies": {
@@ -55609,7 +55472,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/builder-webpack4/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
@@ -55618,7 +55480,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/builder-webpack4/node_modules/micromatch": {
       "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "dependencies": {
@@ -55642,7 +55503,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/builder-webpack4/node_modules/postcss": {
       "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
       "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
       "dev": true,
       "dependencies": {
@@ -55659,7 +55519,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/builder-webpack4/node_modules/semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
       "bin": {
@@ -55668,7 +55527,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/builder-webpack4/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "dependencies": {
@@ -55680,7 +55538,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/channel-postmessage": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.5.14.tgz",
       "integrity": "sha512-0Cmdze5G3Qwxf7yYPGlJxGiY+KiEUQ+8GfpohsKGfvrP8cfSrx6VhxupHA7hDNyRh75hqZq5BrkW4HO9Ypbt5A==",
       "dev": true,
       "dependencies": {
@@ -55699,7 +55556,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/channel-websocket": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-6.5.14.tgz",
       "integrity": "sha512-ZyDL5PBFWuFQ15NBljhbOaD/3FAijXvLj5oxfNris2khdkqlP6/8JmcIvfohJJcqepGZHUF9H29OaUsRC35ftA==",
       "dev": true,
       "dependencies": {
@@ -55716,7 +55572,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/channels": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.5.14.tgz",
       "integrity": "sha512-hHpr4Sya6fuEDhy7vnfD2QnL5wy1CaAK9BC0FLupndXnQyKJtygfIaUP4a0B2KntuNPbzPhclb2Hb4yM7CExmQ==",
       "dev": true,
       "dependencies": {
@@ -55731,7 +55586,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/client-api": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.5.14.tgz",
       "integrity": "sha512-G5mBQCKn8/VqE9XDCL19ixcvu8YhaQZ0AE+EXGYXUsvPpyQ43oGoGJry5IqOzeRlc7dbglFWpMkB6PeeUD7aCw==",
       "dev": true,
       "dependencies": {
@@ -55767,7 +55621,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/client-logger": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.5.14.tgz",
       "integrity": "sha512-r1pY69DGKzX9/GngkudthaaPxPlka16zjG7Y58psunwcoUuH3riAP1cjqhXt5+S8FKCNI/MGb82PLlCPX2Liuw==",
       "dev": true,
       "dependencies": {
@@ -55781,7 +55634,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/components": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.5.14.tgz",
       "integrity": "sha512-wqB9CF3sjxtgffnDW1G/W5SsKumsFQ0ftn/3PdrsvKULu5LM5bjNEqC2cTCWrk9vQhj+EVQxzdVM/BlPl/lSwg==",
       "dev": true,
       "dependencies": {
@@ -55805,7 +55657,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/core": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.5.14.tgz",
       "integrity": "sha512-5rjwZXk++NkKWCmHt/CC+h2L4ZbOYkLJpMmaB97CwgQCA6kaF8xuJqlAwG72VUH3oV+6RntW02X6/ypgX1atPw==",
       "dev": true,
       "dependencies": {
@@ -55835,7 +55686,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/core-client": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.5.14.tgz",
       "integrity": "sha512-d5mUgz1xSvrAdal8XKI5YOZOM/XUly90vis3DboeZRO58qSp+NH5xFYIBBED5qefDgmGU0Yv4rXHQlph96LSHQ==",
       "dev": true,
       "dependencies": {
@@ -55877,7 +55727,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/core-common": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-6.5.14.tgz",
       "integrity": "sha512-MrxhYXYrtN6z/+tydjPkCIwDQm5q8Jx+w4TPdLKBZu7vzfp6T3sT12Ym96j9MJ42CvE4vSDl/Njbw6C0D+yEVw==",
       "dev": true,
       "dependencies": {
@@ -55948,7 +55797,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/core-events": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.5.14.tgz",
       "integrity": "sha512-PLu0M8Mqt9ruN5RupgcFKHEybiSm3CdWQyylWO5FRGg+WZV3BCm0aI8ujvO1GAm+YEi57Lull+M9d6NUycTpRg==",
       "dev": true,
       "dependencies": {
@@ -55961,7 +55809,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/core-server": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-6.5.14.tgz",
       "integrity": "sha512-+Z3lHEsDpiBXt6xBwU5AVBoEkicndnHoiLwhEGPkfixy7POYEEny3cm54tteVxV8O5AHMwsHs54/QD+hHxAXnQ==",
       "dev": true,
       "dependencies": {
@@ -56033,7 +55880,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/csf-tools": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-6.5.14.tgz",
       "integrity": "sha512-PgCKgyfD6UD9aNilDxmKJRbCZwcZl8t8Orb6+vVGuzB5f0BV92NqnHS4sgAlFoZ+iqcQGUEU9vRIdUxNcyItaw==",
       "dev": true,
       "dependencies": {
@@ -56067,7 +55913,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/docs-tools": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-6.5.14.tgz",
       "integrity": "sha512-qA0UWvrZ7XyIWD+01NGHiiGPSbfercrxjphM9wHgF6KrO6e5iykNKIEL4elsM+EV4szfhlalQdtpnwM7WtXODA==",
       "dev": true,
       "dependencies": {
@@ -56086,7 +55931,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/manager-webpack4": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/manager-webpack4/-/manager-webpack4-6.5.14.tgz",
       "integrity": "sha512-ixfJuaG0eiOlxn4i+LJNRUZkm+3WMsiaGUm0hw2XHF0pW3cBIA/+HyzkEwVh/fROHbsOERTkjNl0Ygl12Imw9w==",
       "dev": true,
       "dependencies": {
@@ -56142,7 +55986,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/node-logger": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.5.14.tgz",
       "integrity": "sha512-MbEEgUEfrDN8Y0vzZJqPcxwWvX0l8zAsXy6d/DORP2AmwuNmnWTy++BE9YhxH6HMdM1ivRDmBbT30+KBUWhnUA==",
       "dev": true,
       "dependencies": {
@@ -56159,7 +56002,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/postinstall": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/postinstall/-/postinstall-6.5.14.tgz",
       "integrity": "sha512-vtnQczSSkz7aPIc2dsDaZWlCDAcJb258KGXk72w7MEY9/zLlr6tdQLI30B6SkRNFnR8fQQf4H2gbFq/GM0EF5A==",
       "dev": true,
       "dependencies": {
@@ -56172,7 +56014,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/preview-web": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-web/-/preview-web-6.5.14.tgz",
       "integrity": "sha512-ey2E7222xw0itPgCWH7ZIrdgM1yCdYte/QxRvwv/O4us4SUs/RQaL1aoCD+hCRwd0BNyZUk/u1KnqB4y0MnHww==",
       "dev": true,
       "dependencies": {
@@ -56204,7 +56045,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/react": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-6.5.14.tgz",
       "integrity": "sha512-SL0P5czN3g/IZAYw8ur9I/O8MPZI7Lyd46Pw+B1f7+Ou8eLmhqa8Uc8+3fU6v7ohtUDwsBiTsg3TAfTVEPog4A==",
       "dev": true,
       "dependencies": {
@@ -56285,7 +56125,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/router": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.5.14.tgz",
       "integrity": "sha512-AvHbpRUAHnzm5pmwFPjDR09uPjQITD6kA0QNa2pe+7/Q/b4k40z5dHvHZJ/YhWhwVwGqGBG20KdDOl30wLXAZw==",
       "dev": true,
       "dependencies": {
@@ -56306,7 +56145,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/source-loader": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-6.5.14.tgz",
       "integrity": "sha512-0GKMZ6IMVGxfQn/RYdRdnzxCe4+zZsxHBY9SQB2bbYWyfjJQ5rCJvmYQuMAuuuUmXBv9gk50iJLwai+lb4tbFg==",
       "dev": true,
       "dependencies": {
@@ -56332,7 +56170,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/source-loader/node_modules/loader-utils": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
       "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "dependencies": {
@@ -56346,7 +56183,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/source-loader/node_modules/prettier": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
       "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true,
       "bin": {
@@ -56358,7 +56194,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/store": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/store/-/store-6.5.14.tgz",
       "integrity": "sha512-s07Vw4nbShPYwBJmVXzptuyCkrDQD3khcrKB5L7NsHHgWsm2QI0OyiPMuMbSvgipjcMc/oRqdL3tFUeFak9EMg==",
       "dev": true,
       "dependencies": {
@@ -56389,7 +56224,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/telemetry": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-6.5.14.tgz",
       "integrity": "sha512-AVSw7WyKHrVbXMSZZ0fvg3oAb8xAS7OrmNU6++yUfbuqpF0JNtNkNnRSaJ4Nh7Vujzloy5jYhbpfY44nb/hsCw==",
       "dev": true,
       "dependencies": {
@@ -56413,7 +56247,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/testing-react": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@storybook/testing-react/-/testing-react-1.3.0.tgz",
       "integrity": "sha512-TfxzflxwBHSPhetWKuYt239t+1iN8gnnUN8OKo5UGtwwirghKQlApjH23QXW6j8YBqFhmq+yP29Oqf8HgKCFLw==",
       "dev": true,
       "dependencies": {
@@ -56432,7 +56265,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/testing-react/node_modules/@storybook/csf": {
       "version": "0.0.2--canary.87bc651.0",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.2--canary.87bc651.0.tgz",
       "integrity": "sha512-ajk1Uxa+rBpFQHKrCcTmJyQBXZ5slfwHVEaKlkuFaW77it8RgbPJp/ccna3sgoi8oZ7FkkOyvv1Ve4SmwFqRqw==",
       "dev": true,
       "dependencies": {
@@ -56441,7 +56273,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/theming": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.14.tgz",
       "integrity": "sha512-3ff6RLZGaIil/AFJ0/BRlE2hhdPrC5v6wGbRfroZVmGldRCxio/7+KAA3LH6cuHnjK5MeBcCBaHuxzXqGmbEFw==",
       "dev": true,
       "dependencies": {
@@ -56461,7 +56292,6 @@
     },
     "packages/scene-composer/node_modules/@storybook/ui": {
       "version": "6.5.14",
-      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-6.5.14.tgz",
       "integrity": "sha512-dXlCIULh8ytgdFrvVoheQLlZjAyyYmGCuw+6m+s+2yF/oUbFREG/5Zo9hDwlJ4ZiAyqNLkuwg2tnMYtjapZSog==",
       "dev": true,
       "dependencies": {
@@ -56557,7 +56387,6 @@
     },
     "packages/scene-composer/node_modules/@types/estree": {
       "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
@@ -56686,7 +56515,6 @@
     },
     "packages/scene-composer/node_modules/autoprefixer": {
       "version": "9.8.8",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
       "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
       "dev": true,
       "dependencies": {
@@ -56708,7 +56536,6 @@
     },
     "packages/scene-composer/node_modules/autoprefixer/node_modules/postcss": {
       "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
       "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
       "dev": true,
       "dependencies": {
@@ -56725,7 +56552,6 @@
     },
     "packages/scene-composer/node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz",
       "integrity": "sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==",
       "dev": true,
       "dependencies": {
@@ -56738,7 +56564,6 @@
     },
     "packages/scene-composer/node_modules/braces": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "dependencies": {
@@ -56759,7 +56584,6 @@
     },
     "packages/scene-composer/node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
@@ -56843,7 +56667,6 @@
     },
     "packages/scene-composer/node_modules/commander": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "dev": true,
       "engines": {
@@ -56917,7 +56740,6 @@
     },
     "packages/scene-composer/node_modules/fill-range": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
       "dev": true,
       "dependencies": {
@@ -56932,7 +56754,6 @@
     },
     "packages/scene-composer/node_modules/fill-range/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "dependencies": {
@@ -56944,7 +56765,6 @@
     },
     "packages/scene-composer/node_modules/fs-extra": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "dependencies": {
@@ -57012,13 +56832,11 @@
     },
     "packages/scene-composer/node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "packages/scene-composer/node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
       "engines": {
@@ -57027,7 +56845,6 @@
     },
     "packages/scene-composer/node_modules/is-number": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
       "dev": true,
       "dependencies": {
@@ -57039,7 +56856,6 @@
     },
     "packages/scene-composer/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
       "dev": true,
       "dependencies": {
@@ -57999,7 +57815,6 @@
     },
     "packages/scene-composer/node_modules/picocolors": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
       "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
       "dev": true
     },
@@ -58165,7 +57980,6 @@
     },
     "packages/scene-composer/node_modules/schema-utils": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
       "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
       "dev": true,
       "dependencies": {
@@ -58200,7 +58014,6 @@
     },
     "packages/scene-composer/node_modules/style-loader": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
       "integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
       "dev": true,
       "dependencies": {
@@ -58220,7 +58033,6 @@
     },
     "packages/scene-composer/node_modules/style-loader/node_modules/loader-utils": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
       "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "dependencies": {
@@ -58252,7 +58064,6 @@
     },
     "packages/scene-composer/node_modules/to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
       "dev": true,
       "dependencies": {
@@ -58623,7 +58434,6 @@
     },
     "packages/source-iotsitewise/node_modules/@synchro-charts/core": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@synchro-charts/core/-/core-7.1.0.tgz",
       "integrity": "sha512-cT3RlsS2cIkRtda5BzlsqMXQb6oSfFfzJTHTlCGeVrJShgtSwTMGKLtiDrwa2JMU4W5+GbgJqBK2yyuGgcplDQ==",
       "dependencies": {
         "@stencil/redux": "^0.1.1",
@@ -58658,7 +58468,6 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3": {
       "version": "5.16.4",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
       "integrity": "sha512-2u0O9iP1MubFiQ+AhR1id4Egs+07BLtvRATG6IL2Gs9+KzdrfaxCKNq5hxEyw1kxwsqB/lCgr108XuHcKtb/5w==",
       "dependencies": {
         "@types/d3-array": "^1",
@@ -58696,12 +58505,10 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3-array": {
       "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.9.tgz",
       "integrity": "sha512-E/7RgPr2ylT5dWG0CswMi9NpFcjIEDqLcUSBgNHe/EMahfqYaTx4zhcggG3khqoEB/leY4Vl6nTSbwLUPjXceA=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-axis": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.16.tgz",
       "integrity": "sha512-p7085weOmo4W+DzlRRVC/7OI/jugaKbVa6WMQGCQscaMylcbuaVEGk7abJLNyGVFLeCBNrHTdDiqRGnzvL0nXQ==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -58709,7 +58516,6 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3-brush": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.1.5.tgz",
       "integrity": "sha512-4zGkBafJf5zCsBtLtvDj/pNMo5X9+Ii/1hUz0GvQ+wEwelUBm2AbIDAzJnp2hLDFF307o0fhxmmocHclhXC+tw==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -58717,17 +58523,14 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3-chord": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.11.tgz",
       "integrity": "sha512-0DdfJ//bxyW3G9Nefwq/LDgazSKNN8NU0lBT3Cza6uVuInC2awMNsAcv1oKyRFLn9z7kXClH5XjwpveZjuz2eg=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-color": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.2.tgz",
       "integrity": "sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-contour": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-1.3.3.tgz",
       "integrity": "sha512-LxwmGIfVJIc1cKs7ZFRQ1FbtXpfH7QTXYRdMIJsFP71uCMdF6jJ0XZakYDX6Hn4yZkLf+7V8FgD34yCcok+5Ww==",
       "dependencies": {
         "@types/d3-array": "^1",
@@ -58736,12 +58539,10 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3-dispatch": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.9.tgz",
       "integrity": "sha512-zJ44YgjqALmyps+II7b1mZLhrtfV/FOxw9owT87mrweGWcg+WK5oiJX2M3SYJ0XUAExBduarysfgbR11YxzojQ=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-drag": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.5.tgz",
       "integrity": "sha512-7NeTnfolst1Js3Vs7myctBkmJWu6DMI3k597AaHUX98saHjHWJ6vouT83UrpE+xfbSceHV+8A0JgxuwgqgmqWw==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -58749,17 +58550,14 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3-dsv": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.1.tgz",
       "integrity": "sha512-LLmJmjiqp/fTNEdij5bIwUJ6P6TVNk5hKM9/uk5RPO2YNgEu9XvKO0dJ7Iqd3psEdmZN1m7gB1bOsjr4HmO2BA=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-ease": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.11.tgz",
       "integrity": "sha512-wUigPL0kleGZ9u3RhzBP07lxxkMcUjL5IODP42mN/05UNL+JJCDnpEPpFbJiPvLcTeRKGIRpBBJyP/1BNwYsVA=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-fetch": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.2.2.tgz",
       "integrity": "sha512-rtFs92GugtV/NpiJQd0WsmGLcg52tIL0uF0bKbbJg231pR9JEb6HT4AUwrtuLq3lOeKdLBhsjV14qb0pMmd0Aw==",
       "dependencies": {
         "@types/d3-dsv": "^1"
@@ -58767,17 +58565,14 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3-force": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.4.tgz",
       "integrity": "sha512-fkorLTKvt6AQbFBQwn4aq7h9rJ4c7ZVcPMGB8X6eFFveAyMZcv7t7m6wgF4Eg93rkPgPORU7sAho1QSHNcZu6w=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-format": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
       "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-geo": {
       "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.12.3.tgz",
       "integrity": "sha512-yZbPb7/5DyL/pXkeOmZ7L5ySpuGr4H48t1cuALjnJy5sXQqmSSAYBiwa6Ya/XpWKX2rJqGDDubmh3nOaopOpeA==",
       "dependencies": {
         "@types/geojson": "*"
@@ -58785,12 +58580,10 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3-hierarchy": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
       "integrity": "sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-interpolate": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.2.tgz",
       "integrity": "sha512-ylycts6llFf8yAEs1tXzx2loxxzDZHseuhPokrqKprTQSTcD3JbJI1omZP1rphsELZO3Q+of3ff0ZS7+O6yVzg==",
       "dependencies": {
         "@types/d3-color": "^1"
@@ -58798,27 +58591,22 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3-path": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-polygon": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.8.tgz",
       "integrity": "sha512-1TOJPXCBJC9V3+K3tGbTqD/CsqLyv/YkTXAcwdsZzxqw5cvpdnCuDl42M4Dvi8XzMxZNCT9pL4ibrK2n4VmAcw=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-quadtree": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.9.tgz",
       "integrity": "sha512-5E0OJJn2QVavITFEc1AQlI8gLcIoDZcTKOD3feKFckQVmFV4CXhqRFt83tYNVNIN4ZzRkjlAMavJa1ldMhf5rA=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-random": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.3.tgz",
       "integrity": "sha512-XXR+ZbFCoOd4peXSMYJzwk0/elP37WWAzS/DG+90eilzVbUSsgKhBcWqylGWe+lA2ubgr7afWAOBaBxRgMUrBQ=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-scale": {
       "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.6.tgz",
       "integrity": "sha512-CHu34T5bGrJOeuhGxyiz9Xvaa9PlsIaQoOqjDg7zqeGj2x0rwPhGquiy03unigvcMxmvY0hEaAouT0LOFTLpIw==",
       "dependencies": {
         "@types/d3-time": "^1"
@@ -58826,17 +58614,14 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3-scale-chromatic": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.1.tgz",
       "integrity": "sha512-7FtJYrmXTEWLykShjYhoGuDNR/Bda0+tstZMkFj4RRxUEryv16AGh3be21tqg84B6KfEwiZyEpBcTyPyU+GWjg=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-selection": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.3.tgz",
       "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-shape": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
       "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
       "dependencies": {
         "@types/d3-path": "^1"
@@ -58844,22 +58629,18 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3-time": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
       "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-time-format": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
       "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-timer": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.10.tgz",
       "integrity": "sha512-ZnAbquVqy+4ZjdW0cY6URp+qF/AzTVNda2jYyOzpR2cPT35FTXl78s15Bomph9+ckOiI1TtkljnWkwbIGAb6rg=="
     },
     "packages/source-iotsitewise/node_modules/@types/d3-transition": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.2.tgz",
       "integrity": "sha512-J+a3SuF/E7wXbOSN19p8ZieQSFIm5hU2Egqtndbc54LXaAEOpLfDx4sBu/PKAKzHOdgKK1wkMhINKqNh4aoZAg==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -58867,7 +58648,6 @@
     },
     "packages/source-iotsitewise/node_modules/@types/d3-zoom": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.3.tgz",
       "integrity": "sha512-3kHkL6sPiDdbfGhzlp5gIHyu3kULhtnHTTAl3UBZVtWB1PzcLL8vdmz5mTx7plLiUqOA2Y+yT2GKjt/TdA2p7Q==",
       "dependencies": {
         "@types/d3-interpolate": "^1",
@@ -58967,7 +58747,6 @@
     },
     "packages/source-iotsitewise/node_modules/d3-format": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "engines": {
         "node": ">=12"
@@ -58975,7 +58754,6 @@
     },
     "packages/source-iotsitewise/node_modules/d3-scale": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
       "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "dependencies": {
         "d3-array": "^2.3.0",
@@ -58987,12 +58765,10 @@
     },
     "packages/source-iotsitewise/node_modules/d3-scale/node_modules/d3-format": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
       "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
     },
     "packages/source-iotsitewise/node_modules/d3-time": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
       "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
       "dependencies": {
         "d3-array": "2"
@@ -59683,7 +59459,6 @@
     },
     "packages/source-iotsitewise/node_modules/minimatch": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -59765,7 +59540,6 @@
     },
     "packages/source-iotsitewise/node_modules/three": {
       "version": "0.125.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
       "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
     },
     "packages/source-iotsitewise/node_modules/throat": {
@@ -59834,7 +59608,6 @@
     },
     "packages/source-iotsitewise/node_modules/uuid": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
@@ -60131,7 +59904,6 @@
     },
     "packages/source-iottwinmaker/node_modules/@synchro-charts/core": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@synchro-charts/core/-/core-7.1.0.tgz",
       "integrity": "sha512-cT3RlsS2cIkRtda5BzlsqMXQb6oSfFfzJTHTlCGeVrJShgtSwTMGKLtiDrwa2JMU4W5+GbgJqBK2yyuGgcplDQ==",
       "dependencies": {
         "@stencil/redux": "^0.1.1",
@@ -60166,7 +59938,6 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3": {
       "version": "5.16.4",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
       "integrity": "sha512-2u0O9iP1MubFiQ+AhR1id4Egs+07BLtvRATG6IL2Gs9+KzdrfaxCKNq5hxEyw1kxwsqB/lCgr108XuHcKtb/5w==",
       "dependencies": {
         "@types/d3-array": "^1",
@@ -60204,12 +59975,10 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-array": {
       "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.9.tgz",
       "integrity": "sha512-E/7RgPr2ylT5dWG0CswMi9NpFcjIEDqLcUSBgNHe/EMahfqYaTx4zhcggG3khqoEB/leY4Vl6nTSbwLUPjXceA=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-axis": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.16.tgz",
       "integrity": "sha512-p7085weOmo4W+DzlRRVC/7OI/jugaKbVa6WMQGCQscaMylcbuaVEGk7abJLNyGVFLeCBNrHTdDiqRGnzvL0nXQ==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -60217,7 +59986,6 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-brush": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.1.5.tgz",
       "integrity": "sha512-4zGkBafJf5zCsBtLtvDj/pNMo5X9+Ii/1hUz0GvQ+wEwelUBm2AbIDAzJnp2hLDFF307o0fhxmmocHclhXC+tw==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -60225,17 +59993,14 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-chord": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.11.tgz",
       "integrity": "sha512-0DdfJ//bxyW3G9Nefwq/LDgazSKNN8NU0lBT3Cza6uVuInC2awMNsAcv1oKyRFLn9z7kXClH5XjwpveZjuz2eg=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-color": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.2.tgz",
       "integrity": "sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-contour": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-1.3.3.tgz",
       "integrity": "sha512-LxwmGIfVJIc1cKs7ZFRQ1FbtXpfH7QTXYRdMIJsFP71uCMdF6jJ0XZakYDX6Hn4yZkLf+7V8FgD34yCcok+5Ww==",
       "dependencies": {
         "@types/d3-array": "^1",
@@ -60244,12 +60009,10 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-dispatch": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.9.tgz",
       "integrity": "sha512-zJ44YgjqALmyps+II7b1mZLhrtfV/FOxw9owT87mrweGWcg+WK5oiJX2M3SYJ0XUAExBduarysfgbR11YxzojQ=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-drag": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.5.tgz",
       "integrity": "sha512-7NeTnfolst1Js3Vs7myctBkmJWu6DMI3k597AaHUX98saHjHWJ6vouT83UrpE+xfbSceHV+8A0JgxuwgqgmqWw==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -60257,17 +60020,14 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-dsv": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.1.tgz",
       "integrity": "sha512-LLmJmjiqp/fTNEdij5bIwUJ6P6TVNk5hKM9/uk5RPO2YNgEu9XvKO0dJ7Iqd3psEdmZN1m7gB1bOsjr4HmO2BA=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-ease": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.11.tgz",
       "integrity": "sha512-wUigPL0kleGZ9u3RhzBP07lxxkMcUjL5IODP42mN/05UNL+JJCDnpEPpFbJiPvLcTeRKGIRpBBJyP/1BNwYsVA=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-fetch": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.2.2.tgz",
       "integrity": "sha512-rtFs92GugtV/NpiJQd0WsmGLcg52tIL0uF0bKbbJg231pR9JEb6HT4AUwrtuLq3lOeKdLBhsjV14qb0pMmd0Aw==",
       "dependencies": {
         "@types/d3-dsv": "^1"
@@ -60275,17 +60035,14 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-force": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.4.tgz",
       "integrity": "sha512-fkorLTKvt6AQbFBQwn4aq7h9rJ4c7ZVcPMGB8X6eFFveAyMZcv7t7m6wgF4Eg93rkPgPORU7sAho1QSHNcZu6w=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-format": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
       "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-geo": {
       "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.12.3.tgz",
       "integrity": "sha512-yZbPb7/5DyL/pXkeOmZ7L5ySpuGr4H48t1cuALjnJy5sXQqmSSAYBiwa6Ya/XpWKX2rJqGDDubmh3nOaopOpeA==",
       "dependencies": {
         "@types/geojson": "*"
@@ -60293,12 +60050,10 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-hierarchy": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
       "integrity": "sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-interpolate": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.2.tgz",
       "integrity": "sha512-ylycts6llFf8yAEs1tXzx2loxxzDZHseuhPokrqKprTQSTcD3JbJI1omZP1rphsELZO3Q+of3ff0ZS7+O6yVzg==",
       "dependencies": {
         "@types/d3-color": "^1"
@@ -60306,27 +60061,22 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-path": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-polygon": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.8.tgz",
       "integrity": "sha512-1TOJPXCBJC9V3+K3tGbTqD/CsqLyv/YkTXAcwdsZzxqw5cvpdnCuDl42M4Dvi8XzMxZNCT9pL4ibrK2n4VmAcw=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-quadtree": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.9.tgz",
       "integrity": "sha512-5E0OJJn2QVavITFEc1AQlI8gLcIoDZcTKOD3feKFckQVmFV4CXhqRFt83tYNVNIN4ZzRkjlAMavJa1ldMhf5rA=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-random": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.3.tgz",
       "integrity": "sha512-XXR+ZbFCoOd4peXSMYJzwk0/elP37WWAzS/DG+90eilzVbUSsgKhBcWqylGWe+lA2ubgr7afWAOBaBxRgMUrBQ=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-scale": {
       "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.6.tgz",
       "integrity": "sha512-CHu34T5bGrJOeuhGxyiz9Xvaa9PlsIaQoOqjDg7zqeGj2x0rwPhGquiy03unigvcMxmvY0hEaAouT0LOFTLpIw==",
       "dependencies": {
         "@types/d3-time": "^1"
@@ -60334,17 +60084,14 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-scale-chromatic": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.1.tgz",
       "integrity": "sha512-7FtJYrmXTEWLykShjYhoGuDNR/Bda0+tstZMkFj4RRxUEryv16AGh3be21tqg84B6KfEwiZyEpBcTyPyU+GWjg=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-selection": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.3.tgz",
       "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-shape": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
       "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
       "dependencies": {
         "@types/d3-path": "^1"
@@ -60352,22 +60099,18 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-time": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
       "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-time-format": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
       "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-timer": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.10.tgz",
       "integrity": "sha512-ZnAbquVqy+4ZjdW0cY6URp+qF/AzTVNda2jYyOzpR2cPT35FTXl78s15Bomph9+ckOiI1TtkljnWkwbIGAb6rg=="
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-transition": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.2.tgz",
       "integrity": "sha512-J+a3SuF/E7wXbOSN19p8ZieQSFIm5hU2Egqtndbc54LXaAEOpLfDx4sBu/PKAKzHOdgKK1wkMhINKqNh4aoZAg==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -60375,7 +60118,6 @@
     },
     "packages/source-iottwinmaker/node_modules/@types/d3-zoom": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.3.tgz",
       "integrity": "sha512-3kHkL6sPiDdbfGhzlp5gIHyu3kULhtnHTTAl3UBZVtWB1PzcLL8vdmz5mTx7plLiUqOA2Y+yT2GKjt/TdA2p7Q==",
       "dependencies": {
         "@types/d3-interpolate": "^1",
@@ -60475,7 +60217,6 @@
     },
     "packages/source-iottwinmaker/node_modules/d3-format": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "engines": {
         "node": ">=12"
@@ -60483,7 +60224,6 @@
     },
     "packages/source-iottwinmaker/node_modules/d3-scale": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
       "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "dependencies": {
         "d3-array": "^2.3.0",
@@ -60495,12 +60235,10 @@
     },
     "packages/source-iottwinmaker/node_modules/d3-scale/node_modules/d3-format": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
       "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
     },
     "packages/source-iottwinmaker/node_modules/d3-time": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
       "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
       "dependencies": {
         "d3-array": "2"
@@ -61191,7 +60929,6 @@
     },
     "packages/source-iottwinmaker/node_modules/minimatch": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -61273,7 +61010,6 @@
     },
     "packages/source-iottwinmaker/node_modules/three": {
       "version": "0.125.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
       "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
     },
     "packages/source-iottwinmaker/node_modules/throat": {
@@ -61342,7 +61078,6 @@
     },
     "packages/source-iottwinmaker/node_modules/uuid": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
@@ -62046,7 +61781,6 @@
     },
     "packages/table/node_modules/@synchro-charts/core": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@synchro-charts/core/-/core-7.1.0.tgz",
       "integrity": "sha512-cT3RlsS2cIkRtda5BzlsqMXQb6oSfFfzJTHTlCGeVrJShgtSwTMGKLtiDrwa2JMU4W5+GbgJqBK2yyuGgcplDQ==",
       "dependencies": {
         "@stencil/redux": "^0.1.1",
@@ -62081,7 +61815,6 @@
     },
     "packages/table/node_modules/@synchro-charts/core/node_modules/d3-array": {
       "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
       "dependencies": {
         "internmap": "^1.0.0"
@@ -62089,7 +61822,6 @@
     },
     "packages/table/node_modules/@types/d3": {
       "version": "5.16.4",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
       "integrity": "sha512-2u0O9iP1MubFiQ+AhR1id4Egs+07BLtvRATG6IL2Gs9+KzdrfaxCKNq5hxEyw1kxwsqB/lCgr108XuHcKtb/5w==",
       "dependencies": {
         "@types/d3-array": "^1",
@@ -62127,12 +61859,10 @@
     },
     "packages/table/node_modules/@types/d3-array": {
       "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.9.tgz",
       "integrity": "sha512-E/7RgPr2ylT5dWG0CswMi9NpFcjIEDqLcUSBgNHe/EMahfqYaTx4zhcggG3khqoEB/leY4Vl6nTSbwLUPjXceA=="
     },
     "packages/table/node_modules/@types/d3-axis": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.16.tgz",
       "integrity": "sha512-p7085weOmo4W+DzlRRVC/7OI/jugaKbVa6WMQGCQscaMylcbuaVEGk7abJLNyGVFLeCBNrHTdDiqRGnzvL0nXQ==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -62140,7 +61870,6 @@
     },
     "packages/table/node_modules/@types/d3-brush": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.1.5.tgz",
       "integrity": "sha512-4zGkBafJf5zCsBtLtvDj/pNMo5X9+Ii/1hUz0GvQ+wEwelUBm2AbIDAzJnp2hLDFF307o0fhxmmocHclhXC+tw==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -62148,17 +61877,14 @@
     },
     "packages/table/node_modules/@types/d3-chord": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.11.tgz",
       "integrity": "sha512-0DdfJ//bxyW3G9Nefwq/LDgazSKNN8NU0lBT3Cza6uVuInC2awMNsAcv1oKyRFLn9z7kXClH5XjwpveZjuz2eg=="
     },
     "packages/table/node_modules/@types/d3-color": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.2.tgz",
       "integrity": "sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA=="
     },
     "packages/table/node_modules/@types/d3-contour": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-1.3.3.tgz",
       "integrity": "sha512-LxwmGIfVJIc1cKs7ZFRQ1FbtXpfH7QTXYRdMIJsFP71uCMdF6jJ0XZakYDX6Hn4yZkLf+7V8FgD34yCcok+5Ww==",
       "dependencies": {
         "@types/d3-array": "^1",
@@ -62167,12 +61893,10 @@
     },
     "packages/table/node_modules/@types/d3-dispatch": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.9.tgz",
       "integrity": "sha512-zJ44YgjqALmyps+II7b1mZLhrtfV/FOxw9owT87mrweGWcg+WK5oiJX2M3SYJ0XUAExBduarysfgbR11YxzojQ=="
     },
     "packages/table/node_modules/@types/d3-drag": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.5.tgz",
       "integrity": "sha512-7NeTnfolst1Js3Vs7myctBkmJWu6DMI3k597AaHUX98saHjHWJ6vouT83UrpE+xfbSceHV+8A0JgxuwgqgmqWw==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -62180,17 +61904,14 @@
     },
     "packages/table/node_modules/@types/d3-dsv": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.1.tgz",
       "integrity": "sha512-LLmJmjiqp/fTNEdij5bIwUJ6P6TVNk5hKM9/uk5RPO2YNgEu9XvKO0dJ7Iqd3psEdmZN1m7gB1bOsjr4HmO2BA=="
     },
     "packages/table/node_modules/@types/d3-ease": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.11.tgz",
       "integrity": "sha512-wUigPL0kleGZ9u3RhzBP07lxxkMcUjL5IODP42mN/05UNL+JJCDnpEPpFbJiPvLcTeRKGIRpBBJyP/1BNwYsVA=="
     },
     "packages/table/node_modules/@types/d3-fetch": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.2.2.tgz",
       "integrity": "sha512-rtFs92GugtV/NpiJQd0WsmGLcg52tIL0uF0bKbbJg231pR9JEb6HT4AUwrtuLq3lOeKdLBhsjV14qb0pMmd0Aw==",
       "dependencies": {
         "@types/d3-dsv": "^1"
@@ -62198,17 +61919,14 @@
     },
     "packages/table/node_modules/@types/d3-force": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.4.tgz",
       "integrity": "sha512-fkorLTKvt6AQbFBQwn4aq7h9rJ4c7ZVcPMGB8X6eFFveAyMZcv7t7m6wgF4Eg93rkPgPORU7sAho1QSHNcZu6w=="
     },
     "packages/table/node_modules/@types/d3-format": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
       "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
     },
     "packages/table/node_modules/@types/d3-geo": {
       "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.12.3.tgz",
       "integrity": "sha512-yZbPb7/5DyL/pXkeOmZ7L5ySpuGr4H48t1cuALjnJy5sXQqmSSAYBiwa6Ya/XpWKX2rJqGDDubmh3nOaopOpeA==",
       "dependencies": {
         "@types/geojson": "*"
@@ -62216,12 +61934,10 @@
     },
     "packages/table/node_modules/@types/d3-hierarchy": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
       "integrity": "sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg=="
     },
     "packages/table/node_modules/@types/d3-interpolate": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.2.tgz",
       "integrity": "sha512-ylycts6llFf8yAEs1tXzx2loxxzDZHseuhPokrqKprTQSTcD3JbJI1omZP1rphsELZO3Q+of3ff0ZS7+O6yVzg==",
       "dependencies": {
         "@types/d3-color": "^1"
@@ -62229,27 +61945,22 @@
     },
     "packages/table/node_modules/@types/d3-path": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
     },
     "packages/table/node_modules/@types/d3-polygon": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.8.tgz",
       "integrity": "sha512-1TOJPXCBJC9V3+K3tGbTqD/CsqLyv/YkTXAcwdsZzxqw5cvpdnCuDl42M4Dvi8XzMxZNCT9pL4ibrK2n4VmAcw=="
     },
     "packages/table/node_modules/@types/d3-quadtree": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.9.tgz",
       "integrity": "sha512-5E0OJJn2QVavITFEc1AQlI8gLcIoDZcTKOD3feKFckQVmFV4CXhqRFt83tYNVNIN4ZzRkjlAMavJa1ldMhf5rA=="
     },
     "packages/table/node_modules/@types/d3-random": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.3.tgz",
       "integrity": "sha512-XXR+ZbFCoOd4peXSMYJzwk0/elP37WWAzS/DG+90eilzVbUSsgKhBcWqylGWe+lA2ubgr7afWAOBaBxRgMUrBQ=="
     },
     "packages/table/node_modules/@types/d3-scale": {
       "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.6.tgz",
       "integrity": "sha512-CHu34T5bGrJOeuhGxyiz9Xvaa9PlsIaQoOqjDg7zqeGj2x0rwPhGquiy03unigvcMxmvY0hEaAouT0LOFTLpIw==",
       "dependencies": {
         "@types/d3-time": "^1"
@@ -62257,17 +61968,14 @@
     },
     "packages/table/node_modules/@types/d3-scale-chromatic": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.1.tgz",
       "integrity": "sha512-7FtJYrmXTEWLykShjYhoGuDNR/Bda0+tstZMkFj4RRxUEryv16AGh3be21tqg84B6KfEwiZyEpBcTyPyU+GWjg=="
     },
     "packages/table/node_modules/@types/d3-selection": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.3.tgz",
       "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA=="
     },
     "packages/table/node_modules/@types/d3-shape": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
       "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
       "dependencies": {
         "@types/d3-path": "^1"
@@ -62275,22 +61983,18 @@
     },
     "packages/table/node_modules/@types/d3-time": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
       "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
     },
     "packages/table/node_modules/@types/d3-time-format": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
       "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
     },
     "packages/table/node_modules/@types/d3-timer": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.10.tgz",
       "integrity": "sha512-ZnAbquVqy+4ZjdW0cY6URp+qF/AzTVNda2jYyOzpR2cPT35FTXl78s15Bomph9+ckOiI1TtkljnWkwbIGAb6rg=="
     },
     "packages/table/node_modules/@types/d3-transition": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.2.tgz",
       "integrity": "sha512-J+a3SuF/E7wXbOSN19p8ZieQSFIm5hU2Egqtndbc54LXaAEOpLfDx4sBu/PKAKzHOdgKK1wkMhINKqNh4aoZAg==",
       "dependencies": {
         "@types/d3-selection": "^1"
@@ -62298,7 +62002,6 @@
     },
     "packages/table/node_modules/@types/d3-zoom": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.3.tgz",
       "integrity": "sha512-3kHkL6sPiDdbfGhzlp5gIHyu3kULhtnHTTAl3UBZVtWB1PzcLL8vdmz5mTx7plLiUqOA2Y+yT2GKjt/TdA2p7Q==",
       "dependencies": {
         "@types/d3-interpolate": "^1",
@@ -62461,7 +62164,6 @@
     },
     "packages/table/node_modules/d3-format": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "engines": {
         "node": ">=12"
@@ -62469,7 +62171,6 @@
     },
     "packages/table/node_modules/d3-scale": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
       "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "dependencies": {
         "d3-array": "^2.3.0",
@@ -62481,7 +62182,6 @@
     },
     "packages/table/node_modules/d3-scale/node_modules/d3-array": {
       "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
       "dependencies": {
         "internmap": "^1.0.0"
@@ -62489,12 +62189,10 @@
     },
     "packages/table/node_modules/d3-scale/node_modules/d3-format": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
       "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
     },
     "packages/table/node_modules/d3-time": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
       "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
       "dependencies": {
         "d3-array": "2"
@@ -62502,7 +62200,6 @@
     },
     "packages/table/node_modules/d3-time/node_modules/d3-array": {
       "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
       "dependencies": {
         "internmap": "^1.0.0"
@@ -64155,7 +63852,6 @@
     },
     "packages/table/node_modules/minimatch": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -64237,7 +63933,6 @@
     },
     "packages/table/node_modules/three": {
       "version": "0.125.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
       "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
     },
     "packages/table/node_modules/throat": {
@@ -64348,7 +64043,6 @@
     },
     "packages/table/node_modules/uuid": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
@@ -65611,7 +65305,6 @@
     },
     "@aws-sdk/credential-providers": {
       "version": "3.163.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.163.0.tgz",
       "integrity": "sha512-xOV8btU1zeeqSGapV4irUPkSgTwbDpZ8QT8MZDPZAvbCW8slYwci4TO2W1iOdbTaEH32zhXXrYqyqjU3bG476g==",
       "requires": {
         "@aws-sdk/client-cognito-identity": "3.163.0",
@@ -68169,7 +67862,6 @@
       "dependencies": {
         "@synchro-charts/core": {
           "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@synchro-charts/core/-/core-7.1.0.tgz",
           "integrity": "sha512-cT3RlsS2cIkRtda5BzlsqMXQb6oSfFfzJTHTlCGeVrJShgtSwTMGKLtiDrwa2JMU4W5+GbgJqBK2yyuGgcplDQ==",
           "requires": {
             "@stencil/redux": "^0.1.1",
@@ -68204,14 +67896,12 @@
           "dependencies": {
             "uuid": {
               "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
               "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
             }
           }
         },
         "@types/d3": {
           "version": "5.16.4",
-          "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
           "integrity": "sha512-2u0O9iP1MubFiQ+AhR1id4Egs+07BLtvRATG6IL2Gs9+KzdrfaxCKNq5hxEyw1kxwsqB/lCgr108XuHcKtb/5w==",
           "requires": {
             "@types/d3-array": "^1",
@@ -68249,12 +67939,10 @@
         },
         "@types/d3-array": {
           "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.9.tgz",
           "integrity": "sha512-E/7RgPr2ylT5dWG0CswMi9NpFcjIEDqLcUSBgNHe/EMahfqYaTx4zhcggG3khqoEB/leY4Vl6nTSbwLUPjXceA=="
         },
         "@types/d3-axis": {
           "version": "1.0.16",
-          "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.16.tgz",
           "integrity": "sha512-p7085weOmo4W+DzlRRVC/7OI/jugaKbVa6WMQGCQscaMylcbuaVEGk7abJLNyGVFLeCBNrHTdDiqRGnzvL0nXQ==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -68262,7 +67950,6 @@
         },
         "@types/d3-brush": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.1.5.tgz",
           "integrity": "sha512-4zGkBafJf5zCsBtLtvDj/pNMo5X9+Ii/1hUz0GvQ+wEwelUBm2AbIDAzJnp2hLDFF307o0fhxmmocHclhXC+tw==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -68270,17 +67957,14 @@
         },
         "@types/d3-chord": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.11.tgz",
           "integrity": "sha512-0DdfJ//bxyW3G9Nefwq/LDgazSKNN8NU0lBT3Cza6uVuInC2awMNsAcv1oKyRFLn9z7kXClH5XjwpveZjuz2eg=="
         },
         "@types/d3-color": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.2.tgz",
           "integrity": "sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA=="
         },
         "@types/d3-contour": {
           "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-1.3.3.tgz",
           "integrity": "sha512-LxwmGIfVJIc1cKs7ZFRQ1FbtXpfH7QTXYRdMIJsFP71uCMdF6jJ0XZakYDX6Hn4yZkLf+7V8FgD34yCcok+5Ww==",
           "requires": {
             "@types/d3-array": "^1",
@@ -68289,12 +67973,10 @@
         },
         "@types/d3-dispatch": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.9.tgz",
           "integrity": "sha512-zJ44YgjqALmyps+II7b1mZLhrtfV/FOxw9owT87mrweGWcg+WK5oiJX2M3SYJ0XUAExBduarysfgbR11YxzojQ=="
         },
         "@types/d3-drag": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.5.tgz",
           "integrity": "sha512-7NeTnfolst1Js3Vs7myctBkmJWu6DMI3k597AaHUX98saHjHWJ6vouT83UrpE+xfbSceHV+8A0JgxuwgqgmqWw==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -68302,17 +67984,14 @@
         },
         "@types/d3-dsv": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.1.tgz",
           "integrity": "sha512-LLmJmjiqp/fTNEdij5bIwUJ6P6TVNk5hKM9/uk5RPO2YNgEu9XvKO0dJ7Iqd3psEdmZN1m7gB1bOsjr4HmO2BA=="
         },
         "@types/d3-ease": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.11.tgz",
           "integrity": "sha512-wUigPL0kleGZ9u3RhzBP07lxxkMcUjL5IODP42mN/05UNL+JJCDnpEPpFbJiPvLcTeRKGIRpBBJyP/1BNwYsVA=="
         },
         "@types/d3-fetch": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.2.2.tgz",
           "integrity": "sha512-rtFs92GugtV/NpiJQd0WsmGLcg52tIL0uF0bKbbJg231pR9JEb6HT4AUwrtuLq3lOeKdLBhsjV14qb0pMmd0Aw==",
           "requires": {
             "@types/d3-dsv": "^1"
@@ -68320,17 +67999,14 @@
         },
         "@types/d3-force": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.4.tgz",
           "integrity": "sha512-fkorLTKvt6AQbFBQwn4aq7h9rJ4c7ZVcPMGB8X6eFFveAyMZcv7t7m6wgF4Eg93rkPgPORU7sAho1QSHNcZu6w=="
         },
         "@types/d3-format": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
           "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
         },
         "@types/d3-geo": {
           "version": "1.12.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.12.3.tgz",
           "integrity": "sha512-yZbPb7/5DyL/pXkeOmZ7L5ySpuGr4H48t1cuALjnJy5sXQqmSSAYBiwa6Ya/XpWKX2rJqGDDubmh3nOaopOpeA==",
           "requires": {
             "@types/geojson": "*"
@@ -68338,12 +68014,10 @@
         },
         "@types/d3-hierarchy": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
           "integrity": "sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg=="
         },
         "@types/d3-interpolate": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.2.tgz",
           "integrity": "sha512-ylycts6llFf8yAEs1tXzx2loxxzDZHseuhPokrqKprTQSTcD3JbJI1omZP1rphsELZO3Q+of3ff0ZS7+O6yVzg==",
           "requires": {
             "@types/d3-color": "^1"
@@ -68351,27 +68025,22 @@
         },
         "@types/d3-path": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
           "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
         },
         "@types/d3-polygon": {
           "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.8.tgz",
           "integrity": "sha512-1TOJPXCBJC9V3+K3tGbTqD/CsqLyv/YkTXAcwdsZzxqw5cvpdnCuDl42M4Dvi8XzMxZNCT9pL4ibrK2n4VmAcw=="
         },
         "@types/d3-quadtree": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.9.tgz",
           "integrity": "sha512-5E0OJJn2QVavITFEc1AQlI8gLcIoDZcTKOD3feKFckQVmFV4CXhqRFt83tYNVNIN4ZzRkjlAMavJa1ldMhf5rA=="
         },
         "@types/d3-random": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.3.tgz",
           "integrity": "sha512-XXR+ZbFCoOd4peXSMYJzwk0/elP37WWAzS/DG+90eilzVbUSsgKhBcWqylGWe+lA2ubgr7afWAOBaBxRgMUrBQ=="
         },
         "@types/d3-scale": {
           "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.6.tgz",
           "integrity": "sha512-CHu34T5bGrJOeuhGxyiz9Xvaa9PlsIaQoOqjDg7zqeGj2x0rwPhGquiy03unigvcMxmvY0hEaAouT0LOFTLpIw==",
           "requires": {
             "@types/d3-time": "^1"
@@ -68379,17 +68048,14 @@
         },
         "@types/d3-scale-chromatic": {
           "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.1.tgz",
           "integrity": "sha512-7FtJYrmXTEWLykShjYhoGuDNR/Bda0+tstZMkFj4RRxUEryv16AGh3be21tqg84B6KfEwiZyEpBcTyPyU+GWjg=="
         },
         "@types/d3-selection": {
           "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.3.tgz",
           "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA=="
         },
         "@types/d3-shape": {
           "version": "1.3.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
           "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
           "requires": {
             "@types/d3-path": "^1"
@@ -68397,22 +68063,18 @@
         },
         "@types/d3-time": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
           "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
         },
         "@types/d3-time-format": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
           "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
         },
         "@types/d3-timer": {
           "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.10.tgz",
           "integrity": "sha512-ZnAbquVqy+4ZjdW0cY6URp+qF/AzTVNda2jYyOzpR2cPT35FTXl78s15Bomph9+ckOiI1TtkljnWkwbIGAb6rg=="
         },
         "@types/d3-transition": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.2.tgz",
           "integrity": "sha512-J+a3SuF/E7wXbOSN19p8ZieQSFIm5hU2Egqtndbc54LXaAEOpLfDx4sBu/PKAKzHOdgKK1wkMhINKqNh4aoZAg==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -68420,7 +68082,6 @@
         },
         "@types/d3-zoom": {
           "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.3.tgz",
           "integrity": "sha512-3kHkL6sPiDdbfGhzlp5gIHyu3kULhtnHTTAl3UBZVtWB1PzcLL8vdmz5mTx7plLiUqOA2Y+yT2GKjt/TdA2p7Q==",
           "requires": {
             "@types/d3-interpolate": "^1",
@@ -68560,12 +68221,10 @@
         },
         "d3-format": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
           "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
         },
         "d3-scale": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
           "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
           "requires": {
             "d3-array": "^2.3.0",
@@ -68577,14 +68236,12 @@
           "dependencies": {
             "d3-format": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
               "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
             }
           }
         },
         "d3-time": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
           "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
           "requires": {
             "d3-array": "2"
@@ -68704,7 +68361,6 @@
         },
         "minimatch": {
           "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
           "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -68753,7 +68409,6 @@
         },
         "three": {
           "version": "0.125.2",
-          "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
           "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
         },
         "yallist": {
@@ -68948,7 +68603,6 @@
         },
         "@synchro-charts/core": {
           "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@synchro-charts/core/-/core-7.1.0.tgz",
           "integrity": "sha512-cT3RlsS2cIkRtda5BzlsqMXQb6oSfFfzJTHTlCGeVrJShgtSwTMGKLtiDrwa2JMU4W5+GbgJqBK2yyuGgcplDQ==",
           "requires": {
             "@stencil/redux": "^0.1.1",
@@ -68983,7 +68637,6 @@
         },
         "@types/d3": {
           "version": "5.16.4",
-          "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
           "integrity": "sha512-2u0O9iP1MubFiQ+AhR1id4Egs+07BLtvRATG6IL2Gs9+KzdrfaxCKNq5hxEyw1kxwsqB/lCgr108XuHcKtb/5w==",
           "requires": {
             "@types/d3-array": "^1",
@@ -69021,12 +68674,10 @@
         },
         "@types/d3-array": {
           "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.9.tgz",
           "integrity": "sha512-E/7RgPr2ylT5dWG0CswMi9NpFcjIEDqLcUSBgNHe/EMahfqYaTx4zhcggG3khqoEB/leY4Vl6nTSbwLUPjXceA=="
         },
         "@types/d3-axis": {
           "version": "1.0.16",
-          "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.16.tgz",
           "integrity": "sha512-p7085weOmo4W+DzlRRVC/7OI/jugaKbVa6WMQGCQscaMylcbuaVEGk7abJLNyGVFLeCBNrHTdDiqRGnzvL0nXQ==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -69034,7 +68685,6 @@
         },
         "@types/d3-brush": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.1.5.tgz",
           "integrity": "sha512-4zGkBafJf5zCsBtLtvDj/pNMo5X9+Ii/1hUz0GvQ+wEwelUBm2AbIDAzJnp2hLDFF307o0fhxmmocHclhXC+tw==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -69042,17 +68692,14 @@
         },
         "@types/d3-chord": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.11.tgz",
           "integrity": "sha512-0DdfJ//bxyW3G9Nefwq/LDgazSKNN8NU0lBT3Cza6uVuInC2awMNsAcv1oKyRFLn9z7kXClH5XjwpveZjuz2eg=="
         },
         "@types/d3-color": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.2.tgz",
           "integrity": "sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA=="
         },
         "@types/d3-contour": {
           "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-1.3.3.tgz",
           "integrity": "sha512-LxwmGIfVJIc1cKs7ZFRQ1FbtXpfH7QTXYRdMIJsFP71uCMdF6jJ0XZakYDX6Hn4yZkLf+7V8FgD34yCcok+5Ww==",
           "requires": {
             "@types/d3-array": "^1",
@@ -69061,12 +68708,10 @@
         },
         "@types/d3-dispatch": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.9.tgz",
           "integrity": "sha512-zJ44YgjqALmyps+II7b1mZLhrtfV/FOxw9owT87mrweGWcg+WK5oiJX2M3SYJ0XUAExBduarysfgbR11YxzojQ=="
         },
         "@types/d3-drag": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.5.tgz",
           "integrity": "sha512-7NeTnfolst1Js3Vs7myctBkmJWu6DMI3k597AaHUX98saHjHWJ6vouT83UrpE+xfbSceHV+8A0JgxuwgqgmqWw==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -69074,17 +68719,14 @@
         },
         "@types/d3-dsv": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.1.tgz",
           "integrity": "sha512-LLmJmjiqp/fTNEdij5bIwUJ6P6TVNk5hKM9/uk5RPO2YNgEu9XvKO0dJ7Iqd3psEdmZN1m7gB1bOsjr4HmO2BA=="
         },
         "@types/d3-ease": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.11.tgz",
           "integrity": "sha512-wUigPL0kleGZ9u3RhzBP07lxxkMcUjL5IODP42mN/05UNL+JJCDnpEPpFbJiPvLcTeRKGIRpBBJyP/1BNwYsVA=="
         },
         "@types/d3-fetch": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.2.2.tgz",
           "integrity": "sha512-rtFs92GugtV/NpiJQd0WsmGLcg52tIL0uF0bKbbJg231pR9JEb6HT4AUwrtuLq3lOeKdLBhsjV14qb0pMmd0Aw==",
           "requires": {
             "@types/d3-dsv": "^1"
@@ -69092,17 +68734,14 @@
         },
         "@types/d3-force": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.4.tgz",
           "integrity": "sha512-fkorLTKvt6AQbFBQwn4aq7h9rJ4c7ZVcPMGB8X6eFFveAyMZcv7t7m6wgF4Eg93rkPgPORU7sAho1QSHNcZu6w=="
         },
         "@types/d3-format": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
           "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
         },
         "@types/d3-geo": {
           "version": "1.12.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.12.3.tgz",
           "integrity": "sha512-yZbPb7/5DyL/pXkeOmZ7L5ySpuGr4H48t1cuALjnJy5sXQqmSSAYBiwa6Ya/XpWKX2rJqGDDubmh3nOaopOpeA==",
           "requires": {
             "@types/geojson": "*"
@@ -69110,12 +68749,10 @@
         },
         "@types/d3-hierarchy": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
           "integrity": "sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg=="
         },
         "@types/d3-interpolate": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.2.tgz",
           "integrity": "sha512-ylycts6llFf8yAEs1tXzx2loxxzDZHseuhPokrqKprTQSTcD3JbJI1omZP1rphsELZO3Q+of3ff0ZS7+O6yVzg==",
           "requires": {
             "@types/d3-color": "^1"
@@ -69123,27 +68760,22 @@
         },
         "@types/d3-path": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
           "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
         },
         "@types/d3-polygon": {
           "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.8.tgz",
           "integrity": "sha512-1TOJPXCBJC9V3+K3tGbTqD/CsqLyv/YkTXAcwdsZzxqw5cvpdnCuDl42M4Dvi8XzMxZNCT9pL4ibrK2n4VmAcw=="
         },
         "@types/d3-quadtree": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.9.tgz",
           "integrity": "sha512-5E0OJJn2QVavITFEc1AQlI8gLcIoDZcTKOD3feKFckQVmFV4CXhqRFt83tYNVNIN4ZzRkjlAMavJa1ldMhf5rA=="
         },
         "@types/d3-random": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.3.tgz",
           "integrity": "sha512-XXR+ZbFCoOd4peXSMYJzwk0/elP37WWAzS/DG+90eilzVbUSsgKhBcWqylGWe+lA2ubgr7afWAOBaBxRgMUrBQ=="
         },
         "@types/d3-scale": {
           "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.6.tgz",
           "integrity": "sha512-CHu34T5bGrJOeuhGxyiz9Xvaa9PlsIaQoOqjDg7zqeGj2x0rwPhGquiy03unigvcMxmvY0hEaAouT0LOFTLpIw==",
           "requires": {
             "@types/d3-time": "^1"
@@ -69151,17 +68783,14 @@
         },
         "@types/d3-scale-chromatic": {
           "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.1.tgz",
           "integrity": "sha512-7FtJYrmXTEWLykShjYhoGuDNR/Bda0+tstZMkFj4RRxUEryv16AGh3be21tqg84B6KfEwiZyEpBcTyPyU+GWjg=="
         },
         "@types/d3-selection": {
           "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.3.tgz",
           "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA=="
         },
         "@types/d3-shape": {
           "version": "1.3.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
           "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
           "requires": {
             "@types/d3-path": "^1"
@@ -69169,22 +68798,18 @@
         },
         "@types/d3-time": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
           "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
         },
         "@types/d3-time-format": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
           "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
         },
         "@types/d3-timer": {
           "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.10.tgz",
           "integrity": "sha512-ZnAbquVqy+4ZjdW0cY6URp+qF/AzTVNda2jYyOzpR2cPT35FTXl78s15Bomph9+ckOiI1TtkljnWkwbIGAb6rg=="
         },
         "@types/d3-transition": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.2.tgz",
           "integrity": "sha512-J+a3SuF/E7wXbOSN19p8ZieQSFIm5hU2Egqtndbc54LXaAEOpLfDx4sBu/PKAKzHOdgKK1wkMhINKqNh4aoZAg==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -69192,7 +68817,6 @@
         },
         "@types/d3-zoom": {
           "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.3.tgz",
           "integrity": "sha512-3kHkL6sPiDdbfGhzlp5gIHyu3kULhtnHTTAl3UBZVtWB1PzcLL8vdmz5mTx7plLiUqOA2Y+yT2GKjt/TdA2p7Q==",
           "requires": {
             "@types/d3-interpolate": "^1",
@@ -69268,12 +68892,10 @@
         },
         "d3-format": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
           "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
         },
         "d3-scale": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
           "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
           "requires": {
             "d3-array": "^2.3.0",
@@ -69285,14 +68907,12 @@
           "dependencies": {
             "d3-format": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
               "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
             }
           }
         },
         "d3-time": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
           "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
           "requires": {
             "d3-array": "2"
@@ -69782,7 +69402,6 @@
         },
         "minimatch": {
           "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
           "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -69836,7 +69455,6 @@
         },
         "three": {
           "version": "0.125.2",
-          "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
           "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
         },
         "throat": {
@@ -69950,8 +69568,6 @@
         "jest-dom": "^3.0.2",
         "jest-simple-dot-reporter": "^1.0.5",
         "jest-styled-components": "^7.0.0",
-        "m3u8-parser": "4.5.0",
-        "mpd-parser": "0.15.0",
         "mux.js": "5.8.0",
         "np": "^3.1.0",
         "react": "^17.0.2",
@@ -69960,7 +69576,7 @@
         "ts-node": "^10.0.0",
         "typescript": "^3.3.4000",
         "uuid": "^8.3.2",
-        "video.js": "7.14.3"
+        "video.js": "7.20.3"
       },
       "dependencies": {
         "@jest/console": {
@@ -70139,6 +69755,69 @@
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
+          }
+        },
+        "@videojs/http-streaming": {
+          "version": "2.14.3",
+          "integrity": "sha512-2tFwxCaNbcEZzQugWf8EERwNMyNtspfHnvxRGRABQs09W/5SqmkWFuGWfUAm4wQKlXGfdPyAJ1338ASl459xAA==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@videojs/vhs-utils": "3.0.5",
+            "aes-decrypter": "3.1.3",
+            "global": "^4.4.0",
+            "m3u8-parser": "4.7.1",
+            "mpd-parser": "0.21.1",
+            "mux.js": "6.0.1",
+            "video.js": "^6 || ^7"
+          },
+          "dependencies": {
+            "@videojs/vhs-utils": {
+              "version": "3.0.5",
+              "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+              "requires": {
+                "@babel/runtime": "^7.12.5",
+                "global": "^4.4.0",
+                "url-toolkit": "^2.2.1"
+              }
+            },
+            "mux.js": {
+              "version": "6.0.1",
+              "integrity": "sha512-22CHb59rH8pWGcPGW5Og7JngJ9s+z4XuSlYvnxhLuc58cA1WqGDQPzuG8I+sPm1/p0CdgpzVTaKW408k5DNn8w==",
+              "requires": {
+                "@babel/runtime": "^7.11.2",
+                "global": "^4.4.0"
+              }
+            }
+          }
+        },
+        "@videojs/xhr": {
+          "version": "2.6.0",
+          "integrity": "sha512-7J361GiN1tXpm+gd0xz2QWr3xNWBE+rytvo8J3KuggFaLg+U37gZQ2BuPLcnkfGffy2e+ozY70RHC8jt7zjA6Q==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "global": "~4.4.0",
+            "is-function": "^1.0.1"
+          }
+        },
+        "aes-decrypter": {
+          "version": "3.1.3",
+          "integrity": "sha512-VkG9g4BbhMBy+N5/XodDeV6F02chEk9IpgRTq/0bS80y4dzy79VH2Gtms02VXomf3HmyRe3yyJYkJ990ns+d6A==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@videojs/vhs-utils": "^3.0.5",
+            "global": "^4.4.0",
+            "pkcs7": "^1.0.4"
+          },
+          "dependencies": {
+            "@videojs/vhs-utils": {
+              "version": "3.0.5",
+              "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+              "requires": {
+                "@babel/runtime": "^7.12.5",
+                "global": "^4.4.0",
+                "url-toolkit": "^2.2.1"
+              }
+            }
           }
         },
         "ansi-styles": {
@@ -70664,6 +70343,47 @@
             "yallist": "^4.0.0"
           }
         },
+        "m3u8-parser": {
+          "version": "4.7.1",
+          "integrity": "sha512-pbrQwiMiq+MmI9bl7UjtPT3AK603PV9bogNlr83uC+X9IoxqL5E4k7kU7fMQ0dpRgxgeSMygqUa0IMLQNXLBNA==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@videojs/vhs-utils": "^3.0.5",
+            "global": "^4.4.0"
+          },
+          "dependencies": {
+            "@videojs/vhs-utils": {
+              "version": "3.0.5",
+              "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+              "requires": {
+                "@babel/runtime": "^7.12.5",
+                "global": "^4.4.0",
+                "url-toolkit": "^2.2.1"
+              }
+            }
+          }
+        },
+        "mpd-parser": {
+          "version": "0.21.1",
+          "integrity": "sha512-BxlSXWbKE1n7eyEPBnTEkrzhS3PdmkkKdM1pgKbPnPOH0WFZIc0sPOWi7m0Uo3Wd2a4Or8Qf4ZbS7+ASqQ49fw==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@videojs/vhs-utils": "^3.0.5",
+            "@xmldom/xmldom": "^0.7.2",
+            "global": "^4.4.0"
+          },
+          "dependencies": {
+            "@videojs/vhs-utils": {
+              "version": "3.0.5",
+              "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+              "requires": {
+                "@babel/runtime": "^7.12.5",
+                "global": "^4.4.0",
+                "url-toolkit": "^2.2.1"
+              }
+            }
+          }
+        },
         "npm-run-path": {
           "version": "4.0.1",
           "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
@@ -70759,6 +70479,44 @@
               "version": "0.7.4",
               "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
               "dev": true
+            }
+          }
+        },
+        "video.js": {
+          "version": "7.20.3",
+          "integrity": "sha512-JMspxaK74LdfWcv69XWhX4rILywz/eInOVPdKefpQiZJSMD5O8xXYueqACP2Q5yqKstycgmmEKlJzZ+kVmDciw==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@videojs/http-streaming": "2.14.3",
+            "@videojs/vhs-utils": "^3.0.4",
+            "@videojs/xhr": "2.6.0",
+            "aes-decrypter": "3.1.3",
+            "global": "^4.4.0",
+            "keycode": "^2.2.0",
+            "m3u8-parser": "4.7.1",
+            "mpd-parser": "0.21.1",
+            "mux.js": "6.0.1",
+            "safe-json-parse": "4.0.0",
+            "videojs-font": "3.2.0",
+            "videojs-vtt.js": "^0.15.4"
+          },
+          "dependencies": {
+            "@videojs/vhs-utils": {
+              "version": "3.0.5",
+              "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+              "requires": {
+                "@babel/runtime": "^7.12.5",
+                "global": "^4.4.0",
+                "url-toolkit": "^2.2.1"
+              }
+            },
+            "mux.js": {
+              "version": "6.0.1",
+              "integrity": "sha512-22CHb59rH8pWGcPGW5Og7JngJ9s+z4XuSlYvnxhLuc58cA1WqGDQPzuG8I+sPm1/p0CdgpzVTaKW408k5DNn8w==",
+              "requires": {
+                "@babel/runtime": "^7.11.2",
+                "global": "^4.4.0"
+              }
             }
           }
         },
@@ -71040,7 +70798,6 @@
       "dependencies": {
         "@babel/helper-define-polyfill-provider": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz",
           "integrity": "sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==",
           "dev": true,
           "requires": {
@@ -71212,7 +70969,6 @@
         },
         "@storybook/addon-actions": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-6.5.14.tgz",
           "integrity": "sha512-fZt8bn+oCsVDv9yuZfKL4lq77V5EqW60khHpOxLRRK69hMsE+gaylK0O5l/pelVf3Jf3+TablUG+2xWTaJHGlQ==",
           "dev": true,
           "requires": {
@@ -71239,7 +70995,6 @@
         },
         "@storybook/addon-backgrounds": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-6.5.14.tgz",
           "integrity": "sha512-DZY8oizDTiNLsknyrCyjf6OirwyfrXB4+UCXKXT7Xp+S5PHsdHwBZUADgM6yIwLUjDXzcsL7Ok00C1zI9qERdg==",
           "dev": true,
           "requires": {
@@ -71260,7 +71015,6 @@
         },
         "@storybook/addon-controls": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-6.5.14.tgz",
           "integrity": "sha512-p16k/69GjwVtnpEiz0fmb1qoqp/H2d5aaSGDt7VleeXsdhs4Kh0kJyxfLpekHmlzT+5IkO08Nm/U8tJOHbw4Hw==",
           "dev": true,
           "requires": {
@@ -71280,7 +71034,6 @@
         },
         "@storybook/addon-docs": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.5.14.tgz",
           "integrity": "sha512-gapuzDY+dqgS4/Ap9zj5L76OSExBYtVNYej9xTiF+v0Gh4/kty9FIGlVWiqskffOmixL4nlyImpfsSH8V0JnCw==",
           "dev": true,
           "requires": {
@@ -71316,7 +71069,6 @@
           "dependencies": {
             "@jest/transform": {
               "version": "26.6.2",
-              "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
               "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
               "dev": true,
               "requires": {
@@ -71339,7 +71091,6 @@
             },
             "@jest/types": {
               "version": "26.6.2",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
               "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
               "dev": true,
               "requires": {
@@ -71352,7 +71103,6 @@
             },
             "@types/yargs": {
               "version": "15.0.14",
-              "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
               "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
               "dev": true,
               "requires": {
@@ -71361,7 +71111,6 @@
             },
             "jest-haste-map": {
               "version": "26.6.2",
-              "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
               "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
               "dev": true,
               "requires": {
@@ -71383,13 +71132,11 @@
             },
             "jest-regex-util": {
               "version": "26.0.0",
-              "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
               "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
               "dev": true
             },
             "jest-serializer": {
               "version": "26.6.2",
-              "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
               "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
               "dev": true,
               "requires": {
@@ -71399,7 +71146,6 @@
             },
             "jest-util": {
               "version": "26.6.2",
-              "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
               "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
               "dev": true,
               "requires": {
@@ -71413,7 +71159,6 @@
             },
             "jest-worker": {
               "version": "26.6.2",
-              "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
               "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
               "dev": true,
               "requires": {
@@ -71426,7 +71171,6 @@
         },
         "@storybook/addon-essentials": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-6.5.14.tgz",
           "integrity": "sha512-6fmfDHbp1y/hF0GU0W95RLw4rzN3KGcEcpAZ8HbgTyXIF528j0hhlvkD5AjnQ5dVarlHdKAtMRZA9Y3OCEZD6A==",
           "dev": true,
           "requires": {
@@ -71449,7 +71193,6 @@
         },
         "@storybook/addon-links": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-6.5.14.tgz",
           "integrity": "sha512-Q4gNVFi3PqJH/YYmYJ6xX7a2VPZYs8QV97fMIjdg7/k4FLelSRj7QfsHc7jO2RGG2qQpenapO569jFoVNAW4/Q==",
           "dev": true,
           "requires": {
@@ -71469,7 +71212,6 @@
         },
         "@storybook/addon-measure": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-6.5.14.tgz",
           "integrity": "sha512-7JH35z7NRaNiOMYIG+tJQrQdV2fdURUK94g9x58rNBT4GCtXTclFvhWiwKHHT2CnM8xdYuKGMt3DY9U0urq3Gg==",
           "dev": true,
           "requires": {
@@ -71485,7 +71227,6 @@
         },
         "@storybook/addon-outline": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-6.5.14.tgz",
           "integrity": "sha512-eXkkRmSxfPIcztfcLxGO1Cj61Ohx4qKuYSjNh25CRc+HYbBjQkWyxOXZP+x4Ritx4IuQsgWiCJJO3/zdgXLRgw==",
           "dev": true,
           "requires": {
@@ -71503,7 +71244,6 @@
         },
         "@storybook/addon-toolbars": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-6.5.14.tgz",
           "integrity": "sha512-BZGQ9YadVRtSd5mpmrwnJta0wK1leX/vgziJX4gUKX2A5JX7VWsiswUGVukLVtE9Oa1jp3fJXE3O5Ip9moj0Ag==",
           "dev": true,
           "requires": {
@@ -71518,7 +71258,6 @@
         },
         "@storybook/addon-viewport": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-6.5.14.tgz",
           "integrity": "sha512-QtcQZe5ahWcMr4oRgfjeCIJtweTitArc8x1cDfS8maEEy965JJGjrR9xBIOLaw6IEiRtBuvrewYAWbRLLsUE+g==",
           "dev": true,
           "requires": {
@@ -71537,7 +71276,6 @@
         },
         "@storybook/addons": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.5.14.tgz",
           "integrity": "sha512-8wVy1eDKipj+dmWpVmmPa1p2jYVqDvrkWll4IsP/KU7AYFCiyCiVAd1ZPDv9EhDnwArfYYjrdJjAl6gmP0UMag==",
           "dev": true,
           "requires": {
@@ -71556,7 +71294,6 @@
         },
         "@storybook/api": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.5.14.tgz",
           "integrity": "sha512-RpgEWV4mxD1mNsGWkjSNq3+B/LFNIhXZc4OapEEK5u0jgCZKB7OCsRL9NJZB5WfpyN+vx8SwbUTgo8DIkes3qw==",
           "dev": true,
           "requires": {
@@ -71581,7 +71318,6 @@
         },
         "@storybook/builder-webpack4": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/builder-webpack4/-/builder-webpack4-6.5.14.tgz",
           "integrity": "sha512-0pv8BlsMeiP9VYU2CbCZaa3yXDt1ssb8OeTRDbFC0uFFb3eqslsH68I7XsC8ap/dr0RZR0Edtw0OW3HhkjUXXw==",
           "dev": true,
           "requires": {
@@ -71636,7 +71372,6 @@
           "dependencies": {
             "chalk": {
               "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
@@ -71647,7 +71382,6 @@
             },
             "fork-ts-checker-webpack-plugin": {
               "version": "4.1.6",
-              "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-4.1.6.tgz",
               "integrity": "sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==",
               "dev": true,
               "requires": {
@@ -71662,13 +71396,11 @@
             },
             "has-flag": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
               "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
               "dev": true
             },
             "micromatch": {
               "version": "3.1.10",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
               "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
               "dev": true,
               "requires": {
@@ -71689,7 +71421,6 @@
             },
             "postcss": {
               "version": "7.0.39",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
               "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
               "dev": true,
               "requires": {
@@ -71699,13 +71430,11 @@
             },
             "semver": {
               "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
               "dev": true
             },
             "supports-color": {
               "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
@@ -71716,7 +71445,6 @@
         },
         "@storybook/channel-postmessage": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.5.14.tgz",
           "integrity": "sha512-0Cmdze5G3Qwxf7yYPGlJxGiY+KiEUQ+8GfpohsKGfvrP8cfSrx6VhxupHA7hDNyRh75hqZq5BrkW4HO9Ypbt5A==",
           "dev": true,
           "requires": {
@@ -71731,7 +71459,6 @@
         },
         "@storybook/channel-websocket": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-6.5.14.tgz",
           "integrity": "sha512-ZyDL5PBFWuFQ15NBljhbOaD/3FAijXvLj5oxfNris2khdkqlP6/8JmcIvfohJJcqepGZHUF9H29OaUsRC35ftA==",
           "dev": true,
           "requires": {
@@ -71744,7 +71471,6 @@
         },
         "@storybook/channels": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.5.14.tgz",
           "integrity": "sha512-hHpr4Sya6fuEDhy7vnfD2QnL5wy1CaAK9BC0FLupndXnQyKJtygfIaUP4a0B2KntuNPbzPhclb2Hb4yM7CExmQ==",
           "dev": true,
           "requires": {
@@ -71755,7 +71481,6 @@
         },
         "@storybook/client-api": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.5.14.tgz",
           "integrity": "sha512-G5mBQCKn8/VqE9XDCL19ixcvu8YhaQZ0AE+EXGYXUsvPpyQ43oGoGJry5IqOzeRlc7dbglFWpMkB6PeeUD7aCw==",
           "dev": true,
           "requires": {
@@ -71783,7 +71508,6 @@
         },
         "@storybook/client-logger": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.5.14.tgz",
           "integrity": "sha512-r1pY69DGKzX9/GngkudthaaPxPlka16zjG7Y58psunwcoUuH3riAP1cjqhXt5+S8FKCNI/MGb82PLlCPX2Liuw==",
           "dev": true,
           "requires": {
@@ -71793,7 +71517,6 @@
         },
         "@storybook/components": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.5.14.tgz",
           "integrity": "sha512-wqB9CF3sjxtgffnDW1G/W5SsKumsFQ0ftn/3PdrsvKULu5LM5bjNEqC2cTCWrk9vQhj+EVQxzdVM/BlPl/lSwg==",
           "dev": true,
           "requires": {
@@ -71809,7 +71532,6 @@
         },
         "@storybook/core": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.5.14.tgz",
           "integrity": "sha512-5rjwZXk++NkKWCmHt/CC+h2L4ZbOYkLJpMmaB97CwgQCA6kaF8xuJqlAwG72VUH3oV+6RntW02X6/ypgX1atPw==",
           "dev": true,
           "requires": {
@@ -71819,7 +71541,6 @@
         },
         "@storybook/core-client": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.5.14.tgz",
           "integrity": "sha512-d5mUgz1xSvrAdal8XKI5YOZOM/XUly90vis3DboeZRO58qSp+NH5xFYIBBED5qefDgmGU0Yv4rXHQlph96LSHQ==",
           "dev": true,
           "requires": {
@@ -71847,7 +71568,6 @@
         },
         "@storybook/core-common": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-6.5.14.tgz",
           "integrity": "sha512-MrxhYXYrtN6z/+tydjPkCIwDQm5q8Jx+w4TPdLKBZu7vzfp6T3sT12Ym96j9MJ42CvE4vSDl/Njbw6C0D+yEVw==",
           "dev": true,
           "requires": {
@@ -71905,7 +71625,6 @@
         },
         "@storybook/core-events": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.5.14.tgz",
           "integrity": "sha512-PLu0M8Mqt9ruN5RupgcFKHEybiSm3CdWQyylWO5FRGg+WZV3BCm0aI8ujvO1GAm+YEi57Lull+M9d6NUycTpRg==",
           "dev": true,
           "requires": {
@@ -71914,7 +71633,6 @@
         },
         "@storybook/core-server": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-6.5.14.tgz",
           "integrity": "sha512-+Z3lHEsDpiBXt6xBwU5AVBoEkicndnHoiLwhEGPkfixy7POYEEny3cm54tteVxV8O5AHMwsHs54/QD+hHxAXnQ==",
           "dev": true,
           "requires": {
@@ -71967,7 +71685,6 @@
         },
         "@storybook/csf-tools": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-6.5.14.tgz",
           "integrity": "sha512-PgCKgyfD6UD9aNilDxmKJRbCZwcZl8t8Orb6+vVGuzB5f0BV92NqnHS4sgAlFoZ+iqcQGUEU9vRIdUxNcyItaw==",
           "dev": true,
           "requires": {
@@ -71989,7 +71706,6 @@
         },
         "@storybook/docs-tools": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-6.5.14.tgz",
           "integrity": "sha512-qA0UWvrZ7XyIWD+01NGHiiGPSbfercrxjphM9wHgF6KrO6e5iykNKIEL4elsM+EV4szfhlalQdtpnwM7WtXODA==",
           "dev": true,
           "requires": {
@@ -72004,7 +71720,6 @@
         },
         "@storybook/manager-webpack4": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/manager-webpack4/-/manager-webpack4-6.5.14.tgz",
           "integrity": "sha512-ixfJuaG0eiOlxn4i+LJNRUZkm+3WMsiaGUm0hw2XHF0pW3cBIA/+HyzkEwVh/fROHbsOERTkjNl0Ygl12Imw9w==",
           "dev": true,
           "requires": {
@@ -72047,7 +71762,6 @@
         },
         "@storybook/node-logger": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.5.14.tgz",
           "integrity": "sha512-MbEEgUEfrDN8Y0vzZJqPcxwWvX0l8zAsXy6d/DORP2AmwuNmnWTy++BE9YhxH6HMdM1ivRDmBbT30+KBUWhnUA==",
           "dev": true,
           "requires": {
@@ -72060,7 +71774,6 @@
         },
         "@storybook/postinstall": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/postinstall/-/postinstall-6.5.14.tgz",
           "integrity": "sha512-vtnQczSSkz7aPIc2dsDaZWlCDAcJb258KGXk72w7MEY9/zLlr6tdQLI30B6SkRNFnR8fQQf4H2gbFq/GM0EF5A==",
           "dev": true,
           "requires": {
@@ -72069,7 +71782,6 @@
         },
         "@storybook/preview-web": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/preview-web/-/preview-web-6.5.14.tgz",
           "integrity": "sha512-ey2E7222xw0itPgCWH7ZIrdgM1yCdYte/QxRvwv/O4us4SUs/RQaL1aoCD+hCRwd0BNyZUk/u1KnqB4y0MnHww==",
           "dev": true,
           "requires": {
@@ -72093,7 +71805,6 @@
         },
         "@storybook/react": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/react/-/react-6.5.14.tgz",
           "integrity": "sha512-SL0P5czN3g/IZAYw8ur9I/O8MPZI7Lyd46Pw+B1f7+Ou8eLmhqa8Uc8+3fU6v7ohtUDwsBiTsg3TAfTVEPog4A==",
           "dev": true,
           "requires": {
@@ -72136,7 +71847,6 @@
         },
         "@storybook/router": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.5.14.tgz",
           "integrity": "sha512-AvHbpRUAHnzm5pmwFPjDR09uPjQITD6kA0QNa2pe+7/Q/b4k40z5dHvHZJ/YhWhwVwGqGBG20KdDOl30wLXAZw==",
           "dev": true,
           "requires": {
@@ -72149,7 +71859,6 @@
         },
         "@storybook/source-loader": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-6.5.14.tgz",
           "integrity": "sha512-0GKMZ6IMVGxfQn/RYdRdnzxCe4+zZsxHBY9SQB2bbYWyfjJQ5rCJvmYQuMAuuuUmXBv9gk50iJLwai+lb4tbFg==",
           "dev": true,
           "requires": {
@@ -72167,7 +71876,6 @@
           "dependencies": {
             "loader-utils": {
               "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
               "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
               "dev": true,
               "requires": {
@@ -72178,7 +71886,6 @@
             },
             "prettier": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
               "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
               "dev": true
             }
@@ -72186,7 +71893,6 @@
         },
         "@storybook/store": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/store/-/store-6.5.14.tgz",
           "integrity": "sha512-s07Vw4nbShPYwBJmVXzptuyCkrDQD3khcrKB5L7NsHHgWsm2QI0OyiPMuMbSvgipjcMc/oRqdL3tFUeFak9EMg==",
           "dev": true,
           "requires": {
@@ -72209,7 +71915,6 @@
         },
         "@storybook/telemetry": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-6.5.14.tgz",
           "integrity": "sha512-AVSw7WyKHrVbXMSZZ0fvg3oAb8xAS7OrmNU6++yUfbuqpF0JNtNkNnRSaJ4Nh7Vujzloy5jYhbpfY44nb/hsCw==",
           "dev": true,
           "requires": {
@@ -72229,7 +71934,6 @@
         },
         "@storybook/testing-react": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@storybook/testing-react/-/testing-react-1.3.0.tgz",
           "integrity": "sha512-TfxzflxwBHSPhetWKuYt239t+1iN8gnnUN8OKo5UGtwwirghKQlApjH23QXW6j8YBqFhmq+yP29Oqf8HgKCFLw==",
           "dev": true,
           "requires": {
@@ -72238,7 +71942,6 @@
           "dependencies": {
             "@storybook/csf": {
               "version": "0.0.2--canary.87bc651.0",
-              "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.2--canary.87bc651.0.tgz",
               "integrity": "sha512-ajk1Uxa+rBpFQHKrCcTmJyQBXZ5slfwHVEaKlkuFaW77it8RgbPJp/ccna3sgoi8oZ7FkkOyvv1Ve4SmwFqRqw==",
               "dev": true,
               "requires": {
@@ -72249,7 +71952,6 @@
         },
         "@storybook/theming": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.14.tgz",
           "integrity": "sha512-3ff6RLZGaIil/AFJ0/BRlE2hhdPrC5v6wGbRfroZVmGldRCxio/7+KAA3LH6cuHnjK5MeBcCBaHuxzXqGmbEFw==",
           "dev": true,
           "requires": {
@@ -72261,7 +71963,6 @@
         },
         "@storybook/ui": {
           "version": "6.5.14",
-          "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-6.5.14.tgz",
           "integrity": "sha512-dXlCIULh8ytgdFrvVoheQLlZjAyyYmGCuw+6m+s+2yF/oUbFREG/5Zo9hDwlJ4ZiAyqNLkuwg2tnMYtjapZSog==",
           "dev": true,
           "requires": {
@@ -72320,7 +72021,6 @@
         },
         "@types/estree": {
           "version": "0.0.51",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
           "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
           "dev": true
         },
@@ -72423,7 +72123,6 @@
         },
         "autoprefixer": {
           "version": "9.8.8",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
           "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
           "dev": true,
           "requires": {
@@ -72438,7 +72137,6 @@
           "dependencies": {
             "postcss": {
               "version": "7.0.39",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
               "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
               "dev": true,
               "requires": {
@@ -72450,7 +72148,6 @@
         },
         "babel-plugin-polyfill-corejs3": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz",
           "integrity": "sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==",
           "dev": true,
           "requires": {
@@ -72460,7 +72157,6 @@
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
@@ -72478,7 +72174,6 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
@@ -72541,7 +72236,6 @@
         },
         "commander": {
           "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
           "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
           "dev": true
         },
@@ -72589,7 +72283,6 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
           "dev": true,
           "requires": {
@@ -72601,7 +72294,6 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
               "dev": true,
               "requires": {
@@ -72612,7 +72304,6 @@
         },
         "fs-extra": {
           "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
           "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
@@ -72649,19 +72340,16 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
           "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
           "dev": true,
           "requires": {
@@ -72670,7 +72358,6 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
               "dev": true,
               "requires": {
@@ -73356,7 +73043,6 @@
         },
         "picocolors": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
           "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
           "dev": true
         },
@@ -73479,7 +73165,6 @@
         },
         "schema-utils": {
           "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
           "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
           "dev": true,
           "requires": {
@@ -73506,7 +73191,6 @@
         },
         "style-loader": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
           "integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
           "dev": true,
           "requires": {
@@ -73516,7 +73200,6 @@
           "dependencies": {
             "loader-utils": {
               "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
               "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
               "dev": true,
               "requires": {
@@ -73542,7 +73225,6 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
           "dev": true,
           "requires": {
@@ -73800,7 +73482,6 @@
         },
         "@synchro-charts/core": {
           "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@synchro-charts/core/-/core-7.1.0.tgz",
           "integrity": "sha512-cT3RlsS2cIkRtda5BzlsqMXQb6oSfFfzJTHTlCGeVrJShgtSwTMGKLtiDrwa2JMU4W5+GbgJqBK2yyuGgcplDQ==",
           "requires": {
             "@stencil/redux": "^0.1.1",
@@ -73835,7 +73516,6 @@
         },
         "@types/d3": {
           "version": "5.16.4",
-          "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
           "integrity": "sha512-2u0O9iP1MubFiQ+AhR1id4Egs+07BLtvRATG6IL2Gs9+KzdrfaxCKNq5hxEyw1kxwsqB/lCgr108XuHcKtb/5w==",
           "requires": {
             "@types/d3-array": "^1",
@@ -73873,12 +73553,10 @@
         },
         "@types/d3-array": {
           "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.9.tgz",
           "integrity": "sha512-E/7RgPr2ylT5dWG0CswMi9NpFcjIEDqLcUSBgNHe/EMahfqYaTx4zhcggG3khqoEB/leY4Vl6nTSbwLUPjXceA=="
         },
         "@types/d3-axis": {
           "version": "1.0.16",
-          "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.16.tgz",
           "integrity": "sha512-p7085weOmo4W+DzlRRVC/7OI/jugaKbVa6WMQGCQscaMylcbuaVEGk7abJLNyGVFLeCBNrHTdDiqRGnzvL0nXQ==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -73886,7 +73564,6 @@
         },
         "@types/d3-brush": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.1.5.tgz",
           "integrity": "sha512-4zGkBafJf5zCsBtLtvDj/pNMo5X9+Ii/1hUz0GvQ+wEwelUBm2AbIDAzJnp2hLDFF307o0fhxmmocHclhXC+tw==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -73894,17 +73571,14 @@
         },
         "@types/d3-chord": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.11.tgz",
           "integrity": "sha512-0DdfJ//bxyW3G9Nefwq/LDgazSKNN8NU0lBT3Cza6uVuInC2awMNsAcv1oKyRFLn9z7kXClH5XjwpveZjuz2eg=="
         },
         "@types/d3-color": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.2.tgz",
           "integrity": "sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA=="
         },
         "@types/d3-contour": {
           "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-1.3.3.tgz",
           "integrity": "sha512-LxwmGIfVJIc1cKs7ZFRQ1FbtXpfH7QTXYRdMIJsFP71uCMdF6jJ0XZakYDX6Hn4yZkLf+7V8FgD34yCcok+5Ww==",
           "requires": {
             "@types/d3-array": "^1",
@@ -73913,12 +73587,10 @@
         },
         "@types/d3-dispatch": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.9.tgz",
           "integrity": "sha512-zJ44YgjqALmyps+II7b1mZLhrtfV/FOxw9owT87mrweGWcg+WK5oiJX2M3SYJ0XUAExBduarysfgbR11YxzojQ=="
         },
         "@types/d3-drag": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.5.tgz",
           "integrity": "sha512-7NeTnfolst1Js3Vs7myctBkmJWu6DMI3k597AaHUX98saHjHWJ6vouT83UrpE+xfbSceHV+8A0JgxuwgqgmqWw==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -73926,17 +73598,14 @@
         },
         "@types/d3-dsv": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.1.tgz",
           "integrity": "sha512-LLmJmjiqp/fTNEdij5bIwUJ6P6TVNk5hKM9/uk5RPO2YNgEu9XvKO0dJ7Iqd3psEdmZN1m7gB1bOsjr4HmO2BA=="
         },
         "@types/d3-ease": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.11.tgz",
           "integrity": "sha512-wUigPL0kleGZ9u3RhzBP07lxxkMcUjL5IODP42mN/05UNL+JJCDnpEPpFbJiPvLcTeRKGIRpBBJyP/1BNwYsVA=="
         },
         "@types/d3-fetch": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.2.2.tgz",
           "integrity": "sha512-rtFs92GugtV/NpiJQd0WsmGLcg52tIL0uF0bKbbJg231pR9JEb6HT4AUwrtuLq3lOeKdLBhsjV14qb0pMmd0Aw==",
           "requires": {
             "@types/d3-dsv": "^1"
@@ -73944,17 +73613,14 @@
         },
         "@types/d3-force": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.4.tgz",
           "integrity": "sha512-fkorLTKvt6AQbFBQwn4aq7h9rJ4c7ZVcPMGB8X6eFFveAyMZcv7t7m6wgF4Eg93rkPgPORU7sAho1QSHNcZu6w=="
         },
         "@types/d3-format": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
           "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
         },
         "@types/d3-geo": {
           "version": "1.12.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.12.3.tgz",
           "integrity": "sha512-yZbPb7/5DyL/pXkeOmZ7L5ySpuGr4H48t1cuALjnJy5sXQqmSSAYBiwa6Ya/XpWKX2rJqGDDubmh3nOaopOpeA==",
           "requires": {
             "@types/geojson": "*"
@@ -73962,12 +73628,10 @@
         },
         "@types/d3-hierarchy": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
           "integrity": "sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg=="
         },
         "@types/d3-interpolate": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.2.tgz",
           "integrity": "sha512-ylycts6llFf8yAEs1tXzx2loxxzDZHseuhPokrqKprTQSTcD3JbJI1omZP1rphsELZO3Q+of3ff0ZS7+O6yVzg==",
           "requires": {
             "@types/d3-color": "^1"
@@ -73975,27 +73639,22 @@
         },
         "@types/d3-path": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
           "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
         },
         "@types/d3-polygon": {
           "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.8.tgz",
           "integrity": "sha512-1TOJPXCBJC9V3+K3tGbTqD/CsqLyv/YkTXAcwdsZzxqw5cvpdnCuDl42M4Dvi8XzMxZNCT9pL4ibrK2n4VmAcw=="
         },
         "@types/d3-quadtree": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.9.tgz",
           "integrity": "sha512-5E0OJJn2QVavITFEc1AQlI8gLcIoDZcTKOD3feKFckQVmFV4CXhqRFt83tYNVNIN4ZzRkjlAMavJa1ldMhf5rA=="
         },
         "@types/d3-random": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.3.tgz",
           "integrity": "sha512-XXR+ZbFCoOd4peXSMYJzwk0/elP37WWAzS/DG+90eilzVbUSsgKhBcWqylGWe+lA2ubgr7afWAOBaBxRgMUrBQ=="
         },
         "@types/d3-scale": {
           "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.6.tgz",
           "integrity": "sha512-CHu34T5bGrJOeuhGxyiz9Xvaa9PlsIaQoOqjDg7zqeGj2x0rwPhGquiy03unigvcMxmvY0hEaAouT0LOFTLpIw==",
           "requires": {
             "@types/d3-time": "^1"
@@ -74003,17 +73662,14 @@
         },
         "@types/d3-scale-chromatic": {
           "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.1.tgz",
           "integrity": "sha512-7FtJYrmXTEWLykShjYhoGuDNR/Bda0+tstZMkFj4RRxUEryv16AGh3be21tqg84B6KfEwiZyEpBcTyPyU+GWjg=="
         },
         "@types/d3-selection": {
           "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.3.tgz",
           "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA=="
         },
         "@types/d3-shape": {
           "version": "1.3.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
           "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
           "requires": {
             "@types/d3-path": "^1"
@@ -74021,22 +73677,18 @@
         },
         "@types/d3-time": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
           "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
         },
         "@types/d3-time-format": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
           "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
         },
         "@types/d3-timer": {
           "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.10.tgz",
           "integrity": "sha512-ZnAbquVqy+4ZjdW0cY6URp+qF/AzTVNda2jYyOzpR2cPT35FTXl78s15Bomph9+ckOiI1TtkljnWkwbIGAb6rg=="
         },
         "@types/d3-transition": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.2.tgz",
           "integrity": "sha512-J+a3SuF/E7wXbOSN19p8ZieQSFIm5hU2Egqtndbc54LXaAEOpLfDx4sBu/PKAKzHOdgKK1wkMhINKqNh4aoZAg==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -74044,7 +73696,6 @@
         },
         "@types/d3-zoom": {
           "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.3.tgz",
           "integrity": "sha512-3kHkL6sPiDdbfGhzlp5gIHyu3kULhtnHTTAl3UBZVtWB1PzcLL8vdmz5mTx7plLiUqOA2Y+yT2GKjt/TdA2p7Q==",
           "requires": {
             "@types/d3-interpolate": "^1",
@@ -74120,12 +73771,10 @@
         },
         "d3-format": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
           "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
         },
         "d3-scale": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
           "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
           "requires": {
             "d3-array": "^2.3.0",
@@ -74137,14 +73786,12 @@
           "dependencies": {
             "d3-format": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
               "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
             }
           }
         },
         "d3-time": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
           "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
           "requires": {
             "d3-array": "2"
@@ -74634,7 +74281,6 @@
         },
         "minimatch": {
           "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
           "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -74688,7 +74334,6 @@
         },
         "three": {
           "version": "0.125.2",
-          "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
           "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
         },
         "throat": {
@@ -74723,7 +74368,6 @@
         },
         "uuid": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "v8-to-istanbul": {
@@ -74947,7 +74591,6 @@
         },
         "@synchro-charts/core": {
           "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@synchro-charts/core/-/core-7.1.0.tgz",
           "integrity": "sha512-cT3RlsS2cIkRtda5BzlsqMXQb6oSfFfzJTHTlCGeVrJShgtSwTMGKLtiDrwa2JMU4W5+GbgJqBK2yyuGgcplDQ==",
           "requires": {
             "@stencil/redux": "^0.1.1",
@@ -74982,7 +74625,6 @@
         },
         "@types/d3": {
           "version": "5.16.4",
-          "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
           "integrity": "sha512-2u0O9iP1MubFiQ+AhR1id4Egs+07BLtvRATG6IL2Gs9+KzdrfaxCKNq5hxEyw1kxwsqB/lCgr108XuHcKtb/5w==",
           "requires": {
             "@types/d3-array": "^1",
@@ -75020,12 +74662,10 @@
         },
         "@types/d3-array": {
           "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.9.tgz",
           "integrity": "sha512-E/7RgPr2ylT5dWG0CswMi9NpFcjIEDqLcUSBgNHe/EMahfqYaTx4zhcggG3khqoEB/leY4Vl6nTSbwLUPjXceA=="
         },
         "@types/d3-axis": {
           "version": "1.0.16",
-          "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.16.tgz",
           "integrity": "sha512-p7085weOmo4W+DzlRRVC/7OI/jugaKbVa6WMQGCQscaMylcbuaVEGk7abJLNyGVFLeCBNrHTdDiqRGnzvL0nXQ==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -75033,7 +74673,6 @@
         },
         "@types/d3-brush": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.1.5.tgz",
           "integrity": "sha512-4zGkBafJf5zCsBtLtvDj/pNMo5X9+Ii/1hUz0GvQ+wEwelUBm2AbIDAzJnp2hLDFF307o0fhxmmocHclhXC+tw==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -75041,17 +74680,14 @@
         },
         "@types/d3-chord": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.11.tgz",
           "integrity": "sha512-0DdfJ//bxyW3G9Nefwq/LDgazSKNN8NU0lBT3Cza6uVuInC2awMNsAcv1oKyRFLn9z7kXClH5XjwpveZjuz2eg=="
         },
         "@types/d3-color": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.2.tgz",
           "integrity": "sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA=="
         },
         "@types/d3-contour": {
           "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-1.3.3.tgz",
           "integrity": "sha512-LxwmGIfVJIc1cKs7ZFRQ1FbtXpfH7QTXYRdMIJsFP71uCMdF6jJ0XZakYDX6Hn4yZkLf+7V8FgD34yCcok+5Ww==",
           "requires": {
             "@types/d3-array": "^1",
@@ -75060,12 +74696,10 @@
         },
         "@types/d3-dispatch": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.9.tgz",
           "integrity": "sha512-zJ44YgjqALmyps+II7b1mZLhrtfV/FOxw9owT87mrweGWcg+WK5oiJX2M3SYJ0XUAExBduarysfgbR11YxzojQ=="
         },
         "@types/d3-drag": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.5.tgz",
           "integrity": "sha512-7NeTnfolst1Js3Vs7myctBkmJWu6DMI3k597AaHUX98saHjHWJ6vouT83UrpE+xfbSceHV+8A0JgxuwgqgmqWw==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -75073,17 +74707,14 @@
         },
         "@types/d3-dsv": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.1.tgz",
           "integrity": "sha512-LLmJmjiqp/fTNEdij5bIwUJ6P6TVNk5hKM9/uk5RPO2YNgEu9XvKO0dJ7Iqd3psEdmZN1m7gB1bOsjr4HmO2BA=="
         },
         "@types/d3-ease": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.11.tgz",
           "integrity": "sha512-wUigPL0kleGZ9u3RhzBP07lxxkMcUjL5IODP42mN/05UNL+JJCDnpEPpFbJiPvLcTeRKGIRpBBJyP/1BNwYsVA=="
         },
         "@types/d3-fetch": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.2.2.tgz",
           "integrity": "sha512-rtFs92GugtV/NpiJQd0WsmGLcg52tIL0uF0bKbbJg231pR9JEb6HT4AUwrtuLq3lOeKdLBhsjV14qb0pMmd0Aw==",
           "requires": {
             "@types/d3-dsv": "^1"
@@ -75091,17 +74722,14 @@
         },
         "@types/d3-force": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.4.tgz",
           "integrity": "sha512-fkorLTKvt6AQbFBQwn4aq7h9rJ4c7ZVcPMGB8X6eFFveAyMZcv7t7m6wgF4Eg93rkPgPORU7sAho1QSHNcZu6w=="
         },
         "@types/d3-format": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
           "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
         },
         "@types/d3-geo": {
           "version": "1.12.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.12.3.tgz",
           "integrity": "sha512-yZbPb7/5DyL/pXkeOmZ7L5ySpuGr4H48t1cuALjnJy5sXQqmSSAYBiwa6Ya/XpWKX2rJqGDDubmh3nOaopOpeA==",
           "requires": {
             "@types/geojson": "*"
@@ -75109,12 +74737,10 @@
         },
         "@types/d3-hierarchy": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
           "integrity": "sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg=="
         },
         "@types/d3-interpolate": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.2.tgz",
           "integrity": "sha512-ylycts6llFf8yAEs1tXzx2loxxzDZHseuhPokrqKprTQSTcD3JbJI1omZP1rphsELZO3Q+of3ff0ZS7+O6yVzg==",
           "requires": {
             "@types/d3-color": "^1"
@@ -75122,27 +74748,22 @@
         },
         "@types/d3-path": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
           "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
         },
         "@types/d3-polygon": {
           "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.8.tgz",
           "integrity": "sha512-1TOJPXCBJC9V3+K3tGbTqD/CsqLyv/YkTXAcwdsZzxqw5cvpdnCuDl42M4Dvi8XzMxZNCT9pL4ibrK2n4VmAcw=="
         },
         "@types/d3-quadtree": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.9.tgz",
           "integrity": "sha512-5E0OJJn2QVavITFEc1AQlI8gLcIoDZcTKOD3feKFckQVmFV4CXhqRFt83tYNVNIN4ZzRkjlAMavJa1ldMhf5rA=="
         },
         "@types/d3-random": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.3.tgz",
           "integrity": "sha512-XXR+ZbFCoOd4peXSMYJzwk0/elP37WWAzS/DG+90eilzVbUSsgKhBcWqylGWe+lA2ubgr7afWAOBaBxRgMUrBQ=="
         },
         "@types/d3-scale": {
           "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.6.tgz",
           "integrity": "sha512-CHu34T5bGrJOeuhGxyiz9Xvaa9PlsIaQoOqjDg7zqeGj2x0rwPhGquiy03unigvcMxmvY0hEaAouT0LOFTLpIw==",
           "requires": {
             "@types/d3-time": "^1"
@@ -75150,17 +74771,14 @@
         },
         "@types/d3-scale-chromatic": {
           "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.1.tgz",
           "integrity": "sha512-7FtJYrmXTEWLykShjYhoGuDNR/Bda0+tstZMkFj4RRxUEryv16AGh3be21tqg84B6KfEwiZyEpBcTyPyU+GWjg=="
         },
         "@types/d3-selection": {
           "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.3.tgz",
           "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA=="
         },
         "@types/d3-shape": {
           "version": "1.3.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
           "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
           "requires": {
             "@types/d3-path": "^1"
@@ -75168,22 +74786,18 @@
         },
         "@types/d3-time": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
           "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
         },
         "@types/d3-time-format": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
           "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
         },
         "@types/d3-timer": {
           "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.10.tgz",
           "integrity": "sha512-ZnAbquVqy+4ZjdW0cY6URp+qF/AzTVNda2jYyOzpR2cPT35FTXl78s15Bomph9+ckOiI1TtkljnWkwbIGAb6rg=="
         },
         "@types/d3-transition": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.2.tgz",
           "integrity": "sha512-J+a3SuF/E7wXbOSN19p8ZieQSFIm5hU2Egqtndbc54LXaAEOpLfDx4sBu/PKAKzHOdgKK1wkMhINKqNh4aoZAg==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -75191,7 +74805,6 @@
         },
         "@types/d3-zoom": {
           "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.3.tgz",
           "integrity": "sha512-3kHkL6sPiDdbfGhzlp5gIHyu3kULhtnHTTAl3UBZVtWB1PzcLL8vdmz5mTx7plLiUqOA2Y+yT2GKjt/TdA2p7Q==",
           "requires": {
             "@types/d3-interpolate": "^1",
@@ -75267,12 +74880,10 @@
         },
         "d3-format": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
           "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
         },
         "d3-scale": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
           "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
           "requires": {
             "d3-array": "^2.3.0",
@@ -75284,14 +74895,12 @@
           "dependencies": {
             "d3-format": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
               "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
             }
           }
         },
         "d3-time": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
           "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
           "requires": {
             "d3-array": "2"
@@ -75781,7 +75390,6 @@
         },
         "minimatch": {
           "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
           "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -75835,7 +75443,6 @@
         },
         "three": {
           "version": "0.125.2",
-          "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
           "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
         },
         "throat": {
@@ -75870,7 +75477,6 @@
         },
         "uuid": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "v8-to-istanbul": {
@@ -76427,7 +76033,6 @@
         },
         "@synchro-charts/core": {
           "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@synchro-charts/core/-/core-7.1.0.tgz",
           "integrity": "sha512-cT3RlsS2cIkRtda5BzlsqMXQb6oSfFfzJTHTlCGeVrJShgtSwTMGKLtiDrwa2JMU4W5+GbgJqBK2yyuGgcplDQ==",
           "requires": {
             "@stencil/redux": "^0.1.1",
@@ -76462,7 +76067,6 @@
           "dependencies": {
             "d3-array": {
               "version": "2.12.1",
-              "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
               "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
               "requires": {
                 "internmap": "^1.0.0"
@@ -76472,7 +76076,6 @@
         },
         "@types/d3": {
           "version": "5.16.4",
-          "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
           "integrity": "sha512-2u0O9iP1MubFiQ+AhR1id4Egs+07BLtvRATG6IL2Gs9+KzdrfaxCKNq5hxEyw1kxwsqB/lCgr108XuHcKtb/5w==",
           "requires": {
             "@types/d3-array": "^1",
@@ -76510,12 +76113,10 @@
         },
         "@types/d3-array": {
           "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.9.tgz",
           "integrity": "sha512-E/7RgPr2ylT5dWG0CswMi9NpFcjIEDqLcUSBgNHe/EMahfqYaTx4zhcggG3khqoEB/leY4Vl6nTSbwLUPjXceA=="
         },
         "@types/d3-axis": {
           "version": "1.0.16",
-          "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.16.tgz",
           "integrity": "sha512-p7085weOmo4W+DzlRRVC/7OI/jugaKbVa6WMQGCQscaMylcbuaVEGk7abJLNyGVFLeCBNrHTdDiqRGnzvL0nXQ==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -76523,7 +76124,6 @@
         },
         "@types/d3-brush": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.1.5.tgz",
           "integrity": "sha512-4zGkBafJf5zCsBtLtvDj/pNMo5X9+Ii/1hUz0GvQ+wEwelUBm2AbIDAzJnp2hLDFF307o0fhxmmocHclhXC+tw==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -76531,17 +76131,14 @@
         },
         "@types/d3-chord": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.11.tgz",
           "integrity": "sha512-0DdfJ//bxyW3G9Nefwq/LDgazSKNN8NU0lBT3Cza6uVuInC2awMNsAcv1oKyRFLn9z7kXClH5XjwpveZjuz2eg=="
         },
         "@types/d3-color": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.2.tgz",
           "integrity": "sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA=="
         },
         "@types/d3-contour": {
           "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-1.3.3.tgz",
           "integrity": "sha512-LxwmGIfVJIc1cKs7ZFRQ1FbtXpfH7QTXYRdMIJsFP71uCMdF6jJ0XZakYDX6Hn4yZkLf+7V8FgD34yCcok+5Ww==",
           "requires": {
             "@types/d3-array": "^1",
@@ -76550,12 +76147,10 @@
         },
         "@types/d3-dispatch": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.9.tgz",
           "integrity": "sha512-zJ44YgjqALmyps+II7b1mZLhrtfV/FOxw9owT87mrweGWcg+WK5oiJX2M3SYJ0XUAExBduarysfgbR11YxzojQ=="
         },
         "@types/d3-drag": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.5.tgz",
           "integrity": "sha512-7NeTnfolst1Js3Vs7myctBkmJWu6DMI3k597AaHUX98saHjHWJ6vouT83UrpE+xfbSceHV+8A0JgxuwgqgmqWw==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -76563,17 +76158,14 @@
         },
         "@types/d3-dsv": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.1.tgz",
           "integrity": "sha512-LLmJmjiqp/fTNEdij5bIwUJ6P6TVNk5hKM9/uk5RPO2YNgEu9XvKO0dJ7Iqd3psEdmZN1m7gB1bOsjr4HmO2BA=="
         },
         "@types/d3-ease": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.11.tgz",
           "integrity": "sha512-wUigPL0kleGZ9u3RhzBP07lxxkMcUjL5IODP42mN/05UNL+JJCDnpEPpFbJiPvLcTeRKGIRpBBJyP/1BNwYsVA=="
         },
         "@types/d3-fetch": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.2.2.tgz",
           "integrity": "sha512-rtFs92GugtV/NpiJQd0WsmGLcg52tIL0uF0bKbbJg231pR9JEb6HT4AUwrtuLq3lOeKdLBhsjV14qb0pMmd0Aw==",
           "requires": {
             "@types/d3-dsv": "^1"
@@ -76581,17 +76173,14 @@
         },
         "@types/d3-force": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.4.tgz",
           "integrity": "sha512-fkorLTKvt6AQbFBQwn4aq7h9rJ4c7ZVcPMGB8X6eFFveAyMZcv7t7m6wgF4Eg93rkPgPORU7sAho1QSHNcZu6w=="
         },
         "@types/d3-format": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.2.tgz",
           "integrity": "sha512-WeGCHAs7PHdZYq6lwl/+jsl+Nfc1J2W1kNcMeIMYzQsT6mtBDBgtJ/rcdjZ0k0rVIvqEZqhhuD5TK/v3P2gFHQ=="
         },
         "@types/d3-geo": {
           "version": "1.12.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.12.3.tgz",
           "integrity": "sha512-yZbPb7/5DyL/pXkeOmZ7L5ySpuGr4H48t1cuALjnJy5sXQqmSSAYBiwa6Ya/XpWKX2rJqGDDubmh3nOaopOpeA==",
           "requires": {
             "@types/geojson": "*"
@@ -76599,12 +76188,10 @@
         },
         "@types/d3-hierarchy": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
           "integrity": "sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg=="
         },
         "@types/d3-interpolate": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.2.tgz",
           "integrity": "sha512-ylycts6llFf8yAEs1tXzx2loxxzDZHseuhPokrqKprTQSTcD3JbJI1omZP1rphsELZO3Q+of3ff0ZS7+O6yVzg==",
           "requires": {
             "@types/d3-color": "^1"
@@ -76612,27 +76199,22 @@
         },
         "@types/d3-path": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
           "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
         },
         "@types/d3-polygon": {
           "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.8.tgz",
           "integrity": "sha512-1TOJPXCBJC9V3+K3tGbTqD/CsqLyv/YkTXAcwdsZzxqw5cvpdnCuDl42M4Dvi8XzMxZNCT9pL4ibrK2n4VmAcw=="
         },
         "@types/d3-quadtree": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.9.tgz",
           "integrity": "sha512-5E0OJJn2QVavITFEc1AQlI8gLcIoDZcTKOD3feKFckQVmFV4CXhqRFt83tYNVNIN4ZzRkjlAMavJa1ldMhf5rA=="
         },
         "@types/d3-random": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.3.tgz",
           "integrity": "sha512-XXR+ZbFCoOd4peXSMYJzwk0/elP37WWAzS/DG+90eilzVbUSsgKhBcWqylGWe+lA2ubgr7afWAOBaBxRgMUrBQ=="
         },
         "@types/d3-scale": {
           "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.6.tgz",
           "integrity": "sha512-CHu34T5bGrJOeuhGxyiz9Xvaa9PlsIaQoOqjDg7zqeGj2x0rwPhGquiy03unigvcMxmvY0hEaAouT0LOFTLpIw==",
           "requires": {
             "@types/d3-time": "^1"
@@ -76640,17 +76222,14 @@
         },
         "@types/d3-scale-chromatic": {
           "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.1.tgz",
           "integrity": "sha512-7FtJYrmXTEWLykShjYhoGuDNR/Bda0+tstZMkFj4RRxUEryv16AGh3be21tqg84B6KfEwiZyEpBcTyPyU+GWjg=="
         },
         "@types/d3-selection": {
           "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.3.tgz",
           "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA=="
         },
         "@types/d3-shape": {
           "version": "1.3.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
           "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
           "requires": {
             "@types/d3-path": "^1"
@@ -76658,22 +76237,18 @@
         },
         "@types/d3-time": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
           "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw=="
         },
         "@types/d3-time-format": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.1.tgz",
           "integrity": "sha512-fck0Z9RGfIQn3GJIEKVrp15h9m6Vlg0d5XXeiE/6+CQiBmMDZxfR21XtjEPuDeg7gC3bBM0SdieA5XF3GW1wKA=="
         },
         "@types/d3-timer": {
           "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.10.tgz",
           "integrity": "sha512-ZnAbquVqy+4ZjdW0cY6URp+qF/AzTVNda2jYyOzpR2cPT35FTXl78s15Bomph9+ckOiI1TtkljnWkwbIGAb6rg=="
         },
         "@types/d3-transition": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.2.tgz",
           "integrity": "sha512-J+a3SuF/E7wXbOSN19p8ZieQSFIm5hU2Egqtndbc54LXaAEOpLfDx4sBu/PKAKzHOdgKK1wkMhINKqNh4aoZAg==",
           "requires": {
             "@types/d3-selection": "^1"
@@ -76681,7 +76256,6 @@
         },
         "@types/d3-zoom": {
           "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.3.tgz",
           "integrity": "sha512-3kHkL6sPiDdbfGhzlp5gIHyu3kULhtnHTTAl3UBZVtWB1PzcLL8vdmz5mTx7plLiUqOA2Y+yT2GKjt/TdA2p7Q==",
           "requires": {
             "@types/d3-interpolate": "^1",
@@ -76798,12 +76372,10 @@
         },
         "d3-format": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
           "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
         },
         "d3-scale": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
           "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
           "requires": {
             "d3-array": "^2.3.0",
@@ -76815,7 +76387,6 @@
           "dependencies": {
             "d3-array": {
               "version": "2.12.1",
-              "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
               "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
               "requires": {
                 "internmap": "^1.0.0"
@@ -76823,14 +76394,12 @@
             },
             "d3-format": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
               "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
             }
           }
         },
         "d3-time": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
           "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
           "requires": {
             "d3-array": "2"
@@ -76838,7 +76407,6 @@
           "dependencies": {
             "d3-array": {
               "version": "2.12.1",
-              "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
               "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
               "requires": {
                 "internmap": "^1.0.0"
@@ -78104,7 +77672,6 @@
         },
         "minimatch": {
           "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
           "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -78158,7 +77725,6 @@
         },
         "three": {
           "version": "0.125.2",
-          "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
           "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
         },
         "throat": {
@@ -78226,7 +77792,6 @@
         },
         "uuid": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "v8-to-istanbul": {
@@ -82931,61 +82496,6 @@
         }
       }
     },
-    "@videojs/http-streaming": {
-      "version": "2.9.2",
-      "integrity": "sha512-2ZsxJn4/nZZ6k6jIhic2l9ynGmKwprtuI5b3+M6JgqOSLvQQ/ah+heVs/0g2Ze7qJxodqR+aSY948JwJIz1gCw==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.2",
-        "aes-decrypter": "3.1.2",
-        "global": "^4.4.0",
-        "m3u8-parser": "4.7.0",
-        "mpd-parser": "0.17.0",
-        "mux.js": "5.12.2",
-        "video.js": "^6 || ^7"
-      },
-      "dependencies": {
-        "@videojs/vhs-utils": {
-          "version": "3.0.5",
-          "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "global": "^4.4.0",
-            "url-toolkit": "^2.2.1"
-          }
-        },
-        "m3u8-parser": {
-          "version": "4.7.0",
-          "integrity": "sha512-48l/OwRyjBm+QhNNigEEcRcgbRvnUjL7rxs597HmW9QSNbyNvt+RcZ9T/d9vxi9A9z7EZrB1POtZYhdRlwYQkQ==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "@videojs/vhs-utils": "^3.0.0",
-            "global": "^4.4.0"
-          }
-        },
-        "mpd-parser": {
-          "version": "0.17.0",
-          "integrity": "sha512-oKS5G0jCcHHJ3sHYlcLeM9Xcbuixl08eAx7QW0Th7ChlZiI0YvLtGaHE/L0aKUBJFNvtkeksIr8XgJgSBBsS4g==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "@videojs/vhs-utils": "^3.0.2",
-            "global": "^4.4.0",
-            "xmldom": "^0.5.0"
-          }
-        },
-        "mux.js": {
-          "version": "5.12.2",
-          "integrity": "sha512-9OY1lrFIo7FxMeIC6aLUftiNv97AztufDfi30N7qDll1Pcy7bCxlHztyHp1Ce0KQwy2XqchGeENPS4v1NJngHQ==",
-          "requires": {
-            "@babel/runtime": "^7.11.2"
-          }
-        },
-        "xmldom": {
-          "version": "0.5.0",
-          "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
-        }
-      }
-    },
     "@videojs/vhs-utils": {
       "version": "2.3.0",
       "integrity": "sha512-ThSmm91S7tuIJ757ON50K4y7S/bvKN4+B0tu303gCOxaG57PoP1UvPfMQZ90XGhxwNgngexVojOqbBHhTvXVHQ==",
@@ -82994,15 +82504,6 @@
         "@babel/runtime": "^7.5.5",
         "global": "^4.3.2",
         "url-toolkit": "^2.1.6"
-      }
-    },
-    "@videojs/xhr": {
-      "version": "2.5.1",
-      "integrity": "sha512-wV9nGESHseSK+S9ePEru2+OJZ1jq/ZbbzniGQ4weAmTIepuBMSYPx5zrxxQA0E786T5ykpO8ts+LayV+3/oI2w==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "global": "~4.4.0",
-        "is-function": "^1.0.1"
       }
     },
     "@vue/cli-overlay": {
@@ -84247,6 +83748,10 @@
       "version": "1.0.0",
       "integrity": "sha512-Ppxde+G1/QZbU8ShCQg+eq5VtlcL/FPkerF1dkDOLlIml0LJD1tFqnCZYR0SrHzYleIQ2siRnOx7xbFLaCpExQ=="
     },
+    "@xmldom/xmldom": {
+      "version": "0.7.9",
+      "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA=="
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
@@ -84315,27 +83820,6 @@
       "version": "1.2.0",
       "integrity": "sha512-tNEZYz5G/zYunxFm7sfhAxkXEuLj3K6BKwv6ZURlsF6yiUQ65z0Q2wZW9L5cPUl9ocofGvXOdFYbFHp0+6MOig==",
       "dev": true
-    },
-    "aes-decrypter": {
-      "version": "3.1.2",
-      "integrity": "sha512-42nRwfQuPRj9R1zqZBdoxnaAmnIFyDi0MNyTVhjdFOd8fifXKKRfwIHIZ6AMn1or4x5WONzjwRTbTWcsIQ0O4A==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.0",
-        "global": "^4.4.0",
-        "pkcs7": "^1.0.4"
-      },
-      "dependencies": {
-        "@videojs/vhs-utils": {
-          "version": "3.0.5",
-          "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "global": "^4.4.0",
-            "url-toolkit": "^2.2.1"
-          }
-        }
-      }
     },
     "agent-base": {
       "version": "6.0.2",
@@ -88846,7 +88330,6 @@
     },
     "decode-uri-component": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
       "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true
     },
@@ -97989,16 +97472,6 @@
       "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
       "dev": true
     },
-    "m3u8-parser": {
-      "version": "4.5.0",
-      "integrity": "sha512-RGm/1WVCX3o1bSWbJGmJUu4zTbtJy8lImtgHM4CESFvJRXYztr1j6SW/q9/ghYOrUjgH7radsIar+z1Leln0sA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "@videojs/vhs-utils": "^2.2.1",
-        "global": "^4.3.2"
-      }
-    },
     "magic-string": {
       "version": "0.25.9",
       "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
@@ -98782,17 +98255,6 @@
             "glob": "^7.1.3"
           }
         }
-      }
-    },
-    "mpd-parser": {
-      "version": "0.15.0",
-      "integrity": "sha512-GfspJVaEnVbWKZQASvh9nsJkvxWh3M/c5Kb2RPnN5ZXPZ7jWWfarWkNKTEuqvoaAKIT8IB/r6PFTWA1GY4fzGg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "@videojs/vhs-utils": "^2.2.1",
-        "global": "^4.3.2",
-        "xmldom": "^0.1.27"
       }
     },
     "mri": {
@@ -107835,66 +107297,6 @@
         "unist-util-stringify-position": "^2.0.0"
       }
     },
-    "video.js": {
-      "version": "7.14.3",
-      "integrity": "sha512-6avCdSIfn5ss5NOgoQfY/xEfPNcz9DXSw+ZN80NwPguCdRd4VL4y40b/d7osYJwyCdF+YkvhqAW7dw4s0vBigg==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "2.9.2",
-        "@videojs/vhs-utils": "^3.0.2",
-        "@videojs/xhr": "2.5.1",
-        "aes-decrypter": "3.1.2",
-        "global": "^4.4.0",
-        "keycode": "^2.2.0",
-        "m3u8-parser": "4.7.0",
-        "mpd-parser": "0.17.0",
-        "mux.js": "5.12.2",
-        "safe-json-parse": "4.0.0",
-        "videojs-font": "3.2.0",
-        "videojs-vtt.js": "^0.15.3"
-      },
-      "dependencies": {
-        "@videojs/vhs-utils": {
-          "version": "3.0.5",
-          "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "global": "^4.4.0",
-            "url-toolkit": "^2.2.1"
-          }
-        },
-        "m3u8-parser": {
-          "version": "4.7.0",
-          "integrity": "sha512-48l/OwRyjBm+QhNNigEEcRcgbRvnUjL7rxs597HmW9QSNbyNvt+RcZ9T/d9vxi9A9z7EZrB1POtZYhdRlwYQkQ==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "@videojs/vhs-utils": "^3.0.0",
-            "global": "^4.4.0"
-          }
-        },
-        "mpd-parser": {
-          "version": "0.17.0",
-          "integrity": "sha512-oKS5G0jCcHHJ3sHYlcLeM9Xcbuixl08eAx7QW0Th7ChlZiI0YvLtGaHE/L0aKUBJFNvtkeksIr8XgJgSBBsS4g==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "@videojs/vhs-utils": "^3.0.2",
-            "global": "^4.4.0",
-            "xmldom": "^0.5.0"
-          }
-        },
-        "mux.js": {
-          "version": "5.12.2",
-          "integrity": "sha512-9OY1lrFIo7FxMeIC6aLUftiNv97AztufDfi30N7qDll1Pcy7bCxlHztyHp1Ce0KQwy2XqchGeENPS4v1NJngHQ==",
-          "requires": {
-            "@babel/runtime": "^7.11.2"
-          }
-        },
-        "xmldom": {
-          "version": "0.5.0",
-          "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
-        }
-      }
-    },
     "videojs-font": {
       "version": "3.2.0",
       "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA=="
@@ -109536,11 +108938,6 @@
     "xmlchars": {
       "version": "2.2.0",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
-    },
-    "xmldom": {
-      "version": "0.1.31",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
       "dev": true
     },
     "xtend": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -67,8 +67,6 @@
     "jest-dom": "^3.0.2",
     "jest-simple-dot-reporter": "^1.0.5",
     "jest-styled-components": "^7.0.0",
-    "m3u8-parser": "4.5.0",
-    "mpd-parser": "0.15.0",
     "mux.js": "5.8.0",
     "np": "^3.1.0",
     "react": "^17.0.2",
@@ -84,7 +82,7 @@
     "@iot-app-kit/source-iottwinmaker": "^2.6.0",
     "dompurify": "2.3.4",
     "uuid": "^8.3.2",
-    "video.js": "7.14.3"
+    "video.js": "7.20.3"
   },
   "peerDependencies": {
     "react": "^17.0.2",


### PR DESCRIPTION
## Overview
upgrade video.js to fix dependabot alert:
- https://github.com/awslabs/iot-app-kit/security/dependabot/51
- https://github.com/awslabs/iot-app-kit/security/dependabot/52
- https://github.com/awslabs/iot-app-kit/security/dependabot/61

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
