### PR TITLE
fix(react-components): set timezone for jest to UTC to prevent local …

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -27,7 +27,7 @@
     "copy:notice": "cp ../../NOTICE NOTICE",
     "prepack": "npm run copy:license && npm run copy:notice",
     "pack": "npm pack",
-    "test": "jest --config jest.config.ts --coverage",
+    "test": "TZ=utc jest --config jest.config.ts --coverage",
     "posttest": "jest-coverage-ratchet",
     "test:update": "jest --config jest.config.ts --updateSnapshot",
     "test:unit": "jest --config jest.config.ts",


### PR DESCRIPTION
Sets the unit testing environment to always have the same timezone to prevent test failures locally

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
