### PR TITLE
refactor(dashboard): add DashboardMessageContext and useMessage hook.

### DIFF
--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -12,7 +12,7 @@ import { configureDashboardStore } from '../../store';
 import { DashboardState, SaveableDashboard } from '../../store/state';
 import { PickRequiredOptional, RecursivePartial } from '../../types';
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
-import { DashboardMessages, DefaultDashboardMessages } from '../../messages';
+import { DashboardMessageContext, DashboardMessages, DefaultDashboardMessages } from '../../messages';
 import { ClientContext } from './clientContext';
 
 import '@cloudscape-design/global-styles/index.css';
@@ -29,22 +29,24 @@ export type IotDashboardProps = {
 const Dashboard: React.FC<IotDashboardProps> = ({ messageOverrides, query, onSave, client, ...dashboardState }) => {
   return (
     <ClientContext.Provider value={client}>
-      <Provider store={configureDashboardStore({ ...dashboardState }, client)}>
-        <DndProvider
-          backend={TouchBackend}
-          options={{
-            enableMouseEvents: true,
-            enableKeyboardEvents: true,
-          }}
-        >
-          <InternalDashboard
-            query={query}
-            onSave={onSave}
-            messageOverrides={merge(messageOverrides, DefaultDashboardMessages)}
-          />
-          <WebglContext />
-        </DndProvider>
-      </Provider>
+      <DashboardMessageContext.Provider value={merge(messageOverrides, DefaultDashboardMessages)}>
+        <Provider store={configureDashboardStore({ ...dashboardState })}>
+          <DndProvider
+            backend={TouchBackend}
+            options={{
+              enableMouseEvents: true,
+              enableKeyboardEvents: true,
+            }}
+          >
+            <InternalDashboard
+              query={query}
+              onSave={onSave}
+              messageOverrides={merge(messageOverrides, DefaultDashboardMessages)}
+            />
+            <WebglContext />
+          </DndProvider>
+        </Provider>
+      </DashboardMessageContext.Provider>
     </ClientContext.Provider>
   );
 };

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -441,7 +441,7 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
               </Grid>
             </div>
           }
-          rightPane={<SidePanel messageOverrides={messageOverrides} />}
+          rightPane={<SidePanel />}
         />
       </div>
     </div>

--- a/packages/dashboard/src/components/sidePanel/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/index.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { Header, SpaceBetween } from '@cloudscape-design/components';
 import { useSelector } from 'react-redux';
 import { DashboardState } from '../../store/state';
-import { DashboardMessages } from '../../messages';
+import { useMessage } from '../../messages';
 import { AppKitComponentTags } from '../../types';
 import TextSettings from './sections/textSettingSection/text';
 import LinkSettings from './sections/textSettingSection/link';
@@ -11,28 +11,29 @@ import AxisSetting from './sections/axisSettingSection';
 import ThresholdsSection from './sections/thresholdsSection/thresholdsSection';
 import PropertiesAlarmsSection from './sections/propertiesAlarmSection';
 import './index.scss';
-const SidePanel: FC<{ messageOverrides: DashboardMessages }> = ({ messageOverrides }) => {
+
+const SidePanel: FC = () => {
+  const { defaultMessage, header } = useMessage((message) => message.sidePanel);
   const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
   if (selectedWidgets.length !== 1) {
-    return <div className="iot-side-panel">{messageOverrides.sidePanel.defaultMessage}</div>;
+    return <div className="iot-side-panel">{defaultMessage}</div>;
   }
 
   const selectedWidget = selectedWidgets[0];
   const isAppKitWidget = AppKitComponentTags.find((tag) => tag === selectedWidget.componentTag);
   const isTextWidget = selectedWidget.componentTag === 'text';
-
   return (
     <div className="iot-side-panel">
-      <Header variant="h3">{messageOverrides.sidePanel.header}</Header>
+      <Header variant="h3">{header}</Header>
       <SpaceBetween size={'xs'} direction={'vertical'}>
-        <BaseSettings messageOverrides={messageOverrides} />
-        {isTextWidget && <TextSettings messageOverride={messageOverrides} />}
-        {isTextWidget && <LinkSettings messageOverride={messageOverrides} />}
+        <BaseSettings />
+        {isTextWidget && <TextSettings />}
+        {isTextWidget && <LinkSettings />}
         {isAppKitWidget && (
           <>
-            <PropertiesAlarmsSection messageOverrides={messageOverrides} />
-            <ThresholdsSection messageOverrides={messageOverrides} />
-            <AxisSetting messageOverrides={messageOverrides} />
+            <PropertiesAlarmsSection />
+            <ThresholdsSection />
+            <AxisSetting />
           </>
         )}
       </SpaceBetween>

--- a/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.spec.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { configureDashboardStore } from '../../../../store';
 import { DefaultDashboardMessages } from '../../../../messages';
 import { render } from '@testing-library/react';
-import React from 'react';
+import * as React from 'react';
 import AxisSetting from './index';
 
 const widget: Widget = {
@@ -22,7 +22,7 @@ const state: Partial<DashboardState> = {
 
 const TestComponent = () => (
   <Provider store={configureDashboardStore(state)}>
-    <AxisSetting messageOverrides={DefaultDashboardMessages} />
+    <AxisSetting />
   </Provider>
 );
 

--- a/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { DashboardMessages } from '../../../../messages';
+import { useMessage } from '../../../../messages';
 import {
   ExpandableSection,
   Grid,
@@ -23,11 +23,8 @@ const defaultAxisSetting: Axis.Options = {
   showY: true,
   showX: true,
 };
-const AxisSetting: FC<{ messageOverrides: DashboardMessages }> = ({
-  messageOverrides: {
-    sidePanel: { axisMessages },
-  },
-}) => {
+const AxisSetting: FC = () => {
+  const { axisMessages } = useMessage((message) => message.sidePanel);
   const [axisSetting = defaultAxisSetting, updateAxisSettings] = useAppKitWidgetInput('axis');
 
   const toggleShowX: NonCancelableEventHandler<ToggleProps.ChangeDetail> = ({ detail: { checked } }) => {
@@ -60,7 +57,7 @@ const AxisSetting: FC<{ messageOverrides: DashboardMessages }> = ({
             {axisMessages.toggleXLabel}
           </Toggle>
           <Toggle checked={!!axisSetting.showY} onChange={toggleShowY} data-test-id="axis-setting-y-toggle">
-            {axisMessages.toggleXLabel}
+            {axisMessages.toggleYLabel}
           </Toggle>
         </Grid>
         <Grid disableGutters gridDefinition={[{ colspan: 2 }, { colspan: 10 }]}>

--- a/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.spec.tsx
@@ -3,10 +3,9 @@ import { MOCK_KPI_WIDGET } from '../../../../../testing/mocks';
 import { DashboardState } from '../../../../store/state';
 import { Provider } from 'react-redux';
 import { configureDashboardStore } from '../../../../store';
-import { DefaultDashboardMessages } from '../../../../messages';
-import React from 'react';
 import { BaseSettings } from './index';
 import { render } from '@testing-library/react';
+import * as React from 'react';
 
 const widget: Widget = {
   ...MOCK_KPI_WIDGET,
@@ -22,7 +21,7 @@ const state: Partial<DashboardState> = {
 
 const TestBaseSettingSection = () => (
   <Provider store={configureDashboardStore(state)}>
-    <BaseSettings messageOverrides={DefaultDashboardMessages} />
+    <BaseSettings />
   </Provider>
 );
 

--- a/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.tsx
@@ -1,15 +1,12 @@
 import React, { FC } from 'react';
-import { DashboardMessages } from '../../../../messages';
+import { useMessage } from '../../../../messages';
 import { useInput } from '../../utils';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import { BaseChangeDetail } from '@cloudscape-design/components/input/interfaces';
 import { ExpandableSection, Grid, Input } from '@cloudscape-design/components';
 
-export const BaseSettings: FC<{ messageOverrides: DashboardMessages }> = ({
-  messageOverrides: {
-    sidePanel: { baseSettings },
-  },
-}) => {
+export const BaseSettings: FC = () => {
+  const baseSettings = useMessage((message) => message.sidePanel.baseSettings);
   const [x, updateX] = useInput('x');
   const [y, updateY] = useInput('y');
   const onXChange: NonCancelableEventHandler<BaseChangeDetail> = ({ detail: { value } }) => updateX(parseInt(value));

--- a/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.test.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.test.tsx
@@ -9,7 +9,6 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { MOCK_KPI_WIDGET } from '../../../../../testing/mocks';
 import { AppKitWidget } from '../../../../types';
 import PropertiesAlarmsSection from './index';
-import { DefaultDashboardMessages } from '../../../../messages';
 
 const mockOnDeleteAssetQuery = jest.fn();
 const MockAssetQuery: AssetQuery = {
@@ -62,7 +61,6 @@ describe('PropertyComponent', () => {
       <Provider store={configureDashboardStore(state)}>
         {MockAssetQuery.properties.map(({ propertyId, refId }) => (
           <PropertyComponent
-            messageOverrides={DefaultDashboardMessages}
             key={propertyId}
             assetId={MockAssetQuery.assetId}
             propertyId={propertyId}
@@ -117,7 +115,7 @@ describe('PropertyComponent', () => {
 describe('propertiesSectionComponent', () => {
   const TestSection = () => (
     <Provider store={configureDashboardStore(state)}>
-      <PropertiesAlarmsSection messageOverrides={DefaultDashboardMessages} />
+      <PropertiesAlarmsSection />
     </Provider>
   );
 

--- a/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.tsx
@@ -8,12 +8,8 @@ import { useInput } from '../../utils';
 import { onUpdateAssetQueryAction } from '../../../../store/actions/updateAssetQuery';
 import { AppKitWidget, Widget } from '../../../../types';
 import { PropertyComponent } from './propertyComponent';
-import { DashboardMessages } from '../../../../messages';
 
-export type PropertiesAlarmsSectionProps = {
-  messageOverrides: DashboardMessages;
-};
-const PropertiesAlarmsSection: FC<PropertiesAlarmsSectionProps> = ({ messageOverrides }) => {
+const PropertiesAlarmsSection: FC = () => {
   const [assetQueries] = useInput<AssetQuery[]>('assets');
 
   const selectedWidget = useSelector<DashboardState, Widget>((state) => state.selectedWidgets[0]);
@@ -43,7 +39,6 @@ const PropertiesAlarmsSection: FC<PropertiesAlarmsSectionProps> = ({ messageOver
   const components = assetQueries?.flatMap(({ assetId, properties }) =>
     properties.map(({ propertyId, refId = propertyId }) => (
       <PropertyComponent
-        messageOverrides={messageOverrides}
         key={`${assetId}-${propertyId}`}
         propertyId={propertyId}
         assetId={assetId}

--- a/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/propertyComponent.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/propertyComponent.tsx
@@ -4,7 +4,7 @@ import { DashboardState } from '../../../../store/state';
 import { useInput } from '../../utils';
 import { StyleSettingsMap } from '@iot-app-kit/core';
 import { Button, Grid, SpaceBetween } from '@cloudscape-design/components';
-import { DashboardMessages } from '../../../../messages';
+import { useMessage } from '../../../../messages';
 import ColorPicker from '../../shared/colorPicker';
 
 export type PropertyComponentProps = {
@@ -12,20 +12,11 @@ export type PropertyComponentProps = {
   propertyId: string;
   refId: string;
   onDeleteAssetQuery: () => void;
-  messageOverrides: DashboardMessages;
 };
 
-export const PropertyComponent: FC<PropertyComponentProps> = ({
-  assetId,
-  propertyId,
-  refId,
-  onDeleteAssetQuery,
-  messageOverrides: {
-    sidePanel: {
-      propertySection: { propertyComponent },
-    },
-  },
-}) => {
+export const PropertyComponent: FC<PropertyComponentProps> = ({ assetId, propertyId, refId, onDeleteAssetQuery }) => {
+  const { propertyComponent } = useMessage((message) => message.sidePanel.propertySection);
+
   const assetDescription = useSelector((state: DashboardState) => state.assetsDescriptionMap)?.[assetId];
   const assetProperties = assetDescription?.assetProperties;
   const assetProperty = assetProperties?.find((prop) => prop.id === propertyId);

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { TextWidget } from '../../../../types';
 import { MOCK_TEXT_WIDGET } from '../../../../../testing/mocks';
 import { DashboardState } from '../../../../store/state';
@@ -20,7 +20,7 @@ const state: Partial<DashboardState> = {
 
 const TestComponent = () => (
   <Provider store={configureDashboardStore(state)}>
-    <LinkSettings messageOverride={DefaultDashboardMessages} />
+    <LinkSettings />
   </Provider>
 );
 

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.tsx
@@ -1,18 +1,12 @@
 import React, { FC } from 'react';
 import { ExpandableSection, Grid, Input, InputProps, Toggle } from '@cloudscape-design/components';
-import { DashboardMessages } from '../../../../messages';
+import { useMessage } from '../../../../messages';
 import { useTextWidgetInput } from '../../utils';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import './index.scss';
 
-export type LinkComponentProp = {
-  messageOverride: DashboardMessages;
-};
-const LinkSettings: FC<LinkComponentProp> = ({
-  messageOverride: {
-    sidePanel: { linkSettings },
-  },
-}) => {
+const LinkSettings: FC = () => {
+  const { linkSettings } = useMessage((message) => message.sidePanel);
   const [link = '', updateLink] = useTextWidgetInput('link');
   const [isLink = false, toggleIsLink] = useTextWidgetInput('isLink');
 

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { TextWidget } from '../../../../types';
 import { MOCK_TEXT_WIDGET } from '../../../../../testing/mocks';
 import { DashboardState } from '../../../../store/state';
@@ -6,7 +6,6 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureDashboardStore } from '../../../../store';
 import TextSettings from './text';
-import { DefaultDashboardMessages } from '../../../../messages';
 import wrapper from '@cloudscape-design/components/test-utils/dom';
 
 const widget: TextWidget = { ...MOCK_TEXT_WIDGET, bold: true, italic: true, underline: false };
@@ -21,7 +20,7 @@ const state: Partial<DashboardState> = {
 
 const TestComponent = () => (
   <Provider store={configureDashboardStore(state)}>
-    <TextSettings messageOverride={DefaultDashboardMessages} />
+    <TextSettings />
   </Provider>
 );
 

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.tsx
@@ -1,15 +1,11 @@
 import React, { FC, MouseEventHandler } from 'react';
-import { DashboardMessages } from '../../../../messages';
+import { useMessage } from '../../../../messages';
 import { useTextWidgetInput } from '../../utils';
 import { ExpandableSection, Grid, Select, SelectProps } from '@cloudscape-design/components';
 import ColorPicker from '../../shared/colorPicker';
 import { fontFamilyBase, fontFamilyMonospace } from '@cloudscape-design/design-tokens';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import './index.scss';
-
-export type TextComponentProps = {
-  messageOverride: DashboardMessages;
-};
 
 const ButtonWithState: FC<{ checked: boolean; onToggle: MouseEventHandler }> = ({
   checked,
@@ -33,10 +29,8 @@ const getFontLabel = (font: string) => {
   return fontLabelMap[font] || font;
 };
 
-const TextSettings: FC<TextComponentProps> = ({ messageOverride }) => {
-  const {
-    sidePanel: { textSettings },
-  } = messageOverride;
+const TextSettings: FC = () => {
+  const { textSettings } = useMessage((message) => message.sidePanel);
   const [font = 'unset', updateFont] = useTextWidgetInput('font');
   const [color = '#000000', updateColor] = useTextWidgetInput('color');
   const [bold = false, toggleBold] = useTextWidgetInput('bold');

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/index.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/index.spec.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-
+import * as React from 'react';
 import { AppKitWidget } from '../../../../types';
 import { MOCK_KPI_WIDGET } from '../../../../../testing/mocks';
 import { DashboardState } from '../../../../store/state';
@@ -7,7 +6,6 @@ import { COMPARISON_OPERATOR, Threshold } from '@synchro-charts/core';
 import { Provider } from 'react-redux';
 import { configureDashboardStore } from '../../../../store';
 import ThresholdsSection from './thresholdsSection';
-import { DefaultDashboardMessages } from '../../../../messages';
 import { render } from '@testing-library/react';
 import { ThresholdComponent } from './thresholdComponent';
 
@@ -40,13 +38,13 @@ const state: Partial<DashboardState> = {
 
 const TestThresholdSection = () => (
   <Provider store={configureDashboardStore(state)}>
-    <ThresholdsSection messageOverrides={DefaultDashboardMessages} />
+    <ThresholdsSection />
   </Provider>
 );
 
 const TestThresholdComponent = () => (
   <Provider store={configureDashboardStore(state)}>
-    <ThresholdComponent path={'0'} deleteSelf={jest.fn()} messageOverrides={DefaultDashboardMessages} />
+    <ThresholdComponent path={'0'} deleteSelf={jest.fn()} />
   </Provider>
 );
 

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdComponent.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdComponent.tsx
@@ -1,6 +1,6 @@
 import { COMPARISON_OPERATOR, ThresholdValue } from '@synchro-charts/core';
 import React, { FC, useEffect, useState } from 'react';
-import { DashboardMessages } from '../../../../messages';
+import { useMessage } from '../../../../messages';
 import { useInput } from '../../utils';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import { Button, Grid, Input, InputProps, Select, SelectProps } from '@cloudscape-design/components';
@@ -16,13 +16,8 @@ const widgetsSupportsContainOp: AppKitComponentTag[] = [
   'iot-table',
 ];
 
-export const ThresholdComponent: FC<{ path: string; deleteSelf: () => void; messageOverrides: DashboardMessages }> = ({
-  path,
-  deleteSelf,
-  messageOverrides: {
-    sidePanel: { thresholdSettings },
-  },
-}) => {
+export const ThresholdComponent: FC<{ path: string; deleteSelf: () => void }> = ({ path, deleteSelf }) => {
+  const { thresholdSettings } = useMessage((message) => message.sidePanel);
   const validateValue: (value: ThresholdValue) => boolean = (value: ThresholdValue) => {
     const notAllowString = !OPS_ALLOWED_WITH_STRING.find((op) => comparisonOperator === op);
     const parsedValue = parseFloat(value as string);

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
@@ -4,15 +4,13 @@ import ExpandableSectionHeader from '../../shared/expandableSectionHeader';
 import { useInput } from '../../utils';
 import { COMPARISON_OPERATOR, YAnnotation } from '@synchro-charts/core';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
-import { DashboardMessages } from '../../../../messages';
+import { useMessage } from '../../../../messages';
 import './index.scss';
 import { DEFAULT_THRESHOLD_COLOR } from './defaultValues';
 import { ThresholdComponent } from './thresholdComponent';
 
-export type ThresholdsSectionProps = {
-  messageOverrides: DashboardMessages;
-};
-const ThresholdsSection: FC<ThresholdsSectionProps> = ({ messageOverrides }) => {
+const ThresholdsSection: FC = () => {
+  const { colorDataToggle } = useMessage((message) => message.sidePanel.thresholdSettings);
   const [thresholdList = [], updateThresholdList] = useInput<YAnnotation[]>('annotations.y');
   const [colorDataAcrossThresholds = true, updateColorDataAcrossThresholds] =
     useInput<boolean>('annotations.thresholdOptions');
@@ -41,7 +39,6 @@ const ThresholdsSection: FC<ThresholdsSectionProps> = ({ messageOverrides }) => 
         path={`annotations.y.${index}`}
         key={threshold.id || index}
         deleteSelf={() => deleteThresholdWithIndex(index)}
-        messageOverrides={messageOverrides}
       />
     );
   });
@@ -52,7 +49,7 @@ const ThresholdsSection: FC<ThresholdsSectionProps> = ({ messageOverrides }) => 
     >
       <SpaceBetween size={'xs'}>
         <Toggle checked={colorDataAcrossThresholds} onChange={onCheckColorData}>
-          {messageOverrides.sidePanel.thresholdSettings.colorDataToggle}
+          {colorDataToggle}
         </Toggle>
         {thresholdComponents}
       </SpaceBetween>

--- a/packages/dashboard/src/messages.ts
+++ b/packages/dashboard/src/messages.ts
@@ -1,6 +1,7 @@
 import { DateRangePickerProps } from '@cloudscape-design/components';
 
 import { isMacLike } from './util/browser';
+import { createContext, useContext } from 'react';
 
 export type ResourceExplorerMessages = {
   explorerEmptyLabel: string;
@@ -274,4 +275,11 @@ export const keyboardShortcuts = {
   paste: `${mod}V`,
   bringToFront: ']',
   sendToBack: '[',
+};
+
+export const DashboardMessageContext = createContext<DashboardMessages>(DefaultDashboardMessages);
+type useMessageType<M extends DashboardMessages = DashboardMessages> = <T>(getMessage: (message: M) => T) => T;
+export const useMessage: useMessageType = (getMessage) => {
+  const messages = useContext(DashboardMessageContext);
+  return getMessage(messages);
 };


### PR DESCRIPTION
## Overview
Previously we have to do prop drill to pass messageOverride to child components. Mid level components have to have the messageOverrides object to provide the object to children.
```
<ParentComponent messageOverrides={messageOverrides}>
  <..many layers messageOverrides={messageOverrides}>
    <ChildrenComponent messageOverrides={messageOverrides}>
  <.../>
</ParentComponent>
```

Now we can avoid the prop drill by using this hook.
```
<DashboardMessageContext.Provider value={messageOverrides}>
  <ParentComponent >
    <..many layers >
      <ChildrenComponent>
    <.../>
  </ParentComponent>
</DashboardMessageContext.Provider/>

const ChildrenComponent = ()=> {
  const someLabel = useMessage(message=>message.settings.subsettings)
  return <div> {someLabel} </div>
} 


```

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
