### PR TITLE
fix: propertyName with multi hyphen not working

### DIFF
--- a/packages/scene-composer/src/utils/dataBindingUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingUtils.ts
@@ -115,7 +115,7 @@ export const dataBindingValuesProvider = (
  * Currently, the jexl in TwinMaker can't handle "-", while the TwinMaker property can accept "-". This function will escape the special character
  */
 const escapeRestrictedKeys = (value: Record<string, unknown>): [Record<string, string>, Record<string, unknown>] => {
-  const restrictedCharRegex = /-/;
+  const restrictedCharRegex = /-/g;
   const escapedKeyMap: Record<string, string> = {};
   const escapedValues: Record<string, unknown> = {};
 

--- a/packages/scene-composer/tests/utils/dataBindingUtils.spec.ts
+++ b/packages/scene-composer/tests/utils/dataBindingUtils.spec.ts
@@ -276,7 +276,7 @@ describe('ruleEvaluator', () => {
   });
 
   it('should property names with special characters should work correctly', async () => {
-    const key1 = 'my-temperature';
+    const key1 = 'my-temperature-prop';
     const key2 = 'myRPM';
     const value = {
       [key1]: 22,


### PR DESCRIPTION
## Overview
when the propertyName used in rules has multiple hyphen characters, the rule won't be evaluated properly because only one occurrence of the hyphen is escaped. this change is to escape all occurrences.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
