### PR TITLE
chore(dashboard): refactor keyboard shortcuts to hooks

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -5,7 +5,6 @@ import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 
 import { Position, Widget } from '~/types';
 import { selectedRect } from '~/util/select';
-import { useKeyPress } from '~/hooks/useKeyPress';
 import { DashboardMessages } from '~/messages';
 
 /**
@@ -28,23 +27,20 @@ import Actions from '../actions';
  */
 import {
   onBringWidgetsToFrontAction,
-  onChangeDashboardHeightAction,
-  onChangeDashboardWidthAction,
   onCopyWidgetsAction,
   onCreateWidgetsAction,
   onPasteWidgetsAction,
-  onSelectWidgetsAction,
   onSendWidgetsToBackAction,
   onDeleteWidgetsAction,
 } from '~/store/actions';
 import { DashboardState, SaveableDashboard } from '~/store/state';
 import { widgetCreator } from '~/store/actions/createWidget/presets';
-import { DASHBOARD_CONTAINER_ID } from '../grid/getDashboardPosition';
 
 import './index.css';
 import '@iot-app-kit/components/styles.css';
 import { toGridPosition } from '~/util/position';
 import { useGestures } from './gestures';
+import { useKeyboardShortcuts } from './keyboardShortcuts';
 
 type InternalDashboardProps = {
   messageOverrides: DashboardMessages;
@@ -105,43 +101,19 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
     );
   };
 
-  // leaving these in for when we hook this up later
-  // eslint-disable-next-line
-  const changeWidth = (e: React.ChangeEvent<HTMLInputElement>) =>
-    dispatch(
-      onChangeDashboardWidthAction({
-        width: parseInt(e.target.value),
-      })
-    );
-
-  // eslint-disable-next-line
-  const changeHeight = (e: React.ChangeEvent<HTMLInputElement>) =>
-    dispatch(
-      onChangeDashboardHeightAction({
-        height: parseInt(e.target.value),
-      })
-    );
+  /**
+   * setup keyboard shortcuts for actions
+   */
+  useKeyboardShortcuts();
 
   /**
-   * Local variables
+   * setup gesture handling for grid
    */
   const { activeGesture, userSelection, onPointClick, onGestureStart, onGestureUpdate, onGestureEnd } = useGestures({
     dashboardConfiguration,
     selectedWidgets,
     cellSize,
   });
-
-  /**
-   * Selection handlers
-   */
-  const onClearSelection = () => {
-    dispatch(
-      onSelectWidgetsAction({
-        widgets: [],
-        union: false,
-      })
-    );
-  };
 
   const onDrop = (e: DropEvent) => {
     const { item, position } = e;
@@ -159,23 +131,6 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
     };
     createWidgets([widget]);
   };
-
-  /**
-   * Keyboard hotkey / shortcut configuration
-   * key press filter makes sure that the event is not coming from
-   * other areas where we might use keyboard interactions such as
-   * the settings pane or a text area in a widget
-   */
-  const keyPressFilter = (e: KeyboardEvent) =>
-    e.target !== null &&
-    e.target instanceof Element &&
-    (e.target.id === DASHBOARD_CONTAINER_ID || e.target === document.body);
-  useKeyPress('esc', { filter: keyPressFilter, callback: onClearSelection });
-  useKeyPress('backspace, del', { filter: keyPressFilter, callback: deleteWidgets });
-  useKeyPress('mod+c', { filter: keyPressFilter, callback: copyWidgets });
-  useKeyPress('mod+v', { filter: keyPressFilter, callback: () => pasteWidgets() });
-  useKeyPress('[', { filter: keyPressFilter, callback: sendWidgetsToBack });
-  useKeyPress(']', { filter: keyPressFilter, callback: bringWidgetsToFront });
 
   /**
    *

--- a/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.test.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
+
+import { act } from 'react-dom/test-utils';
+
+import InternalDashboard from './index';
+import { configureDashboardStore } from '../../store';
+import { DefaultDashboardMessages } from '../../messages';
+
+import {
+  onBringWidgetsToFrontAction,
+  // onCopyWidgetsAction,
+  onDeleteWidgetsAction,
+  // onPasteWidgetsAction,
+  onSelectWidgetsAction,
+  onSendWidgetsToBackAction,
+} from '../../store/actions';
+
+jest.mock('../../store/actions', () => {
+  const originalModule = jest.requireActual('../../store/actions');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    onSelectWidgetsAction: jest.fn(),
+    onDeleteWidgetsAction: jest.fn(),
+    onBringWidgetsToFrontAction: jest.fn(),
+    onSendWidgetsToBackAction: jest.fn(),
+    // onCopyWidgetsAction: jest.fn(),
+    // onPasteWidgetsAction: jest.fn(),
+  };
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const renderDashboardAndPressKey = ({ key, meta }: { key: string; meta: boolean }) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const args = {
+    dashboardConfiguration: {
+      widgets: [],
+      viewport: { duration: '5m' },
+    },
+  };
+
+  act(() => {
+    ReactDOM.render(
+      <Provider store={configureDashboardStore(args)}>
+        <DndProvider
+          backend={TouchBackend}
+          options={{
+            enableMouseEvents: true,
+            enableKeyboardEvents: true,
+          }}
+        >
+          <InternalDashboard query={undefined} messageOverrides={DefaultDashboardMessages} />
+        </DndProvider>
+      </Provider>,
+      container
+    );
+  });
+
+  act(() => {
+    if (meta)
+      document.body.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Control', metaKey: meta, ctrlKey: meta, bubbles: true })
+      );
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key, metaKey: meta, ctrlKey: meta, bubbles: true }));
+  });
+};
+
+it('can clear the selection', () => {
+  (onSelectWidgetsAction as jest.Mock).mockImplementation(() => ({ type: '', payload: {} }));
+
+  renderDashboardAndPressKey({ key: 'Escape', meta: false });
+
+  expect(onSelectWidgetsAction).toBeCalledWith({
+    widgets: [],
+    union: false,
+  });
+});
+
+it('can delete the selection', () => {
+  (onDeleteWidgetsAction as jest.Mock).mockImplementation(() => ({ type: '', payload: {} }));
+
+  renderDashboardAndPressKey({ key: 'Backspace', meta: false });
+
+  expect(onDeleteWidgetsAction).toBeCalledWith({
+    widgets: [],
+  });
+});
+
+it('can send the selection to the back', () => {
+  (onSendWidgetsToBackAction as jest.Mock).mockImplementation(() => ({ type: '', payload: {} }));
+
+  renderDashboardAndPressKey({ key: '[', meta: false });
+
+  expect(onSendWidgetsToBackAction).toBeCalled();
+});
+
+it('can bring the selection to the front', () => {
+  (onBringWidgetsToFrontAction as jest.Mock).mockImplementation(() => ({ type: '', payload: {} }));
+
+  renderDashboardAndPressKey({ key: ']', meta: false });
+
+  expect(onBringWidgetsToFrontAction).toBeCalled();
+});
+
+/**
+ * TODO: simulating command + c and command + v does not seem to work within jest.
+ * need to find a different way to do this.
+ * Tried using the fireEvent util and the document dispatch directly, but could
+ * not figure out a way to set the metaKey to true
+ */

--- a/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.ts
+++ b/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.ts
@@ -1,0 +1,72 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useKeyPress } from '../../hooks/useKeyPress';
+import {
+  onBringWidgetsToFrontAction,
+  onCopyWidgetsAction,
+  onDeleteWidgetsAction,
+  onPasteWidgetsAction,
+  onSelectWidgetsAction,
+  onSendWidgetsToBackAction,
+} from '../../store/actions';
+import { DashboardState } from '../../store/state';
+import { DASHBOARD_CONTAINER_ID } from '../grid/getDashboardPosition';
+
+export const useKeyboardShortcuts = () => {
+  const dispatch = useDispatch();
+  const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
+
+  const onClearSelection = () => {
+    dispatch(
+      onSelectWidgetsAction({
+        widgets: [],
+        union: false,
+      })
+    );
+  };
+
+  const copyWidgets = useCallback(() => {
+    dispatch(
+      onCopyWidgetsAction({
+        widgets: selectedWidgets,
+      })
+    );
+  }, [selectedWidgets]);
+
+  const pasteWidgets = () => {
+    dispatch(onPasteWidgetsAction({ position: undefined }));
+  };
+
+  const bringWidgetsToFront = () => {
+    dispatch(onBringWidgetsToFrontAction());
+  };
+
+  const sendWidgetsToBack = () => {
+    dispatch(onSendWidgetsToBackAction());
+  };
+
+  const deleteWidgets = useCallback(() => {
+    dispatch(
+      onDeleteWidgetsAction({
+        widgets: selectedWidgets,
+      })
+    );
+  }, [selectedWidgets]);
+
+  /**
+   * Keyboard hotkey / shortcut configuration
+   * key press filter makes sure that the event is not coming from
+   * other areas where we might use keyboard interactions such as
+   * the settings pane or a text area in a widget
+   */
+  const keyPressFilter = (e: KeyboardEvent) =>
+    e.target !== null &&
+    e.target instanceof Element &&
+    (e.target.id === DASHBOARD_CONTAINER_ID || e.target === document.body);
+  useKeyPress('esc', { filter: keyPressFilter, callback: onClearSelection });
+  useKeyPress('backspace, del', { filter: keyPressFilter, callback: deleteWidgets });
+  useKeyPress('mod+c', { filter: keyPressFilter, callback: copyWidgets });
+  useKeyPress('mod+v', { filter: keyPressFilter, callback: pasteWidgets });
+  useKeyPress('[', { filter: keyPressFilter, callback: sendWidgetsToBack });
+  useKeyPress(']', { filter: keyPressFilter, callback: bringWidgetsToFront });
+};

--- a/packages/dashboard/src/hooks/useKeyPress.ts
+++ b/packages/dashboard/src/hooks/useKeyPress.ts
@@ -44,7 +44,7 @@ export const useKeyPress = (key: string, options?: KeyPressOptions | KeyPressCal
       key
         .split(',')
         .map((k) => k.trim())
-        .some((k) => isHotkey(k, e));
+        .some((k) => isHotkey(k, { byKey: true }, e));
     setKeyPressed(keyPressed);
 
     if (keyPressed && callback && filter && filter(e)) {


### PR DESCRIPTION
## Overview
Move keyboard shortcuts into their own hook to be used in the dashboard. Updated the keypress hook to use the beyKey flag so that we are not using the deprecated which property on a keyboard event.

Note: tests for copy and paste are not included, I was unable to find a way to fire a keydown event which includes the metaKey flag in jest.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
