### PR TITLE
feature(dashboard): add legend configure section

### DIFF
--- a/packages/dashboard/src/components/sidePanel/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/index.tsx
@@ -11,6 +11,8 @@ import AxisSetting from './sections/axisSettingSection';
 import ThresholdsSection from './sections/thresholdsSection/thresholdsSection';
 import PropertiesAlarmsSection from './sections/propertiesAlarmSection';
 import './index.scss';
+import LegendSettings from './sections/legendSettingSection';
+
 const SidePanel: FC<{ messageOverrides: DashboardMessages }> = ({ messageOverrides }) => {
   const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
   if (selectedWidgets.length !== 1) {
@@ -33,6 +35,7 @@ const SidePanel: FC<{ messageOverrides: DashboardMessages }> = ({ messageOverrid
             <PropertiesAlarmsSection messageOverrides={messageOverrides} />
             <ThresholdsSection messageOverrides={messageOverrides} />
             <AxisSetting messageOverrides={messageOverrides} />
+            <LegendSettings messageOverrides={messageOverrides} />
           </>
         )}
       </SpaceBetween>

--- a/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.tsx
@@ -3,7 +3,8 @@ import { DashboardMessages } from '../../../../messages';
 import { useInput } from '../../utils';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import { BaseChangeDetail } from '@cloudscape-design/components/input/interfaces';
-import { ExpandableSection, Grid, Input } from '@cloudscape-design/components';
+import { ExpandableSection, Grid, Input, SpaceBetween } from '@cloudscape-design/components';
+import '../index.scss';
 
 export const BaseSettings: FC<{ messageOverrides: DashboardMessages }> = ({
   messageOverrides: {
@@ -24,18 +25,41 @@ export const BaseSettings: FC<{ messageOverrides: DashboardMessages }> = ({
   const gridDefinition = [{ colspan: 2 }, { colspan: 4 }, { colspan: 2 }, { colspan: 4 }];
   return (
     <ExpandableSection headerText={baseSettings.title} defaultExpanded>
-      <Grid gridDefinition={gridDefinition}>
-        <div className="section-item-label">{baseSettings.x}</div>
-        <Input value={`${x}`} type="number" onChange={onXChange} data-test-id="base-setting-x-input" />
-        <div className="section-item-label">{baseSettings.y}</div>
-        <Input value={`${y}`} type="number" onChange={onYChange} data-test-id="base-setting-y-input" />
-      </Grid>
-      <Grid gridDefinition={gridDefinition}>
-        <div className="section-item-label">{baseSettings.width}</div>
-        <Input value={`${width}`} type="number" onChange={onWidthChange} data-test-id="base-setting-width-input" />
-        <div className="section-item-label">{baseSettings.height}</div>
-        <Input value={`${height}`} type="number" onChange={onHeightChange} data-test-id="base-setting-height-input" />
-      </Grid>
+      <SpaceBetween size={'xs'} direction={'vertical'}>
+        <Grid gridDefinition={gridDefinition} disableGutters>
+          <div className="side-panel-input">
+            <span>{baseSettings.x}</span>
+          </div>
+          <div className="side-panel-input with-gutter">
+            <Input value={`${x}`} type="number" onChange={onXChange} data-test-id="base-setting-x-input" />
+          </div>
+          <div className="side-panel-input">
+            <span>{baseSettings.y}</span>
+          </div>
+          <div className="side-panel-input">
+            <Input value={`${y}`} type="number" onChange={onYChange} data-test-id="base-setting-y-input" />
+          </div>
+        </Grid>
+        <Grid gridDefinition={gridDefinition} disableGutters>
+          <div className="side-panel-input grow with-gutter">
+            <span>{baseSettings.width}</span>
+          </div>
+          <div className="side-panel-input with-gutter">
+            <Input value={`${width}`} type="number" onChange={onWidthChange} data-test-id="base-setting-width-input" />
+          </div>
+          <div className="side-panel-input">
+            <span>{baseSettings.height}</span>
+          </div>
+          <div className="side-panel-input">
+            <Input
+              value={`${height}`}
+              type="number"
+              onChange={onHeightChange}
+              data-test-id="base-setting-height-input"
+            />
+          </div>
+        </Grid>
+      </SpaceBetween>
     </ExpandableSection>
   );
 };

--- a/packages/dashboard/src/components/sidePanel/sections/index.scss
+++ b/packages/dashboard/src/components/sidePanel/sections/index.scss
@@ -1,6 +1,6 @@
 @import "~@cloudscape-design/design-tokens/index";
 
-.threshold-content-item {
+.side-panel-input {
   display: flex;
   align-items: center;
   height: 100%;

--- a/packages/dashboard/src/components/sidePanel/sections/legendSettingSection/index.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/legendSettingSection/index.spec.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import LegendSettings from './index';
+import { DefaultDashboardMessages } from '../../../../messages';
+import { configureDashboardStore } from '../../../../store';
+import { Widget } from '../../../../types';
+import { MOCK_KPI_WIDGET } from '../../../../../testing/mocks';
+import { DashboardState } from '../../../../store/state';
+import { render } from '@testing-library/react';
+
+const widget: Widget = {
+  ...MOCK_KPI_WIDGET,
+};
+
+const state: Partial<DashboardState> = {
+  dashboardConfiguration: {
+    widgets: [widget],
+    viewport: { duration: '5m' },
+  },
+  selectedWidgets: [widget],
+};
+
+const TestComponent = () => (
+  <Provider store={configureDashboardStore(state)}>
+    <LegendSettings messageOverrides={DefaultDashboardMessages} />
+  </Provider>
+);
+
+it('renders', () => {
+  const elem = render(<TestComponent />).baseElement;
+  expect(elem).toBeTruthy();
+});
+
+it('renders toggle for viewing legend', () => {
+  const elem = render(<TestComponent />).baseElement;
+  expect(elem.querySelector('[data-test-id="legend-setting-view-toggle"]')).toBeTruthy();
+});
+
+it('renders legend position select', () => {
+  const elem = render(<TestComponent />).baseElement;
+  expect(elem.querySelector('[data-test-id="legend-setting-position-select"]')).toBeTruthy();
+});
+
+it('renders legend width input', () => {
+  const elem = render(<TestComponent />).baseElement;
+  expect(elem.querySelector('[data-test-id="legend-setting-width-input"]')).toBeTruthy();
+});
+
+it('renders show data color toggle', () => {
+  const elem = render(<TestComponent />).baseElement;
+  expect(elem.querySelector('[data-test-id="legend-setting-color-data-toggle"]')).toBeTruthy();
+});

--- a/packages/dashboard/src/components/sidePanel/sections/legendSettingSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/legendSettingSection/index.tsx
@@ -1,0 +1,125 @@
+import React, { FC, useEffect, useState } from 'react';
+import { DashboardMessages } from '../../../../messages';
+import {
+  ExpandableSection,
+  Grid,
+  Input,
+  InputProps,
+  Select,
+  SpaceBetween,
+  Toggle,
+} from '@cloudscape-design/components';
+import { useAppKitWidgetInput } from '../../utils';
+import { LEGEND_POSITION, LegendConfig } from '@synchro-charts/core';
+import ExpandableSectionHeader from '../../shared/expandableSectionHeader';
+import { SelectProps } from '@cloudscape-design/components/select/interfaces';
+
+const defaultLegendSettings: LegendConfig = {
+  legendLabels: { title: '' },
+  position: LEGEND_POSITION.BOTTOM,
+  showDataStreamColor: true,
+  width: 150,
+};
+const LegendSettings: FC<{ messageOverrides: DashboardMessages }> = ({
+  messageOverrides: {
+    sidePanel: { legendSettingMessages },
+  },
+}) => {
+  const [legendSettings, setLegendSettings] = useAppKitWidgetInput('legend');
+  const onWidthChange = ({ detail }: { detail: InputProps.ChangeDetail }) => {
+    setLegendSettings({ ...defaultLegendSettings, ...legendSettings, width: parseInt(detail.value) });
+  };
+  const [showLegend, setShowLegend] = useState<boolean>(!!legendSettings);
+  const [recentLegendSettings, setRecentLegendSettings] = useState<LegendConfig>();
+
+  useEffect(() => {
+    if (!showLegend) {
+      setRecentLegendSettings(legendSettings);
+      setLegendSettings(undefined);
+    } else {
+      setLegendSettings(recentLegendSettings || defaultLegendSettings);
+    }
+  }, [showLegend]);
+
+  const header = (
+    <ExpandableSectionHeader>
+      <div className="expandable-section-header">
+        {legendSettingMessages.header}
+        <div className="expandable-section-header-icon" onClick={(e) => e.stopPropagation()}>
+          <Toggle
+            checked={showLegend}
+            onChange={({ detail }) => setShowLegend(detail.checked)}
+            data-test-id="legend-setting-view-toggle"
+          >
+            {legendSettingMessages.showLegend}
+          </Toggle>
+        </div>
+      </div>
+    </ExpandableSectionHeader>
+  );
+
+  const positionOptions: SelectProps.Option[] = [
+    { label: legendSettingMessages.position.right, value: LEGEND_POSITION.RIGHT },
+    { label: legendSettingMessages.position.bottom, value: LEGEND_POSITION.BOTTOM },
+  ];
+  const selectedOption = positionOptions.find((option) => option.value === legendSettings?.position) || null;
+
+  const onSelectChange = ({ detail }: { detail: SelectProps.ChangeDetail }) => {
+    setLegendSettings({
+      ...defaultLegendSettings,
+      ...legendSettings,
+      position: detail.selectedOption.value as LEGEND_POSITION,
+    });
+  };
+
+  return (
+    <ExpandableSection headerText={header} defaultExpanded>
+      <SpaceBetween size={'xs'} direction={'vertical'}>
+        <Grid gridDefinition={[{ colspan: 2 }, { colspan: 4 }, { colspan: 2 }, { colspan: 4 }]} disableGutters>
+          <div className="side-panel-input">
+            <span>{legendSettingMessages.position.label}</span>
+          </div>
+          <div className="side-panel-input grow with-gutter">
+            <Select
+              disabled={!showLegend}
+              options={positionOptions}
+              selectedOption={selectedOption}
+              onChange={onSelectChange}
+              data-test-id="legend-setting-position-select"
+            />
+          </div>
+          <div className="side-panel-input">
+            <span>{legendSettingMessages.width} </span>
+          </div>
+          <div className="side-panel-input grow">
+            <Input
+              disabled={!showLegend || legendSettings?.position === LEGEND_POSITION.BOTTOM}
+              value={`${legendSettings?.width}`}
+              onChange={onWidthChange}
+              data-test-id="legend-setting-width-input"
+            />
+          </div>
+        </Grid>
+
+        <div className="side-panel-input grow">
+          <Toggle
+            disabled={!showLegend}
+            checked={legendSettings?.showDataStreamColor || false}
+            onChange={({ detail }) =>
+              setLegendSettings({
+                ...defaultLegendSettings,
+                ...legendSettings,
+                showDataStreamColor: detail.checked,
+              })
+            }
+            data-test-id="legend-setting-color-data-toggle"
+          >
+            {legendSettingMessages.showColor}
+          </Toggle>
+        </div>
+      </SpaceBetween>
+    </ExpandableSection>
+  );
+};
+
+export default LegendSettings;

--- a/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/propertyComponent.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/propertyComponent.tsx
@@ -48,13 +48,13 @@ export const PropertyComponent: FC<PropertyComponentProps> = ({
     <Grid gridDefinition={[{ colspan: 12 }]}>
       <SpaceBetween size="xxxs" direction={'vertical'}>
         <Grid gridDefinition={[{ colspan: 9 }, { colspan: 3 }]} disableGutters>
-          <div className="threshold-content-item with-gutter grow">
-            <div className="threshold-content-item with-gutter">
+          <div className="side-panel-input with-gutter grow">
+            <div className="side-panel-input with-gutter">
               <ColorPicker color={color || ''} updateColor={updatePropertyColor} />
             </div>
             <span>{label}</span>
           </div>
-          <div className="threshold-content-item grow ">
+          <div className="side-panel-input grow ">
             <div className="justify-content-end">
               <Button onClick={onDeleteAssetQuery} variant={'icon'} iconName={'close'} />
             </div>

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdComponent.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdComponent.tsx
@@ -6,7 +6,7 @@ import { NonCancelableEventHandler } from '@cloudscape-design/components/interna
 import { Button, Grid, Input, InputProps, Select, SelectProps } from '@cloudscape-design/components';
 import { DEFAULT_THRESHOLD_COLOR, OPS_ALLOWED_WITH_STRING } from './defaultValues';
 import { AppKitComponentTag } from '../../../../types';
-import './index.scss';
+import '../index.scss';
 import ColorPicker from '../../shared/colorPicker';
 
 const widgetsSupportsContainOp: AppKitComponentTag[] = [
@@ -79,10 +79,10 @@ export const ThresholdComponent: FC<{ path: string; deleteSelf: () => void; mess
       disableGutters
       data-test-id="threshold-component"
     >
-      <div className="threshold-content-item">
-        <span className="threshold-content-item label with-gutter">{thresholdSettings.if}</span>
+      <div className="side-panel-input">
+        <span className="side-panel-input label with-gutter">{thresholdSettings.if}</span>
         <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]} disableGutters>
-          <div className="threshold-content-item with-gutter grow">
+          <div className="side-panel-input with-gutter grow">
             <Select
               options={COMPARISON_OPERATOR_OPTIONS}
               selectedOption={selectedOption}
@@ -90,7 +90,7 @@ export const ThresholdComponent: FC<{ path: string; deleteSelf: () => void; mess
               data-test-id="threshold-component-operator-select"
             />
           </div>
-          <div className="threshold-content-item with-gutter grow">
+          <div className="side-panel-input with-gutter grow">
             <Input
               value={`${value}`}
               placeholder="Threshold value"
@@ -100,7 +100,7 @@ export const ThresholdComponent: FC<{ path: string; deleteSelf: () => void; mess
             />
           </div>
         </Grid>
-        <div className="threshold-content-item ">
+        <div className="side-panel-input">
           <ColorPicker
             color={color}
             updateColor={updateThresholdColor}
@@ -109,7 +109,7 @@ export const ThresholdComponent: FC<{ path: string; deleteSelf: () => void; mess
         </div>
       </div>
 
-      <div className="threshold-content-item justify-content-end">
+      <div className="side-panel-input justify-content-end">
         <Button iconName="close" variant="icon" onClick={deleteSelf} data-test-id="threshold-component-delete-button" />
       </div>
     </Grid>

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
@@ -5,7 +5,7 @@ import { useInput } from '../../utils';
 import { COMPARISON_OPERATOR, YAnnotation } from '@synchro-charts/core';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import { DashboardMessages } from '../../../../messages';
-import './index.scss';
+import '../index.scss';
 import { DEFAULT_THRESHOLD_COLOR } from './defaultValues';
 import { ThresholdComponent } from './thresholdComponent';
 

--- a/packages/dashboard/src/components/sidePanel/utils/index.ts
+++ b/packages/dashboard/src/components/sidePanel/utils/index.ts
@@ -6,7 +6,10 @@ import { DashboardState } from '../../../store/state';
 import { onUpdateWidgetsAction } from '../../../store/actions';
 import { AppKitWidget, TextWidget, Widget } from '../../../types';
 
-export type typedInputHook<T extends Widget = Widget> = <K extends keyof T>(key: K) => [T[K], Dispatch<T[K]>];
+export type typedInputHook<T extends Widget = Widget> = <K extends keyof T>(
+  key: K,
+  validator?: (newValue: T[K]) => boolean
+) => [T[K], Dispatch<T[K]>];
 
 export const useInput: <T>(path: string, validator?: (newValue: T) => boolean) => [T, Dispatch<T>] = (
   path,

--- a/packages/dashboard/src/messages.ts
+++ b/packages/dashboard/src/messages.ts
@@ -129,6 +129,19 @@ export type SidePanelMessages = {
     containsLabel: string;
     thresholdPlaceHolder: string;
   };
+
+  legendSettingMessages: {
+    header: string;
+    position: {
+      label: string;
+      right: string;
+      bottom: string;
+    };
+    showColor: string;
+    title: string;
+    width: string;
+    showLegend: string;
+  };
 };
 
 export type DashboardMessages = {
@@ -261,6 +274,18 @@ export const DefaultDashboardMessages: DashboardMessages = {
       title: 'Threshold',
       containsLabel: 'Contains',
       thresholdPlaceHolder: 'Threshold value',
+    },
+    legendSettingMessages: {
+      width: 'Width',
+      header: 'Legend',
+      title: 'Title',
+      showColor: 'Show data color',
+      position: {
+        label: 'Position',
+        right: 'Right',
+        bottom: 'Bottom',
+      },
+      showLegend: 'View on chart',
     },
   },
 };

--- a/packages/dashboard/src/messages.ts
+++ b/packages/dashboard/src/messages.ts
@@ -122,6 +122,17 @@ export type SidePanelMessages = {
     url: string;
   };
 
+  legendSettingMessages: {
+    header: string;
+    position: {
+      label: string;
+      left: string;
+      middle: string;
+    };
+    showColor: string;
+    title: string;
+  };
+
   thresholdSettings: {
     if: string;
     colorDataToggle: string;


### PR DESCRIPTION
## Overview
Add legend configuration.
<img width="932" alt="image" src="https://user-images.githubusercontent.com/11740421/216155559-bedc6f0e-4acb-441c-946c-6e95c1e7f972.png">

Width input only applies when legend is positioned as `right`. So it will be disabled when legend is positioned at bottom.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
