### PR TITLE
test(dashboard): add tests for Text widget configuration

### DIFF
--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/index.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/index.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { TextWidget } from '../../../../types';
+import { MOCK_TEXT_WIDGET } from '../../../../../testing/mocks';
+import { DashboardState } from '../../../../store/state';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureDashboardStore } from '../../../../store';
+import TextSettings from './text';
+import { DefaultDashboardMessages } from '../../../../messages';
+import wrapper from '@cloudscape-design/components/test-utils/dom';
+
+const widget: TextWidget = { ...MOCK_TEXT_WIDGET, bold: true, italic: true, underline: false };
+
+const state: Partial<DashboardState> = {
+  dashboardConfiguration: {
+    widgets: [widget],
+    viewport: { duration: '5m' },
+  },
+  selectedWidgets: [widget],
+};
+
+const TestComponent = () => (
+  <Provider store={configureDashboardStore(state)}>
+    <TextSettings messageOverride={DefaultDashboardMessages} />
+  </Provider>
+);
+
+it('renders', () => {
+  expect(render(<TestComponent />));
+});
+
+it('renders with font select', () => {
+  const elem = render(<TestComponent />).container;
+  expect(wrapper(elem).findSelect('[data-test-id="text-widget-setting-font"]'));
+});
+
+it('renders with font size select', () => {
+  const elem = render(<TestComponent />).container;
+  expect(wrapper(elem).findSelect('[data-test-id="text-widget-setting-font-size"]'));
+});
+
+it('renders with horizontal alignment select', () => {
+  const elem = render(<TestComponent />).container;
+  expect(wrapper(elem).findSelect('[data-test-id="text-widget-setting-horizontal-align"]'));
+});
+
+it('renders with vertical alignment select', () => {
+  const elem = render(<TestComponent />).container;
+  expect(wrapper(elem).findSelect('[data-test-id="text-widget-setting-vertical-align"]'));
+});
+
+it('renders with font style toggles with correct style', () => {
+  const elem = render(<TestComponent />).container;
+  const bold = elem.querySelector('[data-test-id="text-widget-setting-toggle-text-bold"]');
+  expect(bold?.className).toBe('text-style-button checked');
+  const italic = elem.querySelector('[data-test-id="text-widget-setting-toggle-text-italic"]');
+  expect(italic?.className).toBe('text-style-button checked');
+  const underline = elem.querySelector('[data-test-id="text-widget-setting-toggle-text-underline"]');
+  expect(underline?.className).toBe('text-style-button');
+});

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.tsx
@@ -11,9 +11,14 @@ export type TextComponentProps = {
   messageOverride: DashboardMessages;
 };
 
-const ButtonWithState: FC<{ checked: boolean; onToggle: MouseEventHandler }> = ({ checked, children, onToggle }) => {
+const ButtonWithState: FC<{ checked: boolean; onToggle: MouseEventHandler }> = ({
+  checked,
+  children,
+  onToggle,
+  ...others // passing other attributes like data-test-id
+}) => {
   return (
-    <div className={`text-style-button ${checked ? 'checked' : ''}`} onClick={onToggle}>
+    <div {...others} className={`text-style-button${checked ? ' checked' : ''}`} onClick={onToggle}>
       {children}
     </div>
   );
@@ -53,11 +58,14 @@ const TextSettings: FC<TextComponentProps> = ({ messageOverride }) => {
     <ExpandableSection headerText={textSettings.title} defaultExpanded>
       <Grid gridDefinition={[{ colspan: 2 }, { colspan: 4 }, { colspan: 2 }, { colspan: 4 }]}>
         <label className="section-item-label">{textSettings.font}</label>
-        <Select
-          selectedOption={{ label: getFontLabel(font), value: font }}
-          options={fontOptions}
-          onChange={onFontChange}
-        />
+        <div>
+          <Select
+            selectedOption={{ label: getFontLabel(font), value: font }}
+            options={fontOptions}
+            onChange={onFontChange}
+            data-test-id="text-widget-setting-font-dropdown"
+          />
+        </div>
         <label className="section-item-label">{textSettings.color}</label>
         <div className="grid-content-align-item-center">
           <ColorPicker color={color} updateColor={updateColor} />
@@ -66,25 +74,39 @@ const TextSettings: FC<TextComponentProps> = ({ messageOverride }) => {
       <Grid gridDefinition={[{ colspan: 2 }, { colspan: 4 }, { colspan: 2 }, { colspan: 4 }]}>
         <label className="section-item-label">{textSettings.style}</label>
         <div className="text-setting-style-button-container">
-          <ButtonWithState checked={bold} onToggle={() => toggleBold(!bold)}>
+          <ButtonWithState
+            checked={bold}
+            onToggle={() => toggleBold(!bold)}
+            data-test-id="text-widget-setting-toggle-text-bold"
+          >
             <b>B</b>
           </ButtonWithState>
-          <ButtonWithState checked={italic} onToggle={() => toggleItalic(!italic)}>
+          <ButtonWithState
+            checked={italic}
+            onToggle={() => toggleItalic(!italic)}
+            data-test-id="text-widget-setting-toggle-text-italic"
+          >
             <i>I</i>
           </ButtonWithState>
-          <ButtonWithState checked={underline} onToggle={() => toggleUnderline(!underline)}>
+          <ButtonWithState
+            checked={underline}
+            onToggle={() => toggleUnderline(!underline)}
+            data-test-id="text-widget-setting-toggle-text-underline"
+          >
             <u>U</u>
           </ButtonWithState>
         </div>
         <label className="section-item-label">{textSettings.size}</label>
-        <Select selectedOption={null} disabled />
+        <div>
+          <Select selectedOption={null} disabled data-test-id="text-widget-setting-font-size" />
+        </div>
       </Grid>
 
       <Grid gridDefinition={[{ colspan: 2 }, { colspan: 4 }, { colspan: 2 }, { colspan: 4 }]}>
         <label className="section-item-label">{textSettings.horizontal}</label>
-        <Select selectedOption={null} disabled />
+        <Select selectedOption={null} disabled data-test-id="text-widget-setting-horizontal-align" />
         <label className="section-item-label">{textSettings.vertical}</label>
-        <Select selectedOption={null} disabled />
+        <Select selectedOption={null} disabled data-test-id="text-widget-setting-vertical-align" />
       </Grid>
 
       <Grid gridDefinition={[{ colspan: 2 }, { colspan: 4 }, { colspan: 2 }, { colspan: 4 }]}></Grid>


### PR DESCRIPTION
## Overview

Add UI tests for text widget.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
