### PR TITLE
chore(govcloud): Remove hardcoded partition in parseS3BucketFromArn

### DIFF
--- a/packages/scene-composer/src/utils/pathUtils.ts
+++ b/packages/scene-composer/src/utils/pathUtils.ts
@@ -24,9 +24,9 @@ export function extractFileNameExtFromUrl(fileUrl: string) {
   return [decodeURI(basename), decodeURI(ext)];
 }
 
-// Expecting arn:aws:s3:::<bucket_name>
+// Expecting arn:<partition>:s3:::<bucket_name>
 export function parseS3BucketFromArn(s3Arn: string): string {
-  const arnSplit = s3Arn.split('arn:aws:s3:::');
+  const arnSplit = s3Arn.split('s3:::');
   return arnSplit[1];
 }
 

--- a/packages/source-iottwinmaker/src/utils/s3Utils.ts
+++ b/packages/source-iottwinmaker/src/utils/s3Utils.ts
@@ -18,9 +18,9 @@ export const getS3BucketAndKey = (uri: string): { Bucket: string; Key: string } 
   };
 };
 
-// Expecting arn:aws:s3:::<bucket_name>
+// Expecting arn:<partition>:s3:::<bucket_name>
 export const parseS3BucketFromArn = (s3Arn: string): string => {
-  const arnSplit = s3Arn.split('arn:aws:s3:::');
+  const arnSplit = s3Arn.split('s3:::');
   return arnSplit[1];
 };
 


### PR DESCRIPTION
## Overview
Support the GovCloud partition by removing the hardcoded "aws" partition in S3 bucket ARNs.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
