### PR TITLE
chore(core,source-iotsitewise): add aggregation layer to cache 

### DIFF
--- a/packages/core/src/__mocks__/data-source.ts
+++ b/packages/core/src/__mocks__/data-source.ts
@@ -6,22 +6,23 @@ import {
   SiteWiseDataStreamQuery,
 } from '../data-module/types';
 import { toDataStreamId } from '../common/dataStreamId';
+import { AggregateType } from '@aws-sdk/client-iotsitewise';
 
 // A simple mock data source, which will always immediately return a successful response of your choosing.
 export const createMockSiteWiseDataSource = (
   {
     dataStreams = [],
-    onRequestData = () => {},
+    onRequestData = () => { },
     meta,
   }: {
     dataStreams?: DataStream[];
     onRequestData?: (props: any) => void;
     meta?: DataStream["meta"];
-  } = { dataStreams: [], onRequestData: () => {} }
+  } = { dataStreams: [], onRequestData: () => { } }
 ): DataSource<SiteWiseDataStreamQuery> => ({
   initiateRequest: jest.fn(
     (
-      { query, request, onSuccess = () => {} }: DataSourceRequest<SiteWiseDataStreamQuery>,
+      { query, request, onSuccess = () => { } }: DataSourceRequest<SiteWiseDataStreamQuery>,
       requestInformations: RequestInformationAndRange[]
     ) => {
       query.assets.forEach(({ assetId, properties }) =>

--- a/packages/core/src/data-module/TimeSeriesDataModule.spec.ts
+++ b/packages/core/src/data-module/TimeSeriesDataModule.spec.ts
@@ -542,7 +542,7 @@ describe('error handling', () => {
 
   const CACHE_WITH_ERROR: DataStreamsStore = {
     [DATA_STREAM_INFO.id]: {
-      [DATA_STREAM_INFO.resolution]: {
+      rawData: {
         id: DATA_STREAM.id,
         resolution: DATA_STREAM.resolution,
         dataCache: EMPTY_CACHE,
@@ -557,7 +557,7 @@ describe('error handling', () => {
 
   const CACHE_WITHOUT_ERROR: DataStreamsStore = {
     [DATA_STREAM_INFO.id]: {
-      [DATA_STREAM_INFO.resolution]: {
+      rawData: {
         id: DATA_STREAM.id,
         resolution: DATA_STREAM.resolution,
         dataCache: EMPTY_CACHE,

--- a/packages/core/src/data-module/TimeSeriesDataModule.ts
+++ b/packages/core/src/data-module/TimeSeriesDataModule.ts
@@ -80,19 +80,24 @@ export class TimeSeriesDataModule<Query extends DataStreamQuery> {
   }) => {
     const requestedStreams = await this.dataSourceStore.getRequestsFromQueries({ queries, request });
 
-    const isRequestedDataStream = ({ id, resolution }: RequestInformation) =>
-      this.dataCache.shouldRequestDataStream({ dataStreamId: id, resolution: parseDuration(resolution) });
+    const isRequestedDataStream = ({ id, resolution, aggregationType }: RequestInformation) =>
+      this.dataCache.shouldRequestDataStream({
+        dataStreamId: id,
+        resolution: parseDuration(resolution),
+        aggregationType,
+      });
 
     const requiredStreams = requestedStreams.filter(isRequestedDataStream);
 
     const requests = requiredStreams
-      .map(({ resolution, id, cacheSettings, meta }) =>
+      .map(({ resolution, id, cacheSettings, aggregationType, meta }) =>
         getRequestInformations({
           request,
           meta,
           store: this.dataCache.getState(),
           start: viewportStartDate(viewport),
           end: viewportEndDate(viewport),
+          aggregationType,
           resolution,
           dataStreamId: id,
           cacheSettings: { ...this.cacheSettings, ...cacheSettings },

--- a/packages/core/src/data-module/data-cache/bestStreamStore.spec.ts
+++ b/packages/core/src/data-module/data-cache/bestStreamStore.spec.ts
@@ -1,6 +1,9 @@
 import { getBestStreamStore } from './bestStreamStore';
 import { DataStreamStore } from './types';
+import { AggregateType } from '@aws-sdk/client-iotsitewise';
 import { EMPTY_CACHE } from './caching/caching';
+
+const AGGREGATE_TYPE = AggregateType.AVERAGE;
 
 describe(' get best stream store based', () => {
   it('returns undefined if there are no stream stores', () => {
@@ -11,7 +14,7 @@ describe(' get best stream store based', () => {
     expect(
       getBestStreamStore('data-stream-id', 100, {
         'data-stream-id': {
-          0: {
+          rawData: {
             id: 'data-stream-id',
             resolution: 0,
             requestHistory: [],
@@ -38,7 +41,7 @@ describe(' get best stream store based', () => {
     expect(
       getBestStreamStore(STREAM_STORE.id, 0, {
         [STREAM_STORE.id]: {
-          0: STREAM_STORE,
+          rawData: STREAM_STORE,
         },
       })
     ).toBe(STREAM_STORE);
@@ -52,14 +55,20 @@ describe(' get best stream store based', () => {
       isLoading: false,
       isRefreshing: false,
       requestCache: EMPTY_CACHE,
+      aggregationType: AGGREGATE_TYPE,
       dataCache: EMPTY_CACHE,
     };
     expect(
-      getBestStreamStore(STREAM_STORE.id, 0, {
-        [STREAM_STORE.id]: {
-          100: STREAM_STORE,
+      getBestStreamStore(
+        STREAM_STORE.id,
+        0,
+        {
+          [STREAM_STORE.id]: {
+            resolutions: { 100: { [AGGREGATE_TYPE]: STREAM_STORE } },
+          },
         },
-      })
+        AGGREGATE_TYPE
+      )
     ).toBe(STREAM_STORE);
   });
 
@@ -71,6 +80,7 @@ describe(' get best stream store based', () => {
       isLoading: false,
       isRefreshing: false,
       requestCache: EMPTY_CACHE,
+      aggregationType: AGGREGATE_TYPE,
       dataCache: EMPTY_CACHE,
     };
     const STREAM_STORE_TWO: DataStreamStore = {
@@ -83,14 +93,19 @@ describe(' get best stream store based', () => {
       dataCache: EMPTY_CACHE,
     };
     expect(
-      getBestStreamStore('data-stream-id', 0, {
-        [STREAM_STORE_TWO.id]: {
-          0: STREAM_STORE_TWO,
+      getBestStreamStore(
+        'data-stream-id',
+        0,
+        {
+          [STREAM_STORE_TWO.id]: {
+            rawData: STREAM_STORE_TWO,
+          },
+          [STREAM_STORE.id]: {
+            resolutions: { 100: { [AGGREGATE_TYPE]: STREAM_STORE } },
+          },
         },
-        [STREAM_STORE.id]: {
-          100: STREAM_STORE,
-        },
-      })
+        AGGREGATE_TYPE
+      )
     ).toBe(STREAM_STORE);
   });
 
@@ -103,24 +118,35 @@ describe(' get best stream store based', () => {
       isLoading: false,
       isRefreshing: false,
       requestCache: EMPTY_CACHE,
+      aggregationType: AGGREGATE_TYPE,
       dataCache: EMPTY_CACHE,
     };
     expect(
-      getBestStreamStore(ID, 0, {
-        [ID]: {
-          50: {
-            id: ID,
-            resolution: 50,
-            error: { msg: 'woah an error!', type: 'ResourceNotFoundException', status: '404' },
-            requestHistory: [],
-            isLoading: false,
-            isRefreshing: false,
-            requestCache: EMPTY_CACHE,
-            dataCache: EMPTY_CACHE,
+      getBestStreamStore(
+        ID,
+        0,
+        {
+          [ID]: {
+            resolutions: {
+              50: {
+                [AGGREGATE_TYPE]: {
+                  id: ID,
+                  resolution: 50,
+                  error: { msg: 'woah an error!', type: 'ResourceNotFoundException', status: '404' },
+                  requestHistory: [],
+                  isLoading: false,
+                  isRefreshing: false,
+                  requestCache: EMPTY_CACHE,
+                  aggregationType: AGGREGATE_TYPE,
+                  dataCache: EMPTY_CACHE,
+                },
+              },
+              100: { [AGGREGATE_TYPE]: STREAM_STORE },
+            },
           },
-          100: STREAM_STORE,
         },
-      })
+        AGGREGATE_TYPE
+      )
     ).toBe(STREAM_STORE);
   });
 
@@ -133,6 +159,7 @@ describe(' get best stream store based', () => {
       resolution: 100,
       isRefreshing: false,
       requestCache: EMPTY_CACHE,
+      aggregationType: AGGREGATE_TYPE,
       dataCache: EMPTY_CACHE,
     };
     const ERROR_STORE: DataStreamStore = {
@@ -146,12 +173,17 @@ describe(' get best stream store based', () => {
       dataCache: EMPTY_CACHE,
     };
     expect(
-      getBestStreamStore(ID, 0, {
-        [ID]: {
-          0: ERROR_STORE,
-          100: STREAM_STORE,
+      getBestStreamStore(
+        ID,
+        0,
+        {
+          [ID]: {
+            resolutions: { 100: { [AGGREGATE_TYPE]: STREAM_STORE } },
+            rawData: ERROR_STORE,
+          },
         },
-      })
+        AGGREGATE_TYPE
+      )
     ).toBe(ERROR_STORE);
   });
 });

--- a/packages/core/src/data-module/data-cache/bestStreamStore.ts
+++ b/packages/core/src/data-module/data-cache/bestStreamStore.ts
@@ -1,5 +1,6 @@
 import { isDefined } from '../../common/predicates';
 import { DataStreamsStore, DataStreamStore } from './types';
+import { AggregateType } from '@aws-sdk/client-iotsitewise';
 
 // i.e. [12, -21, 0, 13] => [-21, 0, 12, 13]
 const ascendingSort = (a: number, b: number): number => a - b;
@@ -7,7 +8,7 @@ const ascendingSort = (a: number, b: number): number => a - b;
 /**
  * Get Best Stream Store
  *
- * Returns the best data stream store based on what resolution we would like to visualize
+ * Returns the best data stream store based on what resolution and/or aggregation we would like to visualize
  * on connected widgets
  * This will be the store with the smallest resolution which is not smaller than the requested resolution,
  * that is not in a loading or error state.
@@ -15,25 +16,42 @@ const ascendingSort = (a: number, b: number): number => a - b;
 export const getBestStreamStore = (
   dataStreamId: string,
   requestResolution: number,
-  store: DataStreamsStore
+  store: DataStreamsStore,
+  requestAggregation?: AggregateType
 ): undefined | DataStreamStore => {
-  const resMap = store[dataStreamId];
-  if (resMap == null) {
+  const resolutionStreamStore = store[dataStreamId]?.resolutions;
+  const rawDataStreamStore = store[dataStreamId]?.rawData;
+
+  if (requestResolution === 0 && rawDataStreamStore && !rawDataStreamStore.isLoading) {
+    return rawDataStreamStore;
+  }
+
+  if (resolutionStreamStore == null) {
     return undefined;
   }
-  const resolutions = Object.keys(resMap)
+
+  const resolutions = Object.keys(resolutionStreamStore)
     .map(Number)
     .sort(ascendingSort)
     .filter((res) => res >= requestResolution);
-  const streamStores = resolutions.map((res) => resMap[res]).filter(isDefined);
+
+  const streamStores = resolutions
+    .map((res) => resolutionStreamStore[res]?.[AggregateType.AVERAGE]) // just retrieving AVERAGE for now since its the only one we support
+    .filter(isDefined);
+
   const closestAvailableData = streamStores.find(
     ({ error, isLoading }: DataStreamStore) => error == null && !isLoading
   );
-  // If the exact sore is present and is not in a loading state, return it!
+
+  // If the exact store is present and is not in a loading state, return it!
   // This is because we want to display an error if it occurs on our requested resolution.
   const exactStore = resolutions[0] === requestResolution ? streamStores[0] : undefined;
   if (exactStore && !exactStore.isLoading) {
     return exactStore;
   }
-  return closestAvailableData || resMap[requestResolution];
+
+  return (
+    closestAvailableData ||
+    (requestAggregation ? resolutionStreamStore[requestResolution]?.[requestAggregation] : undefined)
+  );
 };

--- a/packages/core/src/data-module/data-cache/caching/caching.spec.ts
+++ b/packages/core/src/data-module/data-cache/caching/caching.spec.ts
@@ -50,7 +50,7 @@ describe('getDateRangesToRequest', () => {
 
     const store: DataStreamsStore = {
       [STREAM_ID]: {
-        [RESOLUTION]: {
+        rawData: {
           id: STREAM_ID,
           resolution: RESOLUTION,
           isLoading: false,
@@ -89,7 +89,7 @@ describe('getDateRangesToRequest', () => {
 
     const store: DataStreamsStore = {
       [STREAM_ID]: {
-        [RESOLUTION]: {
+        rawData: {
           id: STREAM_ID,
           resolution: RESOLUTION,
           isLoading: false,
@@ -133,7 +133,7 @@ describe('getDateRangesToRequest', () => {
 
     const store: DataStreamsStore = {
       [STREAM_ID]: {
-        [RESOLUTION]: {
+        rawData: {
           id: STREAM_ID,
           resolution: RESOLUTION,
           isLoading: false,
@@ -183,7 +183,7 @@ describe('getDateRangesToRequest', () => {
         getDateRangesToRequest({
           store: {
             [STREAM_ID]: {
-              0: {
+              rawData: {
                 id: STREAM_ID,
                 resolution: 0,
                 requestHistory: [],
@@ -211,7 +211,7 @@ describe('getDateRangesToRequest', () => {
         getDateRangesToRequest({
           store: {
             [STREAM_ID]: {
-              0: {
+              rawData: {
                 id: STREAM_ID,
                 resolution: 0,
                 isLoading: false,
@@ -239,7 +239,7 @@ describe('getDateRangesToRequest', () => {
         getDateRangesToRequest({
           store: {
             [STREAM_ID]: {
-              0: {
+              rawData: {
                 id: STREAM_ID,
                 resolution: 0,
                 isLoading: false,
@@ -314,7 +314,7 @@ describe('getDateRangesToRequest', () => {
         getDateRangesToRequest({
           store: {
             [STREAM_ID]: {
-              0: {
+              rawData: {
                 id: STREAM_ID,
                 resolution: 0,
                 requestHistory: [],
@@ -345,7 +345,7 @@ describe('getDateRangesToRequest', () => {
           resolution: 0,
           store: {
             [STREAM_ID]: {
-              0: {
+              rawData: {
                 id: STREAM_ID,
                 resolution: 0,
                 requestHistory: [],
@@ -383,7 +383,7 @@ describe('getRequestInformations', () => {
         },
         store: {
           [STREAM_ID]: {
-            0: {
+            rawData: {
               id: STREAM_ID,
               resolution: 0,
               requestHistory: [],
@@ -420,7 +420,7 @@ describe('getRequestInformations', () => {
         },
         store: {
           [STREAM_ID]: {
-            0: {
+            rawData: {
               id: STREAM_ID,
               resolution: 0,
               requestHistory: [],
@@ -455,7 +455,7 @@ describe('getRequestInformations', () => {
         },
         store: {
           [STREAM_ID]: {
-            0: {
+            rawData: {
               id: STREAM_ID,
               resolution: 0,
               requestHistory: [],
@@ -498,7 +498,7 @@ describe('getRequestInformations', () => {
         },
         store: {
           [STREAM_ID]: {
-            0: {
+            rawData: {
               id: STREAM_ID,
               resolution: 0,
               requestHistory: [],
@@ -533,7 +533,7 @@ describe('getRequestInformations', () => {
         },
         store: {
           [STREAM_ID]: {
-            0: {
+            rawData: {
               id: STREAM_ID,
               resolution: 0,
               requestHistory: [],
@@ -580,7 +580,7 @@ describe('getRequestInformations', () => {
         },
         store: {
           [STREAM_ID]: {
-            0: {
+            rawData: {
               id: STREAM_ID,
               resolution: 0,
               requestHistory: [],
@@ -639,7 +639,7 @@ describe('getRequestInformations', () => {
         },
         store: {
           [STREAM_ID]: {
-            0: {
+            rawData: {
               id: STREAM_ID,
               resolution: 0,
               requestHistory: [],
@@ -690,7 +690,7 @@ describe('getRequestInformations', () => {
         },
         store: {
           [STREAM_ID]: {
-            0: {
+            rawData: {
               id: STREAM_ID,
               resolution: 0,
               requestHistory: [],
@@ -744,7 +744,7 @@ describe('getRequestInformations', () => {
         },
         store: {
           [STREAM_ID]: {
-            0: {
+            rawData: {
               id: STREAM_ID,
               resolution: 0,
               requestHistory: [],
@@ -794,7 +794,7 @@ describe('getRequestInformations', () => {
         },
         store: {
           [STREAM_ID]: {
-            0: {
+            rawData: {
               id: STREAM_ID,
               resolution: 0,
               requestHistory: [],
@@ -838,7 +838,7 @@ describe('getRequestInformations', () => {
         },
         store: {
           [STREAM_ID]: {
-            0: {
+            rawData: {
               id: STREAM_ID,
               resolution: 0,
               requestHistory: [],
@@ -1427,7 +1427,7 @@ describe('checkCacheForRecentPoint', () => {
   const RESOLUTION = 0;
   const STORE: DataStreamsStore = {
     [STREAM_ID]: {
-      [RESOLUTION]: {
+      rawData: {
         id: STREAM_ID,
         resolution: RESOLUTION,
         isLoading: false,
@@ -1488,8 +1488,8 @@ describe('checkCacheForRecentPoint', () => {
       ],
     };
 
-    STORE[STREAM_ID]![RESOLUTION]!.dataCache = dataCache;
-    STORE[STREAM_ID]![RESOLUTION]!.requestCache.intervals = dataCache.intervals;
+    STORE[STREAM_ID]!.rawData!.dataCache = dataCache;
+    STORE[STREAM_ID]!.rawData!.requestCache.intervals = dataCache.intervals;
 
     const presentInCache = checkCacheForRecentPoint({
       store: STORE,
@@ -1540,8 +1540,8 @@ describe('checkCacheForRecentPoint', () => {
       ],
     };
 
-    STORE[STREAM_ID]![RESOLUTION]!.dataCache = dataCache;
-    STORE[STREAM_ID]![RESOLUTION]!.requestCache.intervals = dataCache.intervals;
+    STORE[STREAM_ID]!.rawData!.dataCache = dataCache;
+    STORE[STREAM_ID]!.rawData!.requestCache.intervals = dataCache.intervals;
 
     const presentInCache = checkCacheForRecentPoint({
       store: STORE,
@@ -1559,8 +1559,8 @@ describe('checkCacheForRecentPoint', () => {
       intervals: [[1621879661000, 1621879912500]],
       items: [],
     };
-    STORE[STREAM_ID]![RESOLUTION]!.dataCache = EMPTY_CACHE;
-    STORE[STREAM_ID]![RESOLUTION]!.requestCache = requestCache;
+    STORE[STREAM_ID]!.rawData!.dataCache = EMPTY_CACHE;
+    STORE[STREAM_ID]!.rawData!.requestCache = requestCache;
 
     const presentInCache = checkCacheForRecentPoint({
       store: STORE,
@@ -1593,8 +1593,8 @@ describe('checkCacheForRecentPoint', () => {
         ],
       ],
     };
-    STORE[STREAM_ID]![RESOLUTION]!.dataCache = dataCache;
-    STORE[STREAM_ID]![RESOLUTION]!.requestCache = EMPTY_CACHE;
+    STORE[STREAM_ID]!.rawData!.dataCache = dataCache;
+    STORE[STREAM_ID]!.rawData!.requestCache = EMPTY_CACHE;
 
     const presentInCache = checkCacheForRecentPoint({
       store: STORE,
@@ -1631,8 +1631,8 @@ describe('checkCacheForRecentPoint', () => {
         ],
       ],
     };
-    STORE[STREAM_ID]![RESOLUTION]!.dataCache = dataCache;
-    STORE[STREAM_ID]![RESOLUTION]!.requestCache.intervals = [[14, 18]];
+    STORE[STREAM_ID]!.rawData!.dataCache = dataCache;
+    STORE[STREAM_ID]!.rawData!.requestCache.intervals = [[14, 18]];
 
     const presentInCache = checkCacheForRecentPoint({
       store: STORE,
@@ -1669,8 +1669,8 @@ describe('checkCacheForRecentPoint', () => {
         ],
       ],
     };
-    STORE[STREAM_ID]![RESOLUTION]!.dataCache = dataCache;
-    STORE[STREAM_ID]![RESOLUTION]!.requestCache.intervals = [[13, 18]];
+    STORE[STREAM_ID]!.rawData!.dataCache = dataCache;
+    STORE[STREAM_ID]!.rawData!.requestCache.intervals = [[13, 18]];
 
     const presentInCache = checkCacheForRecentPoint({
       store: STORE,
@@ -1707,8 +1707,8 @@ describe('checkCacheForRecentPoint', () => {
         ],
       ],
     };
-    STORE[STREAM_ID]![RESOLUTION]!.dataCache = dataCache;
-    STORE[STREAM_ID]![RESOLUTION]!.requestCache.intervals = [[16, 18]];
+    STORE[STREAM_ID]!.rawData!.dataCache = dataCache;
+    STORE[STREAM_ID]!.rawData!.requestCache.intervals = [[16, 18]];
 
     const presentInCache = checkCacheForRecentPoint({
       store: STORE,

--- a/packages/core/src/data-module/data-cache/caching/caching.ts
+++ b/packages/core/src/data-module/data-cache/caching/caching.ts
@@ -8,7 +8,7 @@ import {
   IntervalStructure,
   subtractIntervals,
 } from '../../../common/intervalStructure';
-
+import { AggregateType } from '@aws-sdk/client-iotsitewise';
 import { CacheSettings, DataStreamsStore, DataStreamStore, TTLDurationMapping } from '../types';
 import { getExpiredCacheIntervals } from './expiredCacheIntervals';
 import { TimeSeriesDataRequestSettings, TimeSeriesDataRequest } from '../requestTypes';
@@ -75,6 +75,7 @@ export const getDateRangesToRequest = ({
   end,
   resolution,
   cacheSettings,
+  aggregationType,
 }: {
   store: DataStreamsStore;
   dataStreamId: string;
@@ -82,8 +83,9 @@ export const getDateRangesToRequest = ({
   end: Date;
   resolution: number;
   cacheSettings: CacheSettings;
+  aggregationType?: AggregateType;
 }): [Date, Date][] => {
-  const streamStore = getDataStreamStore(dataStreamId, resolution, store);
+  const streamStore = getDataStreamStore(dataStreamId, resolution, store, aggregationType);
 
   if (end.getTime() === start.getTime()) {
     // nothing to request
@@ -122,6 +124,7 @@ export const getRequestInformations = ({
   meta,
   end,
   resolution,
+  aggregationType,
   cacheSettings,
 }: {
   request: TimeSeriesDataRequest;
@@ -129,6 +132,7 @@ export const getRequestInformations = ({
   dataStreamId: string;
   start: Date;
   end: Date;
+  aggregationType?: AggregateType;
   meta?: RequestInformation['meta'];
   resolution: string;
   cacheSettings: CacheSettings;
@@ -139,6 +143,7 @@ export const getRequestInformations = ({
     dataStreamId,
     start,
     end,
+    aggregationType,
     resolution: parseDuration(resolution),
     cacheSettings,
   });
@@ -155,6 +160,7 @@ export const getRequestInformations = ({
       id: dataStreamId,
       meta,
       resolution,
+      aggregationType,
       fetchFromStartToEnd,
     }));
   }
@@ -165,6 +171,7 @@ export const getRequestInformations = ({
     !checkCacheForRecentPoint({
       store,
       dataStreamId,
+      aggregationType,
       resolution: parseDuration(resolution),
       start: end,
       cacheSettings,
@@ -177,6 +184,7 @@ export const getRequestInformations = ({
       id: dataStreamId,
       resolution,
       fetchMostRecentBeforeEnd: true,
+      aggregationType,
     });
   }
 
@@ -186,6 +194,7 @@ export const getRequestInformations = ({
     !checkCacheForRecentPoint({
       store,
       dataStreamId,
+      aggregationType,
       resolution: parseDuration(resolution),
       start,
       cacheSettings,
@@ -198,6 +207,7 @@ export const getRequestInformations = ({
       id: dataStreamId,
       resolution,
       fetchMostRecentBeforeStart: true,
+      aggregationType,
     });
   }
 
@@ -273,14 +283,16 @@ export const checkCacheForRecentPoint = ({
   resolution,
   start,
   cacheSettings,
+  aggregationType,
 }: {
   store: DataStreamsStore;
   dataStreamId: string;
   resolution: number;
   start: Date;
   cacheSettings: CacheSettings;
+  aggregationType?: AggregateType;
 }) => {
-  const streamStore = getDataStreamStore(dataStreamId, resolution, store);
+  const streamStore = getDataStreamStore(dataStreamId, resolution, store, aggregationType);
 
   if (streamStore && streamStore.dataCache.intervals.length > 0) {
     const { dataCache } = streamStore;

--- a/packages/core/src/data-module/data-cache/dataActions.ts
+++ b/packages/core/src/data-module/data-cache/dataActions.ts
@@ -2,6 +2,7 @@ import { Action, Dispatch } from 'redux';
 import { DataStreamId, Resolution } from '@synchro-charts/core';
 import { DataStream, RequestInformationAndRange } from '../types';
 import { ErrorDetails } from '../../common/types';
+import { AggregateType } from '@aws-sdk/client-iotsitewise';
 
 /**
  *
@@ -43,21 +44,30 @@ export interface ErrorResponse extends Action<'ERROR'> {
     id: DataStreamId;
     resolution: Resolution;
     error: ErrorDetails;
+    aggregationType?: AggregateType;
   };
 }
 
-export const onErrorAction = (id: DataStreamId, resolution: Resolution, error: ErrorDetails): ErrorResponse => ({
+export const onErrorAction = (
+  id: DataStreamId,
+  resolution: Resolution,
+  error: ErrorDetails,
+  aggregationType?: AggregateType
+): ErrorResponse => ({
   type: ERROR,
   payload: {
     id,
     resolution,
     error,
+    aggregationType,
   },
 });
 
-export const onError = (id: DataStreamId, resolution: Resolution, error: ErrorDetails) => (dispatch: Dispatch) => {
-  dispatch(onErrorAction(id, resolution, error));
-};
+export const onError =
+  (id: DataStreamId, resolution: Resolution, error: ErrorDetails, aggregationType?: AggregateType) =>
+  (dispatch: Dispatch) => {
+    dispatch(onErrorAction(id, resolution, error, aggregationType));
+  };
 
 /**
  * On Success

--- a/packages/core/src/data-module/data-cache/getDataStreamStore.ts
+++ b/packages/core/src/data-module/data-cache/getDataStreamStore.ts
@@ -1,14 +1,23 @@
 import { DataStreamsStore, DataStreamStore } from './types';
+import { AggregateType } from '@aws-sdk/client-iotsitewise';
 import { parseDuration } from '../../common/time';
 
 export const getDataStreamStore = (
   dataStreamId: string,
   resolution: number | string,
-  store: DataStreamsStore | undefined
+  store: DataStreamsStore | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  aggregationType?: AggregateType
 ): DataStreamStore | undefined => {
-  const resolutionCache = store && store[dataStreamId];
-  if (resolutionCache == null) {
-    return undefined;
+  const resolutionStreamStore = store?.[dataStreamId]?.resolutions;
+  const rawDataStreamStore = store?.[dataStreamId]?.rawData;
+  const parsedDuration = parseDuration(resolution);
+
+  if (parsedDuration === 0 && rawDataStreamStore) {
+    return rawDataStreamStore;
+  } else if (resolutionStreamStore) {
+    return resolutionStreamStore[parsedDuration]?.[AggregateType.AVERAGE];
   }
-  return resolutionCache[parseDuration(resolution)];
+
+  return undefined;
 };

--- a/packages/core/src/data-module/data-cache/toDataStreams.spec.ts
+++ b/packages/core/src/data-module/data-cache/toDataStreams.spec.ts
@@ -1,11 +1,13 @@
 import { toDataStreams } from './toDataStreams';
-import { DataStreamsStore } from './types';
+import { DataStreamsStore, DataStreamStore } from './types';
+import { AggregateType } from '@aws-sdk/client-iotsitewise';
 import { addToDataPointCache, EMPTY_CACHE } from './caching/caching';
 import { MINUTE_IN_MS } from '../../common/time';
 import { DataStreamInfo, DataStream, DataType, StreamType } from '@synchro-charts/core';
 
 const ALARM = 'alarm';
 const WITHIN_VIEWPORT_DATE = new Date(2000, 0, 1);
+const AGGREGATE_TYPE = AggregateType.AVERAGE;
 
 const NUMBER_INFO_1: DataStreamInfo = {
   id: 'number-some-id',
@@ -53,7 +55,7 @@ const ALARM_STREAM: DataStream<string> = {
   ],
 };
 
-const rawStore = {
+const rawStore: DataStreamStore = {
   id: ALARM_STREAM_INFO.id,
   resolution: 0,
   dataCache: addToDataPointCache({
@@ -84,12 +86,13 @@ const aggregatedStore = {
   requestHistory: [],
   isLoading: false,
   isRefreshing: false,
+  aggregationType: AGGREGATE_TYPE,
 };
 
 const STORE_WITH_NUMBERS_ONLY: DataStreamsStore = {
   [ALARM_STREAM_INFO.id]: {
-    0: rawStore,
-    [MINUTE_IN_MS]: aggregatedStore,
+    resolutions: { [MINUTE_IN_MS]: { [AGGREGATE_TYPE]: aggregatedStore } },
+    rawData: rawStore,
   },
 };
 

--- a/packages/core/src/data-module/data-cache/types.ts
+++ b/packages/core/src/data-module/data-cache/types.ts
@@ -1,4 +1,5 @@
 import { DataPoint, Primitive } from '@synchro-charts/core';
+import { AggregateType } from '@aws-sdk/client-iotsitewise';
 import { IntervalStructure } from '../../common/intervalStructure';
 import { ErrorDetails } from '../../common/types';
 import { DataStream } from '../types';
@@ -27,15 +28,21 @@ export type DataStreamStore = {
   isLoading: boolean;
   // When data is being requested, whether or not data has been previously requested
   isRefreshing: boolean;
+  aggregationType?: AggregateType;
   error?: ErrorDetails;
 } & Omit<DataStream, 'data' | 'aggregates'>;
 
+export type AggregationStreamStore = {
+  [aggregationType in AggregateType]?: DataStreamStore | undefined;
+};
+
+export type DataStoreForID = {
+  resolutions?: { [resolution: number]: AggregationStreamStore | undefined } | undefined;
+  rawData?: DataStreamStore | undefined;
+};
+
 export type DataStreamsStore = {
-  [dataStreamId: string]:
-    | {
-        [resolution: number]: DataStreamStore | undefined;
-      }
-    | undefined;
+  [dataStreamId: string]: DataStoreForID | undefined;
 };
 
 export type CacheSettings = {

--- a/packages/core/src/data-module/types.ts
+++ b/packages/core/src/data-module/types.ts
@@ -1,9 +1,10 @@
 import { DataStreamId, MinimalViewPortConfig, Primitive } from '@synchro-charts/core';
 import { TimeSeriesDataRequest } from './data-cache/requestTypes';
-export { CacheSettings } from './data-cache/types';
+import { AggregateType } from '@aws-sdk/client-iotsitewise';
 import { CacheSettings } from './data-cache/types';
 import { DataPoint, StreamAssociation, Annotations } from '@synchro-charts/core';
 import { ErrorDetails } from '../common/types';
+export { CacheSettings } from './data-cache/types';
 
 export type TimeSeriesData = {
   dataStreams: DataStream[];
@@ -21,6 +22,7 @@ export type RequestInformation = {
   fetchMostRecentBeforeStart?: boolean;
   fetchMostRecentBeforeEnd?: boolean;
   fetchFromStartToEnd?: boolean;
+  aggregationType?: AggregateType;
   // Mechanism to associate some information about how the request should be made
   meta?: Record<string, string | number | boolean>;
 };
@@ -97,11 +99,13 @@ export type AnyDataStreamQuery = DataStreamQuery & any;
 export type ErrorCallback = ({
   id,
   resolution,
+  aggregationType,
   error,
 }: {
   id: string;
   resolution: number;
   error: ErrorDetails;
+  aggregationType?: AggregateType;
 }) => void;
 
 export type SubscriptionUpdate<Query extends DataStreamQuery> = Partial<Omit<Subscription<Query>, 'emit'>>;

--- a/packages/source-iotsitewise/src/time-series-data/client/client.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/client.spec.ts
@@ -13,6 +13,8 @@ import { HOUR_IN_MS } from '@iot-app-kit/core';
 import { MAX_BATCH_RESULTS } from './batch';
 import flushPromises from 'flush-promises';
 
+const AGGREGATE_TYPE = AggregateType.AVERAGE;
+
 it('initializes', () => {
   expect(() => new SiteWiseClient(createMockSiteWiseSDK({}))).not.toThrowError();
 });
@@ -364,6 +366,7 @@ describe('getAggregatedPropertyDataPoints', () => {
         end: endDate,
         resolution,
         fetchFromStartToEnd: true,
+        aggregationType: AGGREGATE_TYPE,
       },
     ];
 
@@ -405,6 +408,7 @@ describe('getAggregatedPropertyDataPoints', () => {
       end: endDate,
       resolution,
       fetchFromStartToEnd: true,
+      aggregationType: AGGREGATE_TYPE,
     };
 
     const requestInformation2 = {
@@ -413,6 +417,7 @@ describe('getAggregatedPropertyDataPoints', () => {
       end: endDate,
       resolution,
       fetchFromStartToEnd: true,
+      aggregationType: AGGREGATE_TYPE,
     };
 
     // batches requests that are sent on a single frame

--- a/packages/source-iotsitewise/src/time-series-data/data-source.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/data-source.spec.ts
@@ -1,5 +1,5 @@
 import flushPromises from 'flush-promises';
-import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { AggregateType, IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { createDataSource } from './data-source';
 import { MINUTE_IN_MS, HOUR_IN_MS, MONTH_IN_MS, TimeSeriesDataModule, TimeSeriesDataRequest } from '@iot-app-kit/core';
 import { SiteWiseDataStreamQuery } from './types';
@@ -687,6 +687,7 @@ describe.skip('aggregated data', () => {
           start,
           end,
           resolution: '1d',
+          aggregationType: AggregateType.AVERAGE,
         },
       ]
     );

--- a/packages/source-iotsitewise/src/time-series-data/provider.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/provider.spec.ts
@@ -15,16 +15,23 @@ import { createMockSiteWiseSDK } from '../__mocks__/iotsitewiseSDK';
 import { createMockIoTEventsSDK } from '../__mocks__/ioteventsSDK';
 import { SiteWiseAssetModule } from '../asset-modules';
 import { SiteWiseAlarmModule } from '../alarms/iotevents';
+import { AggregateType } from '@aws-sdk/client-iotsitewise';
 
 const createMockSource = (dataStreams: DataStream[]): DataSource<SiteWiseDataStreamQuery> => ({
   initiateRequest: jest.fn(({ onSuccess }: { onSuccess: OnSuccessCallback }) =>
-    onSuccess(dataStreams, { start: new Date(), resolution: '1m', end: new Date(), id: '123' }, new Date(), new Date())
+    onSuccess(
+      dataStreams,
+      { start: new Date(), resolution: '1m', end: new Date(), id: '123', aggregationType: AGGREGATE_TYPE },
+      new Date(),
+      new Date()
+    )
   ),
   getRequestsFromQuery: async () => dataStreams.map((dataStream) => ({ id: dataStream.id, resolution: '0' })),
 });
 
 const dataSource = createMockSource([DATA_STREAM]);
 const timeSeriesModule = new TimeSeriesDataModule(dataSource);
+const AGGREGATE_TYPE = AggregateType.AVERAGE;
 
 const assetModule = new SiteWiseAssetModule(
   createSiteWiseAssetDataSource(


### PR DESCRIPTION
## Overview
- add a layer to the cache so that we can support multiple aggregations in the future
```
[dataStreamId: string]: {
        rawData: DataStream | undefined,
        resolutions: {
                [resolution: number]: { 
                        [aggregationType in AggregateType]?: DataStreamStore | undefined; 
                } | undefined;
        } | undefined;
} | undefined;
```

## Verifying Changes
still receiving and displaying data properly :) 
<img width="461" alt="image" src="https://user-images.githubusercontent.com/28601414/217948110-ae36a810-095f-4cce-aba0-9af72ab2c2ed.png">

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
