### PR TITLE
fix(source-iotsitewise): deduplicate batch requests

### DIFF
--- a/packages/source-iotsitewise/package.json
+++ b/packages/source-iotsitewise/package.json
@@ -55,13 +55,16 @@
     "@synchro-charts/core": "7.2.0",
     "dataloader": "^2.1.0",
     "flush-promises": "^1.0.2",
+    "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.2",
+    "lodash.uniqwith": "^4.5.0",
     "rxjs": "^7.4.0",
     "typescript": "4.4.4"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/lodash.merge": "^4.6.7",
+    "@types/lodash.uniqwith": "^4.5.7",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
     "npm-watch": "^0.11.0",

--- a/packages/source-iotsitewise/src/time-series-data/client/batchGetAggregatedPropertyDataPoints.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batchGetAggregatedPropertyDataPoints.ts
@@ -14,8 +14,9 @@ import { isDefined } from '../../common/predicates';
 import { AggregatedPropertyParams } from './client';
 import { createEntryBatches, calculateNextBatchSize, shouldFetchNextBatch } from './batch';
 import { RESOLUTION_TO_MS_MAPPING } from '../util/resolution';
+import { deduplicateBatch } from '../util/deduplication';
 
-type BatchAggregatedEntry = {
+export type BatchAggregatedEntry = {
   requestInformation: RequestInformationAndRange;
   aggregateTypes: AggregateType[];
   maxResults?: number;
@@ -56,7 +57,7 @@ const sendRequest = ({
   client
     .send(
       new BatchGetAssetPropertyAggregatesCommand({
-        entries: batch.map((entry, entryIndex) => {
+        entries: deduplicateBatch(batch).map((entry, entryIndex) => {
           const { requestInformation, aggregateTypes, onError, onSuccess, requestStart, requestEnd } = entry;
           const { id, resolution } = requestInformation;
 

--- a/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.ts
@@ -12,8 +12,9 @@ import { toSiteWiseAssetProperty } from '../util/dataStreamId';
 import { isDefined } from '../../common/predicates';
 import { HistoricalPropertyParams } from './client';
 import { createEntryBatches, calculateNextBatchSize, shouldFetchNextBatch } from './batch';
+import { deduplicateBatch } from '../util/deduplication';
 
-type BatchHistoricalEntry = {
+export type BatchHistoricalEntry = {
   requestInformation: RequestInformationAndRange;
   maxResults?: number;
   onError: ErrorCallback;
@@ -53,7 +54,7 @@ const sendRequest = ({
   client
     .send(
       new BatchGetAssetPropertyValueHistoryCommand({
-        entries: batch.map((entry, entryIndex) => {
+        entries: deduplicateBatch(batch).map((entry, entryIndex) => {
           const { requestInformation, onError, onSuccess, requestStart, requestEnd } = entry;
           const { id } = requestInformation;
 

--- a/packages/source-iotsitewise/src/time-series-data/client/batchGetLatestPropertyDataPoints.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batchGetLatestPropertyDataPoints.ts
@@ -11,8 +11,9 @@ import { toSiteWiseAssetProperty } from '../util/dataStreamId';
 import { isDefined } from '../../common/predicates';
 import { LatestPropertyParams } from './client';
 import { createEntryBatches, shouldFetchNextBatch, NO_LIMIT_BATCH } from './batch';
+import { deduplicateBatch } from '../util/deduplication';
 
-type BatchLatestEntry = {
+export type BatchLatestEntry = {
   requestInformation: RequestInformationAndRange;
   onError: ErrorCallback;
   onSuccess: OnSuccessCallback;
@@ -51,7 +52,7 @@ const sendRequest = ({
   client
     .send(
       new BatchGetAssetPropertyValueCommand({
-        entries: batch.map((entry, entryIndex) => {
+        entries: deduplicateBatch(batch).map((entry, entryIndex) => {
           const { requestInformation, onError, onSuccess, requestStart, requestEnd } = entry;
           const { id } = requestInformation;
 

--- a/packages/source-iotsitewise/src/time-series-data/util/deduplication.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/util/deduplication.spec.ts
@@ -1,0 +1,24 @@
+import { deduplicateBatch } from './deduplication';
+
+describe('deduplicateBatch', () => {
+  it('removes duplicate entries from a given batch', () => {
+    const entry = {
+      onError: jest.fn(),
+      onSuccess: jest.fn(),
+      requestEnd: new Date(2001, 0, 0),
+      requestStart: new Date(2000, 0, 0),
+      requestInformation: {
+        id: 'asset-property',
+        start: new Date(2001, 0, 0),
+        end: new Date(2000, 0, 0),
+        resolution: '0',
+        fetchMostRecentBeforeEnd: true,
+      },
+    };
+
+    const originalBatch = [entry, entry];
+    const deduplicatedBatch = [entry];
+
+    expect(deduplicateBatch(originalBatch)).toEqual(deduplicatedBatch);
+  });
+});

--- a/packages/source-iotsitewise/src/time-series-data/util/deduplication.ts
+++ b/packages/source-iotsitewise/src/time-series-data/util/deduplication.ts
@@ -1,0 +1,34 @@
+import isEqual from 'lodash.isequal';
+import uniqWith from 'lodash.uniqwith';
+import { BatchAggregatedEntry } from '../client/batchGetAggregatedPropertyDataPoints';
+import { BatchHistoricalEntry } from '../client/batchGetHistoricalPropertyDataPoints';
+import { BatchLatestEntry } from '../client/batchGetLatestPropertyDataPoints';
+
+export type Entry = BatchAggregatedEntry | BatchHistoricalEntry | BatchLatestEntry;
+
+/**
+ * Given a batch, or array of entries, deduplicate the batch.
+ */
+export function deduplicateBatch<T extends Entry>(batch: T[]): T[] {
+  return uniqWith(batch, compareEntryUniqueness);
+}
+
+/**
+ * Compares one entry to another, determining if the first is unique.
+ */
+function compareEntryUniqueness(a: Entry, b: Entry) {
+  return isEqual(getEntryRequestInformation(a), getEntryRequestInformation(b));
+}
+
+/**
+ * Gets relevant request information off the entry.
+ */
+function getEntryRequestInformation(entry: Entry) {
+  const {
+    refId: _refId,
+    cacheSettings: _cacheSettings,
+    ...requestInformationWithoutOmittedFields
+  } = entry.requestInformation;
+
+  return requestInformationWithoutOmittedFields;
+}


### PR DESCRIPTION
## Overview

Deduplicates individual requests in a batch in the `source-iotsitewise` package. This eliminates duplicate calls to sitewise for the same data, like when multiple charts are rendering the same data at once.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
