### PR TITLE
dashboard: describeCurrentAsset test

### DIFF
--- a/packages/dashboard/src/components/resourceExplorer/describeCurrentAsset.test.ts
+++ b/packages/dashboard/src/components/resourceExplorer/describeCurrentAsset.test.ts
@@ -1,0 +1,38 @@
+import { IoTSiteWiseClient, DescribeAssetResponse } from '@aws-sdk/client-iotsitewise';
+import { describeCurrentAsset, blank } from './describeCurrentAsset';
+import { HIERARCHY_ROOT_ID } from '.';
+
+const fakeAssetId = 'fake-asset-id';
+
+const client = {
+  send: () => ({ assetId: fakeAssetId } as DescribeAssetResponse),
+} as unknown as IoTSiteWiseClient;
+
+const response = JSON.parse(JSON.stringify(blank)); // Copy blank
+response.assetId = fakeAssetId;
+
+describe('describeCurrentAsset', () => {
+  it('returns a blank asset if client is undefined', async () => {
+    const result = await describeCurrentAsset(HIERARCHY_ROOT_ID, undefined);
+    expect(result).toEqual(blank);
+  });
+
+  it('returns a blank asset if currentBranchId is HIERARCHY_ROOT_ID', async () => {
+    const result = await describeCurrentAsset(HIERARCHY_ROOT_ID, client);
+    expect(result).toEqual(blank);
+  });
+
+  it('returns a blank asset on error', async () => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    client.send = jest.fn().mockImplementation(() => {
+      throw new Error('Error');
+    });
+    const result = await describeCurrentAsset(fakeAssetId, client);
+    expect(result).toEqual(blank);
+  });
+
+  it('returns the response from describeAsset', async () => {
+    const result = await describeCurrentAsset(fakeAssetId, client);
+    expect(result).toEqual(blank as DescribeAssetResponse);
+  });
+});

--- a/packages/dashboard/src/components/resourceExplorer/describeCurrentAsset.ts
+++ b/packages/dashboard/src/components/resourceExplorer/describeCurrentAsset.ts
@@ -1,7 +1,7 @@
 import { IoTSiteWiseClient, DescribeAssetCommand, DescribeAssetResponse } from '@aws-sdk/client-iotsitewise';
 import { HIERARCHY_ROOT_ID } from '.';
 
-const blank = {
+export const blank = {
   assetId: undefined,
   assetArn: undefined,
   assetName: undefined,

--- a/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.test.ts
+++ b/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.test.ts
@@ -91,6 +91,7 @@ describe('getCurrentAssetProperties', () => {
   });
 
   it('should return empty array when there is an error', async () => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
     const client: unknown = {
       send: async () => {
         throw new Error('Something went wrong!');


### PR DESCRIPTION
## Overview
- Adds test for describeCurrentAsset
- Silences another test that was leaking a log into the jest output

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
