### PR TITLE
chore(react-components): port over component utils from synchro-charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "fix:stylelint": "stylelint '**/*.css' --fix",
     "test": "npm-run-all -p test:unit test:eslint test:stylelint test:git",
     "test:integration": "npm run test:integration -ws --if-present",
-    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=46",
+    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=44",
     "test:stylelint": "stylelint '**/*.css' --max-warnings 0",
     "test:unit": "npm run test -ws --if-present",
     "test:git": "git diff --exit-code",

--- a/packages/react-components/src/common/constants.ts
+++ b/packages/react-components/src/common/constants.ts
@@ -1,0 +1,87 @@
+import { ActivePoint, Primitive } from './dataTypes';
+
+export enum DataType {
+  NUMBER = 'NUMBER',
+  STRING = 'STRING',
+  BOOLEAN = 'BOOLEAN',
+}
+
+/**
+ * Stream type is a classification of a `DataStream`, which contains with it additional structure and features specific
+ * to the stream type.
+ *
+ * For example, for an alarm stream, if a stream is associated to the alarm stream, we interpret the stream as
+ * representing the status for the given alarm and present alarm specific UX such as alarm status on the legend and tooltip.
+ */
+export enum StreamType {
+  ALARM = 'ALARM',
+  ANOMALY = 'ANOMALY',
+  ALARM_THRESHOLD = 'ALARM_THRESHOLD',
+}
+
+/**
+ * Maps the view model to d3 axis types. In the future we could add additional
+ * custom scale types beyond what's available in `d3-axis`.
+ */
+export enum ScaleType {
+  TimeSeries = 'time-series',
+  Log = 'log',
+  Linear = 'linear',
+}
+
+export enum LEGEND_POSITION {
+  RIGHT = 'RIGHT',
+  BOTTOM = 'BOTTOM',
+}
+
+export enum COMPARISON_OPERATOR {
+  LESS_THAN = 'LT',
+  GREATER_THAN = 'GT',
+  LESS_THAN_EQUAL = 'LTE',
+  GREATER_THAN_EQUAL = 'GTE',
+  EQUAL = 'EQ',
+  CONTAINS = 'CONTAINS',
+}
+
+export const COMPARATOR_MAP = {
+  GTE: '>=',
+  GT: '>',
+  LTE: '<=',
+  LT: '<',
+  EQ: '=',
+};
+
+export enum StatusIcon {
+  ERROR = 'error',
+  ACTIVE = 'active',
+  NORMAL = 'normal',
+  ACKNOWLEDGED = 'acknowledged',
+  SNOOZED = 'snoozed',
+  DISABLED = 'disabled',
+  LATCHED = 'latched',
+}
+
+export const STATUS_ICONS = [
+  StatusIcon.ERROR,
+  StatusIcon.ACTIVE,
+  StatusIcon.NORMAL,
+  StatusIcon.ACKNOWLEDGED,
+  StatusIcon.SNOOZED,
+  StatusIcon.DISABLED,
+  StatusIcon.LATCHED,
+];
+
+export enum DATA_ALIGNMENT {
+  EITHER = 'EITHER',
+  RIGHT = 'RIGHT',
+  LEFT = 'LEFT',
+}
+
+/**
+ * To differentiate between points that come from data streams and points that come from trend lines
+ */
+export const enum POINT_TYPE {
+  DATA = 'data',
+  TREND = 'trend',
+}
+export type ActivePointWithType<T extends Primitive> = ActivePoint<T> & { type: POINT_TYPE };

--- a/packages/react-components/src/common/dataTypes.ts
+++ b/packages/react-components/src/common/dataTypes.ts
@@ -1,0 +1,270 @@
+import { DataType, StreamType } from './constants';
+
+/**
+ * Types which represent the data and data streams.
+ */
+
+export type Primitive = string | number | boolean;
+
+export type ThresholdDataTypes = string | string[] | number | boolean;
+
+export type Timestamp = number;
+
+export type DataPoint<T extends Primitive = Primitive> = { x: Timestamp; y: T };
+
+// An id associated to a data stream. used to relate streams to data stream infos, and streams to other streams.
+export type DataStreamId = string;
+
+// An association to a stream of a given type. Allows a semantic understanding of how different data streams are associated,
+// to enable rich functionality within various SynchroChart widgets
+//
+// I.e. to express that a given property has an alarm associated with it, we would specify that the property, contains
+// a stream association of type ALARM.
+export type StreamAssociation = {
+  id: DataStreamId;
+  type: StreamType;
+};
+
+/**
+ * Data Stream Info
+ *
+ * A view model representation of a data stream.
+ * Is utilized to request and display data within widgets
+ */
+export interface DataStreamInfo {
+  id: DataStreamId;
+  resolution: number;
+  name: string;
+  color?: string;
+  dataType: DataType;
+  unit?: string;
+  detailedName?: string;
+  streamType?: StreamType;
+  associatedStreams?: StreamAssociation[];
+}
+
+/**
+ * Minimal Size Configuration request for implementing a component
+ */
+export interface MinimalSizeConfig {
+  width?: number; // Full width of widget, including margins
+  height?: number; // Full height of widget, including margins
+  // Margins, which are provided by default if left off by the widget.
+  // Widgets should be designed not to require custom margins to be presented in an expected manner
+  marginRight?: number;
+  marginLeft?: number;
+  marginTop?: number;
+  marginBottom?: number;
+}
+
+/**
+ * Size Configuration
+ *
+ * An internal model which widgets utilize internally,
+ * after the default margins are set.
+ */
+export interface SizeConfig extends MinimalSizeConfig {
+  width: number;
+  height: number;
+  marginRight: number;
+  marginLeft: number;
+  marginTop: number;
+  marginBottom: number;
+}
+
+export interface SizePositionConfig extends SizeConfig {
+  x: number;
+  y: number;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+export type ActivePoint<T extends Primitive> = {
+  // The id of the data stream that this point is associated with
+  streamId: string;
+  // An optional label for the data point. Most use cases should default this to the name of the data stream.
+  label?: string;
+  // The point that is closest to the current selected date, if there is one.
+  point?: DataPoint<T>;
+};
+
+interface MinimalViewportConfigBase {
+  // The identifier for the viewport group which the widget will belong to. All widgets within a viewport group
+  // will have their viewports 'synced' to the same value, i.e. if you pan on one chart, all charts within
+  // the viewport group will view the same data.
+  // Omitting the `group` results in the widget not being part of any viewport group.
+  group?: string;
+
+  yMin?: number;
+  yMax?: number;
+
+  // NOTE: Deprecated
+  // A unique identifier of the updater of the viewport. Utilized to prevent widgets from re-applying updates they've already applied.
+  lastUpdatedBy?: string;
+}
+
+/**
+ * To differentiate between points that come from data streams and points that come from trend lines
+ */
+export const enum POINT_TYPE {
+  DATA = 'data',
+  TREND = 'trend',
+}
+
+export type ActivePointWithType<T extends Primitive> = ActivePoint<T> & { type: POINT_TYPE };
+
+export interface MinimalStaticViewport extends MinimalViewportConfigBase {
+  start: Date | string;
+  end: Date | string;
+}
+
+export interface MinimalLiveViewport extends MinimalViewportConfigBase {
+  // include to specify that a widget is in live mode. in milliseconds.
+  duration: number | string;
+}
+
+export type MinimalViewPortConfig = MinimalStaticViewport | MinimalLiveViewport;
+
+/**
+ * View Port
+ *
+ * The view port defines the domain and range of the data of which we would like to visualize/analyze.
+ */
+export type ViewPortConfig = MinimalViewPortConfig & {
+  yMin: number;
+  yMax: number;
+};
+
+export type ViewPort = MinimalViewPortConfig & {
+  start: Date;
+  end: Date;
+  yMin: number;
+  yMax: number;
+  duration?: number;
+};
+
+/**
+ * Alarms Configuration
+ *
+ * Configurations to the interoperation of alarm data.
+ */
+export type AlarmsConfig = {
+  // Duration in MS of how long a data point is considered not stale.
+  // The implication is this sets a max-duration of how a status is visualized on the status-timelinme.
+  // No staleness defined implies never stale, i.e. a status-timeline 'bar' extends up to to next point, or to 'now', which ever comes first.
+  expires?: number; // should be value such that x > = or x as `undefined`
+};
+
+/**
+ * Base Config
+ *
+ * The base configuration of which all widgets must implement.
+ * Widgets may however implement more than what is given in the base config.
+ */
+export interface BaseConfig {
+  // A unique identifier to the widget
+  widgetId: string;
+  // The viewport in which the widget analyzes/visualizes data.
+  viewport: MinimalViewPortConfig | ViewPortConfig;
+  // Exact pixel dimensions of the widget
+  size?: MinimalSizeConfig;
+}
+
+/**
+ * Messages which can be customized. i.e. for internationalization, or business domain specific jargon.
+ */
+export type MessageOverrides = {
+  /** value label utilized in some widgets */
+  liveTimeFrameValueLabel?: string;
+  historicalTimeFrameValueLabel?: string;
+  /** no data streams present - msg displayed when there are no data streams present */
+  noDataStreamsPresentHeader?: string;
+  noDataStreamsPresentSubHeader?: string;
+  /** no data present - msg displayed when no streams have any data */
+  noDataPresentHeader?: string;
+  noDataPresentSubHeader?: string;
+  liveModeOnly?: string;
+  /** unsupported data type - msg displayed when a dataStream has a invalid type */
+  unsupportedDataTypeHeader?: string;
+  unsupportedDataTypeSubHeader?: string;
+  supportedTypes?: string;
+};
+export const DEFAULT_MESSAGE_OVERRIDES: Required<MessageOverrides> = {
+  liveTimeFrameValueLabel: 'Value',
+  historicalTimeFrameValueLabel: 'Value',
+  noDataStreamsPresentHeader: 'No properties or alarms',
+  noDataStreamsPresentSubHeader: "This widget doesn't have any properties or alarms.",
+  noDataPresentHeader: 'No data',
+  noDataPresentSubHeader: "There's no data to display for this time range.",
+  liveModeOnly:
+    'This visualization displays only live data. Choose a live time frame to display data in this visualization.',
+  unsupportedDataTypeHeader: 'Unable to render your data',
+  unsupportedDataTypeSubHeader: 'This chart only supports the following DataType(s):',
+  supportedTypes: 'Number, String, Boolean',
+};
+
+/** SVG Constants */
+export const STREAM_ICON_STROKE_LINECAP = 'round';
+export const STREAM_ICON_STROKE_WIDTH = 3;
+export const STREAM_ICON_PATH_COMMAND = 'M 2 2 H 15';
+export const TREND_ICON_DASH_ARRAY = '1, 5';
+
+/**
+ * Data Stream
+ *
+ * Note that each data point represents an interval of data which has a time period of `resolution` milliseconds,
+ *
+ * An aggregation period of a `DataPoint` at time `t`, and `Resolution` `r` (a time duration),
+ * is represented by the time interval `(t - r, t]`. i.e. the time interval `t - r` exclusive, to `t` inclusive.
+ *
+ * A `resolution` of `0` implies that there is no aggregation occurring, and that the data represents a single point in time,
+ * of which has no duration.
+ */
+export interface DataStream<T extends Primitive = Primitive> extends DataStreamInfo {
+  id: DataStreamId;
+
+  // The short form name associated with the data stream
+  name: string;
+
+  // Long form name, utilized in places with more real-estate
+  detailedName?: string;
+
+  // The color to represent the data when visualized
+  color?: string;
+
+  // The unit associated with the values contained within the data stream
+  unit?: string;
+
+  // Raw data (non-aggregated) for the stream
+  data: DataPoint<T>[];
+
+  // Collection of various aggregates available for the data stream
+  aggregates?: {
+    [resolution: number]: DataPoint<T>[] | undefined;
+  };
+
+  // Mechanism to associate some information about the data stream
+  meta?: Record<string, string | number | boolean>;
+
+  dataType: DataType;
+  streamType?: StreamType;
+  associatedStreams?: StreamAssociation[];
+  isLoading?: boolean;
+  isRefreshing?: boolean;
+  error?: string;
+  resolution: number; // length of aggregation period in milliseconds. 0 implies no aggregations.
+}
+
+/**
+ * Resolution
+ *
+ * Represents the number of milliseconds that each data point represents
+ *
+ * If I have a resolution of one minute, that means each data point represents an interval of one minutes worth of data.
+ *
+ * If I have a resolution of zero, that means the data is "raw data", or, each data point represents a
+ * a single point in time (which is an interval of time with a duration of zero).
+ */
+export type Resolution = number;

--- a/packages/react-components/src/common/thresholdTypes.ts
+++ b/packages/react-components/src/common/thresholdTypes.ts
@@ -1,0 +1,67 @@
+import { DataStreamId } from './dataTypes';
+import { COMPARISON_OPERATOR, StatusIcon } from './constants';
+
+type AnnotationLabel = {
+  text: string;
+  show: boolean;
+};
+
+export type AnnotationValue = number | string | boolean | Date;
+export type ThresholdValue = number | string | boolean;
+
+export interface Annotation<T extends AnnotationValue> {
+  color: string;
+  value: T;
+  showValue?: boolean;
+  label?: AnnotationLabel;
+  icon?: StatusIcon;
+  // Description of the annotation, i.e. temperature < 30
+  // Utilized to provide context where annotation/thresholds are utilized/breached
+  description?: string;
+
+  // configures whether the annotation is editable
+  // false or undefined = annotation is not draggable
+  isEditable?: boolean;
+
+  // optional id that can be set to identify annotations
+  // for example, this id can be used by an application to identify and update annotations when a widgetConfigurationUpdate is emitted from SynchroCharts
+  id?: string;
+}
+
+/**
+ * Annotation becomes a threshold when a comparison operator is added.
+ *
+ * The comparison operator determines how the data-value is evaluated against the threshold-value
+ */
+export interface Threshold<T extends ThresholdValue = ThresholdValue> extends Annotation<T> {
+  comparisonOperator: COMPARISON_OPERATOR;
+  // higher severity implies more important threshold. used in evaluating which 'breached' threshold is the most important one to communicate to a user
+  // Thresholds with no severity are considered the least severe
+  severity?: number;
+  // If present, threshold is considered to only only the specified streams. otherwise the threshold
+  // applies to all data streams within a widget which contains the given threshold.
+  dataStreamIds?: DataStreamId[];
+}
+
+export type XAnnotation = Annotation<Date>;
+
+export type YAnnotation = Annotation<number | string | boolean> | Threshold;
+
+export interface Annotations {
+  show?: boolean;
+  x?: XAnnotation[];
+  y?: YAnnotation[];
+  thresholdOptions?: ThresholdOptions | boolean;
+  colorDataAcrossThresholds?: boolean;
+}
+
+export interface ThresholdBand {
+  upper: number;
+  lower: number;
+  // r, g, b
+  color: [number, number, number];
+}
+
+export interface ThresholdOptions {
+  showColor?: boolean;
+}

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -154,10 +154,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 77.00,
-        "statements": 76.00,
-        "functions": 77.0,
-        "branches": 63.0,
+        "lines": 77.58,
+        "statements": 76.74,
+        "functions": 77.15,
+        "branches": 63.43,
         "branchesTrue": 100
       }
     }


### PR DESCRIPTION
## Overview
Port over some of the types and constants from synchro-charts, into `react-components` package to prepare for porting over KPI, Status, Dial and gauge.


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
