### PR TITLE
feat(composer): Implement data overlay container

### DIFF
--- a/packages/scene-composer/__mocks__/mockComponent.tsx
+++ b/packages/scene-composer/__mocks__/mockComponent.tsx
@@ -12,6 +12,8 @@ export default (componentName) => {
         if (typeof value === 'object') {
           if (React.isValidElement(value)) {
             renderProps[key] = value;
+          } else if (key === 'style') {
+            snapshotableProps[key] = value;
           } else {
             snapshotableProps[key] = JSON.stringify(value);
           }

--- a/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
@@ -60,6 +60,10 @@ export const SceneNodeInspectorPanel: React.FC = () => {
       defaultMessage: 'Motion Indicator',
       description: 'Expandable Section title',
     },
+    [KnownComponentType.DataOverlay]: {
+      defaultMessage: 'Data Overlay',
+      description: 'Expandable Section title',
+    },
   });
 
   log?.verbose('render inspect panel with selected scene node ', selectedSceneNodeRef, selectedSceneNode);

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
@@ -1,0 +1,32 @@
+import React, { ReactElement, useContext } from 'react';
+import { Html } from '@react-three/drei';
+
+import { ISceneNodeInternal } from '../../../store';
+import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import { IDataOverlayComponentInternal } from '../../../store/internalInterfaces';
+
+import { DataOverlayContainer } from './DataOverlayContainer';
+
+export interface DataOverlayComponentProps {
+  node: ISceneNodeInternal;
+  component: IDataOverlayComponentInternal;
+}
+
+export const DataOverlayComponent = ({ node, component }: DataOverlayComponentProps): ReactElement => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+
+  return (
+    <group>
+      <Html
+        className='html-wrapper'
+        style={{
+          transform: 'translate3d(-50%,-100%,0)', // make the center of 3D transform the middle of bottom edge
+        }}
+      >
+        <sceneComposerIdContext.Provider value={sceneComposerId}>
+          <DataOverlayContainer node={node} component={component} />
+        </sceneComposerIdContext.Provider>
+      </Html>
+    </group>
+  );
+};

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
@@ -1,0 +1,67 @@
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { Button } from '@awsui/components-react';
+
+import { IDataOverlayComponentInternal, ISceneNodeInternal } from '../../../store/internalInterfaces';
+import { Component } from '../../../models/SceneModels';
+import { useStore } from '../../../store';
+import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import useCallbackWhenNotPanning from '../../../hooks/useCallbackWhenNotPanning';
+
+import { DataOverlayRows } from './DataOverlayRows';
+import './styles.scss';
+
+export interface DataOverlayContainerProps {
+  node: ISceneNodeInternal;
+  component: IDataOverlayComponentInternal;
+}
+
+export const DataOverlayContainer = ({ component, node }: DataOverlayContainerProps) => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedSceneNodeRef = useStore(sceneComposerId)((state) => state.selectedSceneNodeRef);
+  const setSelectedSceneNodeRef = useStore(sceneComposerId)((state) => state.setSelectedSceneNodeRef);
+  const [visible, setVisible] = useState(
+    component.config?.isPinned || component.subType === Component.DataOverlaySubType.TextAnnotation,
+  );
+
+  // Toggle panel visibility
+  useEffect(() => {
+    if (selectedSceneNodeRef === node.ref) {
+      setVisible(true);
+    }
+  }, [selectedSceneNodeRef, node.ref]);
+
+  // Same behavior as other components to select node when clicked on the panel
+  const [onPointerDown, onPointerUp] = useCallbackWhenNotPanning(
+    (e) => {
+      e.stopPropagation();
+      if (selectedSceneNodeRef !== node.ref) {
+        setSelectedSceneNodeRef(node.ref);
+      }
+    },
+    [selectedSceneNodeRef, node.ref],
+  );
+
+  const onClickCloseButton = useCallback(() => {
+    setVisible(false);
+  }, [setVisible]);
+
+  return visible ? (
+    <div
+      ref={containerRef}
+      onPointerUp={onPointerUp}
+      onPointerDown={onPointerDown}
+      className={`container ${
+        component.subType === Component.DataOverlaySubType.TextAnnotation ? 'annotation-container' : 'panel-container'
+      }`}
+    >
+      {component.subType === Component.DataOverlaySubType.OverlayPanel && (
+        <div className='close-button'>
+          <Button iconName='close' variant='icon' iconAlign='right' onClick={onClickCloseButton} />
+        </div>
+      )}
+      <DataOverlayRows component={component} />
+    </div>
+  ) : null;
+};

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayDataRow.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayDataRow.tsx
@@ -1,0 +1,29 @@
+import React, { ReactElement } from 'react';
+
+import { Component } from '../../../models/SceneModels';
+import './styles.scss';
+
+export interface DataOverlayDataRowProps {
+  rowData: Component.DataOverlayRow;
+  overlayType: Component.DataOverlaySubType;
+}
+
+export const DataOverlayDataRow = ({ rowData, overlayType }: DataOverlayDataRowProps): ReactElement => {
+  switch (rowData.rowType) {
+    case Component.DataOverlayRowType.Markdown: {
+      const row = rowData as Component.DataOverlayMarkdownRow;
+      // TODO: use markdown processor in next change
+      return (
+        <p
+          className={`markdown-row ${
+            overlayType === Component.DataOverlaySubType.TextAnnotation ? 'annotation-row' : 'panel-row'
+          }`}
+        >
+          {row.content}
+        </p>
+      );
+    }
+    default:
+      return <></>;
+  }
+};

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayRows.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayRows.tsx
@@ -1,0 +1,25 @@
+import React, { ReactElement } from 'react';
+
+import { Component } from '../../../models/SceneModels';
+import { IDataOverlayComponentInternal } from '../../../store/internalInterfaces';
+
+import { DataOverlayDataRow } from './DataOverlayDataRow';
+import './styles.scss';
+
+export interface DataOverlayRowsProps {
+  component: IDataOverlayComponentInternal;
+}
+
+export const DataOverlayRows = ({ component }: DataOverlayRowsProps): ReactElement => {
+  return (
+    <div
+      className={`${
+        component.subType === Component.DataOverlaySubType.TextAnnotation ? 'annotation-rows' : 'panel-rows'
+      }`}
+    >
+      {component.dataRows.map((row, index) => {
+        return <DataOverlayDataRow rowData={row} overlayType={component.subType} key={index} />;
+      })}
+    </div>
+  );
+};

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayComponentSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayComponentSnap.spec.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { DataOverlayComponent } from '../DataOverlayComponent';
+import { Component } from '../../../../models/SceneModels';
+import { KnownComponentType } from '../../../../interfaces';
+import { IDataOverlayComponentInternal } from '../../../../store';
+
+jest.mock('../DataOverlayContainer', () => ({
+  DataOverlayContainer: (...props: any[]) => <div data-testid='container'>{JSON.stringify(props)}</div>,
+}));
+
+describe('DataOverlayComponent', () => {
+  const mockComponent: IDataOverlayComponentInternal = {
+    ref: 'comp-ref',
+    type: KnownComponentType.DataOverlay,
+    subType: Component.DataOverlaySubType.OverlayPanel,
+    dataRows: [
+      {
+        rowType: Component.DataOverlayRowType.Markdown,
+        content: 'content',
+      },
+    ],
+    valueDataBindings: {
+      bindingA: {
+        valueDataBinding: { dataBindingContext: 'dataBindingContext' },
+      },
+    },
+  };
+  const mockNode: any = { ref: 'node-ref', transform: { position: [1, 2, 3] }, components: [mockComponent] };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should render the component correctly', async () => {
+    const { container } = render(<DataOverlayComponent node={mockNode} component={mockComponent} />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayContainerSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayContainerSnap.spec.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { IDataOverlayComponentInternal, useStore } from '../../../../store';
+import { KnownComponentType } from '../../../../interfaces';
+import { Component } from '../../../../models/SceneModels';
+import { DataOverlayContainer } from '../DataOverlayContainer';
+
+jest.mock('../../../../hooks/useCallbackWhenNotPanning', () => (cb) => [
+  jest.fn(),
+  function Hack(e) {
+    cb(e);
+  },
+]);
+
+jest.mock('../DataOverlayRows', () => ({
+  DataOverlayRows: (...props: any[]) => <div data-testid='rows'>{JSON.stringify(props)}</div>,
+}));
+
+describe('DataOverlayContainer', () => {
+  const mockComponent: IDataOverlayComponentInternal = {
+    ref: 'comp-ref',
+    type: KnownComponentType.DataOverlay,
+    subType: Component.DataOverlaySubType.OverlayPanel,
+    dataRows: [
+      {
+        rowType: Component.DataOverlayRowType.Markdown,
+        content: 'content',
+      },
+    ],
+    valueDataBindings: {},
+  };
+  const mockNode: any = { ref: 'node-ref', transform: { position: [1, 2, 3] }, components: [mockComponent] };
+
+  const mockSetSelectedSceneNodeRef = jest.fn();
+  const baseState = {
+    selectedSceneNodeRef: undefined,
+    setSelectedSceneNodeRef: mockSetSelectedSceneNodeRef,
+    dataInput: undefined,
+  };
+
+  it('should render with panel visible correctly when the overlay node is selected', () => {
+    useStore('default').setState({ ...baseState, selectedSceneNodeRef: mockNode.ref });
+
+    const { container } = render(<DataOverlayContainer node={mockNode} component={mockComponent} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with panel visible correctly when the overlay node is pinned', () => {
+    useStore('default').setState(baseState);
+
+    const { container } = render(
+      <DataOverlayContainer node={mockNode} component={{ ...mockComponent, config: { isPinned: true } }} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with annotation visible correctly', () => {
+    useStore('default').setState(baseState);
+
+    const { container } = render(
+      <DataOverlayContainer
+        node={mockNode}
+        component={{ ...mockComponent, subType: Component.DataOverlaySubType.TextAnnotation }}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with panel invisible correctly', () => {
+    useStore('default').setState(baseState);
+
+    const { container } = render(<DataOverlayContainer node={mockNode} component={mockComponent} />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayDataRowSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayDataRowSnap.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { Component } from '../../../../models/SceneModels';
+import { DataOverlayDataRow } from '../DataOverlayDataRow';
+
+describe('DataOverlayDataRow', () => {
+  describe('Markdown', () => {
+    const mockMarkdownRow: Component.DataOverlayMarkdownRow = {
+      rowType: Component.DataOverlayRowType.Markdown,
+      content: 'content',
+    };
+
+    it('should render markdown row for overlay panel correctly', () => {
+      const { container } = render(
+        <DataOverlayDataRow rowData={mockMarkdownRow} overlayType={Component.DataOverlaySubType.OverlayPanel} />,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should render markdown row for text annotation correctly', () => {
+      const { container } = render(
+        <DataOverlayDataRow rowData={mockMarkdownRow} overlayType={Component.DataOverlaySubType.TextAnnotation} />,
+      );
+      expect(container).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayRowsSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayRowsSnap.spec.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { IDataOverlayComponentInternal } from '../../../../store';
+import { KnownComponentType } from '../../../../interfaces';
+import { Component } from '../../../../models/SceneModels';
+import { DataOverlayRows } from '../DataOverlayRows';
+
+jest.mock('../DataOverlayDataRow', () => ({
+  DataOverlayDataRow: (...props: any[]) => <div data-testid='data-row'>{JSON.stringify(props)}</div>,
+}));
+
+describe('DataOverlayRows', () => {
+  const mockComponent: IDataOverlayComponentInternal = {
+    ref: 'comp-ref',
+    type: KnownComponentType.DataOverlay,
+    subType: Component.DataOverlaySubType.OverlayPanel,
+    dataRows: [
+      {
+        rowType: Component.DataOverlayRowType.Markdown,
+        content: 'content 1',
+      },
+      {
+        rowType: Component.DataOverlayRowType.Markdown,
+        content: 'content 2',
+      },
+    ],
+    valueDataBindings: {},
+  };
+
+  it('should render overlay panel correctly', () => {
+    const { container } = render(<DataOverlayRows component={mockComponent} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render text annotation correctly', () => {
+    const { container } = render(
+      <DataOverlayRows component={{ ...mockComponent, subType: Component.DataOverlaySubType.TextAnnotation }} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayComponentSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayComponentSnap.spec.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataOverlayComponent should render the component correctly 1`] = `
+<div>
+  <group>
+    <div
+      class="html-wrapper"
+      data-mocked="Html"
+      style="transform: translate3d(-50%,-100%,0);"
+    >
+      <div
+        data-testid="container"
+      >
+        [{"node":{"ref":"node-ref","transform":{"position":[1,2,3]},"components":[{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":{"bindingA":{"valueDataBinding":{"dataBindingContext":"dataBindingContext"}}}}]},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":{"bindingA":{"valueDataBinding":{"dataBindingContext":"dataBindingContext"}}}}},{}]
+      </div>
+    </div>
+  </group>
+</div>
+`;

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataOverlayContainer should render with annotation visible correctly 1`] = `
+<div>
+  <div
+    class="container annotation-container"
+  >
+    <div
+      data-testid="rows"
+    >
+      [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"TextAnnotation","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":{}}},{}]
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataOverlayContainer should render with panel invisible correctly 1`] = `<div />`;
+
+exports[`DataOverlayContainer should render with panel visible correctly when the overlay node is pinned 1`] = `
+<div>
+  <div
+    class="container panel-container"
+  >
+    <div
+      class="close-button"
+    >
+      <div
+        data-mocked="Button"
+        iconalign="right"
+        iconname="close"
+        variant="icon"
+      />
+    </div>
+    <div
+      data-testid="rows"
+    >
+      [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":{},"config":{"isPinned":true}}},{}]
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataOverlayContainer should render with panel visible correctly when the overlay node is selected 1`] = `
+<div>
+  <div
+    class="container panel-container"
+  >
+    <div
+      class="close-button"
+    >
+      <div
+        data-mocked="Button"
+        iconalign="right"
+        iconname="close"
+        variant="icon"
+      />
+    </div>
+    <div
+      data-testid="rows"
+    >
+      [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":{}}},{}]
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayDataRowSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayDataRowSnap.spec.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataOverlayDataRow Markdown should render markdown row for overlay panel correctly 1`] = `
+<div>
+  <p
+    class="markdown-row panel-row"
+  >
+    content
+  </p>
+</div>
+`;
+
+exports[`DataOverlayDataRow Markdown should render markdown row for text annotation correctly 1`] = `
+<div>
+  <p
+    class="markdown-row annotation-row"
+  >
+    content
+  </p>
+</div>
+`;

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayRowsSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayRowsSnap.spec.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataOverlayRows should render overlay panel correctly 1`] = `
+<div>
+  <div
+    class="panel-rows"
+  >
+    <div
+      data-testid="data-row"
+    >
+      [{"rowData":{"rowType":"Markdown","content":"content 1"},"overlayType":"OverlayPanel"},{}]
+    </div>
+    <div
+      data-testid="data-row"
+    >
+      [{"rowData":{"rowType":"Markdown","content":"content 2"},"overlayType":"OverlayPanel"},{}]
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataOverlayRows should render text annotation correctly 1`] = `
+<div>
+  <div
+    class="annotation-rows"
+  >
+    <div
+      data-testid="data-row"
+    >
+      [{"rowData":{"rowType":"Markdown","content":"content 1"},"overlayType":"TextAnnotation"},{}]
+    </div>
+    <div
+      data-testid="data-row"
+    >
+      [{"rowData":{"rowType":"Markdown","content":"content 2"},"overlayType":"TextAnnotation"},{}]
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/index.ts
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/index.ts
@@ -1,0 +1,3 @@
+import { DataOverlayComponent } from './DataOverlayComponent';
+
+export default DataOverlayComponent;

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.scss
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.scss
@@ -1,0 +1,31 @@
+@use '@awsui/design-tokens/index.scss' as awsui;
+
+// DataRow
+.markdown-row {
+  a {
+    color: awsui.$color-text-link-default
+  }
+}
+.annotation-row {
+  white-space: nowrap
+}
+
+// Rows
+.panel-rows {
+  margin-left: 1em;
+  margin-right: 1em
+}
+
+// Container
+.container {
+  overflow: auto
+}
+.panel-container {
+  width: 300px;
+  background-color: awsui.$color-background-container-content
+}
+.close-button {
+  float: right;
+  margin-top: 8px;
+  margin-right: 8px
+}

--- a/packages/scene-composer/src/components/three-fiber/EntityGroup/ComponentGroup.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EntityGroup/ComponentGroup.tsx
@@ -11,6 +11,7 @@ import {
   IMotionIndicatorComponentInternal,
   IColorOverlayComponentInternal,
   ISubModelRefComponentInternal,
+  IDataOverlayComponentInternal,
 } from '../../../store';
 import { getComponentsGroupName } from '../../../utils/objectThreeUtils';
 import ModelRefComponent from '../ModelRefComponent';
@@ -20,6 +21,7 @@ import LightComponent from '../LightComponent';
 import MotionIndicatorComponent from '../MotionIndicatorComponent';
 import ColorOverlayComponent from '../ColorOverlayComponent';
 import SubModelComponent from '../SubModelComponent';
+import DataOverlayComponent from '../DataOverlayComponent';
 
 interface ComponentViewProps {
   component: ISceneComponentInternal;
@@ -48,6 +50,8 @@ const ComponentView = ({ component, node }: ComponentViewProps) => {
       return <MotionIndicatorComponent node={node} component={component as IMotionIndicatorComponentInternal} />;
     case KnownComponentType.ModelShader:
       return <ColorOverlayComponent component={component as IColorOverlayComponentInternal} node={node} />;
+    case KnownComponentType.DataOverlay:
+      return <DataOverlayComponent node={node} component={component as IDataOverlayComponentInternal} />;
     default:
       return <Fragment key={component.ref}></Fragment>;
   }

--- a/packages/scene-composer/src/components/three-fiber/EntityGroup/__tests__/ComponentGroup.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EntityGroup/__tests__/ComponentGroup.spec.tsx
@@ -11,6 +11,7 @@ import {
   ILightComponentInternal,
   IMotionIndicatorComponentInternal,
   IColorOverlayComponentInternal,
+  IDataOverlayComponentInternal,
 } from '../../../../store';
 import ComponentGroup from '../ComponentGroup';
 import { fakeSceneNode } from '../fakers';
@@ -22,6 +23,7 @@ jest.mock('../../LightComponent', () => 'LightComponent');
 jest.mock('../../MotionIndicatorComponent', () => 'MotionIndicatorComponent');
 jest.mock('../../ColorOverlayComponent', () => 'ColorOverlayComponent');
 jest.mock('../../SubModelComponent', () => 'SubModelComponent');
+jest.mock('../../DataOverlayComponent', () => 'DataOverlayComponent');
 
 describe('<ComponentGroup />', () => {
   it('should render the appropriate view', () => {
@@ -33,6 +35,7 @@ describe('<ComponentGroup />', () => {
       { type: KnownComponentType.Light, ref: '4' } as ILightComponentInternal,
       { type: KnownComponentType.MotionIndicator, ref: '5' } as IMotionIndicatorComponentInternal,
       { type: KnownComponentType.ModelShader, ref: '6' } as IColorOverlayComponentInternal,
+      { type: KnownComponentType.DataOverlay, ref: '7' } as IDataOverlayComponentInternal,
     ] as ISceneComponentInternal[];
 
     const node = fakeSceneNode('ref');

--- a/packages/scene-composer/src/components/three-fiber/EntityGroup/__tests__/EntityGroup.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EntityGroup/__tests__/EntityGroup.spec.tsx
@@ -20,7 +20,7 @@ jest.mock('../../../../store', () => ({
   })),
 }));
 
-jest.mock('../useCallbackWhenNotPanning', () => (cb) => [
+jest.mock('../../../../hooks/useCallbackWhenNotPanning', () => (cb) => [
   jest.fn(),
   function Hack(e) {
     cb(e);

--- a/packages/scene-composer/src/components/three-fiber/EntityGroup/__tests__/__snapshots__/ComponentGroup.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/EntityGroup/__tests__/__snapshots__/ComponentGroup.spec.tsx.snap
@@ -33,6 +33,10 @@ exports[`<ComponentGroup /> should render the appropriate view 1`] = `
       component="[object Object]"
       node="[object Object]"
     />
+    <dataoverlaycomponent
+      component="[object Object]"
+      node="[object Object]"
+    />
   </group>
 </div>
 `;

--- a/packages/scene-composer/src/components/three-fiber/EntityGroup/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EntityGroup/index.tsx
@@ -15,8 +15,8 @@ import { COMPOSER_FEATURES, KnownComponentType } from '../../../interfaces';
 import LogProvider from '../../../logger/react-logger/log-provider';
 import { findComponentByType, isEnvironmentNode } from '../../../utils/nodeUtils';
 import { getGlobalSettings } from '../../../common/GlobalSettings';
+import useCallbackWhenNotPanning from '../../../hooks/useCallbackWhenNotPanning';
 
-import useCallbackWhenNotPanning from './useCallbackWhenNotPanning';
 import ComponentGroup from './ComponentGroup';
 
 interface IEntityGroupProps {

--- a/packages/scene-composer/src/hooks/useCallbackWhenNotPanning.ts
+++ b/packages/scene-composer/src/hooks/useCallbackWhenNotPanning.ts
@@ -1,5 +1,5 @@
+import { PointerEvent, useRef, useCallback } from 'react';
 import { ThreeEvent } from '@react-three/fiber';
-import { useRef, useCallback } from 'react';
 
 /**
  * This is not generic enough a hook to be used in the rest of the application, and has
@@ -16,7 +16,7 @@ const useCallbackWhenNotPanning = (callback, deps, acceptableDriftDistance = 1) 
   const lastPointerDownLocation = useRef<[number, number] | null>(null);
 
   const onPointerUp = useCallback(
-    (e: ThreeEvent<MouseEvent>) => {
+    (e: ThreeEvent<MouseEvent> | PointerEvent) => {
       const lastPointerPosition = lastPointerDownLocation.current;
       const { clientX, clientY } = e;
       if (!lastPointerPosition) {

--- a/packages/scene-composer/src/interfaces/components.ts
+++ b/packages/scene-composer/src/interfaces/components.ts
@@ -15,6 +15,7 @@ export enum KnownComponentType {
   Tag = 'Tag',
   ModelShader = 'ModelShader',
   MotionIndicator = 'MotionIndicator',
+  DataOverlay = 'DataOverlay',
 }
 
 export interface ISceneComponent {
@@ -120,3 +121,5 @@ export interface IColorOverlayComponent extends ISceneComponent {
 }
 
 export interface IMotionIndicatorComponent extends ISceneComponent, SceneModels.Component.MotionIndicator {}
+
+export interface IDataOverlayComponent extends ISceneComponent, SceneModels.Component.DataOverlay {}

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -115,6 +115,7 @@ export namespace Component {
     OpacityFilter = 'OpacityFilter',
     MotionIndicator = 'MotionIndicator',
     Space = 'Space',
+    DataOverlay = 'DataOverlay',
   }
 
   export interface IComponent {
@@ -193,6 +194,36 @@ export namespace Component {
       | ILinearPlaneMotionIndicatorConfig
       | ILinearCylinderMotionIndicatorConfig
       | ICircularCylinderMotionIndicatorConfig;
+  }
+
+  // Data Overlay
+  export enum DataOverlayRowType {
+    Markdown = 'Markdown',
+  }
+  export interface DataOverlayRow {
+    rowType: DataOverlayRowType;
+  }
+  export interface DataOverlayMarkdownRow extends DataOverlayRow {
+    content: string;
+  }
+  export enum DataOverlaySubType {
+    TextAnnotation = 'TextAnnotation',
+    OverlayPanel = 'OverlayPanel',
+  }
+  export interface OverlayPanelConfig {
+    isPinned: boolean;
+  }
+
+  export interface DataOverlay extends IComponent {
+    subType: DataOverlaySubType;
+    dataRows: Array<DataOverlayMarkdownRow>;
+    config?: OverlayPanelConfig;
+
+    valueDataBindings: {
+      [key: string]: {
+        valueDataBinding?: ValueDataBinding;
+      };
+    };
   }
 
   export interface ILightShadowSettings {

--- a/packages/scene-composer/src/store/Store.ts
+++ b/packages/scene-composer/src/store/Store.ts
@@ -21,6 +21,7 @@ import {
   isISceneComponentInternal,
   isISceneNodeInternal,
   IMotionIndicatorComponentInternal,
+  IDataOverlayComponentInternal,
 } from './internalInterfaces';
 
 export type {
@@ -36,6 +37,7 @@ export type {
   ILightComponentInternal,
   IColorOverlayComponentInternal,
   IMotionIndicatorComponentInternal,
+  IDataOverlayComponentInternal,
 };
 
 export interface ISharedState {

--- a/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
+++ b/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
@@ -155,6 +155,44 @@ describe('serializationHelpers', () => {
     });
   });
 
+  it('should appropriately create data overlay components or log errors when calling createDataOverlayComponent', () => {
+    (generateUUID as jest.Mock).mockReturnValue('test-uuid');
+
+    const component = {
+      type: KnownComponentType.DataOverlay,
+      subtype: Component.DataOverlaySubType.OverlayPanel,
+      dataRows: [
+        {
+          rowType: Component.DataOverlayRowType.Markdown,
+          content: 'content',
+        },
+      ],
+      valueDataBindings: {
+        bindingA: {
+          valueDataBinding: { dataBindingContext: 'dataBindingContext' },
+        },
+      },
+    };
+    const resolver = jest.fn();
+    resolver.mockReturnValueOnce('here is a map');
+    resolver.mockReturnValueOnce(undefined);
+    const errorCollector = [];
+    const overlay = exportsForTesting.createDataOverlayComponent(component as any, resolver, errorCollector);
+
+    expect(overlay).toEqual({
+      ref: 'test-uuid',
+      type: KnownComponentType.DataOverlay,
+      subtype: Component.DataOverlaySubType.OverlayPanel,
+      dataRows: [
+        {
+          rowType: Component.DataOverlayRowType.Markdown,
+          content: 'content',
+        },
+      ],
+      valueDataBindings: component.valueDataBindings,
+    });
+  });
+
   it('should create a scene node when calling createSceneNodeInternal', () => {
     (generateUUID as jest.Mock).mockReturnValueOnce('test-uuid');
 

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -29,6 +29,7 @@ import {
   IColorOverlayComponentInternal,
   IMotionIndicatorComponentInternal,
   ISubModelRefComponentInternal,
+  IDataOverlayComponentInternal,
 } from '../internalInterfaces';
 
 import { addComponentToComponentNodeMap } from './componentMapHelpers';
@@ -203,6 +204,14 @@ function createMotionIndicatorComponent(
   };
 }
 
+function createDataOverlayComponent(
+  component: Component.DataOverlay,
+  resolver: IndexedObjectResolver,
+  errorCollector: ISerializationErrorDetails[],
+): IDataOverlayComponentInternal | undefined {
+  return Object.assign({}, { ref: generateUUID() }, { ...component });
+}
+
 function deserializeComponent(
   component: Component.IComponent,
   node: ISceneNodeInternal,
@@ -243,6 +252,9 @@ function deserializeComponent(
       }
 
       return createMotionIndicatorComponent(component as Component.MotionIndicator, resolver, errorCollector);
+    }
+    case Component.Type.DataOverlay: {
+      return createDataOverlayComponent(component as Component.DataOverlay, resolver, errorCollector);
     }
     default: {
       LOG.warn(`component not supported type[${component.type}]. It will be ignored.`);
@@ -724,6 +736,7 @@ export const exportsForTesting = {
   createLightComponent,
   createModelShaderComponent,
   createMotionIndicatorComponent,
+  createDataOverlayComponent,
   deserializeComponent,
   parseSceneContent,
   createSceneNodeInternal,

--- a/packages/scene-composer/src/store/internalInterfaces.ts
+++ b/packages/scene-composer/src/store/internalInterfaces.ts
@@ -22,6 +22,7 @@ import {
   KnownComponentType,
   WidgetClickEventCallback,
   ISubModelRefComponent,
+  IDataOverlayComponent,
 } from '../interfaces';
 import { MapControls as MapControlsImpl, OrbitControls as OrbitControlsImpl } from '../three/OrbitControls';
 
@@ -114,6 +115,8 @@ export type IAnchorComponentInternal = IDataBoundSceneComponentInternal & IAncho
 export type IColorOverlayComponentInternal = IDataBoundSceneComponentInternal & IColorOverlayComponent;
 
 export type IMotionIndicatorComponentInternal = ISceneComponentInternal & IMotionIndicatorComponent;
+
+export type IDataOverlayComponentInternal = ISceneComponentInternal & IDataOverlayComponent;
 
 /******************************************************************************
  * Type magic...

--- a/packages/scene-composer/tests/scenes/scene_1.json
+++ b/packages/scene-composer/tests/scenes/scene_1.json
@@ -45,7 +45,8 @@
       "children": [
         1,
         4,
-        5
+        5,
+        7
       ],
       "components": [
         {
@@ -81,6 +82,9 @@
       "transformConstraint": {
 
       },
+      "children": [
+        8
+      ],
       "components": [
         {
           "type": "Tag",
@@ -279,6 +283,86 @@
         {
           "type": "Camera",
           "cameraIndex": 0
+        }
+      ],
+      "properties": {
+
+      }
+    },
+    {
+      "name": "Text Annotation",
+      "transform": {
+        "position": [
+          0,
+          0.9,
+          0.25
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {
+
+      },
+      "components": [
+        {
+          "type": "DataOverlay",
+          "subType": "TextAnnotation",
+          "dataRows": [
+            {
+              "rowType": "Markdown",
+              "content": "#|| Annotation ||"
+            }
+          ]
+        }
+      ],
+      "properties": {
+
+      }
+    },
+    {
+      "name": "Overlay Panel",
+      "transform": {
+        "position": [
+          0,
+          0.25,
+          0
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {
+
+      },
+      "components": [
+        {
+          "type": "DataOverlay",
+          "subType": "OverlayPanel",
+          "dataRows": [
+            {
+              "rowType": "Markdown",
+              "content": "##|| Panel ||"
+            },
+            {
+              "rowType": "Markdown",
+              "content": "[Click me](https://github.com/awslabs/iot-app-kit)"
+            }
+          ]
         }
       ],
       "properties": {

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -11,6 +11,10 @@
     "note": "FormField label",
     "text": "Rule Id"
   },
+  "+okT2d": {
+    "note": "Expandable Section title",
+    "text": "Data Overlay"
+  },
   "/OvfUw": {
     "note": "Distance Units in a dropdown menu",
     "text": "Custom Scale"


### PR DESCRIPTION
## Overview
Implement the container of data overlay component with simple text content rendering

<img width="1330" alt="overlay-container" src="https://user-images.githubusercontent.com/9315598/219520159-df4bb5c3-df79-4dc3-ac9e-7e9876102316.png">


## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
