### PR TITLE
fix(dashboard): type exports

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "3.0.0-alpha.2",
+  "version": "3.0.0-alpha.3",
   "description": "A dashboard widget for IoT App Kit components",
   "homepage": "https://github.com/awslabs/iot-app-kit#readme",
   "license": "Apache-2.0",
@@ -14,6 +14,7 @@
   "bugs": {
     "url": "https://github.com/awslabs/iot-app-kit/issues"
   },
+  "types": "dist/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "scripts": {

--- a/packages/dashboard/rollup.config.js
+++ b/packages/dashboard/rollup.config.js
@@ -50,8 +50,8 @@ export default [
     external: ['react', 'react-dom'],
   },
   {
-    input: 'dist/esm/dashboard/src/index.d.ts',
-    output: [{ file: 'dist/index.d.ts', format: 'esm' }],
+    input: 'dist/cjs/dashboard/src/index.d.ts',
+    output: [{ file: 'dist/index.d.ts', format: 'cjs' }],
     external: [/\.css$/],
     plugins: [dts()],
   },

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -1,3 +1,4 @@
 import Dashboard from './components/dashboard';
+export * from './types';
 
 export { Dashboard };


### PR DESCRIPTION
## Overview
fix type exports

was causing `Could not find a declaration file for module` error

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
