### PR TITLE
feat(core, source-iotsitewise, source-iottwinmaker)!: toQueryString on query

### DIFF
--- a/docs/CustomSources.md
+++ b/docs/CustomSources.md
@@ -29,6 +29,7 @@ export {
   query: {
     timeSeriesData: (query: MyCustomQuery): TimeQuery<TimeSeriesData[], TimeSeriesDataRequest> => ({
       build: (sessionId: string, params: TimeSeriesDataRequest): ProviderWithViewport<TimeSeriesData[]> => /* your custom implementation here */
+      toQueryString: () => JSON.stringify({ source: 'my-custom-source', query }),
     }),
   }
 }

--- a/packages/core/src/common/types.ts
+++ b/packages/core/src/common/types.ts
@@ -1,4 +1,5 @@
-import { Viewport } from '../data-module/data-cache/requestTypes';
+import { TimeSeriesDataRequest, Viewport } from '../data-module/data-cache/requestTypes';
+import { TimeSeriesData } from '../data-module/types';
 
 export type ErrorDetails = { msg: string; type?: string; status?: string };
 
@@ -17,7 +18,17 @@ export interface ProviderWithViewport<Result> extends Provider<Result> {
 }
 
 export interface Query<Result, Params = void> {
+  /**
+   * Builds the query into a provider
+   * @param sessionId
+   * @param params
+   */
   build(sessionId: string, params?: Params): Provider<Result>;
+
+  /**
+   * Returns a string which is unique to the query
+   */
+  toQueryString(): string;
 }
 
 export interface TimeQuery<Result, Params = void> extends Query<Result, Params> {
@@ -32,6 +43,8 @@ export interface TreeProvider<Result, Branch> extends Provider<Result> {
 export interface TreeQuery<Result, Branch, Params = void> extends Query<Result, Params> {
   build(sessionId: string, params?: Params): TreeProvider<Result, Branch>;
 }
+
+export type TimeSeriesDataQuery = TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>;
 
 export type DataModuleSession = {
   close: () => void;

--- a/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.spec.ts
+++ b/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.spec.ts
@@ -11,6 +11,11 @@ const queryCreator = (
   const { updateViewport = noop, unsubscribe = noop } = overrides || {};
 
   return {
+    toQueryString: () =>
+      JSON.stringify({
+        source: 'mock',
+        query: timeSeriesData,
+      }),
     build: () => ({
       subscribe: ({ next }) => {
         next(timeSeriesData);
@@ -158,7 +163,7 @@ it('providers updated viewport to query', () => {
   expect(updateViewport).toBeCalledWith(viewport);
 });
 
-it.skip('does not attempt to re-create the subscription when provided a new reference to an unchanged query', () => {
+it('does not attempt to re-create the subscription when provided a new reference to an unchanged query', () => {
   const {
     result: { current: timeSeriesData },
   } = renderHook(() =>

--- a/packages/source-iotsitewise/src/initialize.spec.ts
+++ b/packages/source-iotsitewise/src/initialize.spec.ts
@@ -1,0 +1,42 @@
+import { initialize } from './initialize';
+import { createMockIoTEventsSDK, createMockSiteWiseSDK } from './__mocks__';
+
+it('converts a query to string with contents that uniquely represent the query', () => {
+  const { query } = initialize({
+    iotEventsClient: createMockIoTEventsSDK(),
+    iotSiteWiseClient: createMockSiteWiseSDK(),
+  });
+  const timeSeriesDataQuery = query.timeSeriesData({
+    assets: [{ assetId: 'windmill', properties: [{ propertyId: 'rpm' }] }],
+  });
+  expect(timeSeriesDataQuery.toQueryString()).toMatchInlineSnapshot(
+    `"{\\"source\\":\\"iotsitewise\\",\\"queryType\\":\\"time-series-data\\",\\"query\\":{\\"assets\\":[{\\"assetId\\":\\"windmill\\",\\"properties\\":[{\\"propertyId\\":\\"rpm\\"}]}]}}"`
+  );
+});
+
+it('converts a asset query from root to string with contents that uniquely represent the query', () => {
+  const { query } = initialize({
+    iotEventsClient: createMockIoTEventsSDK(),
+    iotSiteWiseClient: createMockSiteWiseSDK(),
+  });
+  const timeSeriesDataQuery = query.assetTree.fromRoot({
+    withModels: true,
+    withPropertyValues: ['rpm'],
+  });
+  expect(timeSeriesDataQuery.toQueryString()).toMatchInlineSnapshot(
+    `"{\\"source\\":\\"iotsitewise\\",\\"queryType\\":\\"assets-from-root\\",\\"query\\":{\\"withModels\\":true,\\"withPropertyValues\\":[\\"rpm\\"]}}"`
+  );
+});
+
+it('converts a asset query from asset to string with contents that uniquely represent the query', () => {
+  const { query } = initialize({
+    iotEventsClient: createMockIoTEventsSDK(),
+    iotSiteWiseClient: createMockSiteWiseSDK(),
+  });
+  const timeSeriesDataQuery = query.assetTree.fromAsset({
+    asset: { assetId: 'my-asset-id' },
+  });
+  expect(timeSeriesDataQuery.toQueryString()).toMatchInlineSnapshot(
+    `"{\\"source\\":\\"iotsitewise\\",\\"queryType\\":\\"assets-from-asset\\",\\"query\\":{\\"asset\\":{\\"assetId\\":\\"my-asset-id\\"}}}"`
+  );
+});

--- a/packages/source-iottwinmaker/src/initialize.spec.ts
+++ b/packages/source-iottwinmaker/src/initialize.spec.ts
@@ -41,4 +41,17 @@ describe('initialize', () => {
     expect(result['workspaceId']).toEqual('ws-id');
     expect(result['kvsStreamName']).toEqual('kvs-stream-name');
   });
+
+  it('converts a time series data query to string with contents that uniquely represent the query', () => {
+    const { query } = initialize('ws-id', { awsCredentials: {} as Credentials, awsRegion: 'us-east-1' });
+    const timeSeriesDataQuery = query.timeSeriesData({
+      entityId: 'entity-1',
+      componentName: 'comp-1',
+      properties: [{ propertyName: 'prop-1' }],
+    });
+
+    expect(timeSeriesDataQuery.toQueryString()).toMatchInlineSnapshot(
+      `"{\\"source\\":\\"iottwinmaker\\",\\"queryType\\":\\"time-series-data\\",\\"query\\":{\\"entityId\\":\\"entity-1\\",\\"componentName\\":\\"comp-1\\",\\"properties\\":[{\\"propertyName\\":\\"prop-1\\"}]}}"`
+    );
+  });
 });

--- a/packages/source-iottwinmaker/src/initialize.ts
+++ b/packages/source-iottwinmaker/src/initialize.ts
@@ -10,10 +10,12 @@ import { S3SceneLoader } from './scene-loader/S3SceneLoader';
 import { VideoDataImpl } from './video-data/VideoData';
 import { VideoDataProps } from './types';
 import { TwinMakerDataStreamQuery, TwinMakerQuery } from './time-series-data/types';
-import { TimeQuery, TimeSeriesData, TimeSeriesDataModule, TimeSeriesDataRequest } from '@iot-app-kit/core';
+import { TimeSeriesDataModule, TimeSeriesDataQuery, TimeSeriesDataRequest } from '@iot-app-kit/core';
 import { TwinMakerTimeSeriesDataProvider } from './time-series-data/provider';
 import { createDataSource } from './time-series-data/data-source';
 import { TwinMakerMetadataModule } from './metadata-module/TwinMakerMetadataModule';
+
+const SOURCE = 'iottwinmaker';
 
 /**
  * The authInput interface with pre-configured aws client instances.
@@ -110,7 +112,13 @@ export const initialize = (
 
   return {
     query: {
-      timeSeriesData: (query: TwinMakerQuery): TimeQuery<TimeSeriesData[], TimeSeriesDataRequest> => ({
+      timeSeriesData: (query: TwinMakerQuery): TimeSeriesDataQuery => ({
+        toQueryString: () =>
+          JSON.stringify({
+            source: SOURCE,
+            queryType: 'time-series-data',
+            query,
+          }),
         build: (sessionId: string, params: TimeSeriesDataRequest) =>
           new TwinMakerTimeSeriesDataProvider(twinMakerMetadataModule, twinMakerTimeSeriesModule, {
             queries: [


### PR DESCRIPTION
## Overview
Adds toQueryString method on queries which enables IoT App Kit components to determine if a query has changed on re-render, or if only the reference to the query has been updated. The motivation of this is to make a more performant `useTimeSeriesData` hook.

- Adds `toQueryString` method to the `Query` interface
- Implements `toQueryString` method on iotsitewise queries
- Implements `toQueryString` method on iottwinmaker queries
- Update documentation regarding how to create a custom data source

BREAKING CHANGES:
- Adds new required method `toQueryString(): string` on `Query` type.


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
