### PR TITLE
feat(dashboard): dispatch dropped asset property to Redux

### DIFF
--- a/packages/dashboard/src/components/resourceExplorer/index.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/index.tsx
@@ -62,8 +62,6 @@ export const IotResourceExplorer: React.FC<IotResourceExplorerProps> = ({ treeQu
         getCurrentAssetProperties(provider, currentBranchId, messageOverrides),
       ]);
 
-      console.log({ currentAssets, currentAssetProperties });
-
       const nextPanelItems = currentAssetProperties.concat(currentAssets);
       setPanelItems(nextPanelItems);
     })();

--- a/packages/dashboard/src/components/widgets/list.tsx
+++ b/packages/dashboard/src/components/widgets/list.tsx
@@ -53,7 +53,6 @@ const Widgets: React.FC<WidgetsProps> = ({
           key={widget.id}
           cellSize={cellSize}
           widget={widget}
-          widgets={widgets}
           viewport={viewport}
         />
       ))}

--- a/packages/dashboard/src/components/widgets/widget.tsx
+++ b/packages/dashboard/src/components/widgets/widget.tsx
@@ -1,13 +1,10 @@
+import React from 'react';
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
-import React, { useState, useEffect } from 'react';
-import { useDrop } from 'react-dnd';
 import { DashboardMessages } from '../../messages';
-
 import { DashboardConfiguration, Widget } from '../../types';
 import { gestureable } from '../internalDashboard/determineTargetGestures';
 import DynamicWidgetComponent from './dynamicWidget';
-import { ItemTypes } from '../dragLayer/itemTypes';
-import { AssetQuery } from '@iot-app-kit/core';
+import { WidgetDropTarget } from './widgetDropTarget';
 
 import './widget.css';
 
@@ -17,7 +14,6 @@ export type WidgetProps = {
   isSelected: boolean;
   cellSize: number;
   widget: Widget;
-  widgets: Widget[];
   viewport: DashboardConfiguration['viewport'];
   messageOverrides: DashboardMessages;
 };
@@ -33,50 +29,29 @@ const WidgetComponent: React.FC<WidgetProps> = ({
 }) => {
   const { x, y, z, width, height } = widget;
 
-  // TODO: Replace with Redux dispatch
-  const [assets, setAssets] = useState<null | AssetQuery>(null);
-  const [internalWidget, setInternalWidget] = useState(widget);
-
-  const [, drop] = useDrop(
-    () => ({
-      accept: ItemTypes.ResourceExplorerAssetProperty,
-      drop: ({ queryAssetsParam }: { queryAssetsParam: AssetQuery }) => {
-        setAssets(queryAssetsParam);
-      },
-    }),
-    []
-  );
-
-  useEffect(() => {
-    const nextInternalWidget = structuredClone(widget);
-    if (assets) {
-      nextInternalWidget.assets = assets as any;
-    }
-    setInternalWidget(nextInternalWidget);
-  }, [JSON.stringify(widget), JSON.stringify(assets)]);
-
   return (
-    <div
-      ref={drop}
-      {...gestureable('widget')}
-      className={`widget ${readOnly ? 'widget-readonly' : ''}`}
-      style={{
-        zIndex: z.toString(),
-        top: `${cellSize * y}px`,
-        left: `${cellSize * x}px`,
-        width: `${cellSize * width}px`,
-        height: `${cellSize * height}px`,
-      }}
-    >
-      <DynamicWidgetComponent
-        readOnly={readOnly}
-        query={query}
-        viewport={viewport}
-        widget={internalWidget}
-        isSelected={isSelected}
-        widgetsMessages={messageOverrides.widgets}
-      />
-    </div>
+    <WidgetDropTarget widget={widget}>
+      <div
+        {...gestureable('widget')}
+        className={`widget ${readOnly ? 'widget-readonly' : ''}`}
+        style={{
+          zIndex: z.toString(),
+          top: `${cellSize * y}px`,
+          left: `${cellSize * x}px`,
+          width: `${cellSize * width}px`,
+          height: `${cellSize * height}px`,
+        }}
+      >
+        <DynamicWidgetComponent
+          readOnly={readOnly}
+          query={query}
+          viewport={viewport}
+          widget={widget}
+          isSelected={isSelected}
+          widgetsMessages={messageOverrides.widgets}
+        />
+      </div>
+    </WidgetDropTarget>
   );
 };
 

--- a/packages/dashboard/src/components/widgets/widgetDropTarget.tsx
+++ b/packages/dashboard/src/components/widgets/widgetDropTarget.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { AssetQuery } from '@iot-app-kit/core';
+import { useDrop } from 'react-dnd';
+import { useDispatch } from 'react-redux';
+import { onUpdateAssetQueryAction } from '../../store/actions/updateAssetQuery';
+import { Widget, AppKitWidget } from '../../types';
+import { ItemTypes } from '../dragLayer/itemTypes';
+
+export type WidgetDropTargetProps = {
+  widget: Widget;
+  children: React.ReactNode;
+};
+
+export const WidgetDropTarget: React.FC<WidgetDropTargetProps> = ({ widget, children }) => {
+  const dispatch = useDispatch();
+
+  const [, drop] = useDrop(
+    () => ({
+      accept: ItemTypes.ResourceExplorerAssetProperty,
+      drop: ({ queryAssetsParam }: { queryAssetsParam: AssetQuery }) => {
+        const newAssetQueries = queryAssetsParam;
+
+        const appKitWidget = structuredClone(widget) as AppKitWidget;
+        appKitWidget.widgetId = widget.id;
+
+        dispatch(
+          onUpdateAssetQueryAction({
+            // TODO: There is a mismatch between type expectations and what actually results in data being retrieved here; this expects an AssetQuery[] but actually requires an AssetQuery
+            assetQuery: newAssetQueries as any,
+            widget: appKitWidget,
+          })
+        );
+      },
+    }),
+    []
+  );
+
+  return <div ref={drop}>{children}</div>;
+};


### PR DESCRIPTION
## Overview
This change switches the addition of asset properties from an internal state value in `widget.tsx` to a Redux dispatch to the actual widget state.

There are a couple of issues here -- the first is that converting a `Widget` to an `AppKitWidget` is kind of clunky, and the second is that there appears to be a bug in our type annotations; onUpdateAssetQueryAction is typed as if it expects an `AssetQuery[]` but it actually needs to be passed an `AssetQuery`. I'm choosing to punt on both of them for now because I think we may want to step back and think more holistically about data structure, and I'm writing a doc to try and do that.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
