### PR TITLE
chore(dial): Port over dial from synchro charts

### DIFF
--- a/packages/react-components/jest.config.ts
+++ b/packages/react-components/jest.config.ts
@@ -2,6 +2,7 @@
  * For a detailed explanation regarding each configuration property and type check, visit:
  * https://jestjs.io/docs/configuration
  */
+
 export default {
   preset: 'ts-jest',
   clearMocks: true,
@@ -18,6 +19,7 @@ export default {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   moduleNameMapper: {
     '\\.(css|less)$': '<rootDir>/config/jest/styleMock.js',
+    'd3-shape': '<rootDir>/../../node_modules/d3-shape/dist/d3-shape.min.js',
   },
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: ['node_modules', 'dist', 'src/stencil-generated'],

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -106,10 +106,11 @@
   },
   "dependencies": {
     "@awsui/components-react": "^3.0.0",
-    "@iot-app-kit/core": "*",
     "@iot-app-kit/components": "*",
+    "@iot-app-kit/core": "*",
     "@iot-app-kit/source-iottwinmaker": "*",
     "color": "^4.2.3",
+    "d3-shape": "^3.2.0",
     "dompurify": "2.3.4",
     "parse-duration": "^1.0.2",
     "uuid": "^8.3.2",

--- a/packages/react-components/src/common/iconUtils.tsx
+++ b/packages/react-components/src/common/iconUtils.tsx
@@ -1,11 +1,9 @@
-/* eslint-disable max-len */
 import React from 'react';
 import { StatusIconType } from './constants';
 
-interface Icons {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  [statusIcon: string]: Function;
-}
+type Icons = {
+  [statusIcon: string]: (color?: string, size?: number) => JSX.Element;
+};
 
 const DEFAULT_SIZE_PX = 16;
 
@@ -35,6 +33,7 @@ export const icons: Icons = {
       </svg>
     );
   },
+
   acknowledged(color?: string, size: number = DEFAULT_SIZE_PX) {
     return (
       <svg width={`${size}px`} height={`${size}px`} viewBox='0 0 16 16' stroke={color ? `${color}` : '#3184c2'}>
@@ -55,6 +54,7 @@ export const icons: Icons = {
       </svg>
     );
   },
+
   disabled(color?: string, size: number = DEFAULT_SIZE_PX) {
     return (
       <svg width={`${size}px`} height={`${size}px`} viewBox='0 0 16 16' stroke={color ? `${color}` : '#687078'}>
@@ -65,6 +65,7 @@ export const icons: Icons = {
       </svg>
     );
   },
+
   latched(color?: string, size: number = DEFAULT_SIZE_PX) {
     return (
       <svg width={`${size}px`} height={`${size}px`} viewBox='0 0 16 16' fill={color ? `${color}` : '#f89256'}>
@@ -73,6 +74,7 @@ export const icons: Icons = {
       </svg>
     );
   },
+
   snoozed(color?: string, size: number = DEFAULT_SIZE_PX) {
     return (
       <svg width={`${size}px`} height={`${size}px`} viewBox='0 0 16 16' stroke={color ? `${color}` : '#879596'}>
@@ -83,6 +85,7 @@ export const icons: Icons = {
       </svg>
     );
   },
+
   error(color?: string, size: number = DEFAULT_SIZE_PX) {
     return (
       <svg width={`${size}px`} height={`${size}px`} viewBox='0 0 16 16' fill={color || '#FF0000'} data-test-tag='error'>

--- a/packages/react-components/src/components/dial/constants.ts
+++ b/packages/react-components/src/components/dial/constants.ts
@@ -1,0 +1,21 @@
+import { DialSettings } from './types';
+
+export enum ColorConfigurations {
+  BLUE = '#2E72B5',
+  NORMAL = '#3F7E23',
+  WARNING = '#F29D38',
+  CRITICAL = '#C03F25',
+  GRAY = '#D9D9D9',
+  PRIMARY_TEXT = '#16191f',
+  SECONDARY_TEXT = '#687078',
+  WHITE = '#fff',
+}
+
+export const DEFAULT_DIAL_SETTINGS: DialSettings = {
+  showName: true,
+  showUnit: true,
+  dialThickness: 34,
+  fontSize: 48,
+  unitFontSize: 24,
+  labelFontSize: 24,
+};

--- a/packages/react-components/src/components/dial/dial.tsx
+++ b/packages/react-components/src/components/dial/dial.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { DialBase } from './dialBase';
+import { TimeQuery, TimeSeriesData, TimeSeriesDataRequest, StyleSettingsMap, Viewport } from '@iot-app-kit/core';
+import { useTimeSeriesData } from '../../hooks/useTimeSeriesData';
+import { widgetPropertiesFromInputs } from '../../common/widgetPropertiesFromInputs';
+import { Annotations } from '../../common/thresholdTypes';
+import { DialSettings } from './types';
+import { useViewport } from '../../hooks/useViewport';
+
+export const Dial = ({
+  query,
+  viewport: passedInViewport,
+  annotations,
+  styles,
+  settings,
+}: {
+  query: TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>;
+  viewport?: Viewport;
+  annotations?: Annotations;
+  styles?: StyleSettingsMap;
+  settings?: DialSettings;
+}) => {
+  const { dataStreams } = useTimeSeriesData({
+    viewport: passedInViewport,
+    query,
+    settings: { fetchMostRecentBeforeEnd: true },
+    styles,
+  });
+  const { viewport } = useViewport();
+
+  const utilizedViewport = passedInViewport || viewport; // explicitly passed in viewport overrides viewport group
+  const { propertyPoint, alarmPoint, alarmThreshold, propertyThreshold, alarmStream, propertyStream } =
+    widgetPropertiesFromInputs({ dataStreams, annotations, viewport: utilizedViewport });
+
+  const name = propertyStream?.name || alarmStream?.name;
+  const unit = propertyStream?.unit || alarmStream?.unit;
+  const color = alarmThreshold?.color || propertyThreshold?.color || propertyStream?.color;
+
+  return (
+    <DialBase
+      propertyPoint={propertyPoint}
+      alarmPoint={alarmPoint}
+      settings={settings}
+      name={name}
+      unit={unit}
+      color={color}
+    />
+  );
+};

--- a/packages/react-components/src/components/dial/dialBase.spec.tsx
+++ b/packages/react-components/src/components/dial/dialBase.spec.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DialBase } from './dialBase';
+import { DataPoint } from '../../common/dataTypes';
+
+describe('name', () => {
+  it('renders name when showName is true', () => {
+    const someName = 'some-name';
+    render(<DialBase name={someName} settings={{ showName: true }} />);
+
+    expect(screen.queryByText(someName)).not.toBeNull();
+  });
+
+  it('does not render name when showName is false', () => {
+    const someName = 'some-name';
+    render(<DialBase name={someName} settings={{ showName: false }} />);
+
+    expect(screen.queryByText(someName)).toBeNull();
+  });
+});
+
+describe('unit', () => {
+  const point: DataPoint = { x: 1213, y: 123 };
+
+  it('renders unit when showUnit is true and provided a property point', () => {
+    const someUnit = 'some-Unit';
+    render(<DialBase unit={someUnit} propertyPoint={point} settings={{ showUnit: true }} />);
+
+    expect(screen.queryByText(someUnit)).not.toBeNull();
+  });
+
+  it('renders unit when showUnit is true and provided a alarm point', () => {
+    const someUnit = 'some-Unit';
+    render(<DialBase unit={someUnit} alarmPoint={point} settings={{ showUnit: true }} />);
+
+    expect(screen.queryByText(someUnit)).not.toBeNull();
+  });
+
+  it('does not render unit when showUnit is true and is not provided a data point', () => {
+    const someUnit = 'some-Unit';
+    render(<DialBase unit={someUnit} settings={{ showUnit: true }} />);
+
+    expect(screen.queryByText(someUnit)).toBeNull();
+  });
+
+  it('does not render unit when showUnit is false', () => {
+    const someUnit = 'some-Unit';
+    render(<DialBase unit={someUnit} settings={{ showUnit: false }} propertyPoint={point} />);
+
+    expect(screen.queryByText(someUnit)).toBeNull();
+  });
+});
+
+describe('property value', () => {
+  it('renders property points y value', () => {
+    const Y_VALUE = 123445;
+    render(<DialBase propertyPoint={{ x: new Date().getTime(), y: Y_VALUE }} settings={{ showName: false }} />);
+    expect(screen.queryByText(Y_VALUE)).not.toBeNull();
+  });
+
+  it('renders alarm points y value', () => {
+    const Y_VALUE = 123445;
+    render(<DialBase alarmPoint={{ x: new Date().getTime(), y: Y_VALUE }} settings={{ showName: false }} />);
+    expect(screen.queryByText(Y_VALUE)).not.toBeNull();
+  });
+
+  it('renders property points y value and alarm points y value when provided both an alarm and a property', () => {
+    const Y_VALUE_PROPERTY = 123445;
+    const Y_VALUE_ALARM = 'alarm_value';
+    render(
+      <DialBase
+        alarmPoint={{ x: new Date().getTime(), y: Y_VALUE_ALARM }}
+        propertyPoint={{ x: 234324, y: Y_VALUE_PROPERTY }}
+        settings={{ showName: false }}
+      />
+    );
+
+    expect(screen.queryByText(Y_VALUE_PROPERTY)).not.toBeNull();
+    expect(screen.queryByText(Y_VALUE_ALARM)).not.toBeNull();
+  });
+});
+
+describe('error', () => {
+  it('renders error', () => {
+    const someError = 'some-error';
+    render(<DialBase error={someError} settings={{}} />);
+
+    expect(screen.queryByText(someError)).not.toBeNull();
+  });
+});
+
+describe('loading', () => {
+  it('renders loading spinner while isLoading is true', () => {
+    render(<DialBase isLoading settings={{}} />);
+
+    expect(screen.queryByTestId('loading')).not.toBeNull();
+  });
+
+  it('does not render loading spinner while isLoading is false', () => {
+    render(<DialBase isLoading={false} settings={{}} />);
+
+    expect(screen.queryByTestId('loading')).toBeNull();
+  });
+
+  it('renders error while loading', () => {
+    const someError = 'some-error';
+    render(<DialBase error={someError} isLoading settings={{}} />);
+
+    expect(screen.queryByText(someError)).not.toBeNull();
+  });
+
+  it('does not render data point while isLoading is true', () => {
+    const point = { x: 12341, y: 123213 };
+    render(<DialBase propertyPoint={point} isLoading settings={{}} />);
+
+    expect(screen.queryByText(point.y)).toBeNull();
+  });
+
+  it('does not render alarm or property data point while isLoading is true', () => {
+    const point = { x: 12341, y: 123213 };
+    const alarmPoint = { x: 12341, y: 'warning' };
+    render(<DialBase propertyPoint={point} alarmPoint={alarmPoint} isLoading settings={{}} />);
+
+    expect(screen.queryByText(point.y)).toBeNull();
+    expect(screen.queryByText(alarmPoint.y)).toBeNull();
+  });
+});

--- a/packages/react-components/src/components/dial/dialBase.tsx
+++ b/packages/react-components/src/components/dial/dialBase.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { DialProperties } from './types';
+import { ErrorBadge } from '../shared-components';
+import { DialSvg } from './dialSvg';
+import { DEFAULT_DIAL_SETTINGS } from './constants';
+
+export const DialBase: React.FC<DialProperties> = ({
+  propertyPoint,
+  alarmPoint,
+  error,
+  unit,
+  name,
+  isLoading,
+  color,
+  settings = {},
+}) => {
+  const dialSettings = {
+    ...DEFAULT_DIAL_SETTINGS,
+    ...settings,
+  };
+
+  const { yMin, yMax, showName, showUnit } = dialSettings;
+
+  // Primary point to display. Dial Emphasizes the property point over the alarm point.
+  const point = propertyPoint || alarmPoint;
+  const value = point?.y;
+  const label = (propertyPoint != null && alarmPoint != null && alarmPoint.y) || undefined;
+  const percent =
+    yMin != null && yMax != null && typeof value === 'number' ? (value - yMin) / (yMax / yMin) : undefined;
+  return (
+    <div>
+      {showName && name}
+      <DialSvg
+        settings={dialSettings}
+        value={value?.toString()}
+        label={label?.toString()}
+        unit={showUnit ? unit : undefined}
+        percent={percent}
+        isLoading={isLoading}
+        color={color}
+      />
+      {error && <ErrorBadge>{error}</ErrorBadge>}
+    </div>
+  );
+};

--- a/packages/react-components/src/components/dial/dialSvg.tsx
+++ b/packages/react-components/src/components/dial/dialSvg.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import { DialSettings } from './types';
+import { ColorConfigurations } from './constants';
+import { useArcs } from './useArcs';
+
+const NO_VALUE_PRESENT = '-';
+
+const RADIUS = 138;
+const UNIT_SPACE = 4;
+
+export const DialSvg = ({
+  percent,
+  value,
+  color,
+  label,
+  unit,
+  isLoading,
+  settings,
+}: {
+  percent: number;
+  isLoading: boolean;
+  color: string; // hex color string
+  value?: string;
+  label?: string;
+  unit?: string;
+  settings?: DialSettings;
+}) => {
+  const { defaultRing, colorRing } = useArcs({ percent, lineThickness: settings.dialThickness, radius: RADIUS });
+  const displayLabel = label != null && label != '' && !isLoading;
+  const displayValue = !isLoading && value != null && value !== '';
+
+  const valueLength = (value != null ? value.length : 0) + (unit != null ? unit.length : 0);
+  const valueFontSize =
+    value != null
+      ? Math.min(settings.fontSize, Math.floor((2 * (RADIUS - settings.dialThickness)) / valueLength) * 1.6)
+      : settings.fontSize;
+  return (
+    <svg width='100%' height='100%' viewBox={`0 0 ${RADIUS * 2} ${RADIUS * 2}`} preserveAspectRatio='xMidYMin meet'>
+      <g transform={`matrix(1,0,0,1,${RADIUS},${RADIUS})`}>
+        <path
+          d={defaultRing}
+          fill={ColorConfigurations.GRAY}
+          stroke={ColorConfigurations.WHITE}
+          strokeLinejoin='round'
+        />
+        <path d={colorRing} fill={color} stroke={ColorConfigurations.WHITE} strokeLinejoin='round' />
+      </g>
+      {displayValue && (
+        <text y={displayLabel ? '50%' : '55%'} x='50%' textAnchor='middle' fontWeight='bold' fontSize={valueFontSize}>
+          <tspan>
+            {value}
+            {unit && (
+              <tspan fontSize={Math.min(settings.unitFontSize, valueFontSize)} dx={UNIT_SPACE}>
+                {unit}
+              </tspan>
+            )}
+          </tspan>
+        </text>
+      )}
+      {isLoading && (
+        <text y='55%' x='50%' textAnchor='middle' fontWeight='bold' fontSize={settings.fontSize}>
+          Loading
+        </text>
+      )}
+      {!displayValue && !isLoading && (
+        <text
+          y='50%'
+          x='50%'
+          textAnchor='middle'
+          fontWeight='bold'
+          fontSize={settings.fontSize}
+          fill={ColorConfigurations.SECONDARY_TEXT}
+        >
+          {NO_VALUE_PRESENT}
+        </text>
+      )}
+      {displayLabel && (
+        <text x='50%' y='65%' textAnchor='middle' fontWeight='bold' fontSize={settings.labelFontSize} fill={color}>
+          {label}
+        </text>
+      )}
+    </svg>
+  );
+};

--- a/packages/react-components/src/components/dial/types.ts
+++ b/packages/react-components/src/components/dial/types.ts
@@ -1,0 +1,16 @@
+import { WidgetSettings } from '../../common/dataTypes';
+
+export type DialProperties = WidgetSettings & {
+  settings: DialSettings;
+};
+
+export type DialSettings = {
+  dialThickness?: number;
+  showName?: boolean;
+  showUnit?: boolean;
+  fontSize?: number; // pixels
+  labelFontSize?: number; // pixels
+  unitFontSize?: number; // pixels
+  yMin?: number;
+  yMax?: number;
+};

--- a/packages/react-components/src/components/dial/useArcs.ts
+++ b/packages/react-components/src/components/dial/useArcs.ts
@@ -1,0 +1,54 @@
+import { DefaultArcObject, arc } from 'd3-shape';
+import { useEffect, useState } from 'react';
+
+const RADIAN_FULL_CIRCLE = Math.PI * 2;
+const RADIAN = RADIAN_FULL_CIRCLE / 360;
+const CORNER_RADIUS = 4;
+
+const getArcs = (percent: number) => {
+  const flooredPercent = Math.max(0, percent);
+  const startAngle1 = RADIAN_FULL_CIRCLE * flooredPercent;
+  const startAngle2 = RADIAN_FULL_CIRCLE * (1 - flooredPercent);
+  const endAngle1 = startAngle1;
+  const endAngle2 = endAngle1 + startAngle2;
+
+  // Arc representing the value (i.e. if percent is 25%, this would be the arc going a 25% of the circle
+  const valueArc = arc().cornerRadius(CORNER_RADIUS).startAngle(0).endAngle(endAngle1);
+  // The remainder of the arc not representing the value
+  const remainingArc = arc().cornerRadius(CORNER_RADIUS).startAngle(endAngle2).endAngle(endAngle1);
+
+  return {
+    valueArc,
+    remainingArc,
+  };
+};
+
+export const useArcs = ({
+  percent,
+  radius,
+  lineThickness,
+}: {
+  percent: number;
+  radius: number;
+  lineThickness: number;
+}) => {
+  const [colorRing, setColorRing] = useState('');
+  const [defaultRing, setDefaultRing] = useState('');
+
+  /** Compute Arc SVGs */
+  useEffect(() => {
+    const { valueArc, remainingArc } = getArcs(percent || 0);
+    const ringD: DefaultArcObject = {
+      innerRadius: radius,
+      outerRadius: radius - lineThickness,
+      padAngle: RADIAN / 2,
+      startAngle: 0,
+      endAngle: 0,
+    };
+
+    setColorRing(valueArc(ringD));
+    setDefaultRing(remainingArc(ringD));
+  }, [percent]);
+
+  return { colorRing, defaultRing };
+};

--- a/packages/react-components/stories/dial/dial.stories.tsx
+++ b/packages/react-components/stories/dial/dial.stories.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Dial } from '../../src/components/dial/dial';
+import { initialize } from '@iot-app-kit/source-iotsitewise';
+
+const ASSET_ID = '587295b6-e0d0-4862-b7db-b905afd7c514';
+const PROPERTY_ID = '16d45cb7-bb8b-4a1e-8256-55276f261d93';
+
+export default {
+  title: 'Dial',
+  component: Dial,
+  argTypes: {
+    yMin: { control: { type: 'number' }, defaultValue: 0 },
+    yMax: { control: { type: 'number' }, defaultValue: 100 },
+    assetId: { control: { type: 'string' }, defaultValue: ASSET_ID },
+    propertyId: { control: { type: 'string' }, defaultValue: PROPERTY_ID },
+    accessKeyId: { control: { type: 'string' } },
+    secretAccessKey: { control: { type: 'string' } },
+    sessionToken: { control: { type: 'string' } },
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Dial>;
+
+const { query } = initialize({
+  awsCredentials: {
+    accessKeyId: 'xxxx',
+    secretAccessKey: 'xxxx',
+    sessionToken: 'xxxx',
+  },
+});
+
+export const SiteWiseDial: ComponentStory<typeof Dial> = ({ yMin, yMax }) => (
+  <div style={{ width: '200px', height: '200px' }}>
+    <Dial
+      viewport={{ duration: '5m' }}
+      settings={{
+        yMin,
+        yMax,
+      }}
+      query={query.timeSeriesData({
+        assets: [
+          {
+            assetId: ASSET_ID,
+            properties: [
+              {
+                propertyId: PROPERTY_ID,
+              },
+            ],
+          },
+        ],
+      })}
+    />
+  </div>
+);

--- a/packages/react-components/stories/dial/dialBase.stories.tsx
+++ b/packages/react-components/stories/dial/dialBase.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { DialBase } from '../../src/components/dial/dialBase';
+
+export default {
+  title: 'Dial base',
+  component: DialBase,
+  argTypes: {
+    propertyPoint: { control: { type: 'object' }, defaultValue: { x: 123123213, y: 100.13 } },
+    alarmPoint: { control: { type: 'object' }, defaultValue: { x: 123123213, y: 'Warning' } },
+    yMin: { control: { type: 'number' }, defaultValue: 0 },
+    yMax: { control: { type: 'number' }, defaultValue: 100 },
+    showName: { control: { type: 'boolean' }, defaultValue: true },
+    showUnit: { control: { type: 'boolean' }, defaultValue: true },
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof DialBase>;
+
+export const Main: ComponentStory<typeof DialBase> = ({ yMin, yMax, showName, showUnit, ...args }) => (
+  <div style={{ width: '200px', height: '200px' }}>
+    <DialBase {...args} settings={{ yMin, yMax, showName, showUnit }} />
+  </div>
+);


### PR DESCRIPTION
## Overview
Ports over dial component from synchrocharts. Also refactors to remove calls to calculate bounding boxes and eliminate a lot of state mutations, in preference for a simpler, more straightforward implementation

Follow up PR will be made which will add icons, tests, etc. This is the first iteration, and does not expose the dial component publicly. 
## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
