### PR TITLE
chore(react-components): port over status widget

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -99,6 +99,7 @@
     "@iot-app-kit/components": "^2.4.2",
     "@iot-app-kit/core": "^2.4.2",
     "@iot-app-kit/source-iottwinmaker": "^2.4.2",
+    "color": "^4.2.3",
     "dompurify": "2.3.4",
     "parse-duration": "^1.0.2",
     "uuid": "^8.3.2",

--- a/packages/react-components/src/kpi/kpi.tsx
+++ b/packages/react-components/src/kpi/kpi.tsx
@@ -9,14 +9,12 @@ import { KPISettings } from './types';
 export const Kpi = ({
   query,
   viewport,
-  color,
   styles,
   settings,
 }: {
   query: TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>;
   viewport: Viewport;
   annotations?: Annotations;
-  color?: string;
   styles?: StyleSettingsMap;
   settings?: KPISettings;
 }) => {
@@ -27,5 +25,5 @@ export const Kpi = ({
     styles,
   });
 
-  return <KpiBase settings={settings} {...widgetPropertiesFromInputs({ dataStreams, color })} />;
+  return <KpiBase settings={settings} {...widgetPropertiesFromInputs({ dataStreams, color: 'black' })} />;
 };

--- a/packages/react-components/src/status/constants.ts
+++ b/packages/react-components/src/status/constants.ts
@@ -1,0 +1,15 @@
+import { StatusSettings } from './types';
+
+export const DEFAULT_STATUS_COLOR = '#16191f';
+
+export const STATUS_ICON_SHRINK_FACTOR = 0.7;
+
+export const DEFAULT_STATUS_SETTINGS: Required<StatusSettings> = {
+  showTimestamp: true,
+  showUnit: true,
+  showIcon: true,
+  showName: true,
+  showValue: true,
+  fontSize: 30,
+  secondaryFontSize: 15,
+};

--- a/packages/react-components/src/status/highContrastColor.spec.ts
+++ b/packages/react-components/src/status/highContrastColor.spec.ts
@@ -1,0 +1,17 @@
+import { highContrastColor } from './highContrastColor';
+
+it('returns white when given invalid color', () => {
+  expect(highContrastColor('fake-color')).toBe('white');
+});
+
+it('returns white when given black', () => {
+  expect(highContrastColor('black')).toBe('white');
+});
+
+it('returns black when given white', () => {
+  expect(highContrastColor('white')).toBe('black');
+});
+
+it('returns white when given hexadecimal red', () => {
+  expect(highContrastColor('#ff0000')).toBe('white');
+});

--- a/packages/react-components/src/status/highContrastColor.ts
+++ b/packages/react-components/src/status/highContrastColor.ts
@@ -1,0 +1,20 @@
+import parseColor from 'color';
+
+const LOW_LIGHTNESS_COLOR = 'white';
+const HIGH_LIGHTNESS_COLOR = 'black';
+
+/**
+ * Return a color which has good contrast against the inputted color.
+ *
+ * @param backgroundColor - any valid css text string, i.e. 'red' or '#ff0000'
+ */
+export const highContrastColor = (backgroundColor: string): string => {
+  try {
+    return parseColor(backgroundColor).isLight() ? HIGH_LIGHTNESS_COLOR : LOW_LIGHTNESS_COLOR;
+  } catch (err) {
+    // Invalid color string was likely passed into `color`.
+    /* eslint-disable-next-line no-console */
+    console.error(err);
+  }
+  return LOW_LIGHTNESS_COLOR;
+};

--- a/packages/react-components/src/status/status.css
+++ b/packages/react-components/src/status/status.css
@@ -1,0 +1,68 @@
+.status-widget {
+  display: flex;
+  height: 100%;
+  box-sizing: border-box;
+  flex-direction: column;
+  padding: var(--margin-medium);
+  font-size: var(--font-size-3);
+  line-height: var(--line-height-3);
+}
+
+.status-widget .description {
+  font-size: var(--font-size-1);
+  line-height: var(--line-height-1);
+  font-weight: var(--font-weight-light);
+}
+
+.status-widget .secondary {
+  font-size: var(--font-size-1);
+  line-height: var(--line-height-1);
+  font-weight: var(--font-weight-light);
+}
+
+.status-widget .value {
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-3);
+  line-height: var(--line-height-3);
+}
+
+.status-widget .spacer {
+  width: 4px;
+  display: inline-block;
+}
+
+.status-widget .unit {
+  font-size: var(--font-size-0);
+  line-height: var(--line-height-0);
+  padding-left: 2px;
+}
+
+.status-widget .large {
+  font-size: var(--font-size-4);
+  line-height: var(--line-height-4);
+}
+
+.status-widget sc-chart-icon {
+  display: inline-block;
+  position: relative;
+  top: -1px;
+}
+
+.status-widget .sc-expandable-input {
+  margin: 0;
+  font-size: var(--font-size-3);
+  line-height: var(--line-height-3);
+}
+
+.status-widget .large .sc-expandable-input {
+  font-size: var(--font-size-4);
+  line-height: var(--line-height-4);
+}
+
+.status-widget .center {
+  align-self: center;
+}
+
+.status-widget .divider {
+  flex-grow: 1;
+}

--- a/packages/react-components/src/status/status.tsx
+++ b/packages/react-components/src/status/status.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { StatusBase } from './statusBase';
+import { TimeQuery, TimeSeriesData, TimeSeriesDataRequest, StyleSettingsMap, Viewport } from '@iot-app-kit/core';
+import { useTimeSeriesDataFromViewport } from '../hooks/useTimeSeriesDataFromViewport/useTimeSeriesDataFromViewport';
+import { widgetPropertiesFromInputs } from '../common/widgetPropertiesFromInputs';
+import { Annotations } from '../common/thresholdTypes';
+import { StatusSettings } from './types';
+
+export const Status = ({
+  query,
+  viewport,
+  styles,
+  settings,
+}: {
+  query: TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>;
+  viewport: Viewport;
+  annotations?: Annotations;
+  styles?: StyleSettingsMap;
+  settings?: StatusSettings;
+}) => {
+  const { dataStreams } = useTimeSeriesDataFromViewport({
+    viewport,
+    query,
+    settings: { fetchMostRecentBeforeEnd: true },
+    styles,
+  });
+
+  return <StatusBase settings={settings} {...widgetPropertiesFromInputs({ dataStreams, color: 'black' })} />;
+};

--- a/packages/react-components/src/status/statusBase.tsx
+++ b/packages/react-components/src/status/statusBase.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import './status.css';
+import { DEFAULT_STATUS_SETTINGS, DEFAULT_STATUS_COLOR, STATUS_ICON_SHRINK_FACTOR } from './constants';
+
+import { StatusIcon, Value } from '../shared-components';
+import { StatusProperties } from './types';
+import { highContrastColor } from './highContrastColor';
+import { DEFAULT_MESSAGE_OVERRIDES } from '../common/dataTypes';
+import { Threshold } from '../common/thresholdTypes';
+
+export const StatusBase: React.FC<StatusProperties> = ({
+  icon,
+  propertyPoint,
+  alarmPoint,
+  unit,
+  name,
+  color = DEFAULT_STATUS_COLOR,
+  settings = {},
+}) => {
+  const { showName, showUnit, showValue, showIcon, fontSize } = {
+    ...DEFAULT_STATUS_SETTINGS,
+    ...settings,
+  };
+
+  // Primary point to display
+  const point = alarmPoint || propertyPoint;
+
+  const backgroundColor = color;
+  const foregroundColor = highContrastColor(backgroundColor);
+
+  /** Display Settings. We want to dynamically construct the layout dependent on what information is shown */
+  const emphasizeValue = !showValue;
+  const emphasizeNameAndUnit = showValue && !showName && !showUnit;
+
+  /** If anything is emphasized, then something is emphasized */
+  const somethingIsEmphasized = emphasizeValue || emphasizeNameAndUnit;
+
+  const breachedThreshold: Threshold | undefined = undefined;
+
+  return (
+    <div
+      className="status-widget"
+      style={{
+        backgroundColor,
+        color: foregroundColor,
+        justifyContent: somethingIsEmphasized ? 'center' : 'unset',
+      }}
+    >
+      {showName && name}
+      {breachedThreshold && breachedThreshold.description != null && (
+        <div style={{ color: foregroundColor }} className={`description ${emphasizeValue ? 'large center' : ''}`}>
+          {breachedThreshold.description}
+        </div>
+      )}
+      {!somethingIsEmphasized && <div className="divider" />}
+      {showValue && point && (
+        <div className={emphasizeNameAndUnit ? 'center' : ''}>
+          {alarmPoint && propertyPoint && (
+            <div className="secondary">
+              <span style={{ color: foregroundColor }}>
+                {DEFAULT_MESSAGE_OVERRIDES.liveTimeFrameValueLabel}:{' '}
+                <Value value={propertyPoint ? propertyPoint.y : undefined} unit={showUnit ? unit : undefined} />
+              </span>
+            </div>
+          )}
+          <div className={`value ${emphasizeNameAndUnit ? 'large' : ''}`} style={{ color: foregroundColor }}>
+            {showIcon && icon && (
+              <>
+                <StatusIcon
+                  name={icon}
+                  size={fontSize * STATUS_ICON_SHRINK_FACTOR}
+                  color={highContrastColor(backgroundColor)}
+                />
+                <div className="spacer" />
+              </>
+            )}
+            <Value value={point ? point.y : undefined} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/react-components/src/status/types.ts
+++ b/packages/react-components/src/status/types.ts
@@ -1,0 +1,15 @@
+import { WidgetSettings } from '../common/dataTypes';
+
+export type StatusProperties = WidgetSettings & {
+  settings: StatusSettings;
+};
+
+export type StatusSettings = {
+  showTimestamp?: boolean;
+  showName?: boolean;
+  showIcon?: boolean;
+  showValue?: boolean;
+  showUnit?: boolean;
+  fontSize?: number; // pixels
+  secondaryFontSize?: number; // pixels
+};

--- a/packages/react-components/stories/kpi/kpiBase.stories.tsx
+++ b/packages/react-components/stories/kpi/kpiBase.stories.tsx
@@ -4,7 +4,7 @@ import { KpiBase } from '../../src/kpi/kpiBase';
 import { DEFAULT_KPI_SETTINGS } from '../../src/kpi/constants';
 
 export default {
-  title: 'KPI',
+  title: 'KPI visualization only',
   component: KpiBase,
   argTypes: {
     showName: { control: { type: 'boolean' }, defaultValue: DEFAULT_KPI_SETTINGS.showName },

--- a/packages/react-components/stories/status/status.stories.tsx
+++ b/packages/react-components/stories/status/status.stories.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Status } from '../../src/status/status';
+import { initialize } from '@iot-app-kit/source-iotsitewise';
+
+const ASSET_ID = '587295b6-e0d0-4862-b7db-b905afd7c514';
+const PROPERTY_ID = '16d45cb7-bb8b-4a1e-8256-55276f261d93';
+
+export default {
+  title: 'Status',
+  component: Status,
+  argTypes: {
+    assetId: { control: { type: 'string' }, defaultValue: ASSET_ID },
+    propertyId: { control: { type: 'string' }, defaultValue: PROPERTY_ID },
+    accessKeyId: { control: { type: 'string' } },
+    secretAccessKey: { control: { type: 'string' } },
+    sessionToken: { control: { type: 'string' } },
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Status>;
+
+const { query } = initialize({
+  awsCredentials: {
+    accessKeyId: 'xxxx',
+    secretAccessKey: 'xxxx',
+    sessionToken: 'xxxx',
+  },
+});
+
+export const SiteWiseKpi: ComponentStory<typeof Status> = () => (
+  <Status
+    viewport={{ duration: '5m' }}
+    query={query.timeSeriesData({
+      assets: [
+        {
+          assetId: ASSET_ID,
+          properties: [
+            {
+              propertyId: PROPERTY_ID,
+            },
+          ],
+        },
+      ],
+    })}
+  />
+);

--- a/packages/react-components/stories/status/statusBase.stories.tsx
+++ b/packages/react-components/stories/status/statusBase.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { StatusBase } from '../../src/status/statusBase';
+import { DEFAULT_STATUS_SETTINGS } from '../../src/status/constants';
+
+export default {
+  title: 'Status',
+  component: StatusBase,
+  argTypes: {
+    name: { control: { type: 'string' }, defaultValue: 'Windmill turbine #3' },
+    unit: { control: { type: 'string' }, defaultValue: 'mph' },
+    showName: { control: { type: 'boolean' }, defaultValue: DEFAULT_STATUS_SETTINGS.showName },
+    showUnit: { control: { type: 'boolean' }, defaultValue: DEFAULT_STATUS_SETTINGS.showUnit },
+    showValue: { control: { type: 'boolean' }, defaultValue: DEFAULT_STATUS_SETTINGS.showValue },
+    showTimestamp: { control: { type: 'boolean' }, defaultValue: DEFAULT_STATUS_SETTINGS.showTimestamp },
+    fontSize: { control: { type: 'number' }, defaultValue: DEFAULT_STATUS_SETTINGS.fontSize },
+    propertyPoint: { control: { type: 'object' }, defaultValue: { x: 123123213, y: 100 } },
+    alarmPoint: { control: { type: 'object' }, defaultValue: { x: 123123213, y: 'WARNING' } },
+    containerWidth: { control: { type: 'number' }, defaultValue: 200 },
+    containerHeight: { control: { type: 'number' }, defaultValue: 200 },
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof StatusBase>;
+
+export const Main: ComponentStory<typeof StatusBase> = ({
+  showName,
+  showValue,
+  showUnit,
+  showTimestamp,
+  fontSize,
+  secondaryFontSize,
+  containerWidth,
+  containerHeight,
+  ...args
+}) => (
+  <div style={{ width: `${containerWidth}px`, height: `${containerHeight}px` }}>
+    <StatusBase {...args} settings={{ showName, showValue, showUnit, showTimestamp, fontSize, secondaryFontSize }} />
+  </div>
+);


### PR DESCRIPTION
## Overview
Ports over the core parts of the `<Status />` widget, both the visualization portion of the component, and the bindings to IoT App Kit.

Going to follow up with tests after confirming with UX on all the behaviors/configurations.

![Screen Shot 2023-02-06 at 3 52 30 PM](https://user-images.githubusercontent.com/77755322/217113179-de8a7cad-7054-4fb3-abe1-bd1787c5a1a2.png)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
