### PR TITLE
feat(composer): data overlay editor & render markdown

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -157,6 +157,7 @@
     "react-dnd-html5-backend": "^15.1.3",
     "react-error-boundary": "^3.1.3",
     "react-intl": "5.24.1",
+    "react-markdown": "^8.0.5",
     "string-to-arraybuffer": "1.0.2",
     "styled-components": "^5.3.0",
     "three": "^0.131.0",

--- a/packages/scene-composer/src/components/panels/ComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormField, Input, SpaceBetween } from '@awsui/components-react';
 
-import { ISceneComponentInternal, ISceneNodeInternal } from '../../store';
+import { IDataOverlayComponentInternal, ISceneComponentInternal, ISceneNodeInternal } from '../../store';
 import { KnownComponentType } from '../../interfaces';
 import { pascalCase } from '../../utils/stringUtils';
 
@@ -11,6 +11,7 @@ import { ColorOverlayComponentEditor } from './scene-components/ColorOverlayComp
 import { ModelRefComponentEditor } from './scene-components/ModelRefComponentEditor';
 import { MotionIndicatorComponentEditor } from './scene-components/MotionIndicatorComponentEditor';
 import CameraComponentEditor from './scene-components/CameraComponentEditor';
+import { DataOverlayComponentEditor } from './scene-components/DataOverlayComponentEditor';
 
 export interface IComponentEditorProps {
   node: ISceneNodeInternal;
@@ -51,6 +52,8 @@ export const ComponentEditor: React.FC<IComponentEditorProps> = ({ node, compone
       return <ModelRefComponentEditor node={node} component={component} />;
     case KnownComponentType.MotionIndicator:
       return <MotionIndicatorComponentEditor node={node} component={component} />;
+    case KnownComponentType.DataOverlay:
+      return <DataOverlayComponentEditor node={node} component={component as IDataOverlayComponentInternal} />;
     default:
       return <DefaultComponentEditor node={node} component={component} />;
   }

--- a/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.spec.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import wrapper from '@awsui/components-react/test-utils/dom';
+
+import { KnownComponentType } from '../../../interfaces';
+import { IDataOverlayComponentInternal, ISceneNodeInternal, useStore } from '../../../store';
+import { Component } from '../../../models/SceneModels';
+import { mockProvider } from '../../../../tests/components/panels/scene-components/MockComponents';
+
+import { DataOverlayComponentEditor } from './DataOverlayComponentEditor';
+
+jest.mock('@awsui/components-react', () => ({
+  ...jest.requireActual('@awsui/components-react'),
+}));
+
+jest.mock('./data-overlay/DataBindingMapEditor', () => {
+  const originalModule = jest.requireActual('./data-overlay/DataBindingMapEditor');
+  return {
+    ...originalModule,
+    DataBindingMapEditor: (...props: unknown[]) => {
+      return <div data-testid='DataBindingMapEditor'>{JSON.stringify(props)}</div>;
+    },
+  };
+});
+
+describe('DataBindingMapEditor', () => {
+  const component: IDataOverlayComponentInternal = {
+    ref: 'comp-ref',
+    type: KnownComponentType.DataOverlay,
+    subType: Component.DataOverlaySubType.TextAnnotation,
+    dataRows: [
+      {
+        rowType: Component.DataOverlayRowType.Markdown,
+        content: 'markdown-content',
+      },
+    ],
+    valueDataBindings: [],
+  };
+  const node = {
+    ref: 'node-ref',
+  } as ISceneNodeInternal;
+  const updateComponentInternalMock = jest.fn();
+
+  const baseState = {
+    updateComponentInternal: updateComponentInternalMock,
+    getEditorConfig: jest.fn().mockReturnValue({ valueDataBindingProvider: mockProvider }),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should add new binding by clicking add button', async () => {
+    useStore('default').setState(baseState);
+
+    const { container } = render(<DataOverlayComponentEditor node={node} component={component} />);
+    const polarisWrapper = wrapper(container);
+
+    const textarea = polarisWrapper.findTextarea();
+    expect(textarea).not.toBeNull();
+
+    const newContent = 'new content';
+    act(() => {
+      textarea!.setTextareaValue(newContent);
+    });
+
+    expect(updateComponentInternalMock).toBeCalledTimes(1);
+    expect(updateComponentInternalMock).toBeCalledWith(
+      node.ref,
+      { ref: component.ref, dataRows: [{ ...component.dataRows[0], content: newContent }] },
+      undefined,
+    );
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.tsx
@@ -1,0 +1,64 @@
+import React, { useCallback, useContext } from 'react';
+import { FormField, SpaceBetween, Textarea } from '@awsui/components-react';
+import { useIntl } from 'react-intl';
+
+import { IComponentEditorProps } from '../ComponentEditor';
+import { IDataOverlayComponentInternal, ISceneComponentInternal, useStore } from '../../../store';
+import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import { Component } from '../../../models/SceneModels';
+
+import { DataBindingMapEditor } from './data-overlay/DataBindingMapEditor';
+
+export interface IDataOverlayComponentEditorProps extends IComponentEditorProps {
+  component: IDataOverlayComponentInternal;
+}
+
+export const DataOverlayComponentEditor: React.FC<IDataOverlayComponentEditorProps> = ({
+  node,
+  component,
+}: IDataOverlayComponentEditorProps) => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const updateComponentInternal = useStore(sceneComposerId)((state) => state.updateComponentInternal);
+  const valueDataBindingProvider = useStore(sceneComposerId)(
+    (state) => state.getEditorConfig().valueDataBindingProvider,
+  );
+  const { formatMessage } = useIntl();
+
+  const onUpdateCallback = useCallback(
+    (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean) => {
+      const componentPartialWithRef = { ref: component.ref, ...componentPartial };
+      updateComponentInternal(node.ref, componentPartialWithRef as ISceneComponentInternal, replace);
+    },
+    [node.ref, component.ref],
+  );
+
+  return (
+    <SpaceBetween size='s'>
+      <DataBindingMapEditor
+        valueDataBindingProvider={valueDataBindingProvider}
+        component={component}
+        onUpdateCallback={onUpdateCallback}
+      />
+
+      {component.dataRows.length > 0 &&
+        component.dataRows.map(
+          (row, index) =>
+            row.rowType === Component.DataOverlayRowType.Markdown && (
+              <FormField
+                key={index}
+                label={formatMessage({ defaultMessage: 'Markdown content', description: 'FormField label' })}
+              >
+                <Textarea
+                  value={row.content}
+                  onChange={(e) => {
+                    const newRows = [...component.dataRows];
+                    newRows[index] = { ...newRows[index], content: e.detail.value };
+                    onUpdateCallback({ dataRows: newRows });
+                  }}
+                />
+              </FormField>
+            ),
+        )}
+    </SpaceBetween>
+  );
+};

--- a/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditorSnap.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditorSnap.spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { mockProvider } from '../../../../tests/components/panels/scene-components/MockComponents';
+import { IDataOverlayComponentInternal, ISceneNodeInternal, useStore } from '../../../store';
+import { Component } from '../../../models/SceneModels';
+import { KnownComponentType } from '../../../interfaces';
+
+import { DataOverlayComponentEditor } from './DataOverlayComponentEditor';
+
+jest.mock('./data-overlay/DataBindingMapEditor', () => {
+  const originalModule = jest.requireActual('./data-overlay/DataBindingMapEditor');
+  return {
+    ...originalModule,
+    DataBindingMapEditor: (...props: unknown[]) => {
+      return <div data-testid='DataBindingMapEditor'>{JSON.stringify(props)}</div>;
+    },
+  };
+});
+
+describe('DataOverlayComponentEditor', () => {
+  const component: IDataOverlayComponentInternal = {
+    ref: 'comp-ref',
+    type: KnownComponentType.DataOverlay,
+    subType: Component.DataOverlaySubType.TextAnnotation,
+    dataRows: [
+      {
+        rowType: Component.DataOverlayRowType.Markdown,
+        content: 'markdown-content',
+      },
+    ],
+    valueDataBindings: [
+      {
+        bindingName: 'binding-1',
+        valueDataBinding: {
+          dataBindingContext: 'random-1',
+        },
+      },
+    ],
+  };
+  const node = {
+    ref: 'node-ref',
+  } as ISceneNodeInternal;
+
+  const baseState = {
+    updateComponentInternal: jest.fn(),
+    getEditorConfig: jest.fn().mockReturnValue({ valueDataBindingProvider: mockProvider }),
+  };
+
+  it('should render data rows', async () => {
+    useStore('default').setState(baseState);
+
+    const { container } = render(<DataOverlayComponentEditor node={node} component={component} />);
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/DataOverlayComponentEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/DataOverlayComponentEditorSnap.spec.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataOverlayComponentEditor should render data rows 1`] = `
+<div>
+  <div
+    data-mocked="SpaceBetween"
+  >
+    <div
+      data-testid="DataBindingMapEditor"
+    >
+      [{"valueDataBindingProvider":{},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"TextAnnotation","dataRows":[{"rowType":"Markdown","content":"markdown-content"}],"valueDataBindings":[{"bindingName":"binding-1","valueDataBinding":{"dataBindingContext":"random-1"}}]}},{}]
+    </div>
+    <div
+      data-mocked="FormField"
+      label="Markdown content"
+    >
+      <div
+        data-mocked="Textarea"
+        value="markdown-content"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapEditor.spec.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import wrapper from '@awsui/components-react/test-utils/dom';
+
+import { mockProvider } from '../../../../../tests/components/panels/scene-components/MockComponents';
+import { IDataOverlayComponentInternal } from '../../../../store';
+import { Component } from '../../../../models/SceneModels';
+import { IValueDataBindingBuilderProps } from '../ValueDataBindingBuilder';
+
+import { DataBindingMapEditor } from './DataBindingMapEditor';
+
+jest.mock('@awsui/components-react', () => ({
+  ...jest.requireActual('@awsui/components-react'),
+}));
+
+jest.mock('../../../../utils/mathUtils', () => ({
+  generateUUID: jest.fn(() => 'random-uuid'),
+}));
+
+let builderOnChangeCb;
+jest.mock('../ValueDataBindingBuilder', () => {
+  const originalModule = jest.requireActual('../ValueDataBindingBuilder');
+  return {
+    ...originalModule,
+    ValueDataBindingBuilder: (props: IValueDataBindingBuilderProps) => {
+      builderOnChangeCb = props.onChange;
+      return <div data-testid='ValueDataBindingBuilder'>{JSON.stringify(props)}</div>;
+    },
+  };
+});
+
+describe('DataBindingMapEditor', () => {
+  const component = {
+    subType: Component.DataOverlaySubType.OverlayPanel,
+    valueDataBindings: [
+      {
+        bindingName: 'binding-1',
+        valueDataBinding: {
+          dataBindingContext: 'random-1',
+        },
+      },
+    ],
+  } as unknown as IDataOverlayComponentInternal;
+  const onUpdateCallbackMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should add new binding by clicking add button', async () => {
+    const { container } = render(
+      <DataBindingMapEditor
+        valueDataBindingProvider={mockProvider}
+        component={{ valueDataBindings: [] } as unknown as IDataOverlayComponentInternal}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+    const polarisWrapper = wrapper(container);
+
+    const addButton = polarisWrapper.findButton('[data-test-id="add-binding-button"]');
+    expect(addButton).not.toBeNull();
+
+    act(() => {
+      addButton!.click();
+    });
+
+    expect(onUpdateCallbackMock).toBeCalledTimes(1);
+    expect(onUpdateCallbackMock).toBeCalledWith({ valueDataBindings: [{ bindingName: 'random-uuid' }] });
+  });
+
+  it('should add additional binding by clicking add button without removing existing ones', async () => {
+    const { container } = render(
+      <DataBindingMapEditor
+        valueDataBindingProvider={mockProvider}
+        component={component}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+    const polarisWrapper = wrapper(container);
+
+    const addButton = polarisWrapper.findButton('[data-test-id="add-binding-button"]');
+    expect(addButton).not.toBeNull();
+
+    act(() => {
+      addButton!.click();
+    });
+
+    expect(onUpdateCallbackMock).toBeCalledTimes(1);
+    expect(onUpdateCallbackMock).toBeCalledWith({
+      valueDataBindings: [...component.valueDataBindings, { bindingName: 'random-uuid' }],
+    });
+  });
+
+  it('should remove binding by clicking remove button', async () => {
+    const { container } = render(
+      <DataBindingMapEditor
+        valueDataBindingProvider={mockProvider}
+        component={component}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+    const polarisWrapper = wrapper(container);
+
+    const removeButton = polarisWrapper.findButton('[data-test-id="remove-binding-button"]');
+    expect(removeButton).not.toBeNull();
+
+    act(() => {
+      removeButton!.click();
+    });
+
+    expect(onUpdateCallbackMock).toBeCalledTimes(1);
+    expect(onUpdateCallbackMock).toBeCalledWith({ ...component, valueDataBindings: [] }, true);
+  });
+
+  it('should call update when data binding changed', async () => {
+    render(
+      <DataBindingMapEditor
+        valueDataBindingProvider={mockProvider}
+        component={{ ...component, valueDataBindings: [...component.valueDataBindings, { bindingName: 'binding-2' }] }}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+
+    builderOnChangeCb({ key: 'value' }, 1);
+
+    expect(onUpdateCallbackMock).toBeCalledTimes(1);
+    expect(onUpdateCallbackMock).toBeCalledWith(
+      {
+        ...component,
+        valueDataBindings: [
+          ...component.valueDataBindings,
+          { bindingName: 'binding-2', valueDataBinding: { key: 'value' } },
+        ],
+      },
+      true,
+    );
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapEditor.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback } from 'react';
+import { Box, Button, ExpandableSection, SpaceBetween } from '@awsui/components-react';
+import { useIntl } from 'react-intl';
+import { isEmpty } from 'lodash';
+
+import { IValueDataBinding, IValueDataBindingProvider } from '../../../../interfaces';
+import { IDataOverlayComponentInternal } from '../../../../store';
+import { ValueDataBindingBuilder } from '../ValueDataBindingBuilder';
+import { generateUUID } from '../../../../utils/mathUtils';
+
+import { DataBindingMapNameEditor } from './DataBindingMapNameEditor';
+
+interface IDataBindingMapEditorProps {
+  valueDataBindingProvider: IValueDataBindingProvider | undefined;
+  component: IDataOverlayComponentInternal;
+  onUpdateCallback: (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean | undefined) => void;
+}
+
+export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
+  valueDataBindingProvider,
+  component,
+  onUpdateCallback,
+}) => {
+  const intl = useIntl();
+
+  const onBindingChange = useCallback(
+    (valueDataBinding: IValueDataBinding, index) => {
+      // we don't want to merge the dataBindingContext, so we'll need to manually replace it
+      const updatedComponent = {
+        ...component,
+        valueDataBindings: [...component.valueDataBindings],
+      };
+      updatedComponent.valueDataBindings[index] = {
+        ...updatedComponent.valueDataBindings[index],
+        valueDataBinding,
+      };
+      onUpdateCallback(updatedComponent, true);
+    },
+    [component.valueDataBindings, onUpdateCallback],
+  );
+
+  const onRemoveBinding = useCallback(
+    (index) => {
+      const newBindings = component.valueDataBindings.filter((_, i) => i !== index);
+      onUpdateCallback({ ...component, valueDataBindings: newBindings }, true);
+    },
+    [component.valueDataBindings, onUpdateCallback],
+  );
+
+  const onAddBinding = useCallback(() => {
+    const newBindings = [...component.valueDataBindings];
+    newBindings.push({ bindingName: generateUUID() });
+    onUpdateCallback({ valueDataBindings: newBindings });
+  }, [component.valueDataBindings, onUpdateCallback]);
+
+  return (
+    <SpaceBetween size='s'>
+      {valueDataBindingProvider && (
+        <>
+          {!isEmpty(component.valueDataBindings) &&
+            component.valueDataBindings.map(({ bindingName, valueDataBinding }, index) => (
+              <ExpandableSection header={bindingName} key={index}>
+                <DataBindingMapNameEditor
+                  bindingName={bindingName}
+                  index={index}
+                  valueDataBindings={component.valueDataBindings}
+                  onUpdateCallback={onUpdateCallback}
+                />
+
+                <Box margin={{ vertical: 's' }}>
+                  <ValueDataBindingBuilder
+                    componentRef={component.ref}
+                    binding={valueDataBinding}
+                    valueDataBindingProvider={valueDataBindingProvider}
+                    onChange={(v) => onBindingChange(v, index)}
+                  />
+                </Box>
+                <Button data-test-id='remove-binding-button' onClick={() => onRemoveBinding(index)}>
+                  {intl.formatMessage({ defaultMessage: 'Remove data binding', description: 'Button text' })}
+                </Button>
+              </ExpandableSection>
+            ))}
+          <Button data-test-id='add-binding-button' onClick={onAddBinding}>
+            {intl.formatMessage({ defaultMessage: 'Add data binding', description: 'Button text' })}
+          </Button>
+        </>
+      )}
+    </SpaceBetween>
+  );
+};

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapEditorSnap.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapEditorSnap.spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { mockProvider } from '../../../../../tests/components/panels/scene-components/MockComponents';
+import { IDataOverlayComponentInternal } from '../../../../store';
+
+import { DataBindingMapEditor } from './DataBindingMapEditor';
+
+describe('DataBindingMapEditor', () => {
+  const component = {
+    valueDataBindings: [
+      {
+        bindingName: 'binding-1',
+        valueDataBinding: {
+          dataBindingContext: 'random-1',
+        },
+      },
+      {
+        bindingName: 'binding-2',
+        valueDataBinding: {
+          dataBindingContext: 'random-2',
+        },
+      },
+    ],
+  } as unknown as IDataOverlayComponentInternal;
+  const onUpdateCallbackMock = jest.fn();
+
+  it('should render existing maps with bindings', async () => {
+    const { container } = render(
+      <DataBindingMapEditor
+        valueDataBindingProvider={mockProvider}
+        component={component}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with no bindings', async () => {
+    const { container } = render(
+      <DataBindingMapEditor
+        valueDataBindingProvider={mockProvider}
+        component={{} as IDataOverlayComponentInternal}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditor.spec.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import wrapper from '@awsui/components-react/test-utils/dom';
+
+import { DataBindingMapNameEditor } from './DataBindingMapNameEditor';
+
+jest.mock('@awsui/components-react', () => ({
+  ...jest.requireActual('@awsui/components-react'),
+}));
+
+describe('DataBindingMapNameEditor', () => {
+  const valueDataBindings = [
+    {
+      bindingName: 'binding-1',
+      valueDataBinding: {
+        dataBindingContext: 'random-1',
+      },
+    },
+  ];
+  const onUpdateCallbackMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should update binding name', async () => {
+    const { container } = render(
+      <DataBindingMapNameEditor
+        bindingName='binding-1'
+        index={0}
+        valueDataBindings={valueDataBindings}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+    const polarisWrapper = wrapper(container);
+
+    const nameInput = polarisWrapper.findInput('[data-test-id="binding-name-input"]');
+    expect(nameInput).not.toBeNull();
+
+    act(() => {
+      nameInput!.setInputValue('new-name');
+    });
+
+    expect(onUpdateCallbackMock).toBeCalledTimes(1);
+    expect(onUpdateCallbackMock).toBeCalledWith({
+      valueDataBindings: [{ ...valueDataBindings[0], bindingName: 'new-name' }],
+    });
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditor.tsx
@@ -1,0 +1,54 @@
+import React, { useCallback } from 'react';
+import { FormField, Input } from '@awsui/components-react';
+import { useIntl } from 'react-intl';
+import { isEmpty } from 'lodash';
+
+import { IDataOverlayComponentInternal } from '../../../../store';
+import { Component } from '../../../../models/SceneModels';
+
+interface IDataBindingMapNameEditorProps {
+  bindingName: string;
+  index: number;
+  valueDataBindings: Component.ValueDataBindingNamedMap[];
+  onUpdateCallback: (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean | undefined) => void;
+}
+
+export const DataBindingMapNameEditor: React.FC<IDataBindingMapNameEditorProps> = ({
+  bindingName,
+  index,
+  valueDataBindings,
+  onUpdateCallback,
+}) => {
+  const { formatMessage } = useIntl();
+
+  const bindingNameError = useCallback(
+    (bindingName) => {
+      if (isEmpty(bindingName)) {
+        return formatMessage({ defaultMessage: 'Invalid name', description: 'Input error message' });
+      }
+      if (valueDataBindings.filter((v) => v.bindingName === bindingName).length > 1) {
+        return formatMessage({ defaultMessage: 'Duplicate name', description: 'Input error message' });
+      }
+      return null;
+    },
+    [valueDataBindings, formatMessage],
+  );
+
+  const onBindingNameChange = useCallback(
+    (e, index) => {
+      const newBindings = [...valueDataBindings];
+      newBindings[index] = { ...newBindings[index], bindingName: e.detail.value };
+      onUpdateCallback({ valueDataBindings: newBindings });
+    },
+    [valueDataBindings, onUpdateCallback],
+  );
+
+  return (
+    <FormField
+      errorText={bindingNameError(bindingName)}
+      label={formatMessage({ defaultMessage: 'Binding Name', description: 'FormField label' })}
+    >
+      <Input data-test-id='binding-name-input' value={bindingName} onChange={(e) => onBindingNameChange(e, index)} />
+    </FormField>
+  );
+};

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditorSnap.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditorSnap.spec.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { cloneDeep } from 'lodash';
+
+import { DataBindingMapNameEditor } from './DataBindingMapNameEditor';
+
+describe('DataBindingMapNameEditor', () => {
+  const valueDataBindings = [
+    {
+      bindingName: 'binding-1',
+      valueDataBinding: {
+        dataBindingContext: 'random-1',
+      },
+    },
+    {
+      bindingName: 'binding-2',
+      valueDataBinding: {
+        dataBindingContext: 'random-2',
+      },
+    },
+  ];
+  const onUpdateCallbackMock = jest.fn();
+
+  it('should render binding name correctly', async () => {
+    const { container } = render(
+      <DataBindingMapNameEditor
+        bindingName='binding-1'
+        index={0}
+        valueDataBindings={valueDataBindings}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with invalid binding name error', async () => {
+    const { container } = render(
+      <DataBindingMapNameEditor
+        bindingName=''
+        index={0}
+        valueDataBindings={valueDataBindings}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with duplicate binding name error', async () => {
+    const bindings = cloneDeep(valueDataBindings);
+    bindings[0].bindingName = valueDataBindings[1].bindingName;
+    const { container } = render(
+      <DataBindingMapNameEditor
+        bindingName={valueDataBindings[1].bindingName}
+        index={0}
+        valueDataBindings={bindings}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
+<div>
+  <div
+    data-mocked="SpaceBetween"
+  >
+    <div
+      data-mocked="ExpandableSection"
+      header="binding-1"
+    >
+      <div
+        data-mocked="FormField"
+        errortext="null"
+        label="Binding Name"
+      >
+        <div
+          data-mocked="Input"
+          data-test-id="binding-name-input"
+          value="binding-1"
+        />
+      </div>
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Entity Id"
+          >
+            <div
+              data-mocked="Autosuggest"
+              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+              value="value1"
+            />
+          </div>
+          <div
+            data-mocked="FormField"
+            label="Component Type Id"
+          >
+            <div
+              data-mocked="Select"
+              data-testid="value-data-binding-builder-select"
+              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+              placeholder="Select an option"
+              selectedoption="null"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        data-mocked="Button"
+        data-test-id="remove-binding-button"
+      >
+        Remove data binding
+      </div>
+    </div>
+    <div
+      data-mocked="ExpandableSection"
+      header="binding-2"
+    >
+      <div
+        data-mocked="FormField"
+        errortext="null"
+        label="Binding Name"
+      >
+        <div
+          data-mocked="Input"
+          data-test-id="binding-name-input"
+          value="binding-2"
+        />
+      </div>
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Entity Id"
+          >
+            <div
+              data-mocked="Autosuggest"
+              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+              value="value1"
+            />
+          </div>
+          <div
+            data-mocked="FormField"
+            label="Component Type Id"
+          >
+            <div
+              data-mocked="Select"
+              data-testid="value-data-binding-builder-select"
+              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+              placeholder="Select an option"
+              selectedoption="null"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        data-mocked="Button"
+        data-test-id="remove-binding-button"
+      >
+        Remove data binding
+      </div>
+    </div>
+    <div
+      data-mocked="Button"
+      data-test-id="add-binding-button"
+    >
+      Add data binding
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataBindingMapEditor should render with no bindings 1`] = `
+<div>
+  <div
+    data-mocked="SpaceBetween"
+  >
+    <div
+      data-mocked="Button"
+      data-test-id="add-binding-button"
+    >
+      Add data binding
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/__snapshots__/DataBindingMapNameEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/__snapshots__/DataBindingMapNameEditorSnap.spec.tsx.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataBindingMapNameEditor should render binding name correctly 1`] = `
+<div>
+  <div
+    data-mocked="FormField"
+    errortext="null"
+    label="Binding Name"
+  >
+    <div
+      data-mocked="Input"
+      data-test-id="binding-name-input"
+      value="binding-1"
+    />
+  </div>
+</div>
+`;
+
+exports[`DataBindingMapNameEditor should render with duplicate binding name error 1`] = `
+<div>
+  <div
+    data-mocked="FormField"
+    errortext="Duplicate name"
+    label="Binding Name"
+  >
+    <div
+      data-mocked="Input"
+      data-test-id="binding-name-input"
+      value="binding-2"
+    />
+  </div>
+</div>
+`;
+
+exports[`DataBindingMapNameEditor should render with invalid binding name error 1`] = `
+<div>
+  <div
+    data-mocked="FormField"
+    errortext="Invalid name"
+    label="Binding Name"
+  >
+    <div
+      data-mocked="Input"
+      data-test-id="binding-name-input"
+      value=""
+    />
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayDataRow.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayDataRow.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 
 import { Component } from '../../../models/SceneModels';
+import { ReactMarkdownWrapper } from '../../wrappers/ReactMarkdownWrapper';
 import './styles.scss';
 
 export interface DataOverlayDataRowProps {
@@ -12,15 +13,11 @@ export const DataOverlayDataRow = ({ rowData, overlayType }: DataOverlayDataRowP
   switch (rowData.rowType) {
     case Component.DataOverlayRowType.Markdown: {
       const row = rowData as Component.DataOverlayMarkdownRow;
-      // TODO: use markdown processor in next change
       return (
-        <p
-          className={`markdown-row ${
-            overlayType === Component.DataOverlaySubType.TextAnnotation ? 'annotation-row' : 'panel-row'
-          }`}
-        >
-          {row.content}
-        </p>
+        <ReactMarkdownWrapper
+          className={overlayType === Component.DataOverlaySubType.TextAnnotation ? 'annotation-row' : 'panel-row'}
+          content={row.content}
+        />
       );
     }
     default:

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayComponentSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayComponentSnap.spec.tsx
@@ -4,10 +4,10 @@ import { render } from '@testing-library/react';
 import { DataOverlayComponent } from '../DataOverlayComponent';
 import { Component } from '../../../../models/SceneModels';
 import { KnownComponentType } from '../../../../interfaces';
-import { IDataOverlayComponentInternal } from '../../../../store';
+import { IDataOverlayComponentInternal, ISceneNodeInternal } from '../../../../store';
 
 jest.mock('../DataOverlayContainer', () => ({
-  DataOverlayContainer: (...props: any[]) => <div data-testid='container'>{JSON.stringify(props)}</div>,
+  DataOverlayContainer: (...props: unknown[]) => <div data-testid='container'>{JSON.stringify(props)}</div>,
 }));
 
 describe('DataOverlayComponent', () => {
@@ -21,20 +21,27 @@ describe('DataOverlayComponent', () => {
         content: 'content',
       },
     ],
-    valueDataBindings: {
-      bindingA: {
+    valueDataBindings: [
+      {
+        bindingName: 'bindingA',
         valueDataBinding: { dataBindingContext: 'dataBindingContext' },
       },
-    },
+    ],
   };
-  const mockNode: any = { ref: 'node-ref', transform: { position: [1, 2, 3] }, components: [mockComponent] };
+  const mockNode: Partial<ISceneNodeInternal> = {
+    ref: 'node-ref',
+    transform: { position: [1, 2, 3], rotation: [0, 0, 0], scale: [0, 0, 0] },
+    components: [mockComponent],
+  };
 
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   it('should render the component correctly', async () => {
-    const { container } = render(<DataOverlayComponent node={mockNode} component={mockComponent} />);
+    const { container } = render(
+      <DataOverlayComponent node={mockNode as ISceneNodeInternal} component={mockComponent} />,
+    );
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayContainerSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayContainerSnap.spec.tsx
@@ -28,7 +28,7 @@ describe('DataOverlayContainer', () => {
         content: 'content',
       },
     ],
-    valueDataBindings: {},
+    valueDataBindings: [],
   };
   const mockNode: any = { ref: 'node-ref', transform: { position: [1, 2, 3] }, components: [mockComponent] };
 

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayDataRowSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayDataRowSnap.spec.tsx
@@ -4,11 +4,15 @@ import { render } from '@testing-library/react';
 import { Component } from '../../../../models/SceneModels';
 import { DataOverlayDataRow } from '../DataOverlayDataRow';
 
+jest.mock('../../../wrappers/ReactMarkdownWrapper', () => ({
+  ReactMarkdownWrapper: (...props: unknown[]) => <div data-testid='ReactMarkdownWrapper'>{JSON.stringify(props)}</div>,
+}));
+
 describe('DataOverlayDataRow', () => {
   describe('Markdown', () => {
     const mockMarkdownRow: Component.DataOverlayMarkdownRow = {
       rowType: Component.DataOverlayRowType.Markdown,
-      content: 'content',
+      content: '# content',
     };
 
     it('should render markdown row for overlay panel correctly', () => {

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayRowsSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayRowsSnap.spec.tsx
@@ -25,7 +25,7 @@ describe('DataOverlayRows', () => {
         content: 'content 2',
       },
     ],
-    valueDataBindings: {},
+    valueDataBindings: [],
   };
 
   it('should render overlay panel correctly', () => {

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayComponentSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayComponentSnap.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`DataOverlayComponent should render the component correctly 1`] = `
       <div
         data-testid="container"
       >
-        [{"node":{"ref":"node-ref","transform":{"position":[1,2,3]},"components":[{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":{"bindingA":{"valueDataBinding":{"dataBindingContext":"dataBindingContext"}}}}]},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":{"bindingA":{"valueDataBinding":{"dataBindingContext":"dataBindingContext"}}}}},{}]
+        [{"node":{"ref":"node-ref","transform":{"position":[1,2,3],"rotation":[0,0,0],"scale":[0,0,0]},"components":[{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[{"bindingName":"bindingA","valueDataBinding":{"dataBindingContext":"dataBindingContext"}}]}]},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[{"bindingName":"bindingA","valueDataBinding":{"dataBindingContext":"dataBindingContext"}}]}},{}]
       </div>
     </div>
   </group>

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`DataOverlayContainer should render with annotation visible correctly 1`
     <div
       data-testid="rows"
     >
-      [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"TextAnnotation","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":{}}},{}]
+      [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"TextAnnotation","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[]}},{}]
     </div>
   </div>
 </div>
@@ -34,7 +34,7 @@ exports[`DataOverlayContainer should render with panel visible correctly when th
     <div
       data-testid="rows"
     >
-      [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":{},"config":{"isPinned":true}}},{}]
+      [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[],"config":{"isPinned":true}}},{}]
     </div>
   </div>
 </div>
@@ -58,7 +58,7 @@ exports[`DataOverlayContainer should render with panel visible correctly when th
     <div
       data-testid="rows"
     >
-      [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":{}}},{}]
+      [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[]}},{}]
     </div>
   </div>
 </div>

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayDataRowSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayDataRowSnap.spec.tsx.snap
@@ -2,20 +2,20 @@
 
 exports[`DataOverlayDataRow Markdown should render markdown row for overlay panel correctly 1`] = `
 <div>
-  <p
-    class="markdown-row panel-row"
+  <div
+    data-testid="ReactMarkdownWrapper"
   >
-    content
-  </p>
+    [{"className":"panel-row","content":"# content"},{}]
+  </div>
 </div>
 `;
 
 exports[`DataOverlayDataRow Markdown should render markdown row for text annotation correctly 1`] = `
 <div>
-  <p
-    class="markdown-row annotation-row"
+  <div
+    data-testid="ReactMarkdownWrapper"
   >
-    content
-  </p>
+    [{"className":"annotation-row","content":"# content"},{}]
+  </div>
 </div>
 `;

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.scss
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.scss
@@ -1,11 +1,6 @@
 @use '@awsui/design-tokens/index.scss' as awsui;
 
 // DataRow
-.markdown-row {
-  a {
-    color: awsui.$color-text-link-default
-  }
-}
 .annotation-row {
   white-space: nowrap
 }

--- a/packages/scene-composer/src/components/wrappers/ReactMarkdownWrapper.scss
+++ b/packages/scene-composer/src/components/wrappers/ReactMarkdownWrapper.scss
@@ -1,0 +1,7 @@
+@use '@awsui/design-tokens/index.scss' as awsui;
+
+.markdown-wrapper {
+  a {
+    color: awsui.$color-text-link-default
+  }
+}

--- a/packages/scene-composer/src/components/wrappers/ReactMarkdownWrapper.tsx
+++ b/packages/scene-composer/src/components/wrappers/ReactMarkdownWrapper.tsx
@@ -1,0 +1,16 @@
+import React, { FC } from 'react';
+import ReactMarkdown from 'react-markdown';
+
+import './ReactMarkdownWrapper.scss';
+
+export interface ReactMarkdownWrapperProps {
+  content: string;
+  className?: string;
+}
+export const ReactMarkdownWrapper: FC<ReactMarkdownWrapperProps> = ({ content, className }) => {
+  return (
+    <ReactMarkdown skipHtml className={`markdown-wrapper ${className}`} linkTarget='_blank'>
+      {content}
+    </ReactMarkdown>
+  );
+};

--- a/packages/scene-composer/src/components/wrappers/ReactMarkdownWrapperSnap.spec.tsx
+++ b/packages/scene-composer/src/components/wrappers/ReactMarkdownWrapperSnap.spec.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { ReactMarkdownWrapper } from './ReactMarkdownWrapper';
+
+describe('ReactMarkdownWrapper', () => {
+  it('should render markdown correctly', () => {
+    const { container } = render(<ReactMarkdownWrapper content='# header' className='my-class' />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/wrappers/__snapshots__/ReactMarkdownWrapperSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/wrappers/__snapshots__/ReactMarkdownWrapperSnap.spec.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactMarkdownWrapper should render markdown correctly 1`] = `
+<div>
+  <div
+    class="markdown-wrapper my-class"
+  >
+    <h1>
+      header
+    </h1>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -214,16 +214,17 @@ export namespace Component {
     isPinned: boolean;
   }
 
+  export interface ValueDataBindingNamedMap {
+    bindingName: string;
+    valueDataBinding?: ValueDataBinding;
+  }
+
   export interface DataOverlay extends IComponent {
     subType: DataOverlaySubType;
     dataRows: Array<DataOverlayMarkdownRow>;
     config?: OverlayPanelConfig;
 
-    valueDataBindings: {
-      [key: string]: {
-        valueDataBinding?: ValueDataBinding;
-      };
-    };
+    valueDataBindings: ValueDataBindingNamedMap[];
   }
 
   export interface ILightShadowSettings {

--- a/packages/scene-composer/tests/components/panels/ComponentEditor.spec.tsx
+++ b/packages/scene-composer/tests/components/panels/ComponentEditor.spec.tsx
@@ -10,6 +10,7 @@ import { LightComponentEditor } from '../../../src/components/panels/scene-compo
 import { ColorOverlayComponentEditor } from '../../../src/components/panels/scene-components/ColorOverlayComponentEditor';
 import { ModelRefComponentEditor } from '../../../src/components/panels/scene-components/ModelRefComponentEditor';
 import { MotionIndicatorComponentEditor } from '../../../src/components/panels/scene-components/MotionIndicatorComponentEditor';
+import { DataOverlayComponentEditor } from '../../../src/components/panels/scene-components/DataOverlayComponentEditor';
 
 configure({ adapter: new Adapter() });
 describe('ComponentEditor renders correct component', () => {
@@ -46,6 +47,11 @@ describe('ComponentEditor renders correct component', () => {
       <ComponentEditor node={{} as any} component={{ ref: 'refId', type: KnownComponentType.MotionIndicator }} />,
     );
     expect(wrapper.find(MotionIndicatorComponentEditor).length).toBe(1);
+
+    wrapper = shallow(
+      <ComponentEditor node={{} as any} component={{ ref: 'refId', type: KnownComponentType.DataOverlay }} />,
+    );
+    expect(wrapper.find(DataOverlayComponentEditor).length).toBe(1);
 
     wrapper = shallow(<ComponentEditor node={{} as any} component={{ ref: 'refId', type: 'unknown' }} />);
     expect(wrapper.find(DefaultComponentEditor).length).toBe(1);

--- a/packages/scene-composer/tests/scenes/scene_1.json
+++ b/packages/scene-composer/tests/scenes/scene_1.json
@@ -315,10 +315,11 @@
         {
           "type": "DataOverlay",
           "subType": "TextAnnotation",
+          "valueDataBindings": [],
           "dataRows": [
             {
               "rowType": "Markdown",
-              "content": "#|| Annotation ||"
+              "content": "# || Annotation || \n Second line"
             }
           ]
         }
@@ -353,14 +354,14 @@
         {
           "type": "DataOverlay",
           "subType": "OverlayPanel",
+          "config": {
+            "isPinned": true
+          },
+          "valueDataBindings": [],
           "dataRows": [
             {
               "rowType": "Markdown",
-              "content": "##|| Panel ||"
-            },
-            {
-              "rowType": "Markdown",
-              "content": "[Click me](https://github.com/awslabs/iot-app-kit)"
+              "content": "## || Panel || \n ## [Click me](https://github.com/awslabs/iot-app-kit)"
             }
           ]
         }

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -35,6 +35,10 @@
     "note": "ExpandableInfoSection Title",
     "text": "Tag Settings"
   },
+  "15KXQ/": {
+    "note": "Input error message",
+    "text": "Invalid name"
+  },
   "1cVQu5": {
     "note": "label for an input component selecting number of arrows",
     "text": "# of arrows"
@@ -198,6 +202,10 @@
   "DVJ3oz": {
     "note": "view options dropdown button text",
     "text": "View Options"
+  },
+  "DsNVlc": {
+    "note": "Input error message",
+    "text": "Duplicate name"
   },
   "ENcryP": {
     "note": "Panel Tab title",
@@ -643,6 +651,10 @@
     "note": "label",
     "text": "Selected"
   },
+  "lxQp5c": {
+    "note": "FormField label",
+    "text": "Markdown content"
+  },
   "mhM85K": {
     "note": "Form Field label",
     "text": "Entity Path"
@@ -671,6 +683,10 @@
     "note": "dropdown button option text for motion indicator component",
     "text": "Motion indicator"
   },
+  "oQw+fr": {
+    "note": "Button text",
+    "text": "Add data binding"
+  },
   "oiGDox": {
     "note": "Field label",
     "text": "Value"
@@ -686,6 +702,10 @@
   "oppsQx": {
     "note": "placeholder",
     "text": "Choose a rule"
+  },
+  "pNCs6s": {
+    "note": "Button text",
+    "text": "Remove data binding"
   },
   "pyg21P": {
     "note": "Number of Triangles in a scene",
@@ -782,6 +802,10 @@
   "vMsay3": {
     "note": "Scene Resource types in a dropdown menu",
     "text": "Icon"
+  },
+  "vlWCF3": {
+    "note": "FormField label",
+    "text": "Binding Name"
   },
   "w4ByXF": {
     "note": "15mm lens",


### PR DESCRIPTION
## Overview
- Implement data overlay editor for text annotation
- use `react-markdown` to render markdown
- in order to keep bindings order unchanged during editing, updated data binding field in overlay component interface from 
```
    valueDataBindings: {
      [key: string]: {
        valueDataBinding?: ValueDataBinding;
      };
    };
```
to
```
    valueDataBindings: {
      bindingName: string;
      valueDataBinding?: ValueDataBinding;
    }[];
```

<img width="1048" alt="overlay-editor" src="https://user-images.githubusercontent.com/9315598/222028211-3b82938b-54dc-494d-af07-3e55c7c784b6.png">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
