### PR TITLE
build(dashboard): upgrade to webpack5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 'lts/*'
+          # Node later than 18.13 switched spaces character
+          # in `toLocaleTimeString` and `toLocaleString`,
+          # which breaks our unit test.
+          # force to use node 16 until tests are updated or node revert the change.
+          node-version: '16.x'
 
       - name: Install and Build
         run: |

--- a/packages/dashboard/.storybook/main.js
+++ b/packages/dashboard/.storybook/main.js
@@ -1,17 +1,11 @@
 require('dotenv').config();
 
 module.exports = {
-  "stories": [
-    "../stories/**/*.stories.mdx",
-    "../stories/**/*.stories.@(js|jsx|ts|tsx)"
-  ],
-  "addons": [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/addon-interactions"
-  ],
-  "framework": "@storybook/react",
-  "core": {
-    "builder": "@storybook/builder-webpack4"
-  }
-}
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions'],
+  framework: '@storybook/react',
+  core: {
+    builder: '@storybook/builder-webpack5',
+  },
+  typescript: { reactDocgen: false },
+};

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -37,14 +37,14 @@
     "@storybook/addon-essentials": "^6.5.12",
     "@storybook/addon-interactions": "^6.5.12",
     "@storybook/addon-links": "^6.5.12",
-    "@storybook/builder-webpack4": "^6.5.13",
-    "@storybook/manager-webpack4": "^6.5.13",
+    "@storybook/builder-webpack5": "^6.5.15",
+    "@storybook/manager-webpack5": "^6.5.15",
     "@storybook/react": "^6.5.12",
     "@storybook/testing-library": "^0.0.13",
-    "@types/box-intersect": "^1.0.0",
-    "@types/is-hotkey": "^0.1.7",
     "@swc/core": "^1.3.20",
     "@swc/jest": "^0.2.23",
+    "@types/box-intersect": "^1.0.0",
+    "@types/is-hotkey": "^0.1.7",
     "@types/lodash": "^4.14.186",
     "@types/node": "^18.11.4",
     "@types/react": "^17.0.52",
@@ -68,7 +68,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.34.1",
     "tslib": "^2.4.0",
-    "typescript": "^4.8.3"
+    "typescript": "^4.8.3",
+    "webpack": "^5.75.0"
   },
   "dependencies": {
     "@cloudscape-design/components": "^3.0.126",


### PR DESCRIPTION
## Overview
Upgrade to webpack5. This change allows webpack to import ES6 syntax libs like aws-sdk.

https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-internet-explorer-11-in-the-aws-sdk-for-javascript-v3/

Also update run-tests.yml to fix broken tests under the latest Node LTS version. [more info](https://github.com/nodejs/help/issues/4068)

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
