### PR TITLE
build(components): generate `styles.css` on build

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -7,3 +7,4 @@ examples/
 **/coverage/*
 coverage/
 packages/dashboard/src/components/internalDashboard/index.css
+packages/components/styles.css

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -39,7 +39,7 @@
     }
   },
   "scripts": {
-    "build": "stencil build",
+    "build": "stencil build && npm run copy:styles",
     "copy:license": "cp ../../LICENSE LICENSE",
     "copy:notice": "cp ../../NOTICE NOTICE",
     "copy:styles": "cp dist/iot-app-kit-components/iot-app-kit-components.css styles.css",


### PR DESCRIPTION
## Overview
In local dev environment, `@iot-app-kit/<package>` will ref to local packages. For any packages imports `@iot-app-kit/components/styles.css` will not find the file, since it will only be generated in `prepack` and will only be included in npm distributions. 

Here's some error on starting dashboard on a new fresh install
```
> @iot-app-kit/dashboard@3.0.0 start
> start-storybook -p 6006


webpack built preview 08fabfdc9281b34ce0be in 9982ms
ModuleNotFoundError: Module not found: Error: Can't resolve '@iot-app-kit/components/styles.css' in '/home/bill/WebstormProjects/iot-app-kit/packages/dashboard/src/components/internalDashboard'
    at /home/bill/WebstormProjects/iot-app-kit/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/Compilation.js:2016:28
    at /home/bill/WebstormProjects/iot-app-kit/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/NormalModuleFactory.js:798:13
    at eval (eval at create (/home/bill/WebstormProjects/iot-app-kit/node_modules/@storybook/builder-webpack5/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:10:1)
    at /home/bill/WebstormProjects/iot-app-kit/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/NormalModuleFactory.js:270:22
    at eval (eval at create (/home/bill/WebstormProjects/iot-app-kit/node_modules/@storybook/builder-webpack5/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:9:1)
    at /home/bill/WebstormProjects/iot-app-kit/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/NormalModuleFactory.js:434:22
    at /home/bill/WebstormProjects/iot-app-kit/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/NormalModuleFactory.js:116:11
    at /home/bill/WebstormProjects/iot-app-kit/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/NormalModuleFactory.js:670:25
    at /home/bill/WebstormProjects/iot-app-kit/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/NormalModuleFactory.js:855:8
    at /home/bill/WebstormProjects/iot-app-kit/node_modules/@storybook/builder-webpack5/node_modules/webpack/lib/NormalModuleFactory.js:975:5
resolve '@iot-app-kit/components/styles.css' in '/home/bill/WebstormProjects/iot-app-kit/packages/dashboard/src/components/internalDashboard'
  Parsed request is a module
  using description file: /home/bill/WebstormProjects/iot-app-kit/packages/dashboard/package.json (relative path: ./src/components/internalDashboard)
    Field 'browser' doesn't contain a valid alias configuration
    resolve as module
      /home/bill/WebstormProjects/iot-app-kit/packages/dashboard/src/components/internalDashboard/node_modules doesn't exist or is not a directory
      /home/bill/WebstormProjects/iot-app-kit/packages/dashboard/src/components/node_modules doesn't exist or is not a directory
      /home/bill/WebstormProjects/iot-app-kit/packages/dashboard/src/node_modules doesn't exist or is not a directory
      looking for modules in /home/bill/WebstormProjects/iot-app-kit/packages/dashboard/node_modules
        /home/bill/WebstormProjects/iot-app-kit/packages/dashboard/node_modules/@iot-app-kit/components doesn't exist
      looking for modules in /home/bill/WebstormProjects/iot-app-kit/packages/node_modules
        /home/bill/WebstormProjects/iot-app-kit/packages/node_modules/@iot-app-kit/components doesn't exist
      looking for modules in /home/bill/WebstormProjects/iot-app-kit/node_modules
        existing directory /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components
          using description file: /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components/package.json (relative path: .)
            using description file: /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components/package.json (relative path: ./styles.css)
              no extension
                Field 'browser' doesn't contain a valid alias configuration
                /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components/styles.css doesn't exist
              .mjs
                Field 'browser' doesn't contain a valid alias configuration
                /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components/styles.css.mjs doesn't exist
              .js
                Field 'browser' doesn't contain a valid alias configuration
                /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components/styles.css.js doesn't exist
              .jsx
                Field 'browser' doesn't contain a valid alias configuration
                /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components/styles.css.jsx doesn't exist
              .ts
                Field 'browser' doesn't contain a valid alias configuration
                /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components/styles.css.ts doesn't exist
              .tsx
                Field 'browser' doesn't contain a valid alias configuration
                /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components/styles.css.tsx doesn't exist
              .json
                Field 'browser' doesn't contain a valid alias configuration
                /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components/styles.css.json doesn't exist
              .cjs
                Field 'browser' doesn't contain a valid alias configuration
                /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components/styles.css.cjs doesn't exist
              as directory
                /home/bill/WebstormProjects/iot-app-kit/node_modules/@iot-app-kit/components/styles.css doesn't exist
      /home/bill/WebstormProjects/node_modules doesn't exist or is not a directory
      /home/bill/node_modules doesn't exist or is not a directory
      /home/node_modules doesn't exist or is not a directory
      /node_modules doesn't exist or is not a directory
```  

This change adds the styles.css after each build for local referrencing.


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
