### PR TITLE
fix(dashboard): bugfix for gesture layer overlaying widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "npm-run-all -p test:unit test:eslint test:stylelint test:git",
     "test:integration": "turbo run test:integration",
     "test:ui": "turbo run test:ui",
-    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=40",
+    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=38",
     "test:stylelint": "stylelint '**/*.css' --max-warnings 0",
     "test:unit": "turbo run test",
     "test:git": "git diff --exit-code",

--- a/packages/dashboard/src/components/internalDashboard/useLayers.spec.tsx
+++ b/packages/dashboard/src/components/internalDashboard/useLayers.spec.tsx
@@ -19,6 +19,7 @@ it('has default layers', () => {
   expect(result.current.selectionBoxLayer).toBeGreaterThan(0);
   expect(result.current.userSelectionLayer).toBeGreaterThan(0);
   expect(result.current.contextMenuLayer).toBeGreaterThan(0);
+  expect(result.current.selectionGestureLayer).toBeLessThan(0);
 
   expect(result.current.userSelectionLayer).toBeGreaterThan(result.current.selectionBoxLayer);
   expect(result.current.contextMenuLayer).toBeGreaterThan(result.current.userSelectionLayer);
@@ -41,6 +42,7 @@ it('has updates the layers to be greater than the highest widget in the dashboar
   expect(result.current.selectionBoxLayer).toBeGreaterThan(zTest);
   expect(result.current.userSelectionLayer).toBeGreaterThan(zTest);
   expect(result.current.contextMenuLayer).toBeGreaterThan(zTest);
+  expect(result.current.selectionGestureLayer).toBeLessThan(zTest);
 
   expect(result.current.userSelectionLayer).toBeGreaterThan(result.current.selectionBoxLayer);
   expect(result.current.contextMenuLayer).toBeGreaterThan(result.current.userSelectionLayer);

--- a/packages/dashboard/src/components/internalDashboard/useLayers.ts
+++ b/packages/dashboard/src/components/internalDashboard/useLayers.ts
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 import max from 'lodash/max';
+import min from 'lodash/min';
 
 import { DashboardState } from '~/store/state';
 
@@ -7,21 +8,25 @@ type Layers = {
   userSelectionLayer: number;
   selectionBoxLayer: number;
   contextMenuLayer: number;
+  selectionGestureLayer: number;
 };
 const layers: Layers = {
   userSelectionLayer: 2,
   selectionBoxLayer: 1,
   contextMenuLayer: 3,
+  selectionGestureLayer: -1,
 };
 
 export const useLayers = (): Layers => {
   const widgets = useSelector((state: DashboardState) => state.dashboardConfiguration.widgets);
 
-  const z = max(widgets.map(({ z }) => z)) ?? 0;
+  const top = max(widgets.map(({ z }) => z)) ?? 0;
+  const bottom = min(widgets.map(({ z }) => z)) ?? 0;
 
   return {
-    userSelectionLayer: z + layers.userSelectionLayer,
-    selectionBoxLayer: z + layers.selectionBoxLayer,
-    contextMenuLayer: z + layers.contextMenuLayer,
+    userSelectionLayer: top + layers.userSelectionLayer,
+    selectionBoxLayer: top + layers.selectionBoxLayer,
+    contextMenuLayer: top + layers.contextMenuLayer,
+    selectionGestureLayer: bottom + layers.selectionGestureLayer,
   };
 };

--- a/packages/dashboard/src/components/widgets/selectionBox.tsx
+++ b/packages/dashboard/src/components/widgets/selectionBox.tsx
@@ -15,7 +15,7 @@ export type SelectionBoxProps = {
 };
 
 const SelectionBox: React.FC<SelectionBoxProps> = ({ selectedWidgets, cellSize, dragEnabled }) => {
-  const { selectionBoxLayer } = useLayers();
+  const { selectionBoxLayer, selectionGestureLayer } = useLayers();
 
   const rect = getSelectionBox(selectedWidgets);
 
@@ -34,7 +34,7 @@ const SelectionBox: React.FC<SelectionBoxProps> = ({ selectedWidgets, cellSize, 
           left: `${cellSize * x - 2}px`,
           width: `${cellSize * width + 4}px`,
           height: `${cellSize * height + 4}px`,
-          zIndex: selectionBoxLayer,
+          zIndex: selectionGestureLayer,
         }}
       ></div>
       <div

--- a/packages/dashboard/src/components/widgets/widgetDropTarget.tsx
+++ b/packages/dashboard/src/components/widgets/widgetDropTarget.tsx
@@ -34,5 +34,9 @@ export const WidgetDropTarget: React.FC<WidgetDropTargetProps> = ({ widget, chil
     []
   );
 
-  return <div ref={drop}>{children}</div>;
+  return (
+    <div style={{ height: '100%', width: '100%' }} ref={drop}>
+      {children}
+    </div>
+  );
 };


### PR DESCRIPTION
## Overview
The target for selection gesture handling is on a layer above dashboard widgets. This would intercept drag and drop events, preventing you from dropping resources onto a widget if they were in an active selection. This fix moves that layer to the bottom of the widget stack context so that it does not overlay any widgets

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
