### PR TITLE
chore(dashboard): pretty import path

### DIFF
--- a/packages/dashboard/jest.config.ts
+++ b/packages/dashboard/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   moduleFileExtensions: ['js', 'ts', 'jsx', 'tsx'],
   moduleNameMapper: {
     '\\.(svg|css|less|scss)$': '<rootDir>/testing/styleMock.js',
+    '~/(.*)': '<rootDir>/src/$1',
   },
   testEnvironment: 'jsdom',
   transform: {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -76,6 +76,7 @@
     "rollup-plugin-polyfill-node": "^0.11.0",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-terser": "^7.0.2",
+    "rollup-plugin-tsconfig-paths": "^1.4.0",
     "rollup-plugin-typescript2": "^0.34.1",
     "sass": "^1.57.1",
     "sass-loader": "10.1.1",

--- a/packages/dashboard/rollup.config.js
+++ b/packages/dashboard/rollup.config.js
@@ -7,6 +7,7 @@ import postcss from 'rollup-plugin-postcss';
 import json from '@rollup/plugin-json';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
 import url from 'postcss-url';
+import tsConfigPaths from 'rollup-plugin-tsconfig-paths';
 
 const packageJson = require('./package.json'); // eslint-disable-line
 
@@ -26,6 +27,7 @@ export default [
       },
     ],
     plugins: [
+      tsConfigPaths(),
       nodePolyfills({ crypto: true }),
       peerDepsExternal(),
       nodeResolve({

--- a/packages/dashboard/src/components/actions/index.tsx
+++ b/packages/dashboard/src/components/actions/index.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { Button } from '@cloudscape-design/components';
 
-import { DashboardMessages } from '../../messages';
-import { DashboardState, SaveableDashboard } from '../../store/state';
+import { DashboardMessages } from '~/messages';
+import { DashboardState, SaveableDashboard } from '~/store/state';
 
 export type ActionsProps = {
   onSave: (dashboard: SaveableDashboard) => void;

--- a/packages/dashboard/src/components/contextMenu/contextMenuOptions.ts
+++ b/packages/dashboard/src/components/contextMenu/contextMenuOptions.ts
@@ -1,4 +1,4 @@
-import { ContextMenuMessages, keyboardShortcuts } from '../../messages';
+import { ContextMenuMessages, keyboardShortcuts } from '~/messages';
 
 type ContextMenuOptionConfiguration = {
   id: string;

--- a/packages/dashboard/src/components/contextMenu/index.tsx
+++ b/packages/dashboard/src/components/contextMenu/index.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { Position } from '../../types';
+import { Position } from '~/types';
 
 import './index.css';
 import Menu from './menu';
 import ContextMenuSection from './section';
 import ContextMenuOption from './option';
 import { DASHBOARD_CONTAINER_ID, getDashboardPosition } from '../grid/getDashboardPosition';
-import { useKeyPress } from '../../hooks/useKeyPress';
+import { useKeyPress } from '~/hooks/useKeyPress';
 import { createContextMenuOptions } from './contextMenuOptions';
-import { DashboardMessages } from '../../messages';
+import { DashboardMessages } from '~/messages';
 
 export type ContextMenuProps = {
   copyWidgets: () => void;

--- a/packages/dashboard/src/components/contextMenu/menu.tsx
+++ b/packages/dashboard/src/components/contextMenu/menu.tsx
@@ -3,10 +3,10 @@ import { usePopper } from 'react-popper';
 import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow.js';
 import flip from '@popperjs/core/lib/modifiers/flip.js';
 
-import { Position } from '../../types';
+import { Position } from '~/types';
 
 import './menu.css';
-import { useClickOutside } from '../../hooks/useClickOutside';
+import { useClickOutside } from '~/hooks/useClickOutside';
 
 export type MenuProps = {
   position: Position;

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -8,11 +8,11 @@ import { WebglContext } from '@iot-app-kit/react-components';
 
 import InternalDashboard from '../internalDashboard';
 
-import { configureDashboardStore } from '../../store';
-import { DashboardState, SaveableDashboard } from '../../store/state';
-import { PickRequiredOptional, RecursivePartial } from '../../types';
+import { configureDashboardStore } from '~/store';
+import { DashboardState, SaveableDashboard } from '~/store/state';
+import { PickRequiredOptional, RecursivePartial } from '~/types';
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
-import { DashboardMessages, DefaultDashboardMessages } from '../../messages';
+import { DashboardMessages, DefaultDashboardMessages } from '~/messages';
 import { ClientContext } from './clientContext';
 
 import '@cloudscape-design/global-styles/index.css';

--- a/packages/dashboard/src/components/dragLayer/components/widget.tsx
+++ b/packages/dashboard/src/components/dragLayer/components/widget.tsx
@@ -1,14 +1,14 @@
 import React, { CSSProperties } from 'react';
 
-import { ComponentTag } from '../../../types';
+import { ComponentTag } from '~/types';
 import DynamicWidgetComponent, { getDragLayerProps } from '../../widgets/dynamicWidget';
 
-import { DashboardState } from '../../../store/state';
+import { DashboardState } from '~/store/state';
 import { useSelector } from 'react-redux';
-import { widgetCreator } from '../../../store/actions/createWidget/presets';
+import { widgetCreator } from '~/store/actions/createWidget/presets';
 
 import './widget.css';
-import { DashboardMessages } from '../../../messages';
+import { DashboardMessages } from '~/messages';
 
 export type DragLayerWidgetProps = {
   componentTag: ComponentTag;

--- a/packages/dashboard/src/components/dragLayer/index.tsx
+++ b/packages/dashboard/src/components/dragLayer/index.tsx
@@ -7,7 +7,7 @@ import { ItemTypes } from './itemTypes';
 import Widget from './components/widget';
 
 import './index.css';
-import { DashboardMessages } from '../../messages';
+import { DashboardMessages } from '~/messages';
 
 import { ResourceExplorerPanelAssetPropertyDragGhost } from '../resourceExplorer/components/panel';
 

--- a/packages/dashboard/src/components/grid/getDashboardPosition.ts
+++ b/packages/dashboard/src/components/grid/getDashboardPosition.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Position } from '../../types';
+import { Position } from '~/types';
 
 export const DASHBOARD_CONTAINER_ID = 'container';
 

--- a/packages/dashboard/src/components/grid/index.tsx
+++ b/packages/dashboard/src/components/grid/index.tsx
@@ -1,8 +1,8 @@
 import React, { PointerEventHandler, useEffect, useState } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
-import { useKeyPress } from '../../hooks/useKeyPress';
-import { DashboardState } from '../../store/state';
-import { ComponentTag, MouseClick, Position } from '../../types';
+import { useKeyPress } from '~/hooks/useKeyPress';
+import { DashboardState } from '~/store/state';
+import { ComponentTag, MouseClick, Position } from '~/types';
 import { ItemTypes } from '../dragLayer/itemTypes';
 import { gestureable } from '../internalDashboard/gestures/determineTargetGestures';
 import { ComponentPaletteDraggable } from '../palette/types';

--- a/packages/dashboard/src/components/internalDashboard/gestures/determineTargetGestures.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/determineTargetGestures.ts
@@ -1,4 +1,4 @@
-import { Anchor } from '../../../store/actions';
+import { Anchor } from '~/store/actions';
 import { DragEvent } from '../../grid';
 
 const GESTURE_ATTRIBUTE = 'data-gesture';

--- a/packages/dashboard/src/components/internalDashboard/gestures/index.spec.tsx
+++ b/packages/dashboard/src/components/internalDashboard/gestures/index.spec.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { Provider } from 'react-redux';
 
-import { configureDashboardStore } from '../../../store';
-import { RecursivePartial } from '../../../types';
-import { DashboardState } from '../../../store/state';
+import { configureDashboardStore } from '~/store';
+import { RecursivePartial } from '~/types';
+import { DashboardState } from '~/store/state';
 import { MockDashboardFactory } from '../../../../testing/mocks';
 
 import { useGestures } from './index';

--- a/packages/dashboard/src/components/internalDashboard/gestures/index.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/index.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { DashboardState } from '../../../store/state';
-import { Widget } from '../../../types';
+import { DashboardState } from '~/store/state';
+import { Widget } from '~/types';
 import { DragEvent, PointClickEvent } from '../../grid';
 import { determineTargetGestures } from './determineTargetGestures';
 import { Gesture } from './types';

--- a/packages/dashboard/src/components/internalDashboard/gestures/useMove.spec.tsx
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useMove.spec.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { Provider } from 'react-redux';
 
-import { configureDashboardStore } from '../../../store';
-import { RecursivePartial } from '../../../types';
-import { DashboardState } from '../../../store/state';
+import { configureDashboardStore } from '~/store';
+import { RecursivePartial } from '~/types';
+import { DashboardState } from '~/store/state';
 
 import { useMoveGestures } from './useMove';
 
-import { onMoveWidgetsAction } from '../../../store/actions';
+import { onMoveWidgetsAction } from '~/store/actions';
 
 jest.mock('../../../store/actions', () => {
   const originalModule = jest.requireActual('../../../store/actions');

--- a/packages/dashboard/src/components/internalDashboard/gestures/useMove.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useMove.ts
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { onMoveWidgetsAction } from '../../../store/actions';
-import { DashboardState } from '../../../store/state';
-import { Position, Widget } from '../../../types';
-import { toGridPosition } from '../../../util/position';
+import { onMoveWidgetsAction } from '~/store/actions';
+import { DashboardState } from '~/store/state';
+import { Position, Widget } from '~/types';
+import { toGridPosition } from '~/util/position';
 import { DragEvent } from '../../grid';
 import { Gesture } from './types';
 

--- a/packages/dashboard/src/components/internalDashboard/gestures/useResize.spec.tsx
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useResize.spec.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { Provider } from 'react-redux';
 
-import { configureDashboardStore } from '../../../store';
-import { RecursivePartial } from '../../../types';
-import { DashboardState } from '../../../store/state';
+import { configureDashboardStore } from '~/store';
+import { RecursivePartial } from '~/types';
+import { DashboardState } from '~/store/state';
 
 import { useResizeGestures } from './useResize';
 
-import { onResizeWidgetsAction } from '../../../store/actions';
+import { onResizeWidgetsAction } from '~/store/actions';
 
 jest.mock('../../../store/actions', () => {
   const originalModule = jest.requireActual('../../../store/actions');

--- a/packages/dashboard/src/components/internalDashboard/gestures/useResize.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useResize.ts
@@ -1,9 +1,9 @@
 import React, { useState, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { Anchor, onResizeWidgetsAction } from '../../../store/actions';
-import { DashboardState } from '../../../store/state';
-import { Position, Widget } from '../../../types';
-import { toGridPosition } from '../../../util/position';
+import { Anchor, onResizeWidgetsAction } from '~/store/actions';
+import { DashboardState } from '~/store/state';
+import { Position, Widget } from '~/types';
+import { toGridPosition } from '~/util/position';
 import { DragEvent } from '../../grid';
 import { Gesture } from './types';
 

--- a/packages/dashboard/src/components/internalDashboard/gestures/useSelection.spec.tsx
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useSelection.spec.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { Provider } from 'react-redux';
 
-import { configureDashboardStore } from '../../../store';
+import { configureDashboardStore } from '~/store';
 import { MockDashboardFactory } from '../../../../testing/mocks';
 import { useSelectionGestures } from './useSelection';
-import { RecursivePartial } from '../../../types';
-import { DashboardState } from '../../../store/state';
+import { RecursivePartial } from '~/types';
+import { DashboardState } from '~/store/state';
 
 const TestProvider: React.FC<{
   storeArgs?: RecursivePartial<DashboardState>;

--- a/packages/dashboard/src/components/internalDashboard/gestures/useSelection.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useSelection.ts
@@ -1,9 +1,9 @@
 import React, { useState, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { onSelectWidgetsAction } from '../../../store/actions';
-import { DashboardState } from '../../../store/state';
-import { Position, Widget, Selection } from '../../../types';
-import { getSelectedWidgets, pointSelect, selectedRect } from '../../../util/select';
+import { onSelectWidgetsAction } from '~/store/actions';
+import { DashboardState } from '~/store/state';
+import { Position, Widget, Selection } from '~/types';
+import { getSelectedWidgets, pointSelect, selectedRect } from '~/util/select';
 import { DragEvent } from '../../grid';
 import { Gesture } from './types';
 

--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -11,8 +11,8 @@ import wrapper from '@cloudscape-design/components/test-utils/dom';
 import noop from 'lodash/noop';
 
 import InternalDashboard from './index';
-import { configureDashboardStore } from '../../store';
-import { DefaultDashboardMessages } from '../../messages';
+import { configureDashboardStore } from '~/store';
+import { DefaultDashboardMessages } from '~/messages';
 
 describe('InternalDashboard', () => {
   it('should render', function () {

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -3,10 +3,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import Box from '@cloudscape-design/components/box';
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 
-import { Position, Widget } from '../../types';
-import { selectedRect } from '../../util/select';
-import { useKeyPress } from '../../hooks/useKeyPress';
-import { DashboardMessages } from '../../messages';
+import { Position, Widget } from '~/types';
+import { selectedRect } from '~/util/select';
+import { useKeyPress } from '~/hooks/useKeyPress';
+import { DashboardMessages } from '~/messages';
 
 /**
  * Component imports
@@ -35,15 +35,15 @@ import {
   onPasteWidgetsAction,
   onSelectWidgetsAction,
   onSendWidgetsToBackAction,
-} from '../../store/actions';
-import { DashboardState, SaveableDashboard } from '../../store/state';
-import { onDeleteWidgetsAction } from '../../store/actions/deleteWidgets';
-import { widgetCreator } from '../../store/actions/createWidget/presets';
+  onDeleteWidgetsAction,
+} from '~/store/actions';
+import { DashboardState, SaveableDashboard } from '~/store/state';
+import { widgetCreator } from '~/store/actions/createWidget/presets';
 import { DASHBOARD_CONTAINER_ID } from '../grid/getDashboardPosition';
 
 import './index.css';
 import '@iot-app-kit/components/styles.css';
-import { toGridPosition } from '../../util/position';
+import { toGridPosition } from '~/util/position';
 import { useGestures } from './gestures';
 
 type InternalDashboardProps = {

--- a/packages/dashboard/src/components/palette/component.tsx
+++ b/packages/dashboard/src/components/palette/component.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import { useDrag } from 'react-dnd';
 
 import { ItemTypes } from '../dragLayer/itemTypes';
-import { ComponentTag } from '../../types';
+import { ComponentTag } from '~/types';
 import { ComponentPaletteDraggable } from './types';
 import PaletteComponentIcon from './icons';
 

--- a/packages/dashboard/src/components/palette/icons/index.tsx
+++ b/packages/dashboard/src/components/palette/icons/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ComponentTag } from '../../../types';
+import { ComponentTag } from '~/types';
 
 import { BarComponent } from './bar-component';
 import { GridComponent } from './grid-component';

--- a/packages/dashboard/src/components/palette/index.tsx
+++ b/packages/dashboard/src/components/palette/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { DashboardMessages } from '../../messages';
-import { ComponentTag } from '../../types';
+import { DashboardMessages } from '~/messages';
+import { ComponentTag } from '~/types';
 import PaletteComponent from './component';
 
 import './index.css';

--- a/packages/dashboard/src/components/palette/types.ts
+++ b/packages/dashboard/src/components/palette/types.ts
@@ -1,4 +1,4 @@
-import { ComponentTag } from '../../types';
+import { ComponentTag } from '~/types';
 
 export type ComponentPaletteDraggable = {
   componentTag: ComponentTag;

--- a/packages/dashboard/src/components/resourceExplorer/components/panel.test.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/panel.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { act, render, fireEvent } from '@testing-library/react';
 import { wrapWithTestBackend } from 'react-dnd-test-utils';
 import { ResourceExplorerPanel } from './panel';
-import { DashboardMessages } from '../../../messages';
+import { DashboardMessages } from '~/messages';
 import { ExtendedPanelAssetSummary } from '..';
 
 const mockMessageOverrides = { resourceExplorer: { panelEmptyLabel: 'Empty panel' } } as DashboardMessages;

--- a/packages/dashboard/src/components/resourceExplorer/components/panel.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/panel.tsx
@@ -8,7 +8,7 @@ import { ItemTypes } from '../../dragLayer/itemTypes';
 import { ExtendedPanelAssetSummary, isAlarm } from '..';
 
 import './style.css';
-import { DashboardMessages } from '../../../messages';
+import { DashboardMessages } from '~/messages';
 
 export const ResourceExplorerPanelAssetPropertyDragGhost = ({ item }: { item: ExtendedPanelAssetSummary }) => {
   return (

--- a/packages/dashboard/src/components/resourceExplorer/components/propertySearchbar.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/propertySearchbar.tsx
@@ -5,7 +5,7 @@ import { BaseChangeDetail } from '@cloudscape-design/components/input/interfaces
 import { ClientContext } from '../../dashboard/clientContext';
 import { ListTimeSeriesCommand, ListTimeSeriesCommandInput } from '@aws-sdk/client-iotsitewise';
 import { ResourceExplorerPanel } from '.';
-import { DashboardMessages } from '../../../messages';
+import { DashboardMessages } from '~/messages';
 
 interface PropertySearchbarProperty {
   isAssetProperty: boolean;

--- a/packages/dashboard/src/components/resourceExplorer/components/searchbar.test.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/searchbar.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
 import { ResourceExplorerSearchbar } from './searchbar';
-import { DefaultDashboardMessages } from '../../../messages';
+import { DefaultDashboardMessages } from '~/messages';
 import { MaybeSiteWiseAssetTreeSessionInterface } from '../types';
 
 const mockSetCrumbsToSearch = jest.fn();

--- a/packages/dashboard/src/components/resourceExplorer/components/searchbar.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/searchbar.tsx
@@ -6,7 +6,7 @@ import { BaseChangeDetail } from '@cloudscape-design/components/input/interfaces
 import { MaybeSiteWiseAssetTreeSessionInterface } from '../types';
 import { AssetPropertiesCache } from '../useAssetProperties';
 import { ExtendedPanelAssetSummary } from '..';
-import { DashboardMessages } from '../../../messages';
+import { DashboardMessages } from '~/messages';
 
 interface SearchOption {
   id: string;

--- a/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.test.ts
+++ b/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.test.ts
@@ -1,6 +1,6 @@
 import { getCurrentAssetProperties } from './getCurrentAssetProperties';
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
-import { DashboardMessages } from '../../messages';
+import { DashboardMessages } from '~/messages';
 
 const listAssetPropertiesResponse = {
   assetPropertySummaries: [

--- a/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.ts
+++ b/packages/dashboard/src/components/resourceExplorer/getCurrentAssetProperties.ts
@@ -1,7 +1,7 @@
 import { AssetPropertySummary, IoTSiteWiseClient, ListAssetPropertiesCommand } from '@aws-sdk/client-iotsitewise';
 import { HIERARCHY_ROOT_ID } from '.';
 import { ExtendedPanelAssetSummary } from '.';
-import { DashboardMessages } from '../../messages';
+import { DashboardMessages } from '~/messages';
 
 export const sendCommand = (client: IoTSiteWiseClient, assetId: string) =>
   client.send(new ListAssetPropertiesCommand({ assetId }));

--- a/packages/dashboard/src/components/resourceExplorer/getCurrentAssets.test.ts
+++ b/packages/dashboard/src/components/resourceExplorer/getCurrentAssets.test.ts
@@ -1,7 +1,7 @@
 import { getCurrentAssets } from './getCurrentAssets';
 import { HIERARCHY_ROOT_ID } from '.';
 import { MaybeSiteWiseAssetTreeSessionInterface } from './types';
-import { DashboardMessages } from '../../messages';
+import { DashboardMessages } from '~/messages';
 
 describe('getCurrentAssets', () => {
   it('should return all assets under the root when currentBranchId is hierachy root id', async () => {

--- a/packages/dashboard/src/components/resourceExplorer/getCurrentAssets.ts
+++ b/packages/dashboard/src/components/resourceExplorer/getCurrentAssets.ts
@@ -3,7 +3,7 @@ import { AssetSummary, AssetHierarchy } from '@aws-sdk/client-iotsitewise';
 import { HIERARCHY_ROOT_ID } from '.';
 import { AssetNode, BranchReferenceWithAssetIds, MaybeSiteWiseAssetTreeSessionInterface } from './types';
 import { ExtendedPanelAssetSummary, EitherAssetSummary } from '.';
-import { DashboardMessages } from '../../messages';
+import { DashboardMessages } from '~/messages';
 
 const getAllHierachyAssets = (
   currentAsset: AssetSummary,

--- a/packages/dashboard/src/components/resourceExplorer/index.test.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/index.test.tsx
@@ -11,7 +11,7 @@ import { ResourceExplorer } from './index';
 import { mockListAssets, mockListAssociatedAssets } from '../../../stories/IotDashboard/mockData';
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { act } from 'react-dom/test-utils';
-import { DefaultDashboardMessages } from '../../messages';
+import { DefaultDashboardMessages } from '~/messages';
 
 global.structuredClone = (val: unknown) => JSON.parse(JSON.stringify(val));
 

--- a/packages/dashboard/src/components/resourceExplorer/index.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/index.tsx
@@ -16,7 +16,7 @@ import { describeCurrentAsset } from './describeCurrentAsset';
 import { getCurrentAssets } from './getCurrentAssets';
 import { getCurrentAssetProperties } from './getCurrentAssetProperties';
 import { AssetQuery } from '@iot-app-kit/core';
-import { DashboardMessages } from '../../messages';
+import { DashboardMessages } from '~/messages';
 import { useAssetProperties } from './useAssetProperties';
 import { ClientContext } from '../dashboard/clientContext';
 

--- a/packages/dashboard/src/components/sidePanel/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/index.tsx
@@ -1,9 +1,9 @@
 import React, { FC } from 'react';
 import { Header, SpaceBetween } from '@cloudscape-design/components';
 import { useSelector } from 'react-redux';
-import { DashboardState } from '../../store/state';
-import { DashboardMessages } from '../../messages';
-import { AppKitComponentTags } from '../../types';
+import { DashboardState } from '~/store/state';
+import { DashboardMessages } from '~/messages';
+import { AppKitComponentTags } from '~/types';
 import TextSettings from './sections/textSettingSection/text';
 import LinkSettings from './sections/textSettingSection/link';
 import { BaseSettings } from './sections/baseSettingSection';

--- a/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.spec.tsx
@@ -1,9 +1,9 @@
-import { Widget } from '../../../../types';
+import { Widget } from '~/types';
 import { MOCK_KPI_WIDGET } from '../../../../../testing/mocks';
-import { DashboardState } from '../../../../store/state';
+import { DashboardState } from '~/store/state';
 import { Provider } from 'react-redux';
-import { configureDashboardStore } from '../../../../store';
-import { DefaultDashboardMessages } from '../../../../messages';
+import { configureDashboardStore } from '~/store';
+import { DefaultDashboardMessages } from '~/messages';
 import { render } from '@testing-library/react';
 import React from 'react';
 import AxisSetting from './index';

--- a/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { DashboardMessages } from '../../../../messages';
+import { DashboardMessages } from '~/messages';
 import {
   ExpandableSection,
   Grid,

--- a/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.spec.tsx
@@ -1,9 +1,9 @@
-import { Widget } from '../../../../types';
+import { Widget } from '~/types';
 import { MOCK_KPI_WIDGET } from '../../../../../testing/mocks';
-import { DashboardState } from '../../../../store/state';
+import { DashboardState } from '~/store/state';
 import { Provider } from 'react-redux';
-import { configureDashboardStore } from '../../../../store';
-import { DefaultDashboardMessages } from '../../../../messages';
+import { configureDashboardStore } from '~/store';
+import { DefaultDashboardMessages } from '~/messages';
 import React from 'react';
 import { BaseSettings } from './index';
 import { render } from '@testing-library/react';

--- a/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { DashboardMessages } from '../../../../messages';
+import { DashboardMessages } from '~/messages';
 import { useInput } from '../../utils';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import { BaseChangeDetail } from '@cloudscape-design/components/input/interfaces';

--- a/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.test.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
-import { configureDashboardStore } from '../../../../store';
+import { configureDashboardStore } from '~/store';
 import { PropertyComponent } from './propertyComponent';
 import { AssetQuery } from '@iot-app-kit/core';
-import { DashboardState } from '../../../../store/state';
+import { DashboardState } from '~/store/state';
 import { DescribeAssetResponse, PropertyDataType } from '@aws-sdk/client-iotsitewise';
 import { cleanup, render, screen } from '@testing-library/react';
 import { MOCK_KPI_WIDGET } from '../../../../../testing/mocks';
-import { AppKitWidget } from '../../../../types';
+import { AppKitWidget } from '~/types';
 import PropertiesAlarmsSection from './index';
-import { DefaultDashboardMessages } from '../../../../messages';
+import { DefaultDashboardMessages } from '~/messages';
 
 const mockOnDeleteAssetQuery = jest.fn();
 const MockAssetQuery: AssetQuery = {

--- a/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.tsx
@@ -3,12 +3,12 @@ import { ExpandableSection, SpaceBetween } from '@cloudscape-design/components';
 import ExpandableSectionHeader from '../../shared/expandableSectionHeader';
 import { AssetQuery } from '@iot-app-kit/core';
 import { useDispatch, useSelector } from 'react-redux';
-import { DashboardState } from '../../../../store/state';
+import { DashboardState } from '~/store/state';
 import { useInput } from '../../utils';
-import { onUpdateAssetQueryAction } from '../../../../store/actions/updateAssetQuery';
-import { AppKitWidget, Widget } from '../../../../types';
+import { onUpdateAssetQueryAction } from '~/store/actions/updateAssetQuery';
+import { AppKitWidget, Widget } from '~/types';
 import { PropertyComponent } from './propertyComponent';
-import { DashboardMessages } from '../../../../messages';
+import { DashboardMessages } from '~/messages';
 
 export type PropertiesAlarmsSectionProps = {
   messageOverrides: DashboardMessages;

--- a/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/propertyComponent.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/propertyComponent.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from 'react';
 import { useSelector } from 'react-redux';
-import { DashboardState } from '../../../../store/state';
+import { DashboardState } from '~/store/state';
 import { useInput } from '../../utils';
 import { StyleSettingsMap } from '@iot-app-kit/core';
 import { Button, Grid, SpaceBetween } from '@cloudscape-design/components';
-import { DashboardMessages } from '../../../../messages';
+import { DashboardMessages } from '~/messages';
 import ColorPicker from '../../shared/colorPicker';
 
 export type PropertyComponentProps = {

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.spec.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { TextWidget } from '../../../../types';
+import { TextWidget } from '~/types';
 import { MOCK_TEXT_WIDGET } from '../../../../../testing/mocks';
-import { DashboardState } from '../../../../store/state';
+import { DashboardState } from '~/store/state';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { configureDashboardStore } from '../../../../store';
-import { DefaultDashboardMessages } from '../../../../messages';
+import { configureDashboardStore } from '~/store';
+import { DefaultDashboardMessages } from '~/messages';
 import LinkSettings from './link';
 
 const widget: TextWidget = { ...MOCK_TEXT_WIDGET, link: 'sample-link' };

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/link.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { ExpandableSection, Grid, Input, InputProps, Toggle } from '@cloudscape-design/components';
-import { DashboardMessages } from '../../../../messages';
+import { DashboardMessages } from '~/messages';
 import { useTextWidgetInput } from '../../utils';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import './index.scss';

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.spec.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { TextWidget } from '../../../../types';
+import { TextWidget } from '~/types';
 import { MOCK_TEXT_WIDGET } from '../../../../../testing/mocks';
-import { DashboardState } from '../../../../store/state';
+import { DashboardState } from '~/store/state';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { configureDashboardStore } from '../../../../store';
+import { configureDashboardStore } from '~/store';
 import TextSettings from './text';
-import { DefaultDashboardMessages } from '../../../../messages';
+import { DefaultDashboardMessages } from '~/messages';
 import wrapper from '@cloudscape-design/components/test-utils/dom';
 
 const widget: TextWidget = { ...MOCK_TEXT_WIDGET, bold: true, italic: true, underline: false };

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.tsx
@@ -1,5 +1,5 @@
 import React, { FC, MouseEventHandler } from 'react';
-import { DashboardMessages } from '../../../../messages';
+import { DashboardMessages } from '~/messages';
 import { useTextWidgetInput } from '../../utils';
 import { ExpandableSection, Grid, Select, SelectProps } from '@cloudscape-design/components';
 import ColorPicker from '../../shared/colorPicker';

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/index.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/index.spec.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { AppKitWidget } from '../../../../types';
+import { AppKitWidget } from '~/types';
 import { MOCK_KPI_WIDGET } from '../../../../../testing/mocks';
-import { DashboardState } from '../../../../store/state';
+import { DashboardState } from '~/store/state';
 import { COMPARISON_OPERATOR, Threshold } from '@synchro-charts/core';
 import { Provider } from 'react-redux';
-import { configureDashboardStore } from '../../../../store';
+import { configureDashboardStore } from '~/store';
 import ThresholdsSection from './thresholdsSection';
-import { DefaultDashboardMessages } from '../../../../messages';
+import { DefaultDashboardMessages } from '~/messages';
 import { render } from '@testing-library/react';
 import { ThresholdComponent } from './thresholdComponent';
 

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdComponent.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdComponent.tsx
@@ -1,11 +1,11 @@
 import { COMPARISON_OPERATOR, ThresholdValue } from '@synchro-charts/core';
 import React, { FC, useEffect, useState } from 'react';
-import { DashboardMessages } from '../../../../messages';
+import { DashboardMessages } from '~/messages';
 import { useInput } from '../../utils';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import { Button, Grid, Input, InputProps, Select, SelectProps } from '@cloudscape-design/components';
 import { DEFAULT_THRESHOLD_COLOR, OPS_ALLOWED_WITH_STRING } from './defaultValues';
-import { AppKitComponentTag } from '../../../../types';
+import { AppKitComponentTag } from '~/types';
 import './index.scss';
 import ColorPicker from '../../shared/colorPicker';
 

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
@@ -4,7 +4,7 @@ import ExpandableSectionHeader from '../../shared/expandableSectionHeader';
 import { useInput } from '../../utils';
 import { COMPARISON_OPERATOR, YAnnotation } from '@synchro-charts/core';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
-import { DashboardMessages } from '../../../../messages';
+import { DashboardMessages } from '~/messages';
 import './index.scss';
 import { DEFAULT_THRESHOLD_COLOR } from './defaultValues';
 import { ThresholdComponent } from './thresholdComponent';

--- a/packages/dashboard/src/components/sidePanel/utils/index.ts
+++ b/packages/dashboard/src/components/sidePanel/utils/index.ts
@@ -2,9 +2,9 @@ import { Dispatch, useEffect, useState } from 'react';
 // import { useDispatch } from 'react-redux';
 import { cloneDeep, get, set } from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
-import { DashboardState } from '../../../store/state';
-import { onUpdateWidgetsAction } from '../../../store/actions';
-import { AppKitWidget, TextWidget, Widget } from '../../../types';
+import { DashboardState } from '~/store/state';
+import { onUpdateWidgetsAction } from '~/store/actions';
+import { AppKitWidget, TextWidget, Widget } from '~/types';
 
 export type typedInputHook<T extends Widget = Widget> = <K extends keyof T>(key: K) => [T[K], Dispatch<T[K]>];
 

--- a/packages/dashboard/src/components/userSelection/index.tsx
+++ b/packages/dashboard/src/components/userSelection/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Rect } from '../../types';
+import { Rect } from '~/types';
 
 import './index.css';
 

--- a/packages/dashboard/src/components/viewportSelection/index.test.tsx
+++ b/packages/dashboard/src/components/viewportSelection/index.test.tsx
@@ -9,9 +9,9 @@ import { act } from 'react-dom/test-utils';
 import { screen } from '@testing-library/dom';
 
 import ViewportSelection from './index';
-import { configureDashboardStore } from '../../store';
-import { DefaultDashboardMessages } from '../../messages';
-import { DashboardState } from '../../store/state';
+import { configureDashboardStore } from '~/store';
+import { DefaultDashboardMessages } from '~/messages';
+import { DashboardState } from '~/store/state';
 
 const LAST_MINUTE = 0;
 const CUSTOM = 9;

--- a/packages/dashboard/src/components/viewportSelection/index.tsx
+++ b/packages/dashboard/src/components/viewportSelection/index.tsx
@@ -5,9 +5,9 @@ import { useDispatch } from 'react-redux';
 import DateRangePicker, { DateRangePickerProps } from '@cloudscape-design/components/date-range-picker';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 
-import { DashboardConfiguration } from '../../types';
-import { DashboardMessages } from '../../messages';
-import { onUpdateViewportAction } from '../../store/actions';
+import { DashboardConfiguration } from '~/types';
+import { DashboardMessages } from '~/messages';
+import { onUpdateViewportAction } from '~/store/actions';
 
 import { dateRangeToViewport, relativeOptions, viewportToDateRange } from './viewportAdapter';
 

--- a/packages/dashboard/src/components/viewportSelection/viewportAdapter.ts
+++ b/packages/dashboard/src/components/viewportSelection/viewportAdapter.ts
@@ -1,7 +1,7 @@
 import parse from 'parse-duration';
 import { DateRangePickerProps } from '@cloudscape-design/components';
 
-import { DashboardConfiguration } from '../../types';
+import { DashboardConfiguration } from '~/types';
 
 const relativeOptionKey = (amount: number, unit: DateRangePickerProps.TimeUnit): string =>
   `previous-${amount}-${unit}s`;

--- a/packages/dashboard/src/components/widgets/componentMap.ts
+++ b/packages/dashboard/src/components/widgets/componentMap.ts
@@ -10,7 +10,7 @@ import {
 import TextWidget from './primitives/text';
 import InputWidget from './primitives/input';
 
-import { ComponentTag } from '../../types';
+import { ComponentTag } from '~/types';
 
 // eslint-disable-next-line
 export const ComponentMap: { [key in ComponentTag]: any } = {

--- a/packages/dashboard/src/components/widgets/dynamicWidget.tsx
+++ b/packages/dashboard/src/components/widgets/dynamicWidget.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import './dynamicWidget.css';
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
-import { AppKitComponentTag, AppKitComponentTags, AppKitWidget, DashboardConfiguration, Widget } from '../../types';
+import { AppKitComponentTag, AppKitComponentTags, AppKitWidget, DashboardConfiguration, Widget } from '~/types';
 import { ComponentMap } from './componentMap';
-import { WidgetsMessages } from '../../messages';
+import { WidgetsMessages } from '~/messages';
 
 const IconX: React.FC = () => (
   <svg

--- a/packages/dashboard/src/components/widgets/list.tsx
+++ b/packages/dashboard/src/components/widgets/list.tsx
@@ -4,12 +4,12 @@ import map from 'lodash/map';
 import includes from 'lodash/includes';
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 
-import { DashboardConfiguration, Widget } from '../../types';
+import { DashboardConfiguration, Widget } from '~/types';
 
 import './list.css';
 import WidgetComponent from './widget';
 import SelectionBox from './selectionBox';
-import { DashboardMessages } from '../../messages';
+import { DashboardMessages } from '~/messages';
 
 export type WidgetsProps = {
   readOnly: boolean;

--- a/packages/dashboard/src/components/widgets/primitives/input/index.tsx
+++ b/packages/dashboard/src/components/widgets/primitives/input/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, Select, SelectProps } from '@cloudscape-design/components';
 import SpaceBetween from '@cloudscape-design/components/space-between';
-import { InputWidget as InputWidgetType } from '../../../../types';
+import { InputWidget as InputWidgetType } from '~/types';
 
 export type InputWidgetProps = InputWidgetType & { readOnly: boolean };
 

--- a/packages/dashboard/src/components/widgets/primitives/text/index.tsx
+++ b/packages/dashboard/src/components/widgets/primitives/text/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { onChangeDashboardGridEnabledAction } from '../../../../store/actions';
+import { onChangeDashboardGridEnabledAction } from '~/store/actions';
 
 import { TextWidget as TextWidgetType } from '../../../../types';
 

--- a/packages/dashboard/src/components/widgets/primitives/text/link/editableLink.tsx
+++ b/packages/dashboard/src/components/widgets/primitives/text/link/editableLink.tsx
@@ -12,10 +12,10 @@ import FormField from '@cloudscape-design/components/form-field';
 import Input from '@cloudscape-design/components/input';
 import { CancelableEventHandler } from '@cloudscape-design/components/internal/events';
 
-import { useClickOutside } from '../../../../../hooks/useClickOutside';
-import { useHover } from '../../../../../hooks/useHover';
-import { onUpdateWidgetsAction } from '../../../../../store/actions';
-import { TextWidget } from '../../../../../types';
+import { useClickOutside } from '~/hooks/useClickOutside';
+import { useHover } from '~/hooks/useHover';
+import { onUpdateWidgetsAction } from '~/store/actions';
+import { TextWidget } from '~/types';
 
 import './editableLink.css';
 

--- a/packages/dashboard/src/components/widgets/primitives/text/link/index.tsx
+++ b/packages/dashboard/src/components/widgets/primitives/text/link/index.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties } from 'react';
 
-import { TextWidget } from '../../../../../types';
+import { TextWidget } from '~/types';
 
 type TextLinkProps = TextWidget;
 

--- a/packages/dashboard/src/components/widgets/primitives/text/styledText/editableText.tsx
+++ b/packages/dashboard/src/components/widgets/primitives/text/styledText/editableText.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { TextWidget } from '../../../../../types';
+import { TextWidget } from '~/types';
 import StyledText from './index';
 
 type EditableStyledTextProps = TextWidget & {

--- a/packages/dashboard/src/components/widgets/primitives/text/styledText/index.tsx
+++ b/packages/dashboard/src/components/widgets/primitives/text/styledText/index.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from 'react';
-import { TextWidget } from '../../../../../types';
+import { TextWidget } from '~/types';
 
 import './index.css';
 

--- a/packages/dashboard/src/components/widgets/primitives/text/styledText/textArea.tsx
+++ b/packages/dashboard/src/components/widgets/primitives/text/styledText/textArea.tsx
@@ -1,9 +1,9 @@
 import React, { CSSProperties, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { useClickOutside } from '../../../../../hooks/useClickOutside';
-import { useKeyPress } from '../../../../../hooks/useKeyPress';
-import { onUpdateWidgetsAction } from '../../../../../store/actions';
-import { TextWidget } from '../../../../../types';
+import { useClickOutside } from '~/hooks/useClickOutside';
+import { useKeyPress } from '~/hooks/useKeyPress';
+import { onUpdateWidgetsAction } from '~/store/actions';
+import { TextWidget } from '~/types';
 
 import './textArea.css';
 

--- a/packages/dashboard/src/components/widgets/selectionBox.tsx
+++ b/packages/dashboard/src/components/widgets/selectionBox.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Widget } from '../../types';
+import { Widget } from '~/types';
 import SelectionBoxAnchor from './selectionBoxAnchor';
 import { gestureable } from '../internalDashboard/gestures/determineTargetGestures';
-import { getSelectionBox } from '../../util/getSelectionBox';
+import { getSelectionBox } from '~/util/getSelectionBox';
 
 import './selectionBox.css';
 

--- a/packages/dashboard/src/components/widgets/selectionBoxAnchor.tsx
+++ b/packages/dashboard/src/components/widgets/selectionBoxAnchor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { anchorable, gestureable } from '../internalDashboard/gestures/determineTargetGestures';
-import { Anchor } from '../../store/actions/resizeWidgets';
+import { Anchor } from '~/store/actions';
 
 import './selectionBoxAnchor.css';
 

--- a/packages/dashboard/src/components/widgets/widget.tsx
+++ b/packages/dashboard/src/components/widgets/widget.tsx
@@ -1,9 +1,9 @@
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 import React, { useState, useEffect } from 'react';
 import { useDrop } from 'react-dnd';
-import { DashboardMessages } from '../../messages';
+import { DashboardMessages } from '~/messages';
 
-import { DashboardConfiguration, Widget } from '../../types';
+import { DashboardConfiguration, Widget } from '~/types';
 import { gestureable, idable } from '../internalDashboard/gestures/determineTargetGestures';
 import DynamicWidgetComponent from './dynamicWidget';
 import { ItemTypes } from '../dragLayer/itemTypes';

--- a/packages/dashboard/src/store/actions/bringToFront/index.spec.ts
+++ b/packages/dashboard/src/store/actions/bringToFront/index.spec.ts
@@ -2,7 +2,7 @@ import { bringWidgetsToFront } from '.';
 import { DashboardState, initialState } from '../../state';
 
 import { MockWidgetFactory, MOCK_KPI_WIDGET } from '../../../../testing/mocks';
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 
 const setupDashboardState = (widgets: Widget[] = [], selectedWidgets: Widget[] = []): DashboardState => ({
   ...initialState,

--- a/packages/dashboard/src/store/actions/changeDashboardGrid/updateGrid.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardGrid/updateGrid.ts
@@ -1,4 +1,4 @@
-import { constrainWidgetPositionToGrid } from '../../../util/constrainWidgetPositionToGrid';
+import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
 import { DashboardState } from '../../state';
 
 type GridProperties = keyof DashboardState['grid'];

--- a/packages/dashboard/src/store/actions/copyWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/copyWidgets/index.spec.ts
@@ -2,7 +2,7 @@ import { copyWidgets, onCopyWidgetsAction } from '.';
 import { DashboardState, initialState } from '../../state';
 
 import { MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET, MOCK_SCATTER_CHART_WIDGET } from '../../../../testing/mocks';
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 
 const setupDashboardState = (widgets: Widget[] = [], pasteCounter = 0): DashboardState => ({
   ...initialState,

--- a/packages/dashboard/src/store/actions/copyWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/copyWidgets/index.ts
@@ -2,7 +2,7 @@ import { Action } from 'redux';
 
 import intersectionBy from 'lodash/intersectionBy';
 
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 import { DashboardState } from '../../state';
 
 type CopyWidgetsActionPayload = {

--- a/packages/dashboard/src/store/actions/createWidget/index.ts
+++ b/packages/dashboard/src/store/actions/createWidget/index.ts
@@ -1,8 +1,8 @@
 import { Action } from 'redux';
 
-import { Widget } from '../../../types';
-import { constrainWidgetPositionToGrid } from '../../../util/constrainWidgetPositionToGrid';
-import { trimWidgetPosition } from '../../../util/trimWidgetPosition';
+import { Widget } from '~/types';
+import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
+import { trimWidgetPosition } from '~/util/trimWidgetPosition';
 import { DashboardState } from '../../state';
 
 type CreateWidgetsActionPayload = {

--- a/packages/dashboard/src/store/actions/createWidget/presets/appKit.ts
+++ b/packages/dashboard/src/store/actions/createWidget/presets/appKit.ts
@@ -1,4 +1,4 @@
-import { AppKitComponentTag, AppKitWidget, Widget } from '../../../../types';
+import { AppKitComponentTag, AppKitWidget, Widget } from '~/types';
 
 export const appKitWidgetCreator = (componentTag: AppKitComponentTag, preset: Widget): AppKitWidget => {
   return {

--- a/packages/dashboard/src/store/actions/createWidget/presets/index.ts
+++ b/packages/dashboard/src/store/actions/createWidget/presets/index.ts
@@ -1,6 +1,6 @@
 import { nanoid } from '@reduxjs/toolkit';
-import { ComponentTag, Widget, AppKitComponentTag, AppKitComponentTags } from '../../../../types';
-import { DashboardState } from '../../../state';
+import { ComponentTag, Widget, AppKitComponentTag, AppKitComponentTags } from '~/types';
+import { DashboardState } from '~/store/state';
 import { appKitWidgetCreator } from './appKit';
 import { WidgetSizePresets } from './sizing';
 import { textWidgetCreator } from './text';

--- a/packages/dashboard/src/store/actions/createWidget/presets/input.tsx
+++ b/packages/dashboard/src/store/actions/createWidget/presets/input.tsx
@@ -1,4 +1,4 @@
-import { InputWidget, Widget } from '../../../../types';
+import { InputWidget, Widget } from '~/types';
 
 export const inputWidgetCreator = (componentTag: 'input', preset: Widget): InputWidget => ({
   ...preset,

--- a/packages/dashboard/src/store/actions/createWidget/presets/sizing.ts
+++ b/packages/dashboard/src/store/actions/createWidget/presets/sizing.ts
@@ -1,4 +1,4 @@
-import { ComponentTag, Widget } from '../../../../types';
+import { ComponentTag, Widget } from '~/types';
 
 /**
  * Because the dashboard grid variables can change, these presets are defined in real pixel sizes.

--- a/packages/dashboard/src/store/actions/createWidget/presets/text.ts
+++ b/packages/dashboard/src/store/actions/createWidget/presets/text.ts
@@ -1,4 +1,4 @@
-import { TextWidget, Widget } from '../../../../types';
+import { TextWidget, Widget } from '~/types';
 
 export const textWidgetCreator = (componentTag: 'text', preset: Widget): TextWidget => ({
   ...preset,

--- a/packages/dashboard/src/store/actions/deleteWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/deleteWidgets/index.spec.ts
@@ -2,7 +2,7 @@ import { deleteWidgets, onDeleteWidgetsAction } from './index';
 import { DashboardState, initialState } from '../../state';
 
 import { MockWidgetFactory, MOCK_KPI_WIDGET } from '../../../../testing/mocks';
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 
 const setupDashboardState = (widgets: Widget[] = []): DashboardState => ({
   ...initialState,

--- a/packages/dashboard/src/store/actions/deleteWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/deleteWidgets/index.ts
@@ -1,6 +1,6 @@
 import { Action } from 'redux';
 
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 import { DashboardState } from '../../state';
 
 type DeleteWidgetsActionPayload = {

--- a/packages/dashboard/src/store/actions/moveWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/moveWidgets/index.spec.ts
@@ -2,7 +2,7 @@ import { moveWidgets, onMoveWidgetsAction } from './index';
 import { DashboardState, initialState } from '../../state';
 
 import { MockWidgetFactory, MOCK_KPI_WIDGET } from '../../../../testing/mocks';
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 
 const setupDashboardState = (widgets: Widget[] = []): DashboardState => ({
   ...initialState,

--- a/packages/dashboard/src/store/actions/moveWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/moveWidgets/index.ts
@@ -1,8 +1,8 @@
 import { Action } from 'redux';
 
-import { Position, Widget } from '../../../types';
-import { constrainWidgetPositionToGrid } from '../../../util/constrainWidgetPositionToGrid';
-import { trimWidgetPosition } from '../../../util/trimWidgetPosition';
+import { Position, Widget } from '~/types';
+import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
+import { trimWidgetPosition } from '~/util/trimWidgetPosition';
 import { DashboardState } from '../../state';
 
 type MoveWidgetsActionPayload = {

--- a/packages/dashboard/src/store/actions/pasteWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/pasteWidgets/index.spec.ts
@@ -2,7 +2,7 @@ import { pasteWidgets, onPasteWidgetsAction } from '.';
 import { DashboardState, initialState } from '../../state';
 
 import { MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET } from '../../../../testing/mocks';
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 
 const setupDashboardState = (widgets: Widget[] = [], copiedWidgets: Widget[] = []): DashboardState => ({
   ...initialState,

--- a/packages/dashboard/src/store/actions/pasteWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/pasteWidgets/index.ts
@@ -3,7 +3,7 @@ import { Action } from 'redux';
 import first from 'lodash/first';
 import sortBy from 'lodash/sortBy';
 
-import { Position } from '../../../types';
+import { Position } from '~/types';
 import { DashboardState } from '../../state';
 import { v4 } from 'uuid';
 

--- a/packages/dashboard/src/store/actions/resizeWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/resizeWidgets/index.spec.ts
@@ -4,7 +4,7 @@ import { onResizeWidgetsAction, resizeWidgets } from './index';
 import { DashboardState, initialState } from '../../state';
 
 import { MOCK_KPI_WIDGET } from '../../../../testing/mocks';
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 
 const setupDashboardState = (widgets: Widget[] = []): DashboardState => ({
   ...initialState,

--- a/packages/dashboard/src/store/actions/resizeWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/resizeWidgets/index.ts
@@ -1,8 +1,8 @@
 import { Action } from 'redux';
-import { Position, Rect, Widget } from '../../../types';
-import { constrainWidgetPositionToGrid } from '../../../util/constrainWidgetPositionToGrid';
-import { getSelectionBox } from '../../../util/getSelectionBox';
-import { trimWidgetPosition } from '../../../util/trimWidgetPosition';
+import { Position, Rect, Widget } from '~/types';
+import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
+import { getSelectionBox } from '~/util/getSelectionBox';
+import { trimWidgetPosition } from '~/util/trimWidgetPosition';
 import { DashboardState } from '../../state';
 
 const MIN_HEIGHT = 2;

--- a/packages/dashboard/src/store/actions/selectWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/selectWidgets/index.ts
@@ -1,7 +1,7 @@
 import { Action } from 'redux';
 import uniqBy from 'lodash/uniqBy';
 
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 import { DashboardState } from '../../state';
 
 type SelectWidgetsActionPayload = {

--- a/packages/dashboard/src/store/actions/sendToBack/index.spec.ts
+++ b/packages/dashboard/src/store/actions/sendToBack/index.spec.ts
@@ -1,6 +1,6 @@
 import { sendWidgetsToBack } from '.';
 import { MockWidgetFactory, MOCK_KPI_WIDGET } from '../../../../testing/mocks';
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 import { DashboardState, initialState } from '../../state';
 
 const setupDashboardState = (widgets: Widget[] = [], selectedWidgets: Widget[] = []): DashboardState => ({

--- a/packages/dashboard/src/store/actions/updateAssetQuery/index.ts
+++ b/packages/dashboard/src/store/actions/updateAssetQuery/index.ts
@@ -1,9 +1,9 @@
 import { AssetQuery } from '@iot-app-kit/core';
 import { Action } from 'redux';
 
-import { AppKitWidget, Widget } from '../../../types';
+import { AppKitWidget, Widget } from '~/types';
 import { DashboardState } from '../../state';
-import { colorPalette } from '../../../util/colorPalette';
+import { colorPalette } from '~/util/colorPalette';
 
 type UpdateAssetQueryActionPayload = {
   widget: AppKitWidget;

--- a/packages/dashboard/src/store/actions/updateAssetsDescription/index.spec.ts
+++ b/packages/dashboard/src/store/actions/updateAssetsDescription/index.spec.ts
@@ -1,4 +1,4 @@
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 import { DashboardState, initialState } from '../../state';
 import { onUpdateAssetsDescriptionMap, updateAssetDescriptionMap } from './index';
 import { DescribeAssetResponse, PropertyDataType } from '@aws-sdk/client-iotsitewise';

--- a/packages/dashboard/src/store/actions/updateViewport/index.ts
+++ b/packages/dashboard/src/store/actions/updateViewport/index.ts
@@ -1,6 +1,6 @@
 import { Action } from 'redux';
 
-import { DashboardConfiguration } from '../../../types';
+import { DashboardConfiguration } from '~/types';
 import { DashboardState } from '../../state';
 
 type UpdateViewportActionPayload = {

--- a/packages/dashboard/src/store/actions/updateWidget/index.spec.ts
+++ b/packages/dashboard/src/store/actions/updateWidget/index.spec.ts
@@ -2,7 +2,7 @@ import { updateWidgets, onUpdateWidgetsAction } from '.';
 import { DashboardState, initialState } from '../../state';
 
 import { MockWidgetFactory, MOCK_TEXT_WIDGET } from '../../../../testing/mocks';
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 
 const setupDashboardState = (widgets: Widget[] = []): DashboardState => ({
   ...initialState,

--- a/packages/dashboard/src/store/actions/updateWidget/index.ts
+++ b/packages/dashboard/src/store/actions/updateWidget/index.ts
@@ -1,8 +1,8 @@
 import { Action } from 'redux';
 
-import { Widget } from '../../../types';
-import { constrainWidgetPositionToGrid } from '../../../util/constrainWidgetPositionToGrid';
-import { trimWidgetPosition } from '../../../util/trimWidgetPosition';
+import { Widget } from '~/types';
+import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
+import { trimWidgetPosition } from '~/util/trimWidgetPosition';
 import { DashboardState } from '../../state';
 
 type UpdateWidgetsActionPayload = {

--- a/packages/dashboard/src/store/index.ts
+++ b/packages/dashboard/src/store/index.ts
@@ -6,7 +6,7 @@ import merge from 'lodash/merge';
 import { DashboardAction } from './actions';
 import { DashboardState, initialState } from './state';
 import { dashboardReducer } from './reducer';
-import { RecursivePartial } from '../types';
+import { RecursivePartial } from '~/types';
 import { describeAssetSaga } from './sagas/describeAsset';
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 

--- a/packages/dashboard/src/store/sagas/describeAsset/index.spec.ts
+++ b/packages/dashboard/src/store/sagas/describeAsset/index.spec.ts
@@ -3,7 +3,7 @@
 import { expectSaga } from 'redux-saga-test-plan';
 import { describeAssetSaga, getAssetsDescriptionMap, sendCommand } from './index';
 import { select } from 'redux-saga/effects';
-import { Widget } from '../../../types';
+import { Widget } from '~/types';
 import { DashboardState, initialState } from '../../state';
 import * as matchers from 'redux-saga-test-plan/matchers';
 import { DescribeAssetResponse, PropertyDataType } from '@aws-sdk/client-iotsitewise';

--- a/packages/dashboard/src/store/state.ts
+++ b/packages/dashboard/src/store/state.ts
@@ -1,4 +1,4 @@
-import { DashboardConfiguration, Widget } from '../types';
+import { DashboardConfiguration, Widget } from '~/types';
 import { DescribeAssetResponse } from '@aws-sdk/client-iotsitewise';
 
 export type DashboardState = {

--- a/packages/dashboard/src/util/constrainWidgetPositionToGrid.ts
+++ b/packages/dashboard/src/util/constrainWidgetPositionToGrid.ts
@@ -1,4 +1,4 @@
-import { Rect, Widget } from '../types';
+import { Rect, Widget } from '~/types';
 
 export const constrainWidgetPositionToGrid = (gridRect: Rect, widget: Widget): Widget => ({
   ...widget,

--- a/packages/dashboard/src/util/getSelectionBox.ts
+++ b/packages/dashboard/src/util/getSelectionBox.ts
@@ -1,4 +1,4 @@
-import { Rect, Widget } from '../types';
+import { Rect, Widget } from '~/types';
 
 // Returns the smallest rectangle which can contain all the selected widgets
 export const getSelectionBox = (selectedWidgets: Widget[]): Rect | null => {

--- a/packages/dashboard/src/util/isContained.ts
+++ b/packages/dashboard/src/util/isContained.ts
@@ -1,4 +1,4 @@
-import { Rect } from '../types';
+import { Rect } from '~/types';
 import intersect from 'box-intersect';
 
 export const isContained = (a: Rect, b: Rect): boolean => {

--- a/packages/dashboard/src/util/position.ts
+++ b/packages/dashboard/src/util/position.ts
@@ -1,4 +1,4 @@
-import { Position } from '../types';
+import { Position } from '~/types';
 
 /**
  *

--- a/packages/dashboard/src/util/select.ts
+++ b/packages/dashboard/src/util/select.ts
@@ -1,7 +1,7 @@
 import last from 'lodash/last';
 import sortBy from 'lodash/sortBy';
 
-import { DashboardConfiguration, Position, Rect, Selection, Widget } from '../types';
+import { DashboardConfiguration, Position, Rect, Selection, Widget } from '~/types';
 import { isContained } from './isContained';
 
 export const getSelectedWidgets = ({

--- a/packages/dashboard/src/util/trimWidgetPosition.ts
+++ b/packages/dashboard/src/util/trimWidgetPosition.ts
@@ -1,4 +1,4 @@
-import { Widget } from '../types';
+import { Widget } from '~/types';
 
 export const trimWidgetPosition = (widget: Widget): Widget => {
   return {

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -12,7 +12,11 @@
     "moduleResolution": "Node",
     "declaration": true,
     "declarationDir": "dist",
-    "lib": ["es5", "es6", "dom", "dom.iterable"]
+    "lib": ["es5", "es6", "dom", "dom.iterable"],
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   },
   "include": ["src/**/*", "rollup.config.ts"],
   "exclude": ["jest.config.ts", "dist", "node_modules", "stories/**/*.stories.tsx", "testing"]


### PR DESCRIPTION
## Overview
Adds support for pretty import paths so we can do `import { Widget } from '~/types'`

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
