### PR TITLE
fix(core, source-iotsitewise)!: remove needed exports 

### DIFF
--- a/packages/core/src/__mocks__/data-source.ts
+++ b/packages/core/src/__mocks__/data-source.ts
@@ -1,12 +1,12 @@
 import {
   DataSource,
   DataSourceRequest,
-  DataStream,
+  DataStream, DataStreamQuery,
   RequestInformationAndRange,
-  SiteWiseDataStreamQuery,
 } from '../data-module/types';
 import { toDataStreamId } from '../common/dataStreamId';
-import { AggregateType } from '@aws-sdk/client-iotsitewise';
+
+export type MockSiteWiseQuery = { assets: { assetId: string, properties: { refId?: string; propertyId: string }[] } [] } & DataStreamQuery;
 
 // A simple mock data source, which will always immediately return a successful response of your choosing.
 export const createMockSiteWiseDataSource = (
@@ -19,10 +19,10 @@ export const createMockSiteWiseDataSource = (
     onRequestData?: (props: any) => void;
     meta?: DataStream["meta"];
   } = { dataStreams: [], onRequestData: () => { } }
-): DataSource<SiteWiseDataStreamQuery> => ({
+): DataSource<MockSiteWiseQuery> => ({
   initiateRequest: jest.fn(
     (
-      { query, request, onSuccess = () => { } }: DataSourceRequest<SiteWiseDataStreamQuery>,
+      { query, request, onSuccess = () => { } }: DataSourceRequest<MockSiteWiseQuery>,
       requestInformations: RequestInformationAndRange[]
     ) => {
       query.assets.forEach(({ assetId, properties }) =>

--- a/packages/core/src/data-module/TimeSeriesDataModule.spec.ts
+++ b/packages/core/src/data-module/TimeSeriesDataModule.spec.ts
@@ -1,7 +1,7 @@
 import flushPromises from 'flush-promises';
 import { DATA_STREAM, DATA_STREAM_INFO } from '../mockWidgetProperties';
-import { createMockSiteWiseDataSource } from '../__mocks__';
-import { DataSource, SiteWiseDataStreamQuery } from './types';
+import { createMockSiteWiseDataSource, MockSiteWiseQuery } from '../__mocks__';
+import { DataSource } from './types';
 import { DataPoint } from '@synchro-charts/core';
 import { TimeSeriesDataRequest, TimeSeriesDataRequestSettings } from './data-cache/requestTypes';
 import { DataStreamsStore, DataStreamStore } from './data-cache/types';
@@ -16,7 +16,7 @@ const { EMPTY_CACHE } = caching;
 
 const { propertyId: PROPERTY_ID, assetId: ASSET_ID } = toSiteWiseAssetProperty(DATA_STREAM.id);
 
-const DATA_STREAM_QUERY: SiteWiseDataStreamQuery = {
+const DATA_STREAM_QUERY: MockSiteWiseQuery = {
   assets: [
     {
       assetId: ASSET_ID,
@@ -40,7 +40,7 @@ it('subscribes to an empty set of queries', async () => {
   const onSuccess = jest.fn();
   dataModule.subscribeToDataStreams(
     {
-      queries: [{ assets: [] } as SiteWiseDataStreamQuery],
+      queries: [{ assets: [] }],
       request: {
         viewport: { start: new Date(2000, 0, 0), end: new Date(2000, 0, 2) },
         settings: {
@@ -62,7 +62,7 @@ describe('update subscription', () => {
 
     const timeSeriesCallback = jest.fn();
 
-    const queries: SiteWiseDataStreamQuery[] = [{ assets: [] }];
+    const queries: MockSiteWiseQuery[] = [{ assets: [] }];
 
     const { update } = dataModule.subscribeToDataStreams(
       {
@@ -97,7 +97,7 @@ describe('initial request', () => {
     const dataSource: DataSource = {
       initiateRequest: jest.fn(),
       getRequestsFromQuery: () => Promise.resolve([]),
-    } as DataSource<SiteWiseDataStreamQuery>;
+    } as DataSource<MockSiteWiseQuery>;
     const dataModule = new TimeSeriesDataModule(dataSource);
 
     const timeSeriesCallback = jest.fn();
@@ -123,7 +123,7 @@ describe('initial request', () => {
 
   it('passes back associated refId', async () => {
     const REF_ID = 'ref-id';
-    const query: SiteWiseDataStreamQuery = {
+    const query: MockSiteWiseQuery = {
       assets: [
         {
           assetId: ASSET_ID,
@@ -171,7 +171,7 @@ describe('initial request', () => {
 
   it('passes back meta, name, and dataType information', async () => {
     const REF_ID = 'ref-id';
-    const query: SiteWiseDataStreamQuery = {
+    const query: MockSiteWiseQuery = {
       assets: [
         {
           assetId: ASSET_ID,
@@ -343,7 +343,7 @@ it('requests data from a custom data source', async () => {
       queries: [
         {
           assets: [{ assetId, properties: [{ propertyId }] }],
-        } as SiteWiseDataStreamQuery,
+        },
       ],
       request: {
         viewport: { start: START, end: END },

--- a/packages/core/src/data-module/subscription-store/subscriptionStore.spec.ts
+++ b/packages/core/src/data-module/subscription-store/subscriptionStore.spec.ts
@@ -1,5 +1,5 @@
 import SubscriptionStore from './subscriptionStore';
-import { DataSource, SiteWiseDataStreamQuery, Subscription } from '../types';
+import { DataSource, Subscription } from '../types';
 import { DataCache } from '../data-cache/dataCacheWrapped';
 import DataSourceStore from '../data-source-store/dataSourceStore';
 import { DEFAULT_CACHE_SETTINGS } from '../TimeSeriesDataModule';
@@ -8,7 +8,7 @@ const createSubscriptionStore = () => {
   const store = new DataSourceStore({
     initiateRequest: () => {},
     getRequestsFromQuery: () => Promise.resolve([]),
-  } as DataSource<SiteWiseDataStreamQuery>);
+  } as DataSource);
 
   return new SubscriptionStore({
     dataCache: new DataCache(),
@@ -17,7 +17,7 @@ const createSubscriptionStore = () => {
   });
 };
 
-const MOCK_SUBSCRIPTION: Subscription<SiteWiseDataStreamQuery> = {
+const MOCK_SUBSCRIPTION: Subscription = {
   emit: () => {},
   queries: [{ assets: [] }],
   request: {

--- a/packages/core/src/data-module/types.ts
+++ b/packages/core/src/data-module/types.ts
@@ -146,30 +146,3 @@ export type SubscriptionResponse<Query extends DataStreamQuery> = {
   /** Update the subscription. This will immediately evaluate if a new query must be requested */
   update: (subscriptionUpdate: SubscriptionUpdate<Query>) => Promise<void>;
 };
-
-// SiteWise specific types - eventually remove these from here
-export type AssetPropertyId = string;
-
-export type AssetId = string;
-
-export type PropertyAlias = string;
-
-export type PropertyQuery = {
-  propertyId: string;
-  refId?: RefId;
-  resolution?: string;
-  cacheSettings?: CacheSettings;
-};
-
-export type AssetQuery = {
-  assetId: AssetId;
-  properties: PropertyQuery[];
-};
-
-export type SiteWiseAssetQuery = {
-  assets: AssetQuery[];
-};
-
-export type SiteWiseAssetDataStreamQuery = DataStreamQuery & SiteWiseAssetQuery;
-
-export type SiteWiseDataStreamQuery = SiteWiseAssetDataStreamQuery;

--- a/packages/source-iotsitewise/src/alarms/iotevents/util/fetchAlarmsFromQuery.ts
+++ b/packages/source-iotsitewise/src/alarms/iotevents/util/fetchAlarmsFromQuery.ts
@@ -1,15 +1,15 @@
 import { toId } from '../../../time-series-data/util/dataStreamId';
 import { constructAlarmThresholds } from './constructAlarmThresholds';
-import { SiteWiseDataStreamQuery } from '@iot-app-kit/core';
 import { Alarms } from '../types';
 import { Annotations } from '@synchro-charts/core';
 import { SiteWiseAlarmModule } from '../siteWiseAlarmModule';
+import { SiteWiseAssetQuery } from '../../../time-series-data/types';
 
 export async function* fetchAlarmsFromQuery({
   queries,
   alarmModule,
 }: {
-  queries: SiteWiseDataStreamQuery[];
+  queries: SiteWiseAssetQuery[];
   alarmModule: SiteWiseAlarmModule;
 }): AsyncGenerator<{ alarms: Alarms; annotations: Annotations }> {
   for (const { assets } of queries) {

--- a/packages/source-iotsitewise/src/index.ts
+++ b/packages/source-iotsitewise/src/index.ts
@@ -1,7 +1,8 @@
-export * from './initialize';
+// TODO: Remove exports of mocks. Do not use.
 export * from './__mocks__';
+
+export { initialize, SiteWiseDataSourceInitInputs, SiteWiseQuery } from './initialize';
 export { BranchReference } from './asset-modules/sitewise-asset-tree/types';
 export { SiteWiseAssetTreeNode } from './asset-modules/sitewise-asset-tree/types';
 export { HierarchyGroup } from './asset-modules';
 export { toId } from './time-series-data/util/dataStreamId';
-export * from './alarms/iotevents';


### PR DESCRIPTION
## Overview
The purpose of this PR is to reduce the overall exposed public API of IoT App Kit. No data-source specific code should be exported as part of core.

BREAKING CHANGE:

- Removes SiteWise specific typescript type definitions from being exported from @iot-app-kit/core
- Removes SiteWise alarm module from exported from @iot-app-kit/source-iotsitewise


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
