### PR TITLE
test(dashboard): resource explorer unit tests

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -58,6 +58,8 @@
     "postcss-import": "^14.0.0",
     "postcss-url": "^10.1.3",
     "react": "^17.0.2",
+    "react-dnd-test-backend": "^16.0.1",
+    "react-dnd-test-utils": "^16.0.1",
     "react-dom": "^17.0.2",
     "react-redux": "^8.0.4",
     "redux": "^4.2.0",

--- a/packages/dashboard/src/components/resourceExplorer/components/breadcrumbs.test.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/breadcrumbs.test.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import { act, render, fireEvent } from '@testing-library/react';
+import { IotResourceExplorerBreadcrumbs, BreadcrumbItem } from './breadcrumbs';
+
+global.structuredClone = jest.fn((val) => {
+  return JSON.parse(JSON.stringify(val));
+});
+
+describe('IotResourceExplorerBreadcrumbs', () => {
+  it('should call handleCrumbClick with the correct item when a crumb is clicked', () => {
+    const crumbs = [
+      { name: 'Crumb 1', text: 'Crumb 1', href: '', id: 'Crumb1' },
+      { name: 'Crumb 2', text: 'Crumb 2', href: '', id: 'Crumb2' },
+      { name: 'Crumb 3', text: 'Crumb 3', href: '', id: 'Crumb3' },
+    ] as BreadcrumbItem[];
+    const handleCrumbClickMock = jest.fn();
+    const setCrumbsMock = jest.fn();
+
+    const { getByText } = render(
+      <IotResourceExplorerBreadcrumbs
+        handleCrumbClick={handleCrumbClickMock}
+        setCrumbs={setCrumbsMock}
+        crumbs={crumbs}
+      />
+    );
+    const crumb1 = getByText('Crumb 1');
+
+    act(() => {
+      fireEvent.click(crumb1);
+    });
+
+    expect(handleCrumbClickMock).toHaveBeenCalledWith(crumbs[0]);
+  });
+
+  it('should call setCrumbs with the correct item when a crumb is clicked', () => {
+    const crumbs = [
+      { name: 'Crumb 1', text: 'Crumb 1', href: '', id: 'Crumb1' },
+      { name: 'Crumb 2', text: 'Crumb 2', href: '', id: 'Crumb2' },
+      { name: 'Crumb 3', text: 'Crumb 3', href: '', id: 'Crumb3' },
+    ] as BreadcrumbItem[];
+    const handleCrumbClickMock = jest.fn();
+    const setCrumbsMock = jest.fn();
+
+    const { getByText } = render(
+      <IotResourceExplorerBreadcrumbs
+        handleCrumbClick={handleCrumbClickMock}
+        setCrumbs={setCrumbsMock}
+        crumbs={crumbs}
+      />
+    );
+    const crumb1 = getByText('Crumb 1');
+
+    act(() => {
+      fireEvent.click(crumb1);
+    });
+
+    expect(setCrumbsMock).toHaveBeenCalledWith([crumbs[0]]);
+  });
+
+  it('should call setCrumbs with the correct items when a crumb other than the first is clicked', () => {
+    const crumbs = [
+      { name: 'Crumb 1', text: 'Crumb 1', href: '', id: 'Crumb1' },
+      { name: 'Crumb 2', text: 'Crumb 2', href: '', id: 'Crumb2' },
+      { name: 'Crumb 3', text: 'Crumb 3', href: '', id: 'Crumb3' },
+    ] as BreadcrumbItem[];
+    const handleCrumbClickMock = jest.fn();
+    const setCrumbsMock = jest.fn();
+
+    const { getByText } = render(
+      <IotResourceExplorerBreadcrumbs
+        handleCrumbClick={handleCrumbClickMock}
+        setCrumbs={setCrumbsMock}
+        crumbs={crumbs}
+      />
+    );
+    const crumb2 = getByText('Crumb 2');
+
+    act(() => {
+      fireEvent.click(crumb2);
+    });
+
+    expect(setCrumbsMock).toHaveBeenCalledWith([crumbs[0], crumbs[1]]);
+  });
+
+  it('should not call setCrumbs when the last crumb is clicked', () => {
+    const crumbs = [
+      { name: 'Crumb 1', text: 'Crumb 1', href: '', id: 'Crumb1' },
+      { name: 'Crumb 2', text: 'Crumb 2', href: '', id: 'Crumb2' },
+      { name: 'Crumb 3', text: 'Crumb 3', href: '', id: 'Crumb3' },
+    ] as BreadcrumbItem[];
+    const handleCrumbClickMock = jest.fn();
+    const setCrumbsMock = jest.fn();
+
+    const { getByText } = render(
+      <IotResourceExplorerBreadcrumbs
+        handleCrumbClick={handleCrumbClickMock}
+        setCrumbs={setCrumbsMock}
+        crumbs={crumbs}
+      />
+    );
+    const crumb3 = getByText('Crumb 3');
+
+    act(() => {
+      fireEvent.click(crumb3);
+    });
+
+    expect(setCrumbsMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/components/resourceExplorer/components/breadcrumbs.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/breadcrumbs.tsx
@@ -4,14 +4,14 @@ import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
 
 export const HIERARCHY_ROOT_ID = 'HIERARCHY_ROOT_ID';
 
-interface BreadcrumbEvent {
+export interface BreadcrumbEvent {
   preventDefault: () => void;
   detail: {
     item: AssetSummary;
   };
 }
 
-interface BreadcrumbItem extends AssetSummary {
+export interface BreadcrumbItem extends AssetSummary {
   text: string;
   href: string;
 }

--- a/packages/dashboard/src/components/resourceExplorer/components/panel.test.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/panel.test.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { act, render, fireEvent } from '@testing-library/react';
+import { wrapWithTestBackend } from 'react-dnd-test-utils';
+import { IotResourceExplorerPanel } from './panel';
+import { DashboardMessages } from '../../../messages';
+
+const mockMessageOverrides = { resourceExplorer: { panelEmptyLabel: 'Empty panel' } } as DashboardMessages;
+const mockPanelItems = [
+  { id: 'Asset1', name: 'Asset 1', isAsset: true, isAssetProperty: false },
+  { id: 'Asset2', name: 'Asset 2', isAsset: true, isAssetProperty: false },
+  { id: 'AssetProperty1', name: 'Asset Property 1', isAsset: false, isAssetProperty: true },
+];
+const mockHandlePanelItemClick = jest.fn();
+
+const [PanelContext] = wrapWithTestBackend(IotResourceExplorerPanel);
+
+describe('IotResourceExplorerPanel', () => {
+  it('renders empty panel message when no items passed', () => {
+    const { getByText } = render(
+      <PanelContext
+        panelItems={[]}
+        handlePanelItemClick={mockHandlePanelItemClick}
+        messageOverrides={mockMessageOverrides}
+      />
+    );
+
+    expect(getByText('Empty panel')).toBeTruthy();
+  });
+
+  it('renders panel items and calls handlePanelItemClick when an asset panel item is clicked', () => {
+    const { getByText } = render(
+      <PanelContext
+        panelItems={mockPanelItems}
+        handlePanelItemClick={mockHandlePanelItemClick}
+        messageOverrides={mockMessageOverrides}
+      />
+    );
+
+    expect(getByText('Asset 1')).toBeTruthy();
+    expect(getByText('Asset 2')).toBeTruthy();
+    expect(getByText('Asset Property 1')).toBeTruthy();
+
+    act(() => {
+      fireEvent.click(getByText('Asset 1'));
+    });
+
+    expect(mockHandlePanelItemClick).toHaveBeenCalledWith(mockPanelItems[0]);
+  });
+});

--- a/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.test.ts
+++ b/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.test.ts
@@ -1,0 +1,102 @@
+import { getCurrentAssetProperties } from './getCurrentAssetProperties';
+import { ExtendedPanelAssetSummary } from '.';
+import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { DashboardMessages } from '../../messages';
+import { getEnvCredentials } from '../../../testing/getEnvCredentials';
+
+jest.mock('@aws-sdk/client-iotsitewise');
+jest.mock('../../../testing/getEnvCredentials');
+const mockGetEnvCredentials = getEnvCredentials as jest.MockedFunction<typeof getEnvCredentials>;
+
+mockGetEnvCredentials.mockResolvedValue({
+  accessKeyId: 'accessKeyId',
+  secretAccessKey: 'secretAccessKey',
+} as never);
+
+describe('getCurrentAssetProperties', () => {
+  const messageOverrides = {
+    resourceExplorer: {
+      assetPropertiesHeader: 'Asset Properties',
+    },
+  } as DashboardMessages;
+
+  beforeEach(() => {
+    (IoTSiteWiseClient.prototype.send as jest.Mock).mockResolvedValue({
+      assetPropertySummaries: [
+        { id: 'Asset Property 1', alias: 'Temperature' },
+        { id: 'Asset Property 2', alias: 'Pressure' },
+      ],
+    });
+  });
+
+  it('should return an array of asset properties', async () => {
+    const result = await getCurrentAssetProperties('Asset 1', messageOverrides);
+    expect(result).toEqual([
+      {
+        id: 'Asset Properties',
+        name: 'Asset Properties',
+        isHeader: true,
+        isAssetProperty: false,
+        queryAssetsParam: [],
+      },
+      {
+        id: 'Asset Property 1',
+        name: 'Temperature',
+        isAssetProperty: true,
+        queryAssetsParam: [
+          {
+            assetId: 'Asset 1',
+            properties: [
+              {
+                propertyId: 'Asset Property 1',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'Asset Property 2',
+        name: 'Pressure',
+        isAssetProperty: true,
+        queryAssetsParam: [
+          {
+            assetId: 'Asset 1',
+            properties: [
+              {
+                propertyId: 'Asset Property 2',
+              },
+            ],
+          },
+        ],
+      },
+    ] as ExtendedPanelAssetSummary[]);
+  });
+
+  it('should return empty array when currentBranchId is hierarchy root id', async () => {
+    const result = await getCurrentAssetProperties('HIERARCHY_ROOT_ID', messageOverrides);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when assetProperties is not found', async () => {
+    (IoTSiteWiseClient.prototype.send as jest.Mock).mockResolvedValue({});
+    const result = await getCurrentAssetProperties('Asset 1', messageOverrides);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when there is no aliased properties', async () => {
+    (IoTSiteWiseClient.prototype.send as jest.Mock).mockResolvedValue({
+      assetPropertySummaries: [
+        { id: 'Asset Property 1', alias: null },
+        { id: 'Asset Property 2', alias: null },
+      ],
+    });
+    const result = await getCurrentAssetProperties('Asset 1', messageOverrides);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when there is an error', async () => {
+    (IoTSiteWiseClient.prototype.send as jest.Mock).mockRejectedValue(new Error('Test error'));
+    const result = await getCurrentAssetProperties('Asset 1', messageOverrides);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.ts
+++ b/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.ts
@@ -1,16 +1,11 @@
 import { AssetPropertySummary, IoTSiteWiseClient, ListAssetPropertiesCommand } from '@aws-sdk/client-iotsitewise';
 import { getEnvCredentials } from '../../../testing/getEnvCredentials';
-import { MaybeSiteWiseAssetTreeSessionInterface } from './types';
 import { HIERARCHY_ROOT_ID } from '.';
 import { REGION } from '../../../testing/siteWiseQueries';
 import { ExtendedPanelAssetSummary } from '.';
 import { DashboardMessages } from '../../messages';
 
-export const getCurrentAssetProperties = async (
-  provider: MaybeSiteWiseAssetTreeSessionInterface,
-  currentBranchId: string,
-  messageOverrides: DashboardMessages
-) => {
+export const getCurrentAssetProperties = async (currentBranchId: string, messageOverrides: DashboardMessages) => {
   const assetPropertiesHeaderItem = {
     id: messageOverrides.resourceExplorer.assetPropertiesHeader,
     name: messageOverrides.resourceExplorer.assetPropertiesHeader,

--- a/packages/dashboard/src/components/resourceExplorer/getCurrentAssets.test.ts
+++ b/packages/dashboard/src/components/resourceExplorer/getCurrentAssets.test.ts
@@ -1,0 +1,109 @@
+import { getCurrentAssets } from './getCurrentAssets';
+import { HIERARCHY_ROOT_ID } from '.';
+import { MaybeSiteWiseAssetTreeSessionInterface } from './types';
+import { DashboardMessages } from '../../messages';
+
+describe('getCurrentAssets', () => {
+  it('should return all assets under the root when currentBranchId is hierachy root id', async () => {
+    const provider = {
+      branches: {
+        [HIERARCHY_ROOT_ID]: {
+          assetIds: ['Asset1', 'Asset2'],
+        },
+      },
+      assetNodes: {
+        Asset1: { asset: { name: 'Asset 1' } },
+        Asset2: { asset: { name: 'Asset 2' } },
+      },
+    } as unknown as MaybeSiteWiseAssetTreeSessionInterface;
+    const messageOverrides = {
+      resourceExplorer: {
+        rootAssetsHeader: 'Root Assets',
+        childAssetsHeader: 'Child Assets',
+      },
+    } as DashboardMessages;
+
+    const result = await getCurrentAssets(provider, HIERARCHY_ROOT_ID, messageOverrides);
+
+    expect(result).toEqual([{ isHeader: true, name: 'Root Assets' }, { name: 'Asset 1' }, { name: 'Asset 2' }]);
+  });
+
+  it('should return all assets for the current branch when currentBranchId is valid and something other than hierarchy root id', async () => {
+    const provider = {
+      branches: {
+        [HIERARCHY_ROOT_ID]: {
+          assetIds: ['Asset1'],
+        },
+        Asset3ModelAsset1: {
+          assetIds: ['Asset3'],
+        },
+      },
+      assetNodes: {
+        Asset1: {
+          asset: {
+            id: 'Asset1',
+            name: 'Asset 1',
+            hierarchies: [{ id: 'Asset3Model', name: 'Asset 3 Model' }],
+          },
+        },
+        Asset3: { asset: { id: 'Asset3', name: 'Asset 3' } },
+      },
+    } as unknown as MaybeSiteWiseAssetTreeSessionInterface;
+    const messageOverrides = {
+      resourceExplorer: {
+        rootAssetsHeader: 'Root Assets',
+        childAssetsHeader: 'Child Assets',
+      },
+    } as DashboardMessages;
+
+    const result = await getCurrentAssets(provider, 'Asset1', messageOverrides);
+
+    expect(result).toEqual([
+      { isHeader: true, name: 'Child Assets' },
+      { id: 'Asset3', name: 'Asset 3' },
+    ]);
+  });
+
+  it('should return an empty array when currentBranchId is missing', async () => {
+    const provider = {
+      branches: {
+        [HIERARCHY_ROOT_ID]: {
+          assetIds: ['Asset1'],
+        },
+      },
+      assetNodes: {
+        Asset1: {
+          asset: {
+            id: 'Asset1',
+            name: 'Asset 1',
+            hierarchies: [],
+          },
+        },
+      },
+    } as unknown as MaybeSiteWiseAssetTreeSessionInterface;
+    const messageOverrides = {
+      resourceExplorer: {
+        rootAssetsHeader: 'Root Assets',
+        childAssetsHeader: 'Child Assets',
+      },
+    } as DashboardMessages;
+
+    const result = await getCurrentAssets(provider, 'notARealBranchId', messageOverrides);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when branches or assetNodes are missing', async () => {
+    const provider = {} as unknown as MaybeSiteWiseAssetTreeSessionInterface;
+    const messageOverrides = {
+      resourceExplorer: {
+        rootAssetsHeader: 'Root Assets',
+        childAssetsHeader: 'Child Assets',
+      },
+    } as DashboardMessages;
+
+    const result = await getCurrentAssets(provider, HIERARCHY_ROOT_ID, messageOverrides);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/dashboard/src/components/resourceExplorer/getCurrentAssets.ts
+++ b/packages/dashboard/src/components/resourceExplorer/getCurrentAssets.ts
@@ -15,6 +15,7 @@ const getAllHierachyAssets = (
 
   currentAsset?.hierarchies?.forEach((hierarchy: AssetHierarchy) => {
     const branchRef = new BranchReference(currentAsset.id, hierarchy.id as string);
+
     const branchRefKey = branchRef?.key;
     if (!branchRefKey) return result;
 

--- a/packages/dashboard/src/components/resourceExplorer/index.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/index.tsx
@@ -59,10 +59,8 @@ export const IotResourceExplorer: React.FC<IotResourceExplorerProps> = ({ treeQu
     (async () => {
       const [currentAssets, currentAssetProperties]: [EitherAssetSummary[], EitherAssetSummary[]] = await Promise.all([
         getCurrentAssets(provider, currentBranchId, messageOverrides),
-        getCurrentAssetProperties(provider, currentBranchId, messageOverrides),
+        getCurrentAssetProperties(currentBranchId, messageOverrides),
       ]);
-
-      console.log({ currentAssets, currentAssetProperties });
 
       const nextPanelItems = currentAssetProperties.concat(currentAssets);
       setPanelItems(nextPanelItems);


### PR DESCRIPTION
## Overview
As a fast follow for #481, unit tests for the constituent parts of the resource explorer (panel, breadcrumbs, getCurrentAsset, getCurrentAssetProperties).

Closes #490 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
