### PR TITLE
feat(dashboard): ClientContext and initial resource explorer alarms support

### DIFF
--- a/packages/dashboard/src/components/dashboard/clientContext.ts
+++ b/packages/dashboard/src/components/dashboard/clientContext.ts
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+export const ClientContext = createContext<IoTSiteWiseClient | undefined>(undefined);

--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -15,6 +15,7 @@ describe('Dashboard', () => {
         widgets: [],
         viewport: { duration: '5m' },
       },
+      client: undefined,
     };
 
     act(() => {

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -13,33 +13,40 @@ import { DashboardState, SaveableDashboard } from '../../store/state';
 import { PickRequiredOptional, RecursivePartial } from '../../types';
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 import { DashboardMessages, DefaultDashboardMessages } from '../../messages';
+import { ClientContext } from './clientContext';
 
 import '@cloudscape-design/global-styles/index.css';
 import '../../styles/variables.css';
+import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 
 export type IotDashboardProps = {
   messageOverrides?: RecursivePartial<DashboardMessages>;
   query?: SiteWiseQuery;
   onSave?: (dashboard: SaveableDashboard) => void;
+  client?: IoTSiteWiseClient;
 } & PickRequiredOptional<DashboardState, 'dashboardConfiguration', 'readOnly' | 'grid'>;
 
-const Dashboard: React.FC<IotDashboardProps> = ({ messageOverrides, query, onSave, ...dashboardState }) => (
-  <Provider store={configureDashboardStore({ ...dashboardState })}>
-    <DndProvider
-      backend={TouchBackend}
-      options={{
-        enableMouseEvents: true,
-        enableKeyboardEvents: true,
-      }}
-    >
-      <InternalDashboard
-        query={query}
-        onSave={onSave}
-        messageOverrides={merge(messageOverrides, DefaultDashboardMessages)}
-      />
-      <WebglContext />
-    </DndProvider>
-  </Provider>
-);
+const Dashboard: React.FC<IotDashboardProps> = ({ messageOverrides, query, onSave, client, ...dashboardState }) => {
+  return (
+    <ClientContext.Provider value={client}>
+      <Provider store={configureDashboardStore({ ...dashboardState })}>
+        <DndProvider
+          backend={TouchBackend}
+          options={{
+            enableMouseEvents: true,
+            enableKeyboardEvents: true,
+          }}
+        >
+          <InternalDashboard
+            query={query}
+            onSave={onSave}
+            messageOverrides={merge(messageOverrides, DefaultDashboardMessages)}
+          />
+          <WebglContext />
+        </DndProvider>
+      </Provider>
+    </ClientContext.Provider>
+  );
+};
 
 export default Dashboard;

--- a/packages/dashboard/src/components/dragLayer/itemTypes.ts
+++ b/packages/dashboard/src/components/dragLayer/itemTypes.ts
@@ -2,4 +2,5 @@ export enum ItemTypes {
   Grid = 'Grid',
   Component = 'Component',
   ResourceExplorerAssetProperty = 'ResourceExplorerAssetProperty',
+  ResourceExplorerAlarm = 'ResourceExplorerAlarm',
 }

--- a/packages/dashboard/src/components/resourceExplorer/components/panel.test.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/panel.test.tsx
@@ -3,13 +3,20 @@ import { act, render, fireEvent } from '@testing-library/react';
 import { wrapWithTestBackend } from 'react-dnd-test-utils';
 import { IotResourceExplorerPanel } from './panel';
 import { DashboardMessages } from '../../../messages';
+import { ExtendedPanelAssetSummary } from '..';
 
 const mockMessageOverrides = { resourceExplorer: { panelEmptyLabel: 'Empty panel' } } as DashboardMessages;
+
 const mockPanelItems = [
   { id: 'Asset1', name: 'Asset 1', isAsset: true, isAssetProperty: false },
   { id: 'Asset2', name: 'Asset 2', isAsset: true, isAssetProperty: false },
   { id: 'AssetProperty1', name: 'Asset Property 1', isAsset: false, isAssetProperty: true },
 ];
+
+const mockAlarms = [
+  { id: 'Alarm1', name: 'Alarm 1', assetCompositeModels: [{ type: 'AWS/ALARM' }] } as ExtendedPanelAssetSummary,
+];
+
 const mockHandlePanelItemClick = jest.fn();
 
 const [PanelContext] = wrapWithTestBackend(IotResourceExplorerPanel);
@@ -18,6 +25,7 @@ describe('IotResourceExplorerPanel', () => {
   it('renders empty panel message when no items passed', () => {
     const { getByText } = render(
       <PanelContext
+        alarms={[]}
         panelItems={[]}
         handlePanelItemClick={mockHandlePanelItemClick}
         messageOverrides={mockMessageOverrides}
@@ -30,6 +38,7 @@ describe('IotResourceExplorerPanel', () => {
   it('renders panel items and calls handlePanelItemClick when an asset panel item is clicked', () => {
     const { getByText } = render(
       <PanelContext
+        alarms={mockAlarms}
         panelItems={mockPanelItems}
         handlePanelItemClick={mockHandlePanelItemClick}
         messageOverrides={mockMessageOverrides}
@@ -39,6 +48,7 @@ describe('IotResourceExplorerPanel', () => {
     expect(getByText('Asset 1')).toBeTruthy();
     expect(getByText('Asset 2')).toBeTruthy();
     expect(getByText('Asset Property 1')).toBeTruthy();
+    expect(getByText('Alarm 1')).toBeTruthy();
 
     act(() => {
       fireEvent.click(getByText('Asset 1'));

--- a/packages/dashboard/src/components/resourceExplorer/components/panel.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/panel.tsx
@@ -5,7 +5,7 @@ import Box from '@cloudscape-design/components/box';
 import Icon from '@cloudscape-design/components/icon';
 import Link from '@cloudscape-design/components/link';
 import { ItemTypes } from '../../dragLayer/itemTypes';
-import { ExtendedPanelAssetSummary } from '..';
+import { ExtendedPanelAssetSummary, isAlarm } from '..';
 
 import './style.css';
 import { DashboardMessages } from '../../../messages';
@@ -43,12 +43,14 @@ const PanelAssetPropertyDragHandle = ({ item }: { item: ExtendedPanelAssetSummar
 
 export interface IotResourceExplorerPanelProps {
   panelItems: ExtendedPanelAssetSummary[];
+  alarms: ExtendedPanelAssetSummary[];
   handlePanelItemClick: (item: ExtendedPanelAssetSummary) => void;
   messageOverrides: DashboardMessages;
 }
 
 export const IotResourceExplorerPanel: React.FC<IotResourceExplorerPanelProps> = ({
   panelItems,
+  alarms,
   handlePanelItemClick,
   messageOverrides,
 }) => {
@@ -59,16 +61,16 @@ export const IotResourceExplorerPanel: React.FC<IotResourceExplorerPanelProps> =
 
   const PanelCell = ({ item }: { item: ExtendedPanelAssetSummary }) => {
     if (item?.isHeader) {
-      return <Box variant="awsui-key-label">{item.name}</Box>;
+      return <Box variant="awsui-key-label">{item?.name || ''}</Box>;
     }
 
-    if (item?.isAssetProperty) {
-      return <span>{item.name}</span>;
+    if (isAlarm(item) || item?.isAssetProperty) {
+      return <span>{item?.name || ''}</span>;
     }
 
     return (
       <Link href="#" onFollow={(e) => handlePanelItemClickInner(e, item)}>
-        {item.name}
+        {item?.name || ''}
       </Link>
     );
   };
@@ -78,7 +80,8 @@ export const IotResourceExplorerPanel: React.FC<IotResourceExplorerPanelProps> =
       id: 'drag',
       header: null,
       width: '45px',
-      cell: (item: ExtendedPanelAssetSummary) => item?.isAssetProperty && <PanelAssetPropertyDragHandle item={item} />,
+      cell: (item: ExtendedPanelAssetSummary) =>
+        (item?.isAssetProperty || isAlarm(item)) && <PanelAssetPropertyDragHandle item={item} />,
     },
     {
       id: 'variable',
@@ -92,7 +95,7 @@ export const IotResourceExplorerPanel: React.FC<IotResourceExplorerPanelProps> =
     <Table
       variant="embedded"
       columnDefinitions={tableColumnDefinitions}
-      items={panelItems || []}
+      items={[...panelItems, ...alarms] || []}
       trackBy="name"
       empty={<PanelEmpty messageOverrides={messageOverrides} />}
     />

--- a/packages/dashboard/src/components/resourceExplorer/describeCurrentAsset.ts
+++ b/packages/dashboard/src/components/resourceExplorer/describeCurrentAsset.ts
@@ -1,0 +1,41 @@
+import { IoTSiteWiseClient, DescribeAssetCommand, DescribeAssetResponse } from '@aws-sdk/client-iotsitewise';
+import { HIERARCHY_ROOT_ID } from '.';
+
+const blank = {
+  assetId: undefined,
+  assetArn: undefined,
+  assetName: undefined,
+  assetModelId: undefined,
+  assetProperties: [],
+  assetHierarchies: [],
+  assetCompositeModels: [],
+  assetCreationDate: undefined,
+  assetLastUpdateDate: undefined,
+  assetStatus: undefined,
+  assetDescription: undefined,
+} as DescribeAssetResponse;
+
+export const sendCommand = (client: IoTSiteWiseClient, assetId: string) =>
+  client.send(new DescribeAssetCommand({ assetId }));
+
+export const describeCurrentAsset = async (currentBranchId: string, client: IoTSiteWiseClient | undefined) => {
+  if (!client) return blank;
+
+  const describeAsset = async (assetId: string) => {
+    const response = await sendCommand(client, assetId);
+    return response;
+  };
+
+  // Do not attempt to retrieve properties for the root asset
+  if (currentBranchId === HIERARCHY_ROOT_ID) return blank;
+
+  try {
+    // Attempt to describeAsset. Return nothing if this fails.
+    const asset = await describeAsset(currentBranchId);
+    if (!asset?.assetId || !asset?.assetProperties) return blank;
+    return asset;
+  } catch (err) {
+    console.log(err);
+    return blank;
+  }
+};

--- a/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.test.ts
+++ b/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.test.ts
@@ -1,102 +1,102 @@
 import { getCurrentAssetProperties } from './getCurrentAssetProperties';
-import { ExtendedPanelAssetSummary } from '.';
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { DashboardMessages } from '../../messages';
-import { getEnvCredentials } from '../../../testing/getEnvCredentials';
 
-jest.mock('@aws-sdk/client-iotsitewise');
-jest.mock('../../../testing/getEnvCredentials');
-const mockGetEnvCredentials = getEnvCredentials as jest.MockedFunction<typeof getEnvCredentials>;
+const listAssetPropertiesResponse = {
+  assetPropertySummaries: [
+    { id: 'Asset Property 1', alias: 'Temperature' },
+    { id: 'Asset Property 2', alias: 'Pressure' },
+  ],
+};
 
-mockGetEnvCredentials.mockResolvedValue({
-  accessKeyId: 'accessKeyId',
-  secretAccessKey: 'secretAccessKey',
-} as never);
+const getCurrentAssetPropertiesResponse = [
+  {
+    id: 'Asset Properties',
+    name: 'Asset Properties',
+    isHeader: true,
+    isAssetProperty: false,
+    queryAssetsParam: [],
+  },
+  {
+    id: 'Asset Property 1',
+    name: 'Temperature',
+    isAssetProperty: true,
+    queryAssetsParam: [
+      {
+        assetId: 'Asset 1',
+        properties: [
+          {
+            propertyId: 'Asset Property 1',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'Asset Property 2',
+    name: 'Pressure',
+    isAssetProperty: true,
+    queryAssetsParam: [
+      {
+        assetId: 'Asset 1',
+        properties: [
+          {
+            propertyId: 'Asset Property 2',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const messageOverrides = {
+  resourceExplorer: {
+    assetPropertiesHeader: 'Asset Properties',
+  },
+} as DashboardMessages;
 
 describe('getCurrentAssetProperties', () => {
-  const messageOverrides = {
-    resourceExplorer: {
-      assetPropertiesHeader: 'Asset Properties',
-    },
-  } as DashboardMessages;
-
-  beforeEach(() => {
-    (IoTSiteWiseClient.prototype.send as jest.Mock).mockResolvedValue({
-      assetPropertySummaries: [
-        { id: 'Asset Property 1', alias: 'Temperature' },
-        { id: 'Asset Property 2', alias: 'Pressure' },
-      ],
-    });
-  });
-
   it('should return an array of asset properties', async () => {
-    const result = await getCurrentAssetProperties('Asset 1', messageOverrides);
-    expect(result).toEqual([
-      {
-        id: 'Asset Properties',
-        name: 'Asset Properties',
-        isHeader: true,
-        isAssetProperty: false,
-        queryAssetsParam: [],
-      },
-      {
-        id: 'Asset Property 1',
-        name: 'Temperature',
-        isAssetProperty: true,
-        queryAssetsParam: [
-          {
-            assetId: 'Asset 1',
-            properties: [
-              {
-                propertyId: 'Asset Property 1',
-              },
-            ],
-          },
-        ],
-      },
-      {
-        id: 'Asset Property 2',
-        name: 'Pressure',
-        isAssetProperty: true,
-        queryAssetsParam: [
-          {
-            assetId: 'Asset 1',
-            properties: [
-              {
-                propertyId: 'Asset Property 2',
-              },
-            ],
-          },
-        ],
-      },
-    ] as ExtendedPanelAssetSummary[]);
+    const client: unknown = {
+      send: async () => listAssetPropertiesResponse,
+    };
+    const result = await getCurrentAssetProperties('Asset 1', messageOverrides, client as IoTSiteWiseClient);
+    expect(result).toEqual(getCurrentAssetPropertiesResponse);
   });
 
   it('should return empty array when currentBranchId is hierarchy root id', async () => {
-    const result = await getCurrentAssetProperties('HIERARCHY_ROOT_ID', messageOverrides);
+    const client: unknown = {
+      send: async () => listAssetPropertiesResponse,
+    };
+    const result = await getCurrentAssetProperties('HIERARCHY_ROOT_ID', messageOverrides, client as IoTSiteWiseClient);
     expect(result).toEqual([]);
   });
 
-  it('should return empty array when assetProperties is not found', async () => {
-    (IoTSiteWiseClient.prototype.send as jest.Mock).mockResolvedValue({});
-    const result = await getCurrentAssetProperties('Asset 1', messageOverrides);
+  it('should return empty array when assetPropertieSummaries is not found', async () => {
+    const client: unknown = {
+      send: async () => ({ foo: 'bar' }),
+    };
+    const result = await getCurrentAssetProperties('Asset 1', messageOverrides, client as IoTSiteWiseClient);
     expect(result).toEqual([]);
   });
 
-  it('should return empty array when there is no aliased properties', async () => {
-    (IoTSiteWiseClient.prototype.send as jest.Mock).mockResolvedValue({
-      assetPropertySummaries: [
-        { id: 'Asset Property 1', alias: null },
-        { id: 'Asset Property 2', alias: null },
-      ],
-    });
-    const result = await getCurrentAssetProperties('Asset 1', messageOverrides);
+  it('should return empty array when there are no aliased properties', async () => {
+    const client: unknown = {
+      send: async () => ({
+        assetPropertySummaries: [{ id: 'Asset Property 1' }, { id: 'Asset Property 2' }],
+      }),
+    };
+    const result = await getCurrentAssetProperties('Asset 1', messageOverrides, client as IoTSiteWiseClient);
     expect(result).toEqual([]);
   });
 
   it('should return empty array when there is an error', async () => {
-    (IoTSiteWiseClient.prototype.send as jest.Mock).mockRejectedValue(new Error('Test error'));
-    const result = await getCurrentAssetProperties('Asset 1', messageOverrides);
+    const client: unknown = {
+      send: async () => {
+        throw new Error('Something went wrong!');
+      },
+    };
+    const result = await getCurrentAssetProperties('Asset 1', messageOverrides, client as IoTSiteWiseClient);
     expect(result).toEqual([]);
   });
 });

--- a/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.ts
+++ b/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.ts
@@ -1,11 +1,18 @@
 import { AssetPropertySummary, IoTSiteWiseClient, ListAssetPropertiesCommand } from '@aws-sdk/client-iotsitewise';
-import { getEnvCredentials } from '../../../testing/getEnvCredentials';
 import { HIERARCHY_ROOT_ID } from '.';
-import { REGION } from '../../../testing/siteWiseQueries';
 import { ExtendedPanelAssetSummary } from '.';
 import { DashboardMessages } from '../../messages';
 
-export const getCurrentAssetProperties = async (currentBranchId: string, messageOverrides: DashboardMessages) => {
+export const sendCommand = (client: IoTSiteWiseClient, assetId: string) =>
+  client.send(new ListAssetPropertiesCommand({ assetId }));
+
+export const getCurrentAssetProperties = async (
+  currentBranchId: string,
+  messageOverrides: DashboardMessages,
+  client: IoTSiteWiseClient | undefined
+) => {
+  if (!client) return [];
+
   const assetPropertiesHeaderItem = {
     id: messageOverrides.resourceExplorer.assetPropertiesHeader,
     name: messageOverrides.resourceExplorer.assetPropertiesHeader,
@@ -14,20 +21,8 @@ export const getCurrentAssetProperties = async (currentBranchId: string, message
     queryAssetsParam: [],
   };
 
-  let client: IoTSiteWiseClient;
-  try {
-    client = new IoTSiteWiseClient({
-      region: REGION,
-      credentials: getEnvCredentials(),
-    });
-  } catch (e) {
-    console.log(e);
-    return [];
-  }
-
   const listAssetProperties = async (assetId: string) => {
-    const command = new ListAssetPropertiesCommand({ assetId });
-    const response = await client.send(command);
+    const response = await sendCommand(client, assetId);
     return response;
   };
 

--- a/packages/dashboard/src/messages.ts
+++ b/packages/dashboard/src/messages.ts
@@ -8,6 +8,7 @@ export type ResourceExplorerMessages = {
   rootAssetsHeader: string;
   childAssetsHeader: string;
   assetPropertiesHeader: string;
+  alarmsHeader: string;
   searchQueryHeader: string;
   searchAriaLabel: string;
   searchPlaceholder: string;
@@ -214,6 +215,7 @@ export const DefaultDashboardMessages: DashboardMessages = {
     rootAssetsHeader: 'Root Assets',
     childAssetsHeader: 'Child Assets',
     assetPropertiesHeader: 'Asset Properties',
+    alarmsHeader: 'Alarms',
     searchQueryHeader: 'Search Query',
     searchAriaLabel: 'Search assets, properties, and alarms',
     searchPlaceholder: 'Enter search term',

--- a/packages/dashboard/stories/IotDashboard/IotDashboard.stories.tsx
+++ b/packages/dashboard/stories/IotDashboard/IotDashboard.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import IotDashboard, { IotDashboardProps } from '../../src/components/dashboard';
-import { query } from '../../testing/siteWiseQueries';
+import { query, REGION } from '../../testing/siteWiseQueries';
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { getEnvCredentials } from '../../testing/getEnvCredentials';
 import { Client } from '../../src/util/IotSitewiseClient';
@@ -28,14 +28,19 @@ export default {
   },
 } as ComponentMeta<typeof IotDashboard>;
 
-const client = new IoTSiteWiseClient({
-  region: process.env.REGION || 'us-west-2',
-  credentials: getEnvCredentials(),
-});
-
-Client.setInstance(client);
+let client: IoTSiteWiseClient | undefined;
+try {
+  client = new IoTSiteWiseClient({
+    region: REGION,
+    credentials: getEnvCredentials(),
+  });
+  Client.setInstance(client);
+} catch (e) {
+  console.log(e);
+}
 
 const args = {
+  client,
   dashboardConfiguration: {
     widgets: [],
     viewport: { duration: '5m' },
@@ -50,6 +55,7 @@ const args = {
 export const Main: ComponentStory<typeof IotDashboard> = () => <IotDashboard {...getDashboardProps(args)} />;
 
 const readOnlyArgs = {
+  client,
   grid: {
     height: 100,
     width: 100,
@@ -70,6 +76,16 @@ const readOnlyArgs = {
   readOnly: true,
 } as IotDashboardProps;
 
-export const ReadOnly: ComponentStory<typeof IotDashboard> = () => (
-  <IotDashboard {...getDashboardProps(readOnlyArgs)} />
-);
+export const ReadOnly: ComponentStory<typeof IotDashboard> = () => {
+  let client = undefined as IoTSiteWiseClient | undefined;
+  try {
+    client = new IoTSiteWiseClient({
+      region: REGION,
+      credentials: getEnvCredentials(),
+    });
+    Client.setInstance(client);
+  } catch (e) {
+    console.log(e);
+  }
+  return <IotDashboard {...getDashboardProps(readOnlyArgs)} />;
+};


### PR DESCRIPTION
![Screenshot 2023-02-07 at 10 46 16 AM](https://user-images.githubusercontent.com/15032398/217337494-0f5e2661-8e83-4cbe-9ecf-037a5e648dc6.png)

## Overview
This PR:

1. Wraps the dashboard in a ClientContext that allows us to useContext to access the IoTSiteWiseClient passed into the dashboard anywhere. (The Client.getInstance() pattern doesn't seem to work; looking at it, I think we're trying to do something there that requires a React Context -- as written, getInstance() should return undefined when imported in places other than where the Client was instantiated.)

2. Gets alarms with describeAsset and displays them in sidebar. When we are ready to receive dropped alarms on widgets, will be simple to update this to achieve that.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
