### PR TITLE
fix(dashboard): grow asset properties panel

### DIFF
--- a/packages/dashboard/src/components/resourceExplorer/stencil/style.css
+++ b/packages/dashboard/src/components/resourceExplorer/stencil/style.css
@@ -5,14 +5,13 @@
 }
 
 .stencil-resource-explorer-tree {
-  flex-grow: 1;
-  height: calc(100% - 300px);
   max-height: calc(100% - 300px);
   overflow: hidden;
   overflow-y: scroll;
 }
 
 .stencil-resource-explorer-assets {
-  height: 300px;
+  flex-grow: 1;
   overflow-y: scroll;
+  min-height: 300px;
 }


### PR DESCRIPTION
## Overview

Updates the resource explorer to maximize available screen real estate depending on the quantity of assets and properties.

![Screenshot 2023-03-01 at 2 21 46 PM](https://user-images.githubusercontent.com/12429401/222268217-7d131589-0ee1-4cd4-af0a-51d825d96268.png)

In this scenario, multiple pages of assets are listed and take much of the panel, but it's still clear the asset properties section exists.

![Screenshot 2023-03-01 at 2 22 05 PM](https://user-images.githubusercontent.com/12429401/222268437-6ad62e65-6b70-41a6-9946-e9638ed1446d.png)

Once an asset is selected, the properties panel will grow to a maximum value to display more options at once.

![Screenshot 2023-03-01 at 2 22 18 PM](https://user-images.githubusercontent.com/12429401/222268534-998766a6-d549-4f20-a25f-48708c4cea6e.png)

When there are fewer assets on a page, the asset properties panel will grow up to the bottom of the asset tree.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
