### PR TITLE
feat(dashboard): add table component support

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -99,6 +99,7 @@
     "@iot-app-kit/core": "^2.6.4",
     "@iot-app-kit/react-components": "^2.6.5",
     "@iot-app-kit/source-iotsitewise": "^2.6.4",
+    "@iot-app-kit/table": "^2.6.4",
     "@popperjs/core": "^2.11.6",
     "@synchro-charts/core": "7.2.0",
     "@synchro-charts/react": "^7.2.0",

--- a/packages/dashboard/src/store/actions/index.ts
+++ b/packages/dashboard/src/store/actions/index.ts
@@ -18,6 +18,7 @@ import { UpdateViewportAction } from './updateViewport';
 import { UpdateAssetQueryAction } from './updateAssetQuery';
 import { UpdateAssetsDescriptionMapAction } from './updateAssetsDescription';
 import { DescribeAssetFailedAction } from '../sagas/describeAsset/failed';
+import { UpdateTableAssetsAction } from '~/store/actions/updateTableWidget';
 
 export * from './createWidget';
 export * from './deleteWidgets';
@@ -51,4 +52,5 @@ export type DashboardAction =
   | UpdateViewportAction
   | UpdateAssetQueryAction
   | UpdateAssetsDescriptionMapAction
-  | DescribeAssetFailedAction;
+  | DescribeAssetFailedAction
+  | UpdateTableAssetsAction;

--- a/packages/dashboard/src/store/actions/updateTableWidget/index.spec.tsx
+++ b/packages/dashboard/src/store/actions/updateTableWidget/index.spec.tsx
@@ -1,0 +1,154 @@
+import { AppKitWidget, Widget } from '~/types';
+import { DashboardState, initialState } from '~/store/state';
+import { MOCK_KPI_WIDGET } from '../../../../testing/mocks';
+import { onUpdateTableAssets, updateTableAssets } from '~/store/actions/updateTableWidget/index';
+import { AssetQuery } from '@iot-app-kit/core';
+import { DescribeAssetResponse } from '@aws-sdk/client-iotsitewise';
+import { toId } from '@iot-app-kit/source-iotsitewise';
+import { ColumnDefinition, Item } from '@iot-app-kit/table';
+
+const MOCK_TABLE_WIDGET: AppKitWidget = {
+  height: 0,
+  widgetId: 'mock-table-widget',
+  width: 0,
+  x: 0,
+  y: 0,
+  z: 0,
+  id: 'table-widget',
+  componentTag: 'iot-table',
+};
+const MOCK_ASSET_QUERY: AssetQuery[] = [
+  {
+    assetId: 'mock-asset-id-1',
+    properties: [
+      {
+        propertyId: 'mock-property-id-1',
+      },
+      {
+        propertyId: 'mock-property-id-2',
+      },
+    ],
+  },
+  {
+    assetId: 'mock-asset-id-2',
+    properties: [
+      {
+        propertyId: 'mock-property-id-2',
+      },
+      {
+        propertyId: 'mock-property-id-3',
+      },
+    ],
+  },
+];
+
+const MOCK_DESCRIPTION_MAP: DashboardState['assetsDescriptionMap'] = {
+  'mock-asset-id-1': {
+    assetId: 'mock-asset-id-1',
+    assetName: 'mock-asset-name',
+    assetProperties: [
+      {
+        id: 'mock-property-id-1',
+        name: 'Property 1',
+        dataType: 'DOUBLE',
+      },
+      {
+        id: 'mock-property-id-2',
+        name: 'Property 2',
+        dataType: 'DOUBLE',
+      },
+    ],
+  } as DescribeAssetResponse,
+  'mock-asset-id-2': {
+    assetId: 'mock-asset-id-2',
+    assetName: 'mock-asset-name',
+    assetProperties: [
+      { id: 'mock-property-id-2', name: 'Property 2', dataType: 'DOUBLE' },
+      { id: 'mock-property-id-3', name: 'Property 3', dataType: 'DOUBLE' },
+    ],
+  } as DescribeAssetResponse,
+};
+
+const COL_DEFS: ColumnDefinition[] = [
+  {
+    key: 'Property 1',
+    header: 'Property 1',
+  },
+  {
+    key: 'Property 2',
+    header: 'Property 2',
+  },
+  {
+    key: 'Property 3',
+    header: 'Property 3',
+  },
+];
+
+const ITEMS: Item[] = [
+  {
+    'Property 1': {
+      $cellRef: {
+        id: toId({ assetId: 'mock-asset-id-1', propertyId: 'mock-property-id-1' }),
+        resolution: 0,
+      },
+    },
+    'Property 2': {
+      $cellRef: {
+        id: toId({ assetId: 'mock-asset-id-1', propertyId: 'mock-property-id-2' }),
+        resolution: 0,
+      },
+    },
+  },
+  {
+    'Property 2': {
+      $cellRef: {
+        id: toId({ assetId: 'mock-asset-id-2', propertyId: 'mock-property-id-2' }),
+        resolution: 0,
+      },
+    },
+    'Property 3': {
+      $cellRef: {
+        id: toId({ assetId: 'mock-asset-id-2', propertyId: 'mock-property-id-3' }),
+        resolution: 0,
+      },
+    },
+  },
+];
+const setupDashboardState = (
+  widgets: Widget[] = [],
+  assetsDescriptionMap: DashboardState['assetsDescriptionMap'] = MOCK_DESCRIPTION_MAP
+): DashboardState => ({
+  ...initialState,
+  dashboardConfiguration: {
+    ...initialState.dashboardConfiguration,
+    widgets,
+  },
+  assetsDescriptionMap,
+});
+it('should does nothing on widget other than table', () => {
+  const state = setupDashboardState([MOCK_KPI_WIDGET]);
+  expect(
+    updateTableAssets(
+      state,
+      onUpdateTableAssets({
+        widget: MOCK_KPI_WIDGET,
+        assetQuery: MOCK_ASSET_QUERY,
+      })
+    )
+  ).toEqual(state);
+});
+it('should create item and column definitions', () => {
+  const state = setupDashboardState([MOCK_TABLE_WIDGET]);
+  const widget = updateTableAssets(
+    state,
+    onUpdateTableAssets({
+      widget: MOCK_TABLE_WIDGET,
+      assetQuery: MOCK_ASSET_QUERY,
+    })
+  ).dashboardConfiguration.widgets[0];
+  expect(widget).toMatchObject({
+    ...MOCK_TABLE_WIDGET,
+    items: ITEMS,
+    columnDefinitions: COL_DEFS,
+  });
+});

--- a/packages/dashboard/src/store/actions/updateTableWidget/index.ts
+++ b/packages/dashboard/src/store/actions/updateTableWidget/index.ts
@@ -1,0 +1,68 @@
+import { AssetQuery } from '@iot-app-kit/core';
+import { Action } from 'redux';
+import { DashboardState } from '~/store/state';
+import { ColumnDefinition, Item } from '@iot-app-kit/table';
+import { Widget } from '~/types';
+import { toId } from '@iot-app-kit/source-iotsitewise';
+
+type UpdateTableAssetPayload = {
+  widget: Widget;
+  assetQuery: AssetQuery[];
+};
+
+export interface UpdateTableAssetsAction extends Action {
+  type: 'UPDATE_TABLE_ASSET';
+  payload: UpdateTableAssetPayload;
+}
+
+export const onUpdateTableAssets = (payload: UpdateTableAssetPayload): UpdateTableAssetsAction => ({
+  type: 'UPDATE_TABLE_ASSET',
+  payload,
+});
+
+export const updateTableAssets = (state: DashboardState, action: UpdateTableAssetsAction): DashboardState => {
+  const { assetQuery, widget } = action.payload;
+  if (widget.componentTag !== 'iot-table') return state;
+
+  const descriptionMap = state.assetsDescriptionMap;
+
+  const propertyNames: string[] = [];
+  const items = assetQuery.map<Item>(({ assetId, properties }) => {
+    const item: Item = {};
+
+    properties.forEach(({ propertyId }) => {
+      const name = descriptionMap[assetId]?.assetProperties?.find((p) => p.id === propertyId)?.name || propertyId;
+      item[name] = {
+        $cellRef: {
+          id: toId({ assetId, propertyId }),
+          resolution: 0,
+        },
+      };
+      if (!propertyNames.includes(name)) {
+        propertyNames.push(name);
+      }
+    });
+    return item;
+  });
+  const columnDefinitions: ColumnDefinition[] = propertyNames.map((name) => ({ key: name, header: name }));
+  const updateWidget: (widgets: Widget) => Widget = (w) => {
+    if (w.id === widget.id) {
+      return {
+        ...w,
+        items,
+        columnDefinitions,
+      };
+    }
+    return w;
+  };
+  const widgets = state.dashboardConfiguration.widgets.map(updateWidget);
+  const selectedWidgets = state.selectedWidgets.map(updateWidget);
+  return {
+    ...state,
+    selectedWidgets,
+    dashboardConfiguration: {
+      ...state.dashboardConfiguration,
+      widgets,
+    },
+  };
+};

--- a/packages/dashboard/src/store/reducer.ts
+++ b/packages/dashboard/src/store/reducer.ts
@@ -14,15 +14,16 @@ import {
   resizeWidgets,
   selectWidgets,
   sendWidgetsToBack,
-  updateViewport,
   toggleReadOnly,
+  updateViewport,
   updateWidgets,
 } from './actions';
 
-import { createWidgets } from './actions/createWidget';
+import { createWidgets } from '~/store/actions';
 import { updateAssetQuery } from './actions/updateAssetQuery';
 import { updateAssetDescriptionMap } from './actions/updateAssetsDescription';
 import { describeAssetFailed } from './sagas/describeAsset/failed';
+import { updateTableAssets } from '~/store/actions/updateTableWidget';
 
 export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
   state: DashboardState = initialState,
@@ -99,6 +100,10 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
 
     case 'TOGGLE_READ_ONLY': {
       return toggleReadOnly(state);
+    }
+
+    case 'UPDATE_TABLE_ASSET': {
+      return updateTableAssets(state, action);
     }
 
     default:

--- a/packages/dashboard/src/store/sagas/describeAsset/index.ts
+++ b/packages/dashboard/src/store/sagas/describeAsset/index.ts
@@ -5,6 +5,7 @@ import { DashboardState } from '../../state';
 import { onUpdateAssetsDescriptionMap } from '../../actions/updateAssetsDescription';
 import { onDescribeAssetFailed } from './failed';
 import { getContext } from 'redux-saga-test-plan/matchers';
+import { onUpdateTableAssets } from '~/store/actions/updateTableWidget';
 
 export const getAssetsDescriptionMap = (state: DashboardState) => state.assetsDescriptionMap;
 
@@ -28,6 +29,13 @@ function* describeAsset(action: UpdateAssetQueryAction) {
       describedAssets,
     });
     yield put(updateAssetPropertiesAction);
+    if (action.payload.widget.componentTag === 'iot-table') {
+      const updateTableAssetsAction = onUpdateTableAssets({
+        widget: action.payload.widget,
+        assetQuery: action.payload.assetQuery,
+      });
+      yield put(updateTableAssetsAction);
+    }
   } catch (error) {
     yield put(onDescribeAssetFailed({ error: error as Error }));
   }


### PR DESCRIPTION
## Overview
add `UpdateTableAssetsAction` action to create props that table widget needs.
<img width="433" alt="image" src="https://user-images.githubusercontent.com/11740421/222475694-fd52e0d1-952a-42d7-8f7c-f5c7f16baf40.png">
 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
