### PR TITLE
Add unmodeled data alias.

### DIFF
--- a/packages/source-iotsitewise/src/time-series-data/types.ts
+++ b/packages/source-iotsitewise/src/time-series-data/types.ts
@@ -19,12 +19,21 @@ export type PropertyQuery = {
   alarms?: boolean;
 };
 
+export type PropertyAliasQuery = {
+  propertyAlias: string;
+  refId?: RefId;
+  resolution?: string;
+  cacheSettings?: CacheSettings;
+  alarms?: boolean;
+};
+
 export type AssetQuery = {
   assetId: AssetId;
   properties: PropertyQuery[];
 };
 
 export type SiteWiseAssetQuery = {
+  propertyAliases: PropertyAliasQuery[];
   assets: AssetQuery[];
 };
 


### PR DESCRIPTION
## Overview

This PR is to support unmodeled data as inputs to iot app kit.

Sitewise Monitor currently handles "modeled" data that is associated with a known AssetId/PropertyId and can be identified by an AssetId/PropertyId or PropertyAlias. Customers want the ability to ingest, discover, and transform unmodeled data and control the lifecycle of data separate from the model to increase adoption of Sitewise Monitor.

Adds new `PropertyAliasQuery` that has the `propertyAlias` property, where users can enter paths for their unmodeled JSON data.


TO-DO: Add tests.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
