### PR TITLE
feat(dashboard): add color picker

### DIFF
--- a/packages/dashboard/src/components/sidePanel/sections/index.css
+++ b/packages/dashboard/src/components/sidePanel/sections/index.css
@@ -19,6 +19,14 @@
   border-radius: 0.57rem;
 }
 
+/* hide default color input */
+.threshold-content-color-picker > input {
+  opacity: 0;
+  height: 100%;
+  width: 100%;
+  cursor: pointer;
+}
+
 .threshold-container > div > div:last-child {
   flex-grow: 1;
   justify-content: end;

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MouseEventHandler } from 'react';
+import React, { ChangeEventHandler, FC, MouseEventHandler } from 'react';
 import {
   Button,
   Checkbox,
@@ -26,8 +26,7 @@ const ComparisonOperatorOptions: { label: string; value: COMPARISON_OPERATOR }[]
   { label: '<=', value: COMPARISON_OPERATOR.LESS_THAN_EQUAL },
   // TECHDEBT: support new comparator `contains`
 ];
-const DEFAULT_THRESHOLD_COLOR = '#000000';
-const getRandomColor = () => `#` + Math.floor(Math.random() * 16777215).toString(16);
+const DEFAULT_THRESHOLD_COLOR = '#D0021B';
 
 const ThresholdComponent: FC<{ path: string; deleteSelf: () => void }> = ({ path, deleteSelf }) => {
   const [color = DEFAULT_THRESHOLD_COLOR, updateThresholdColor] = useInput<string>(path + '.color');
@@ -46,9 +45,8 @@ const ThresholdComponent: FC<{ path: string; deleteSelf: () => void }> = ({ path
     updateValue(detail.value);
   };
 
-  const onUpdateThresholdColor = () => {
-    // TODO: add color picker
-    updateThresholdColor(getRandomColor());
+  const onUpdateThresholdColor: ChangeEventHandler<HTMLInputElement> = ({ target: { value } }) => {
+    updateThresholdColor(value);
   };
 
   return (
@@ -63,11 +61,9 @@ const ThresholdComponent: FC<{ path: string; deleteSelf: () => void }> = ({ path
             onChange={onUpdateComparator}
           />
           <Input value={`${value}`} placeholder="Threshold value" onChange={onUpdateThresholdValue} />
-          <div
-            className="threshold-content-color-picker"
-            style={{ backgroundColor: color }}
-            onClick={onUpdateThresholdColor}
-          ></div>
+          <div className="threshold-content-color-picker" style={{ backgroundColor: color }}>
+            <input type="color" value={color} onChange={onUpdateThresholdColor} />
+          </div>
           <div>
             <Button iconName="close" variant="icon" onClick={deleteSelf} />
           </div>


### PR DESCRIPTION
## Overview
Add native color picker for updating threshold colors
<img width="423" alt="image" src="https://user-images.githubusercontent.com/11740421/211633139-ecb5a572-da31-4f8b-a724-202ee917faa0.png">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
