### PR TITLE
Upgrade from NPM Workspaces to Turborepo

### DIFF
--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -28,7 +28,6 @@
   "scripts": {
     "start": "GENERATE_SOURCEMAP=false react-app-rewired start",
     "build": "react-app-rewired build",
-    "test": "react-app-rewired test",
     "eject": "react-scripts eject",
     "link": "./link.sh",
     "hot-link": "node hot-link"

--- a/package.json
+++ b/package.json
@@ -10,38 +10,30 @@
     "node": ">=16.0.0",
     "npm": ">=8.7.0"
   },
-  "workspaces": {
-    "packages": [
-      "packages/core",
-      "packages/source-iotsitewise",
-      "packages/related-table",
-      "packages/table",
-      "packages/components",
-      "packages/source-iottwinmaker",
-      "packages/react-components",
-      "packages/scene-composer"
-    ]
-  },
+  "workspaces": [
+    "examples/*",
+    "packages/*"
+  ],
   "scripts": {
     "start": "cd packages/components && npm start",
     "bootstrap": "npm install && npm run build",
-    "build": "npm run build -ws",
+    "build": "turbo run build --filter='./packages/*'",
     "clean": "git clean -dxf -e /.idea -e /.vscode -e creds.json",
+    "dev": "turbo run dev",
     "fix": "npm-run-all -p fix:eslint fix:stylelint",
     "fix:eslint": "eslint --fix --ext .js,.ts,.tsx .",
     "fix:stylelint": "stylelint '**/*.css' --fix",
     "test": "npm-run-all -p test:unit test:eslint test:stylelint test:git",
-    "test:integration": "npm run test:integration -ws --if-present",
+    "test:integration": "turbo run test:integration",
     "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=39",
     "test:stylelint": "stylelint '**/*.css' --max-warnings 0",
-    "test:unit": "npm run test -ws --if-present",
+    "test:unit": "turbo run test",
     "test:git": "git diff --exit-code",
     "release": "npm run build",
-    "pack": "npm pack -ws",
-    "link": "npm link -ws",
-    "versionup:patch": "npm version --no-git-tag-version -ws patch",
-    "versionup:minor": "npm version --no-git-tag-version -ws minor",
-    "versionup:major": "npm version --no-git-tag-version -ws major"
+    "pack": "turbo run pack",
+    "versionup:patch": "turbo run version --no-git-tag-version patch",
+    "versionup:minor": "turbo run version --no-git-tag-version minor",
+    "versionup:major": "turbo run version --no-git-tag-version major"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",
@@ -102,6 +94,7 @@
     "ts-jest": "26.5.6",
     "ts-loader": "9.2.6",
     "ts-node": "^10.0.0",
+    "turbo": "^1.7.2",
     "webpack": "^4.41.2",
     "write-file-webpack-plugin": "^4.5.0"
   },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,11 +29,21 @@
     "url": "https://github.com/awslabs/iot-app-kit.git",
     "directory": "packages/components"
   },
+  "watch": {
+    "build": {
+      "patterns": [
+        "src"
+      ],
+      "extensions": "ts,html,css,tsx",
+      "quiet": "false"
+    }
+  },
   "scripts": {
     "build": "stencil build",
     "copy:license": "cp ../../LICENSE LICENSE",
     "copy:notice": "cp ../../NOTICE NOTICE",
     "copy:styles": "cp dist/iot-app-kit-components/iot-app-kit-components.css styles.css",
+    "dev": "npm-watch build",
     "prepack": "npm run copy:license && npm run copy:notice && npm run copy:styles",
     "pack": "npm pack",
     "start": "stencil build --dev --watch --serve",
@@ -79,6 +89,7 @@
     "d3-color-1-fix": "^1.4.2",
     "jest": "26.3.0",
     "jest-cli": "^26.5.1",
+    "npm-watch": "^0.11.0",
     "nth-check": "^2.1.1",
     "uuid": "^8.3.2",
     "vue": "^3.2.26"

--- a/packages/components/src/components/iot-resource-explorer/iot-resource-explorer.spec.ts
+++ b/packages/components/src/components/iot-resource-explorer/iot-resource-explorer.spec.ts
@@ -8,6 +8,8 @@ import flushPromises from 'flush-promises';
 import { mocklistAssetsResponse } from '../../testing/mocks/data/listAssetsResponse';
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 
+jest.useFakeTimers();
+
 const resourceExplorerSpec = async (
   propOverrides: Partial<Components.IotResourceExplorer>,
   iotSiteWiseClient: IoTSiteWiseClient

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,9 +23,19 @@
     "url": "https://github.com/awslabs/iot-app-kit.git",
     "directory": "packages/core"
   },
+  "watch": {
+    "build": {
+      "patterns": [
+        "src"
+      ],
+      "extensions": "ts",
+      "quiet": "false"
+    }
+  },
   "scripts": {
     "clean": "rm -rf dist && rm -rf screenshot",
     "build": "npm run clean && rollup --config rollup.config.js",
+    "dev": "npm-watch build",
     "test": "npm-run-all -p test:jest test:typescript",
     "test:jest": "TZ=UTC jest --coverage",
     "test.watch": "TZ=UTC jest --watchAll",
@@ -59,6 +69,7 @@
     "@types/jest": "^27.4.0",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "npm-watch": "^0.11.0",
     "ts-jest": "^27.1.3"
   },
   "bugs": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -20,6 +20,7 @@
     "build": "npm run clean && npm run compile",
     "clean": "rm -rf dist",
     "compile": "npm run tsc",
+    "dev": "npm-watch build",
     "tsc": "tsc",
     "rollup": "rollup -c",
     "copy:license": "cp ../../LICENSE LICENSE",
@@ -40,6 +41,15 @@
     "CHANGELOG.md",
     "*NOTICE"
   ],
+  "watch": {
+    "build": {
+      "patterns": [
+        "src"
+      ],
+      "extensions": "ts,html,css,tsx",
+      "quiet": "false"
+    }
+  },
   "devDependencies": {
     "@babel/code-frame": "^7.18.6",
     "@babel/plugin-transform-runtime": "^7.12.1",
@@ -77,9 +87,9 @@
   },
   "dependencies": {
     "@awsui/components-react": "^3.0.0",
-    "@iot-app-kit/core": "^2.6.5",
-    "@iot-app-kit/components": "^2.6.5",
-    "@iot-app-kit/source-iottwinmaker": "^2.6.5",
+    "@iot-app-kit/core": "*",
+    "@iot-app-kit/components": "*",
+    "@iot-app-kit/source-iottwinmaker": "*",
     "dompurify": "2.3.4",
     "uuid": "^8.3.2",
     "video.js": "7.20.3"

--- a/packages/related-table/package.json
+++ b/packages/related-table/package.json
@@ -25,9 +25,19 @@
     "url": "https://github.com/awslabs/iot-app-kit.git",
     "directory": "packages/related-table"
   },
+  "watch": {
+    "build": {
+      "patterns": [
+        "src"
+      ],
+      "extensions": "ts,html,css,tsx",
+      "quiet": "false"
+    }
+  },
   "scripts": {
     "clean": "rm -rf dist",
     "build": "microbundle --no-compress --format modern,esm,cjs --jsx React.createElement",
+    "dev": "npm-watch build",
     "generate-barrels": "barrelsby --config ./barrel-config.json",
     "test": "jest",
     "test.watch": "TZ=UTC jest --watchAll",
@@ -71,6 +81,7 @@
     "eslint-config-airbnb-typescript": "^12.3.1",
     "husky": "^6.0.0",
     "microbundle": "^0.13.3",
+    "npm-watch": "^0.11.0",
     "postcss": "^8.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -25,9 +25,20 @@
     "type": "git",
     "url": "git+https://github.com/awslabs/iot-app-kit.git"
   },
+  "watch": {
+    "build": {
+      "patterns": [
+        "src"
+      ],
+      "ignore": "src/assets/auto-gen/*",
+      "extensions": "ts,html,css,tsx",
+      "quiet": "false"
+    }
+  },
   "scripts": {
     "build": "run-s compile",
     "build:watch": "node ./tools/watch-build.js",
+    "dev": "npm-watch build",
     "clean": "rimraf dist ./build/* node_modules",
     "compile": "run-s svglint extract-msgs convert-svg tttsc copy-assets",
     "tttsc": "ttsc -p tsconfig.build.json",
@@ -105,6 +116,7 @@
     "jest-styled-components": "^7.0.0",
     "lodash": "^4.17.21",
     "node-sass": "^7.0.3",
+    "npm-watch": "^0.11.0",
     "postcss": "^8.3.6",
     "prettier": "^2.3.2",
     "prettier-eslint": "^13.0.0",
@@ -124,8 +136,8 @@
     "@awsui/design-tokens": "^3.0.19",
     "@awsui/global-styles": "^1.0.12",
     "@formatjs/ts-transformer": "3.9.11",
-    "@iot-app-kit/core": "^2.6.5",
-    "@iot-app-kit/related-table": "^2.6.5",
+    "@iot-app-kit/core": "*",
+    "@iot-app-kit/related-table": "*",
     "@react-three/drei": "7.10.1",
     "@react-three/fiber": "7.0.6",
     "@react-three/postprocessing": "2.0.5",

--- a/packages/source-iotsitewise/package.json
+++ b/packages/source-iotsitewise/package.json
@@ -24,10 +24,20 @@
     "url": "https://github.com/awslabs/iot-app-kit.git",
     "directory": "packages/source-iotsitewise"
   },
+  "watch": {
+    "build": {
+      "patterns": [
+        "src"
+      ],
+      "extensions": "ts,html,css,tsx",
+      "quiet": "false"
+    }
+  },
   "scripts": {
-    "clean": "rm -rf dist && rm -rf screenshot",
     "build": "npm run clean && npm run build:types && rollup --config rollup.config.js",
     "build:types": "tsc --outDir dist/types --declaration true",
+    "clean": "rm -rf dist && rm -rf screenshot",
+    "dev": "npm-watch build",
     "test": "npm-run-all -p test:jest test:typescript",
     "test:jest": "TZ=UTC jest --coverage",
     "test.watch": "TZ=UTC jest --watchAll",
@@ -40,11 +50,11 @@
   "dependencies": {
     "@aws-sdk/client-iot-events": "^3.118.1",
     "@aws-sdk/client-iotsitewise": "^3.87.0",
-    "@iot-app-kit/core": "^2.6.5",
+    "@iot-app-kit/core": "*",
     "@rollup/plugin-typescript": "^8.3.0",
     "@synchro-charts/core": "^7.0.0",
-    "flush-promises": "^1.0.2",
     "dataloader": "^2.1.0",
+    "flush-promises": "^1.0.2",
     "lodash.merge": "^4.6.2",
     "rxjs": "^7.4.0",
     "typescript": "4.4.4"
@@ -54,6 +64,7 @@
     "@types/lodash.merge": "^4.6.7",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "npm-watch": "^0.11.0",
     "ts-jest": "^27.1.3"
   },
   "bugs": {

--- a/packages/source-iottwinmaker/package.json
+++ b/packages/source-iottwinmaker/package.json
@@ -23,12 +23,22 @@
     "type": "git",
     "url": "git+https://github.com/awslabs/iot-app-kit.git"
   },
+  "watch": {
+    "build": {
+      "patterns": [
+        "src"
+      ],
+      "extensions": "ts,html,css,tsx",
+      "quiet": "false"
+    }
+  },
   "scripts": {
     "clean": "rm -rf dist && rm -rf screenshot",
     "build": "npm run clean && npm run build:cjs && npm run build:es && npm run build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
+    "dev": "npm-watch build",
     "test": "npm-run-all -p test:jest test:typescript",
     "test:jest": "TZ=UTC jest --coverage",
     "test:typescript": "tsc --noEmit",
@@ -43,17 +53,18 @@
     "@aws-sdk/client-kinesis-video": "^3.131.0",
     "@aws-sdk/client-kinesis-video-archived-media": "^3.131.0",
     "@aws-sdk/client-s3": "^3.72.0",
-    "@iot-app-kit/core": "^2.6.5",
+    "@iot-app-kit/core": "*",
     "@synchro-charts/core": "^7.0.0",
     "flush-promises": "^1.0.2",
     "rxjs": "^7.4.0",
     "typescript": "4.4.4"
   },
   "devDependencies": {
-    "aws-sdk-client-mock": "^1.0.0",
     "@types/jest": "^27.4.0",
+    "aws-sdk-client-mock": "^1.0.0",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "npm-watch": "^0.11.0",
     "ts-jest": "^27.1.3"
   },
   "bugs": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -21,10 +21,20 @@
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com/"
   },
+  "watch": {
+    "build": {
+      "patterns": [
+        "src"
+      ],
+      "extensions": "ts,html,css,tsx",
+      "quiet": "false"
+    }
+  },
   "scripts": {
     "clean": "rm -rf dist && rm -rf screenshot",
     "build": "npm run clean && npm run build:types && rollup --config rollup.config.js",
     "build:types": "tsc --outDir dist/types --declaration true --emitDeclarationOnly true",
+    "dev": "npm-watch build",
     "test": "npm-run-all -p test:jest test:typescript",
     "test:jest": "TZ=UTC jest --coverage",
     "test.watch": "TZ=UTC jest --watchAll",
@@ -48,6 +58,7 @@
     "jest-cli": "^27.5.0",
     "jest-environment-jsdom": "^27.5.0",
     "jest-extended": "^2.0.0",
+    "npm-watch": "^0.11.0",
     "rollup-plugin-import-css": "^3.0.3",
     "sass": "^1.30.0",
     "ts-jest": "^27.1.3"
@@ -55,7 +66,7 @@
   "dependencies": {
     "@awsui/collection-hooks": "^1.0.0",
     "@awsui/components-react": "^3.0.0",
-    "@iot-app-kit/core": "^2.6.5",
+    "@iot-app-kit/core": "*",
     "@synchro-charts/core": "^7.0.0",
     "d3-array": "^3.1.6",
     "react": "^17.0.2",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "dev": {
+      "dependsOn": []
+    },
+    "pack": {
+      "dependsOn": []
+    },
+    "test": {
+      "dependsOn": []
+    },
+    "test:integration": {
+      "dependsOn": []
+    },
+    "version": {
+      "dependsOn": []
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Changes the monorepo tooling from npm workspaces to turborepo. Adds dev scripts to each package for cross package collaboration.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
