### PR TITLE
fix(dashboard): fix layering of widgets with selection and context menu

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -50,6 +50,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/user-event": "^14.4.3",
     "@types/box-intersect": "^1.0.0",
     "@types/is-hotkey": "^0.1.7",
     "@types/lodash": "^4.14.186",

--- a/packages/dashboard/src/components/contextMenu/index.test.tsx
+++ b/packages/dashboard/src/components/contextMenu/index.test.tsx
@@ -1,0 +1,322 @@
+import * as React from 'react';
+import { Provider } from 'react-redux';
+
+import { act } from 'react-dom/test-utils';
+import { screen } from '@testing-library/dom';
+import { render } from '@testing-library/react';
+import UserEvent from '@testing-library/user-event';
+
+import ContextMenu, { ContextMenuProps } from './index';
+import { DefaultDashboardMessages } from '~/messages';
+import { DASHBOARD_CONTAINER_ID } from '../grid/getDashboardPosition';
+import { configureDashboardStore } from '~/store';
+
+const renderContextMenu = (args: ContextMenuProps, open?: boolean) => {
+  const ret: { container: HTMLElement | null } = {
+    container: null,
+  };
+
+  act(() => {
+    const { container } = render(
+      <Provider store={configureDashboardStore()}>
+        <div id={DASHBOARD_CONTAINER_ID} style={{ height: '1000px', width: '1000px' }}>
+          <ContextMenu {...args} />
+        </div>
+      </Provider>
+    );
+    ret.container = container;
+  });
+
+  if (open) {
+    act(() => {
+      const ev = new MouseEvent('contextmenu', {
+        bubbles: true,
+        clientX: 10,
+        clientY: 10,
+      });
+      document.getElementById(DASHBOARD_CONTAINER_ID)?.dispatchEvent(ev);
+    });
+  }
+
+  return ret;
+};
+
+const clickOption = async (option: string) => {
+  const user = UserEvent.setup();
+  await act(async () => {
+    await user.click(screen.getByText(option));
+  });
+};
+
+describe('ContextMenu', () => {
+  it('can toggle', () => {
+    const args: ContextMenuProps = {
+      messageOverrides: DefaultDashboardMessages,
+      hasCopiedWidgets: false,
+      hasSelectedWidgets: false,
+      copyWidgets: () => {},
+      pasteWidgets: () => {},
+      deleteWidgets: () => {},
+      bringWidgetsToFront: () => {},
+      sendWidgetsToBack: () => {},
+    };
+
+    const { container } = renderContextMenu(args);
+    if (!container) {
+      throw new Error('Container not set');
+    }
+
+    expect(container.querySelector('.iot-context-menu')).toBeFalsy();
+
+    act(() => {
+      const ev = new MouseEvent('contextmenu', {
+        bubbles: true,
+        clientX: 10,
+        clientY: 10,
+      });
+      document.getElementById(DASHBOARD_CONTAINER_ID)?.dispatchEvent(ev);
+    });
+
+    expect(container.querySelector('.iot-context-menu')).toBeTruthy();
+  });
+
+  it('can copy', async () => {
+    const copyWidgets = jest.fn();
+
+    const args: ContextMenuProps = {
+      messageOverrides: DefaultDashboardMessages,
+      hasCopiedWidgets: false,
+      hasSelectedWidgets: true,
+      copyWidgets,
+      pasteWidgets: () => {},
+      deleteWidgets: () => {},
+      bringWidgetsToFront: () => {},
+      sendWidgetsToBack: () => {},
+    };
+
+    const { container } = renderContextMenu(args, true);
+    if (!container) {
+      throw new Error('Container not set');
+    }
+
+    await clickOption('Copy');
+
+    expect(copyWidgets).toBeCalled();
+  });
+
+  it('does not copy if there is no selection', async () => {
+    const copyWidgets = jest.fn();
+
+    const args: ContextMenuProps = {
+      messageOverrides: DefaultDashboardMessages,
+      hasCopiedWidgets: false,
+      hasSelectedWidgets: false,
+      copyWidgets,
+      pasteWidgets: () => {},
+      deleteWidgets: () => {},
+      bringWidgetsToFront: () => {},
+      sendWidgetsToBack: () => {},
+    };
+
+    const { container } = renderContextMenu(args, true);
+    if (!container) {
+      throw new Error('Container not set');
+    }
+
+    await clickOption('Copy');
+
+    expect(copyWidgets).not.toBeCalled();
+  });
+
+  it('can paste', async () => {
+    const pasteWidgets = jest.fn();
+
+    const args: ContextMenuProps = {
+      messageOverrides: DefaultDashboardMessages,
+      hasCopiedWidgets: true,
+      hasSelectedWidgets: false,
+      copyWidgets: () => {},
+      pasteWidgets,
+      deleteWidgets: () => {},
+      bringWidgetsToFront: () => {},
+      sendWidgetsToBack: () => {},
+    };
+
+    const { container } = renderContextMenu(args, true);
+    if (!container) {
+      throw new Error('Container not set');
+    }
+
+    await clickOption('Paste');
+
+    expect(pasteWidgets).toBeCalled();
+  });
+
+  it('does not paste if there are no copied widgets', async () => {
+    const pasteWidgets = jest.fn();
+
+    const args: ContextMenuProps = {
+      messageOverrides: DefaultDashboardMessages,
+      hasCopiedWidgets: false,
+      hasSelectedWidgets: false,
+      copyWidgets: () => {},
+      pasteWidgets,
+      deleteWidgets: () => {},
+      bringWidgetsToFront: () => {},
+      sendWidgetsToBack: () => {},
+    };
+
+    const { container } = renderContextMenu(args, true);
+    if (!container) {
+      throw new Error('Container not set');
+    }
+
+    await clickOption('Paste');
+
+    expect(pasteWidgets).not.toBeCalled();
+  });
+
+  it('can delete', async () => {
+    const deleteWidgets = jest.fn();
+
+    const args: ContextMenuProps = {
+      messageOverrides: DefaultDashboardMessages,
+      hasCopiedWidgets: false,
+      hasSelectedWidgets: true,
+      copyWidgets: () => {},
+      pasteWidgets: () => {},
+      deleteWidgets,
+      bringWidgetsToFront: () => {},
+      sendWidgetsToBack: () => {},
+    };
+
+    const { container } = renderContextMenu(args, true);
+    if (!container) {
+      throw new Error('Container not set');
+    }
+
+    await clickOption('Delete');
+
+    expect(deleteWidgets).toBeCalled();
+  });
+
+  it('does not delete if there are no selected widgets', async () => {
+    const deleteWidgets = jest.fn();
+
+    const args: ContextMenuProps = {
+      messageOverrides: DefaultDashboardMessages,
+      hasCopiedWidgets: false,
+      hasSelectedWidgets: false,
+      copyWidgets: () => {},
+      pasteWidgets: () => {},
+      deleteWidgets,
+      bringWidgetsToFront: () => {},
+      sendWidgetsToBack: () => {},
+    };
+
+    const { container } = renderContextMenu(args, true);
+    if (!container) {
+      throw new Error('Container not set');
+    }
+
+    await clickOption('Delete');
+
+    expect(deleteWidgets).not.toBeCalled();
+  });
+
+  it('can bring to front', async () => {
+    const bringWidgetsToFront = jest.fn();
+
+    const args: ContextMenuProps = {
+      messageOverrides: DefaultDashboardMessages,
+      hasCopiedWidgets: false,
+      hasSelectedWidgets: true,
+      copyWidgets: () => {},
+      pasteWidgets: () => {},
+      deleteWidgets: () => {},
+      bringWidgetsToFront,
+      sendWidgetsToBack: () => {},
+    };
+
+    const { container } = renderContextMenu(args, true);
+    if (!container) {
+      throw new Error('Container not set');
+    }
+
+    await clickOption('Bring to Front');
+
+    expect(bringWidgetsToFront).toBeCalled();
+  });
+
+  it('does not bring to front if there are no selected widgets', async () => {
+    const bringWidgetsToFront = jest.fn();
+
+    const args: ContextMenuProps = {
+      messageOverrides: DefaultDashboardMessages,
+      hasCopiedWidgets: false,
+      hasSelectedWidgets: false,
+      copyWidgets: () => {},
+      pasteWidgets: () => {},
+      deleteWidgets: () => {},
+      bringWidgetsToFront,
+      sendWidgetsToBack: () => {},
+    };
+
+    const { container } = renderContextMenu(args, true);
+    if (!container) {
+      throw new Error('Container not set');
+    }
+
+    await clickOption('Bring to Front');
+
+    expect(bringWidgetsToFront).not.toBeCalled();
+  });
+
+  it('can send to back', async () => {
+    const sendWidgetsToBack = jest.fn();
+
+    const args: ContextMenuProps = {
+      messageOverrides: DefaultDashboardMessages,
+      hasCopiedWidgets: false,
+      hasSelectedWidgets: true,
+      copyWidgets: () => {},
+      pasteWidgets: () => {},
+      deleteWidgets: () => {},
+      bringWidgetsToFront: () => {},
+      sendWidgetsToBack,
+    };
+
+    const { container } = renderContextMenu(args, true);
+    if (!container) {
+      throw new Error('Container not set');
+    }
+
+    await clickOption('Send to Back');
+
+    expect(sendWidgetsToBack).toBeCalled();
+  });
+
+  it('does not send to back if there are no selected widgets', async () => {
+    const sendWidgetsToBack = jest.fn();
+
+    const args: ContextMenuProps = {
+      messageOverrides: DefaultDashboardMessages,
+      hasCopiedWidgets: false,
+      hasSelectedWidgets: false,
+      copyWidgets: () => {},
+      pasteWidgets: () => {},
+      deleteWidgets: () => {},
+      bringWidgetsToFront: () => {},
+      sendWidgetsToBack,
+    };
+
+    const { container } = renderContextMenu(args, true);
+    if (!container) {
+      throw new Error('Container not set');
+    }
+
+    await clickOption('Send to Back');
+
+    expect(sendWidgetsToBack).not.toBeCalled();
+  });
+});

--- a/packages/dashboard/src/components/contextMenu/index.tsx
+++ b/packages/dashboard/src/components/contextMenu/index.tsx
@@ -9,6 +9,7 @@ import { DASHBOARD_CONTAINER_ID, getDashboardPosition } from '../grid/getDashboa
 import { useKeyPress } from '~/hooks/useKeyPress';
 import { createContextMenuOptions } from './contextMenuOptions';
 import { DashboardMessages } from '~/messages';
+import { useLayers } from '../internalDashboard/useLayers';
 
 export type ContextMenuProps = {
   copyWidgets: () => void;
@@ -33,6 +34,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 }) => {
   const [contextMenuOpen, setContextMenuOpen] = useState<boolean>(false);
   const [contextMenuPosition, setContextMenuPosition] = useState<Position | null>(null);
+
+  const { contextMenuLayer } = useLayers();
 
   const toggleContextMenu = (position?: Position) => {
     if (position) {
@@ -93,7 +96,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
   });
 
   return contextMenuOpen && contextMenuPosition ? (
-    <Menu clickOutside={onClickOutside} position={contextMenuPosition}>
+    <Menu clickOutside={onClickOutside} position={{ ...contextMenuPosition, z: contextMenuLayer }}>
       {configuration.map(({ id: sectionId, options }) => (
         <ContextMenuSection key={sectionId}>
           {options.map(({ id: optionId, text, action, hotkey, disabled }) => (

--- a/packages/dashboard/src/components/contextMenu/menu.tsx
+++ b/packages/dashboard/src/components/contextMenu/menu.tsx
@@ -9,7 +9,7 @@ import './menu.css';
 import { useClickOutside } from '~/hooks/useClickOutside';
 
 export type MenuProps = {
-  position: Position;
+  position: Position & { z?: number };
   clickOutside?: (event: PointerEvent) => void;
 };
 
@@ -46,7 +46,10 @@ const Menu: React.FC<MenuProps> = ({ position, clickOutside, children }) => {
       <div
         className='iot-context-menu'
         ref={popperElement}
-        style={styles.popper}
+        style={{
+          ...styles.popper,
+          zIndex: position.z,
+        }}
         {...attributes.popper}
         onPointerDown={(e) => {
           e.stopPropagation();

--- a/packages/dashboard/src/components/internalDashboard/useLayers.spec.tsx
+++ b/packages/dashboard/src/components/internalDashboard/useLayers.spec.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+
+import { configureDashboardStore } from '~/store';
+import { RecursivePartial } from '~/types';
+import { DashboardState } from '~/store/state';
+
+import { useLayers } from './useLayers';
+import { MockDashboardFactory, MockWidgetFactory } from '../../../testing/mocks';
+
+const TestProvider: React.FC<{
+  storeArgs?: RecursivePartial<DashboardState>;
+}> = ({ storeArgs, children }) => <Provider store={configureDashboardStore(storeArgs)}>{children}</Provider>;
+
+it('has default layers', () => {
+  const { result } = renderHook(() => useLayers(), { wrapper: ({ children }) => <TestProvider children={children} /> });
+
+  expect(result.current.selectionBoxLayer).toBeGreaterThan(0);
+  expect(result.current.userSelectionLayer).toBeGreaterThan(0);
+  expect(result.current.contextMenuLayer).toBeGreaterThan(0);
+
+  expect(result.current.userSelectionLayer).toBeGreaterThan(result.current.selectionBoxLayer);
+  expect(result.current.contextMenuLayer).toBeGreaterThan(result.current.userSelectionLayer);
+});
+
+it('has updates the layers to be greater than the highest widget in the dashboard configuration', () => {
+  const zTest = 100;
+  const dashboardConfiguration = MockDashboardFactory.get({
+    widgets: [
+      MockWidgetFactory.getKpiWidget({ z: zTest }),
+      MockWidgetFactory.getKpiWidget({ z: zTest - 10 }),
+      MockWidgetFactory.getKpiWidget({ z: zTest - 20 }),
+      MockWidgetFactory.getKpiWidget({ z: zTest - 50 }),
+    ],
+  });
+  const { result } = renderHook(() => useLayers(), {
+    wrapper: ({ children }) => <TestProvider storeArgs={{ dashboardConfiguration }} children={children} />,
+  });
+
+  expect(result.current.selectionBoxLayer).toBeGreaterThan(zTest);
+  expect(result.current.userSelectionLayer).toBeGreaterThan(zTest);
+  expect(result.current.contextMenuLayer).toBeGreaterThan(zTest);
+
+  expect(result.current.userSelectionLayer).toBeGreaterThan(result.current.selectionBoxLayer);
+  expect(result.current.contextMenuLayer).toBeGreaterThan(result.current.userSelectionLayer);
+});

--- a/packages/dashboard/src/components/internalDashboard/useLayers.ts
+++ b/packages/dashboard/src/components/internalDashboard/useLayers.ts
@@ -1,0 +1,27 @@
+import { useSelector } from 'react-redux';
+import max from 'lodash/max';
+
+import { DashboardState } from '~/store/state';
+
+type Layers = {
+  userSelectionLayer: number;
+  selectionBoxLayer: number;
+  contextMenuLayer: number;
+};
+const layers: Layers = {
+  userSelectionLayer: 2,
+  selectionBoxLayer: 1,
+  contextMenuLayer: 3,
+};
+
+export const useLayers = (): Layers => {
+  const widgets = useSelector((state: DashboardState) => state.dashboardConfiguration.widgets);
+
+  const z = max(widgets.map(({ z }) => z)) ?? 0;
+
+  return {
+    userSelectionLayer: z + layers.userSelectionLayer,
+    selectionBoxLayer: z + layers.selectionBoxLayer,
+    contextMenuLayer: z + layers.contextMenuLayer,
+  };
+};

--- a/packages/dashboard/src/components/userSelection/index.tsx
+++ b/packages/dashboard/src/components/userSelection/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Rect } from '~/types';
+import { useLayers } from '../internalDashboard/useLayers';
 
 import './index.css';
 
@@ -9,6 +10,8 @@ export type UserSelectionProps = {
 };
 
 const UserSelection: React.FC<UserSelectionProps> = ({ rect }) => {
+  const { userSelectionLayer } = useLayers();
+
   return rect ? (
     <div
       className='select-rect'
@@ -17,6 +20,7 @@ const UserSelection: React.FC<UserSelectionProps> = ({ rect }) => {
         top: `${rect.y}px`,
         width: `${rect.width}px`,
         height: `${rect.height}px`,
+        zIndex: userSelectionLayer,
       }}
     ></div>
   ) : null;

--- a/packages/dashboard/src/components/widgets/selectionBox.tsx
+++ b/packages/dashboard/src/components/widgets/selectionBox.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+
 import { Widget } from '~/types';
 import SelectionBoxAnchor from './selectionBoxAnchor';
 import { gestureable } from '../internalDashboard/gestures/determineTargetGestures';
 import { getSelectionBox } from '~/util/getSelectionBox';
 
 import './selectionBox.css';
+import { useLayers } from '../internalDashboard/useLayers';
 
 export type SelectionBoxProps = {
   selectedWidgets: Widget[];
@@ -13,6 +15,8 @@ export type SelectionBoxProps = {
 };
 
 const SelectionBox: React.FC<SelectionBoxProps> = ({ selectedWidgets, cellSize, dragEnabled }) => {
+  const { selectionBoxLayer } = useLayers();
+
   const rect = getSelectionBox(selectedWidgets);
 
   if (!rect) return null;
@@ -30,6 +34,7 @@ const SelectionBox: React.FC<SelectionBoxProps> = ({ selectedWidgets, cellSize, 
           left: `${cellSize * x - 2}px`,
           width: `${cellSize * width + 4}px`,
           height: `${cellSize * height + 4}px`,
+          zIndex: selectionBoxLayer,
         }}
       ></div>
       <div
@@ -39,6 +44,7 @@ const SelectionBox: React.FC<SelectionBoxProps> = ({ selectedWidgets, cellSize, 
           left: `${cellSize * x}px`,
           width: `${cellSize * width}px`,
           height: `${cellSize * height}px`,
+          zIndex: selectionBoxLayer,
         }}
       >
         <SelectionBoxAnchor anchor='top' />

--- a/packages/dashboard/src/store/actions/bringToFront/index.spec.ts
+++ b/packages/dashboard/src/store/actions/bringToFront/index.spec.ts
@@ -19,6 +19,12 @@ it('does nothing if there are no widgets selected', () => {
   ]);
 });
 
+it('does nothing if there all widgets are selected', () => {
+  expect(
+    bringWidgetsToFront(setupDashboardState([MOCK_KPI_WIDGET], [MOCK_KPI_WIDGET])).dashboardConfiguration.widgets
+  ).toEqual([MOCK_KPI_WIDGET]);
+});
+
 it('moves selected widget to front', () => {
   const MOCK_WIDGET = MockWidgetFactory.getKpiWidget({
     id: 'widget-1',

--- a/packages/dashboard/src/store/actions/bringToFront/index.ts
+++ b/packages/dashboard/src/store/actions/bringToFront/index.ts
@@ -1,5 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 
+import xorBy from 'lodash/xorBy';
 import maxBy from 'lodash/maxBy';
 import minBy from 'lodash/minBy';
 
@@ -16,10 +17,18 @@ export const onBringWidgetsToFrontAction = (): BringWidgetsToFrontAction => ({
 
 export const bringWidgetsToFront = (state: DashboardState): DashboardState => {
   const widgets = state.dashboardConfiguration.widgets;
-  const slectedWidgets = state.selectedWidgets;
-  const selectedWidgetsIds = slectedWidgets.map(({ id }) => id);
-  const topZIndex = maxBy(widgets, 'z')?.z ?? 0;
-  const minSelectedZ = minBy(slectedWidgets, 'z')?.z ?? 0;
+  const selectedWidgets = state.selectedWidgets;
+
+  const unselectedWidgets = xorBy(widgets, selectedWidgets, 'id');
+
+  // We don't need to do anything if all widgets are selected
+  if (unselectedWidgets.length === 0) {
+    return state;
+  }
+
+  const selectedWidgetsIds = selectedWidgets.map(({ id }) => id);
+  const topZIndex = maxBy(unselectedWidgets, 'z')?.z ?? 0;
+  const minSelectedZ = minBy(selectedWidgets, 'z')?.z ?? 0;
 
   const zOffset = topZIndex + 1 - minSelectedZ;
 

--- a/packages/dashboard/src/store/actions/sendToBack/index.spec.ts
+++ b/packages/dashboard/src/store/actions/sendToBack/index.spec.ts
@@ -18,6 +18,12 @@ it('does nothing if there are no widgets selected', () => {
   ]);
 });
 
+it('does nothing if all widgets are selected', () => {
+  expect(
+    sendWidgetsToBack(setupDashboardState([MOCK_KPI_WIDGET], [MOCK_KPI_WIDGET])).dashboardConfiguration.widgets
+  ).toEqual([MOCK_KPI_WIDGET]);
+});
+
 it('moves selected widget to back', () => {
   const MOCK_WIDGET = MockWidgetFactory.getKpiWidget({
     id: 'widget-1',

--- a/packages/dashboard/src/store/actions/sendToBack/index.ts
+++ b/packages/dashboard/src/store/actions/sendToBack/index.ts
@@ -1,5 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 
+import xorBy from 'lodash/xorBy';
 import maxBy from 'lodash/maxBy';
 import minBy from 'lodash/minBy';
 
@@ -16,10 +17,18 @@ export const onSendWidgetsToBackAction = (): SendWidgetsToBackAction => ({
 
 export const sendWidgetsToBack = (state: DashboardState): DashboardState => {
   const widgets = state.dashboardConfiguration.widgets;
-  const slectedWidgets = state.selectedWidgets;
-  const selectedWidgetsIds = slectedWidgets.map(({ id }) => id);
-  const bottomZIndex = minBy(widgets, 'z')?.z ?? 0;
-  const maxSelectedZ = maxBy(slectedWidgets, 'z')?.z ?? 0;
+  const selectedWidgets = state.selectedWidgets;
+
+  const unselectedWidgets = xorBy(widgets, selectedWidgets, 'id');
+
+  // We don't need to do anything if all widgets are selected
+  if (unselectedWidgets.length === 0) {
+    return state;
+  }
+
+  const selectedWidgetsIds = selectedWidgets.map(({ id }) => id);
+  const bottomZIndex = minBy(unselectedWidgets, 'z')?.z ?? 0;
+  const maxSelectedZ = maxBy(selectedWidgets, 'z')?.z ?? 0;
 
   const zOffset = bottomZIndex - 1 - maxSelectedZ;
 


### PR DESCRIPTION
## Overview
Add fix for layering bug where you can raise a group of widgets to overlay above the context menu, selection rectangle, and user selection rectangle. 

Adds tests for the context menu.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
