### PR TITLE
fix(dashboard): select newly added widgets on paste

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -339,9 +339,14 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
 
   /**
    * Keyboard hotkey / shortcut configuration
+   * key press filter makes sure that the event is not coming from
+   * other areas where we might use keyboard interactions such as
+   * the settings pane or a text area in a widget
    */
   const keyPressFilter = (e: KeyboardEvent) =>
-    e.target !== null && e.target instanceof Element && e.target.id === DASHBOARD_CONTAINER_ID;
+    e.target !== null &&
+    e.target instanceof Element &&
+    (e.target.id === DASHBOARD_CONTAINER_ID || e.target === document.body);
   useKeyPress('esc', { filter: keyPressFilter, callback: onClearSelection });
   useKeyPress('backspace, del', { filter: keyPressFilter, callback: deleteWidgets });
   useKeyPress('mod+c', { filter: keyPressFilter, callback: copyWidgets });

--- a/packages/dashboard/src/store/actions/pasteWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/pasteWidgets/index.spec.ts
@@ -150,3 +150,44 @@ it('pastes multiple widgets at a specific location', () => {
     ])
   );
 });
+
+it('selects the widgets that are pasted', () => {
+  const selectedWidgets = pasteWidgets(
+    setupDashboardState([MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET], [MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET]),
+    onPasteWidgetsAction({
+      position: { x: 100, y: 100 },
+    })
+  ).selectedWidgets;
+
+  // the newly pasted widgets are selected
+  expect(selectedWidgets).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: 10,
+        y: 10,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_LINE_CHART_WIDGET.componentTag,
+        x: 12,
+        y: 12,
+      }),
+    ])
+  );
+
+  // the initial copied widgets are not selected
+  expect(selectedWidgets).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        componentTag: MOCK_KPI_WIDGET.componentTag,
+        x: MOCK_KPI_WIDGET.x,
+        y: MOCK_KPI_WIDGET.y,
+      }),
+      expect.objectContaining({
+        componentTag: MOCK_LINE_CHART_WIDGET.componentTag,
+        x: MOCK_LINE_CHART_WIDGET.x,
+        y: MOCK_LINE_CHART_WIDGET.y,
+      }),
+    ])
+  );
+});

--- a/packages/dashboard/src/store/actions/pasteWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/pasteWidgets/index.ts
@@ -60,5 +60,6 @@ export const pasteWidgets = (state: DashboardState, action: PasteWidgetsAction):
       widgets: [...state.dashboardConfiguration.widgets, ...widgetsToPaste],
     },
     pasteCounter: position !== undefined ? 0 : pasteCounter,
+    selectedWidgets: widgetsToPaste,
   };
 };


### PR DESCRIPTION
## Overview

Bugfix for copy / paste workflow. We want to auto select the newly pasted widget(s) so that it is easier for a user to position them in the correct spot. This also fixes a bug were keyboard shortcuts wouldn't trigger if the target of the event was the document and not specifically the grid container.