### PR TITLE
feat(dashboard): add readonly view for dashboard

### DIFF
--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -10,7 +10,7 @@ import InternalDashboard from '../internalDashboard';
 
 import { configureDashboardStore } from '../../store';
 import { DashboardState, SaveableDashboard } from '../../store/state';
-import { RecursivePartial } from '../../types';
+import { PickRequiredOptional, RecursivePartial } from '../../types';
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 import { DashboardMessages, DefaultDashboardMessages } from '../../messages';
 
@@ -21,10 +21,10 @@ export type IotDashboardProps = {
   messageOverrides?: RecursivePartial<DashboardMessages>;
   query?: SiteWiseQuery;
   onSave?: (dashboard: SaveableDashboard) => void;
-} & Pick<DashboardState, 'dashboardConfiguration'>;
+} & PickRequiredOptional<DashboardState, 'dashboardConfiguration', 'readOnly' | 'grid'>;
 
-const Dashboard: React.FC<IotDashboardProps> = ({ dashboardConfiguration, messageOverrides, query, onSave }) => (
-  <Provider store={configureDashboardStore({ dashboardConfiguration })}>
+const Dashboard: React.FC<IotDashboardProps> = ({ messageOverrides, query, onSave, ...dashboardState }) => (
+  <Provider store={configureDashboardStore({ ...dashboardState })}>
     <DndProvider
       backend={TouchBackend}
       options={{

--- a/packages/dashboard/src/components/grid/index.tsx
+++ b/packages/dashboard/src/components/grid/index.tsx
@@ -31,6 +31,7 @@ export type DropEvent = {
 };
 
 export type GridProps = {
+  readOnly: boolean;
   grid: DashboardState['grid'];
   click: (e: PointClickEvent) => void;
   dragStart: (e: DragEvent) => void;
@@ -41,7 +42,7 @@ export type GridProps = {
 
 const defaultDelta = { x: 0, y: 0 };
 
-const Grid: React.FC<GridProps> = ({ grid, click, dragStart, drag, dragEnd, drop, children }) => {
+const Grid: React.FC<GridProps> = ({ readOnly, grid, click, dragStart, drag, dragEnd, drop, children }) => {
   const { width, height, cellSize, stretchToFit, enabled } = grid;
 
   const [delta, setDelta] = useState<Position>(defaultDelta);
@@ -85,7 +86,7 @@ const Grid: React.FC<GridProps> = ({ grid, click, dragStart, drag, dragEnd, drop
           clientOffset: monitor.getClientOffset(),
         };
       },
-      canDrag: enabled,
+      canDrag: !readOnly && enabled,
     }),
     [union, start, end]
   );
@@ -152,6 +153,7 @@ const Grid: React.FC<GridProps> = ({ grid, click, dragStart, drag, dragEnd, drop
   }, [collected.isDragging, collected.clientOffset]);
 
   const onPointerDown: PointerEventHandler = (e) => {
+    if (readOnly) return;
     setTarget(e.target);
     setCancelClick(false);
     setStart(getDashboardPosition(e));
@@ -159,7 +161,7 @@ const Grid: React.FC<GridProps> = ({ grid, click, dragStart, drag, dragEnd, drop
   };
 
   const onPointerUp: PointerEventHandler = (e) => {
-    if (cancelClick || !enabled) return;
+    if (cancelClick || !enabled || readOnly) return;
 
     if (e.button === MouseClick.Left) {
       click({

--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -90,4 +90,37 @@ describe('InternalDashboard', () => {
 
     expect(onSave).toBeCalledWith(args);
   });
+
+  it('can display in readonly mode', function () {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const args = {
+      readOnly: true,
+      dashboardConfiguration: {
+        widgets: [],
+        viewport: { duration: '5m' },
+      },
+    };
+
+    act(() => {
+      ReactDOM.render(
+        <Provider store={configureDashboardStore(args)}>
+          <DndProvider
+            backend={TouchBackend}
+            options={{
+              enableMouseEvents: true,
+              enableKeyboardEvents: true,
+            }}
+          >
+            <InternalDashboard query={undefined} messageOverrides={DefaultDashboardMessages} />
+          </DndProvider>
+        </Provider>,
+        container
+      );
+    });
+
+    expect(container.querySelector('.iot-dashboard-toolbar')).toBeFalsy();
+    expect(container.querySelector('.iot-dashboard-panes-area')).toBeFalsy();
+  });
 });

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -89,7 +89,7 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
   const grid = useSelector((state: DashboardState) => state.grid);
   const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
   const copiedWidgets = useSelector((state: DashboardState) => state.copiedWidgets);
-  const readonly = useSelector((state: DashboardState) => state.readonly);
+  const readOnly = useSelector((state: DashboardState) => state.readOnly);
 
   const dispatch = useDispatch();
   const createWidgets = (widgets: Widget[]) =>
@@ -353,6 +353,7 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
    * Child component props configuration
    */
   const gridProps: GridProps = {
+    readOnly,
     grid,
     click: onPointClick,
     dragStart: onGestureStart,
@@ -363,7 +364,7 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
 
   const widgetsProps: WidgetsProps = {
     query,
-    readonly,
+    readOnly,
     dashboardConfiguration,
     selectedWidgets,
     messageOverrides,
@@ -385,6 +386,18 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
     hasCopiedWidgets: copiedWidgets.length > 0,
     hasSelectedWidgets: selectedWidgets.length > 0,
   };
+
+  if (readOnly) {
+    return (
+      <div className="iot-dashboard">
+        <div className="iot-dashboard-grid">
+          <Grid {...gridProps}>
+            <Widgets {...widgetsProps} />
+          </Grid>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="iot-dashboard">

--- a/packages/dashboard/src/components/widgets/dynamicWidget.tsx
+++ b/packages/dashboard/src/components/widgets/dynamicWidget.tsx
@@ -10,7 +10,7 @@ import { WidgetsMessages } from '../../messages';
 const IconX = require('./iconx.svg') as string;
 
 export type DynamicWidgetProps = {
-  readonly: boolean;
+  readOnly: boolean;
   query?: SiteWiseQuery;
   viewport: DashboardConfiguration['viewport'];
   widget: Widget;
@@ -31,11 +31,11 @@ export const getDragLayerProps = ({
   viewport,
   widgetsMessages,
   isSelected: false,
-  readonly: true,
+  readOnly: true,
 });
 
 const DynamicWidgetComponent: React.FC<DynamicWidgetProps> = ({
-  readonly,
+  readOnly,
   query,
   widget,
   viewport,
@@ -64,7 +64,7 @@ const DynamicWidgetComponent: React.FC<DynamicWidgetProps> = ({
   const props = {
     ...componentSpecificProps,
     ...widget,
-    readonly,
+    readOnly,
     isSelected,
   };
 

--- a/packages/dashboard/src/components/widgets/list.tsx
+++ b/packages/dashboard/src/components/widgets/list.tsx
@@ -12,7 +12,7 @@ import SelectionBox from './selectionBox';
 import { DashboardMessages } from '../../messages';
 
 export type WidgetsProps = {
-  readonly: boolean;
+  readOnly: boolean;
   query?: SiteWiseQuery;
   dashboardConfiguration: DashboardConfiguration;
   selectedWidgets: Widget[];
@@ -28,7 +28,7 @@ const Widgets: React.FC<WidgetsProps> = ({
   dragEnabled,
   messageOverrides,
   query,
-  readonly,
+  readOnly,
 }) => {
   const { widgets, viewport } = dashboardConfiguration;
   const isSelected = (id: string) =>
@@ -46,7 +46,7 @@ const Widgets: React.FC<WidgetsProps> = ({
       <SelectionBox {...{ selectedWidgets, cellSize, dragEnabled }} />
       {widgets.map((widget) => (
         <WidgetComponent
-          readonly={readonly}
+          readOnly={readOnly}
           query={query}
           messageOverrides={messageOverrides}
           isSelected={isSelected(widget.id)}

--- a/packages/dashboard/src/components/widgets/primitives/text/index.tsx
+++ b/packages/dashboard/src/components/widgets/primitives/text/index.tsx
@@ -13,9 +13,9 @@ import EditableTextLink from './link/editableLink';
 
 import './index.css';
 
-export type TextWidgetProps = TextWidgetType & { readonly: boolean; isSelected: boolean };
+export type TextWidgetProps = TextWidgetType & { readOnly: boolean; isSelected: boolean };
 
-const TextWidget: React.FC<TextWidgetProps> = ({ readonly, isSelected, ...widget }) => {
+const TextWidget: React.FC<TextWidgetProps> = ({ readOnly, isSelected, ...widget }) => {
   const { isLink } = widget;
 
   const dispatch = useDispatch();
@@ -26,9 +26,9 @@ const TextWidget: React.FC<TextWidgetProps> = ({ readonly, isSelected, ...widget
     setIsEditing(editing);
   };
 
-  const props = { readonly, isSelected, handleSetEdit, ...widget };
+  const props = { readOnly, isSelected, handleSetEdit, ...widget };
 
-  if (readonly) {
+  if (readOnly) {
     if (isLink) {
       return <TextLink {...widget} />;
     } else {

--- a/packages/dashboard/src/components/widgets/widget.css
+++ b/packages/dashboard/src/components/widgets/widget.css
@@ -15,6 +15,10 @@
   border-radius: var(--selection-radius-small);
 }
 
+.widget-readonly:hover {
+  cursor: default;
+}
+
 .widget-selected {
   border: var(--selection-border-width) solid var(--selection-color-secondary);
   border-radius: var(--selection-radius);

--- a/packages/dashboard/src/components/widgets/widget.tsx
+++ b/packages/dashboard/src/components/widgets/widget.tsx
@@ -9,7 +9,7 @@ import DynamicWidgetComponent from './dynamicWidget';
 import './widget.css';
 
 export type WidgetProps = {
-  readonly: boolean;
+  readOnly: boolean;
   query?: SiteWiseQuery;
   isSelected: boolean;
   cellSize: number;
@@ -24,7 +24,7 @@ const WidgetComponent: React.FC<WidgetProps> = ({
   viewport,
   messageOverrides,
   query,
-  readonly,
+  readOnly,
   isSelected,
 }) => {
   const { x, y, z, width, height } = widget;
@@ -32,7 +32,7 @@ const WidgetComponent: React.FC<WidgetProps> = ({
   return (
     <div
       {...gestureable('widget')}
-      className="widget"
+      className={`widget ${readOnly ? 'widget-readonly' : ''}`}
       style={{
         zIndex: z.toString(),
         top: `${cellSize * y}px`,
@@ -42,7 +42,7 @@ const WidgetComponent: React.FC<WidgetProps> = ({
       }}
     >
       <DynamicWidgetComponent
-        readonly={readonly}
+        readOnly={readOnly}
         query={query}
         viewport={viewport}
         widget={widget}

--- a/packages/dashboard/src/store/state.ts
+++ b/packages/dashboard/src/store/state.ts
@@ -8,7 +8,7 @@ export type DashboardState = {
     cellSize: number;
     stretchToFit: boolean;
   };
-  readonly: boolean;
+  readOnly: boolean;
   selectedWidgets: Widget[];
   copiedWidgets: Widget[];
   pasteCounter: number;
@@ -33,7 +33,7 @@ export const initialState: DashboardState = {
     cellSize: 10,
     stretchToFit: false,
   },
-  readonly: false,
+  readOnly: false,
   selectedWidgets: [],
   copiedWidgets: [],
   pasteCounter: 0,

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -100,3 +100,6 @@ export type RecursivePartial<T> = {
     ? RecursivePartial<T[P]>
     : T[P];
 };
+
+export type PickRequiredOptional<T, TRequired extends keyof T, TOptional extends keyof T> = Pick<T, TRequired> &
+  RecursivePartial<Pick<T, TOptional>>;

--- a/packages/dashboard/stories/IotDashboard/IotDashboard.stories.tsx
+++ b/packages/dashboard/stories/IotDashboard/IotDashboard.stories.tsx
@@ -4,6 +4,19 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import IotDashboard, { IotDashboardProps } from '../../src/components/dashboard';
 import { query } from '../../testing/siteWiseQueries';
 
+import { MockWidgetFactory } from '../../testing/mocks';
+import { SaveableDashboard } from '../../src/store/state';
+
+const getDashboardProps = (defaultProps: IotDashboardProps): IotDashboardProps => {
+  const cachedDashboard = window.localStorage.getItem('dashboard');
+  const dashboard = cachedDashboard ? (JSON.parse(cachedDashboard) as SaveableDashboard) : defaultProps;
+
+  return {
+    ...defaultProps,
+    ...dashboard,
+  };
+};
+
 export default {
   title: 'IotDashboard',
   component: IotDashboard,
@@ -18,7 +31,35 @@ const args = {
     viewport: { duration: '5m' },
   },
   query,
-  onSave: (dashboard) => console.log(dashboard),
+  onSave: (dashboard) => {
+    window.localStorage.setItem('dashboard', JSON.stringify(dashboard));
+    console.log(dashboard);
+  },
 } as IotDashboardProps;
 
-export const Main: ComponentStory<typeof IotDashboard> = () => <IotDashboard {...args} />;
+export const Main: ComponentStory<typeof IotDashboard> = () => <IotDashboard {...getDashboardProps(args)} />;
+
+const readOnlyArgs = {
+  grid: {
+    height: 100,
+    width: 100,
+    cellSize: 10,
+    stretchToFit: false,
+  },
+  query,
+  dashboardConfiguration: {
+    viewport: { duration: '5m' },
+    widgets: [
+      MockWidgetFactory.getTextWidget({ x: 0, y: 0, width: 30, height: 2 }),
+      MockWidgetFactory.getKpiWidget({ x: 0, y: 3, width: 30, height: 20 }),
+      MockWidgetFactory.getKpiWidget({ x: 31, y: 3, width: 30, height: 20 }),
+      MockWidgetFactory.getLineChartWidget({ x: 0, y: 24, width: 30, height: 30 }),
+      MockWidgetFactory.getLineChartWidget({ x: 31, y: 24, width: 30, height: 30 }),
+    ],
+  },
+  readOnly: true,
+} as IotDashboardProps;
+
+export const ReadOnly: ComponentStory<typeof IotDashboard> = () => (
+  <IotDashboard {...getDashboardProps(readOnlyArgs)} />
+);


### PR DESCRIPTION
## Overview
Add a readonly property for the dashboard which makes the dashboard only render the grid area. It also disables the context menu and the drag and drop functionality.

This adds a new story for readonly mode. The Save button in the Main dashboard story will write the current state to local storage to be used in the readonly story.