### PR TITLE
feat(dashboard): dispatch updateWidget action from side panel

### DIFF
--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection.tsx
@@ -32,7 +32,7 @@ const ThresholdComponent: FC<{ path: string; deleteSelf: () => void }> = ({ path
   const [color = DEFAULT_THRESHOLD_COLOR, updateThresholdColor] = useInput<string>(path + '.color');
   const [comparisonOperator, updateComparator] = useInput<string>(path + '.comparisonOperator');
   const [value = '', updateValue] = useInput<ThresholdValue>(path + '.value');
-  const [description] = useInput(path + '.description');
+  const [description = 'some text'] = useInput(path + '.description');
   const [id = ''] = useInput(path + '.id');
   const selectedOption =
     ComparisonOperatorOptions.find(({ value }) => value === comparisonOperator) || ComparisonOperatorOptions[0];
@@ -42,7 +42,8 @@ const ThresholdComponent: FC<{ path: string; deleteSelf: () => void }> = ({ path
   };
 
   const onUpdateThresholdValue: NonCancelableEventHandler<InputProps.ChangeDetail> = ({ detail }) => {
-    updateValue(detail.value);
+    const value = parseFloat(detail.value);
+    updateValue(Number.isNaN(value) ? detail.value : value);
   };
 
   const onUpdateThresholdColor: ChangeEventHandler<HTMLInputElement> = ({ target: { value } }) => {
@@ -77,7 +78,7 @@ const ThresholdsSection = () => {
   const [thresholdList = [], updateThresholdList] = useInput<YAnnotation[]>('annotations.y');
   const [colorDataAcrossThresholds, updateColorDataAcrossThresholds] =
     useInput<boolean>('annotations.thresholdOptions');
-  const [showThresholds, updateShowThresholds] = useInput<boolean>('annotations.show');
+  const [showThresholds = true, updateShowThresholds] = useInput<boolean>('annotations.show');
   const onCheckShowThresholds: NonCancelableEventHandler<CheckboxProps.ChangeDetail> = ({ detail: { checked } }) => {
     updateShowThresholds(checked);
   };
@@ -85,7 +86,7 @@ const ThresholdsSection = () => {
     e.stopPropagation();
     const newThreshold: YAnnotation = {
       color: DEFAULT_THRESHOLD_COLOR,
-      comparisonOperator: COMPARISON_OPERATOR.EQUAL,
+      comparisonOperator: COMPARISON_OPERATOR.GREATER_THAN_EQUAL,
       value: 10,
     };
     updateThresholdList([...thresholdList, newThreshold]);

--- a/packages/dashboard/src/components/sidePanel/utils/index.ts
+++ b/packages/dashboard/src/components/sidePanel/utils/index.ts
@@ -1,14 +1,15 @@
 import { Dispatch, useEffect, useState } from 'react';
 // import { useDispatch } from 'react-redux';
-import { get } from 'lodash';
-import { useSelector } from 'react-redux';
+import { cloneDeep, get, set } from 'lodash';
+import { useDispatch, useSelector } from 'react-redux';
 import { DashboardState } from '../../../store/state';
+import { UpdateWidgetsAction } from '../../../store/actions';
 
 export const useInput: <T>(path: string) => [T, Dispatch<T>] = (path) => {
   // TECHDEBT: only support viewing and updating the first selected widget.
-  const [selectedWidget] = useSelector((state: DashboardState) => state.dashboardConfiguration.widgets);
+  const [selectedWidget] = useSelector((state: DashboardState) => state.selectedWidgets);
   const [inputValue, updateInputValue] = useState(get(selectedWidget, path));
-
+  const dispatch = useDispatch();
   const onSelectedWidgetChange = () => {
     const currentWidgetState = get(selectedWidget, path);
     if (inputValue !== currentWidgetState) {
@@ -20,7 +21,14 @@ export const useInput: <T>(path: string) => [T, Dispatch<T>] = (path) => {
   const onInputValueChange = () => {
     const currentWidgetState = get(selectedWidget, path);
     if (inputValue !== currentWidgetState) {
-      // TODO: dispatch an action to update widget
+      const newWidget = set(cloneDeep(selectedWidget), path, inputValue);
+      const updateWidgetAction: UpdateWidgetsAction = {
+        type: 'UPDATE_WIDGET',
+        payload: {
+          widgets: [newWidget],
+        },
+      };
+      dispatch(updateWidgetAction);
     }
   };
   useEffect(onInputValueChange, [inputValue]);


### PR DESCRIPTION
## Overview
Update `useInput` hook. Now it supports to dispatch `UpdateWidgets` action to update widget states. 

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
