### PR TITLE
feat(dashboard): initial resource explorer search

### DIFF
--- a/packages/dashboard/src/components/resourceExplorer/components/breadcrumbs.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/breadcrumbs.tsx
@@ -1,6 +1,7 @@
 import React, { Dispatch, SetStateAction } from 'react';
 import { AssetSummary } from '@aws-sdk/client-iotsitewise';
 import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import { EitherAssetSummary } from '..';
 
 export const HIERARCHY_ROOT_ID = 'HIERARCHY_ROOT_ID';
 
@@ -20,8 +21,8 @@ const rootCrumb = { name: 'Dashboard', id: HIERARCHY_ROOT_ID } as AssetSummary;
 
 export interface IotResourceExplorerBreadcrumbsProps {
   handleCrumbClick: (item: AssetSummary) => void;
-  crumbs: AssetSummary[];
-  setCrumbs: Dispatch<SetStateAction<AssetSummary[]>>;
+  crumbs: EitherAssetSummary[];
+  setCrumbs: Dispatch<SetStateAction<EitherAssetSummary[]>>;
 }
 
 export const IotResourceExplorerBreadcrumbs: React.FC<IotResourceExplorerBreadcrumbsProps> = ({

--- a/packages/dashboard/src/components/resourceExplorer/components/panel.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/panel.tsx
@@ -92,7 +92,7 @@ export const IotResourceExplorerPanel: React.FC<IotResourceExplorerPanelProps> =
     <Table
       variant="embedded"
       columnDefinitions={tableColumnDefinitions}
-      items={panelItems}
+      items={panelItems || []}
       trackBy="name"
       empty={<PanelEmpty messageOverrides={messageOverrides} />}
     />

--- a/packages/dashboard/src/components/resourceExplorer/components/searchbar.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/searchbar.tsx
@@ -1,33 +1,112 @@
-import React, { useState, Dispatch, SetStateAction } from 'react';
+import React, { useState, Dispatch, SetStateAction, useEffect } from 'react';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import Autosuggest from '@cloudscape-design/components/autosuggest';
 import Checkbox from '@cloudscape-design/components/checkbox';
+import { BaseChangeDetail } from '@cloudscape-design/components/input/interfaces';
+import { MaybeSiteWiseAssetTreeSessionInterface } from '../types';
+import { AssetPropertiesCache } from '../useAssetProperties';
+import { ExtendedPanelAssetSummary } from '..';
+import { DashboardMessages } from '../../../messages';
 
-const checkboxOnChange = (setShowFn: Dispatch<SetStateAction<boolean>>) => {
-  return ({ detail }: { detail: { checked: boolean } }) => setShowFn(detail.checked);
-};
+interface SearchOption {
+  id: string;
+  value: string;
+}
 
-export const IotResourceExplorerSearchbar = () => {
+interface IotResourceExplorerSearchbarProps {
+  provider: MaybeSiteWiseAssetTreeSessionInterface;
+  assetPropertiesCache: AssetPropertiesCache;
+  setCrumbsToSearch: () => void;
+  setPanelItems: (panelItems: ExtendedPanelAssetSummary[]) => void;
+  messageOverrides: DashboardMessages;
+}
+
+export const IotResourceExplorerSearchbar: React.FC<IotResourceExplorerSearchbarProps> = ({
+  provider,
+  assetPropertiesCache,
+  setCrumbsToSearch,
+  setPanelItems,
+  messageOverrides,
+}) => {
   const [autosuggestValue, setAutosuggestValue] = useState('');
   const [showAssets, setShowAssets] = useState(true);
-  const [showProperties, setShowProperties] = useState(false);
-  const [showAlarms, setShowAlarms] = useState(false);
+  const [showProperties, setShowProperties] = useState(true);
+  const [showAlarms, setShowAlarms] = useState(true);
+  const [searchOptions = [], setSearchOptions] = useState<SearchOption[]>([]);
+
+  const checkboxOnChange = (setShowFn: Dispatch<SetStateAction<boolean>>) => {
+    return ({ detail }: { detail: { checked: boolean } }) => {
+      if (setPanelItems.length > 0) {
+        setPanelItems([]);
+      }
+      setShowFn(detail.checked);
+    };
+  };
+
+  useEffect(() => {
+    if (!provider?.assetNodes || !assetPropertiesCache) return;
+
+    let allAssetsSearchOptions: SearchOption[] = [];
+    if (showAssets) {
+      allAssetsSearchOptions = Object.entries(provider?.assetNodes).map(([id, asset]) => ({
+        ...asset,
+        value: asset?.asset?.name || '',
+        id,
+      }));
+    }
+
+    let allPropertiesSearchOptions: SearchOption[] = [];
+    const reduceResult: SearchOption[] = [];
+    if (showProperties) {
+      allPropertiesSearchOptions = Object.entries(assetPropertiesCache).reduce((acc, [id, properties]) => {
+        if (properties && properties.length) {
+          for (const property of properties) {
+            const nextProperty = { ...property, id, value: property.name || '' };
+            acc.push(nextProperty);
+          }
+        }
+        return acc;
+      }, reduceResult);
+    }
+
+    const allSearchOptions = [...allAssetsSearchOptions, ...allPropertiesSearchOptions];
+
+    setSearchOptions(allSearchOptions);
+  }, [
+    JSON.stringify(provider?.assetNodes),
+    JSON.stringify(assetPropertiesCache),
+    showProperties,
+    showAssets,
+    showAlarms,
+  ]);
+
+  const onSearchChange = ({ detail }: { detail: BaseChangeDetail }) => {
+    setCrumbsToSearch();
+    setAutosuggestValue(detail.value);
+    let nextPanelItems: ExtendedPanelAssetSummary[] = [];
+    try {
+      const reduceResult: SearchOption[] = [];
+      nextPanelItems = searchOptions.reduce((acc, option) => {
+        if (!option.value.includes(detail.value)) return acc;
+        const nextPanelItem = { ...option, name: option.value };
+        return [...acc, nextPanelItem];
+      }, reduceResult);
+    } catch (e) {
+      console.log(e);
+    }
+    setPanelItems(nextPanelItems);
+  };
 
   return (
     <>
       <Autosuggest
         value={autosuggestValue}
-        onChange={({ detail }) => setAutosuggestValue(detail.value)}
-        options={[
-          { value: 'Suggestion 1' },
-          { value: 'Suggestion 2' },
-          { value: 'Suggestion 3' },
-          { value: 'Suggestion 4' },
-        ]}
+        onChange={onSearchChange}
+        options={searchOptions}
         enteredTextLabel={(value) => `Use: "${value}"`}
-        ariaLabel="Autosuggest example with suggestions"
-        placeholder="Enter value"
-        empty="No matches found"
+        ariaLabel={messageOverrides.resourceExplorer.searchAriaLabel}
+        placeholder={messageOverrides.resourceExplorer.searchPlaceholder}
+        empty={messageOverrides.resourceExplorer.searchEmpty}
       />
 
       <SpaceBetween direction="horizontal" size="xs">

--- a/packages/dashboard/src/components/resourceExplorer/useAssetProperties.test.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/useAssetProperties.test.tsx
@@ -1,0 +1,26 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useAssetProperties } from './useAssetProperties';
+
+const testAssetId = 'warpcore01';
+const testAssetProperties = [{ id: 'tps', name: 'Teradynes/Second' }];
+
+describe('useAssetProperties', () => {
+  it('returns the starting cache', () => {
+    const { result } = renderHook(() => useAssetProperties());
+    expect(result.current.cache).toEqual({});
+  });
+
+  it('hasKey returns false if a key is missing', () => {
+    const { result } = renderHook(() => useAssetProperties());
+    expect(result.current.hasKey(testAssetId)).toBe(false);
+  });
+
+  it('updates the cache with the right key/values and indicates cache hasKey', () => {
+    const { result } = renderHook(() => useAssetProperties());
+    act(() => {
+      result.current.update(testAssetId, testAssetProperties);
+    });
+    expect(result.current.cache).toEqual({ [testAssetId]: testAssetProperties });
+    expect(result.current.hasKey(testAssetId)).toBe(true);
+  });
+});

--- a/packages/dashboard/src/components/resourceExplorer/useAssetProperties.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/useAssetProperties.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { ExtendedPanelAssetSummary } from '.';
+
+export interface AssetPropertiesCache {
+  [key: string]: ExtendedPanelAssetSummary[];
+}
+
+export function useAssetProperties() {
+  const [cache, setCache] = useState<AssetPropertiesCache>({});
+
+  function update(id: string, properties: ExtendedPanelAssetSummary[]) {
+    setCache((prevCache) => ({ ...prevCache, [id]: properties }));
+  }
+
+  function hasKey(id: string) {
+    return id in cache;
+  }
+
+  return { cache, hasKey, update };
+}

--- a/packages/dashboard/src/messages.ts
+++ b/packages/dashboard/src/messages.ts
@@ -8,6 +8,10 @@ export type ResourceExplorerMessages = {
   rootAssetsHeader: string;
   childAssetsHeader: string;
   assetPropertiesHeader: string;
+  searchQueryHeader: string;
+  searchAriaLabel: string;
+  searchPlaceholder: string;
+  searchEmpty: string;
 };
 
 export type ContextMenuMessages = {
@@ -192,6 +196,10 @@ export const DefaultDashboardMessages: DashboardMessages = {
     rootAssetsHeader: 'Root Assets',
     childAssetsHeader: 'Child Assets',
     assetPropertiesHeader: 'Asset Properties',
+    searchQueryHeader: 'Search Query',
+    searchAriaLabel: 'Search assets, properties, and alarms',
+    searchPlaceholder: 'Enter search term',
+    searchEmpty: 'No matches found',
   },
   sidePanel: {
     propertySection: {

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -1,24 +1,19 @@
 {
   "compilerOptions": {
-     "jsx": "react",
-     "target": "es2016",
-     "outDir": "dist",
-     "allowJs": true,
-     "skipLibCheck": true,
-     "strict": true,
-     "forceConsistentCasingInFileNames": true,
-     "module": "ES2020",
-     "allowSyntheticDefaultImports": true,
-     "moduleResolution": "Node",
-     "declaration": true,
-     "declarationDir": "dist"
+    "jsx": "react",
+    "target": "es2016",
+    "outDir": "dist",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ES2020",
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "Node",
+    "declaration": true,
+    "declarationDir": "dist",
+    "lib": ["es5", "es6", "dom", "dom.iterable"]
   },
   "include": ["src/**/*", "rollup.config.ts"],
-  "exclude": [
-    "jest.config.ts",
-    "dist",
-    "node_modules",
-    "stories/**/*.stories.tsx",
-    "testing"
-  ],
+  "exclude": ["jest.config.ts", "dist", "node_modules", "stories/**/*.stories.tsx", "testing"]
 }


### PR DESCRIPTION
## Overview
- Previously, the initial version of the resource explorer would make a call to listAssetProperties whenever we move through the resource explorer onto an asset with properties. This is both inefficient and incompatible with a search that must keep a record of all properties, so here I've added a simple cache so we only attempt to retrieve an asset's properties once. This is simple kludge to enable an initial implementation of search, ultimately we want to be pre-loading the whole asset tree.
- Adds a searchbar that allows you to search all assets and properties. The checkboxes for assets and properties do properly filter the search but the alarms checkbox does not function yet.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
