### PR TITLE
feat(dashboard): add link configuration section for Text widget

### DIFF
--- a/packages/dashboard/src/components/sidePanel/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/index.tsx
@@ -10,6 +10,7 @@ import TextSettings from './sections/textSettingSection/text';
 import ChartSettings from './sections/chartSettings';
 import ThresholdsSection from './sections/thresholdsSection';
 import DataSettings from './sections/dataSettings';
+import LinkSettings from './sections/textSettingSection/link';
 
 const SidePanel: FC<{ messageOverrides: DashboardMessages }> = ({ messageOverrides }) => {
   const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
@@ -28,6 +29,7 @@ const SidePanel: FC<{ messageOverrides: DashboardMessages }> = ({ messageOverrid
     <Container header={<Header variant="h3">Configurations</Header>} className={'iot-side-panel'}>
       <ChartSettings />
       {isTextWidget && <TextSettings messageOverride={messageOverrides} />}
+      {isTextWidget && <LinkSettings messageOverride={messageOverrides} />}
       {isAppKitWidget && (
         <>
           <PropertiesAlarmsSection messages={propertySection} />

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.spec.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { TextWidget } from '../../../../types';
+import { MOCK_TEXT_WIDGET } from '../../../../../testing/mocks';
+import { DashboardState } from '../../../../store/state';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureDashboardStore } from '../../../../store';
+import { DefaultDashboardMessages } from '../../../../messages';
+import LinkSettings from './link';
+
+const widget: TextWidget = { ...MOCK_TEXT_WIDGET, link: 'sample-link' };
+
+const state: Partial<DashboardState> = {
+  dashboardConfiguration: {
+    widgets: [widget],
+    viewport: { duration: '5m' },
+  },
+  selectedWidgets: [widget],
+};
+
+const TestComponent = () => (
+  <Provider store={configureDashboardStore(state)}>
+    <LinkSettings messageOverride={DefaultDashboardMessages} />
+  </Provider>
+);
+
+it('renders', () => {
+  const elem = render(<TestComponent />).baseElement;
+  expect(elem);
+});
+
+it('renders with create link toggle', () => {
+  const elem = render(<TestComponent />).baseElement;
+  const toggle = elem.querySelector('[data-test-id="text-widget-create-link-toggle"]');
+  expect(toggle?.textContent).toMatch(DefaultDashboardMessages.sidePanel.linkSettings.toggle);
+});
+
+it('renders with url input', () => {
+  const elem = render(<TestComponent />).baseElement;
+  const toggle = elem.querySelector('[data-test-id="text-widget-link-input"]');
+  expect(toggle).toBeTruthy();
+});

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from 'react';
+import { ExpandableSection, Grid, Input, InputProps, Toggle } from '@cloudscape-design/components';
+import { DashboardMessages } from '../../../../messages';
+import { useTextWidgetInput } from '../../utils';
+import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
+import './index.scss';
+
+export type LinkComponentProp = {
+  messageOverride: DashboardMessages;
+};
+const LinkSettings: FC<LinkComponentProp> = ({
+  messageOverride: {
+    sidePanel: { linkSettings },
+  },
+}) => {
+  const [link = '', updateLink] = useTextWidgetInput('link');
+  const [isLink = false, toggleIsLink] = useTextWidgetInput('isLink');
+
+  const header = (
+    <div className="expandable-section-header">
+      <span>{linkSettings.title}</span>
+      <div onClick={(e) => e.stopPropagation()}>
+        <Toggle
+          checked={isLink}
+          onChange={({ detail }) => {
+            toggleIsLink(detail.checked);
+          }}
+          data-test-id="text-widget-create-link-toggle"
+        >
+          {linkSettings.toggle}
+        </Toggle>
+      </div>
+    </div>
+  );
+  const onLinkTextChange: NonCancelableEventHandler<InputProps.ChangeDetail> = ({ detail: { value } }) =>
+    updateLink(value);
+  return (
+    <ExpandableSection headerText={header} data-test-id="text-widget-link-section">
+      <Grid gridDefinition={[{ colspan: 2 }, { colspan: 10 }]}>
+        <label className="section-item-label">{linkSettings.url}</label>
+        <div>
+          <Input value={link} onChange={onLinkTextChange} data-test-id="text-widget-link-input" />
+        </div>
+      </Grid>
+    </ExpandableSection>
+  );
+};
+
+export default LinkSettings;


### PR DESCRIPTION
## Overview
add link section to setting panel for updating Text widget's link.
<img width="404" alt="image" src="https://user-images.githubusercontent.com/11740421/214145710-293dcc25-bd33-4f21-be35-3706a35ccb45.png">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
