### PR TITLE
fix: prevent stream render if dataType unknown

### DIFF
--- a/packages/components/src/components/iot-time-series-connector/iot-time-series-connector.spec.ts
+++ b/packages/components/src/components/iot-time-series-connector/iot-time-series-connector.spec.ts
@@ -152,9 +152,6 @@ it('provides data streams', async () => {
         expect.objectContaining({
           id: DATA_STREAM.id,
         }),
-        expect.objectContaining({
-          id: DATA_STREAM_2.id,
-        }),
       ]),
       viewport,
     })
@@ -294,9 +291,6 @@ it('updates with new queries', async () => {
       dataStreams: expect.arrayContaining([
         expect.objectContaining({
           id: DATA_STREAM.id,
-        }),
-        expect.objectContaining({
-          id: DATA_STREAM_2.id,
         }),
       ]),
       viewport,

--- a/packages/components/src/components/iot-time-series-connector/iot-time-series-connector.tsx
+++ b/packages/components/src/components/iot-time-series-connector/iot-time-series-connector.tsx
@@ -79,7 +79,8 @@ export class IotTimeSeriesConnector {
       styleSettings: this.styleSettings,
       assignDefaultColors: this.assignDefaultColors || false,
     }).filter((stream) => {
-      if (!stream.dataType || stream.streamType === 'ALARM') return true;
+      if (stream.error || !stream.dataType) return false;
+      if (stream.streamType === 'ALARM') return true;
       return this.supportedDataTypes.includes(stream.dataType);
     });
 


### PR DESCRIPTION
## Overview
graphs would flicker between the unsupported data warning and the empty graph state due to incomplete data being sent to synchroCharts widget. this prevents this by only rendering data that has a set `dataType`

https://github.com/awslabs/iot-app-kit/issues/405

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
