### PR TITLE
build: Utilize npm cache to increase CI speed

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,0 +1,42 @@
+name: E2E Tests
+on: [pull_request]
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+      - name: Install
+        run:
+          npm ci --prefer-offline --no-audit
+
+      - name: Build
+        run:
+          npm run build
+
+      - name: Run integration tests
+        uses: cypress-io/github-action@v2
+        with:
+          command: npm run test:integration
+      # after the test run completes
+      # store videos and any screenshots
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: packages/components/cypress/screenshots
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-videos
+          path: packages/components/cypress/videos
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-snapshots
+          path: packages/components/cypress/snapshots
+

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,44 +1,23 @@
-name: Test Runner
+name: Unit tests
 on: [pull_request]
 jobs:
-  test-runner:
+  unit-tests:
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: 16
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
 
-      - name: Install and Build
-        run: |
-          npm ci
+      - name: Install
+        run:
+          npm ci --prefer-offline --no-audit
+
+      - name: Build
+        run:
           npm run build
 
       - name: Run unit tests
         run: npm test
-
-      - name: Run integration tests
-        uses: cypress-io/github-action@v2
-        with:
-          command: npm run test:integration
-      # after the test run completes
-      # store videos and any screenshots
-      - uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: packages/components/cypress/screenshots
-      - uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: cypress-videos
-          path: packages/components/cypress/videos
-      - uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: cypress-snapshots
-          path: packages/components/cypress/snapshots
-


### PR DESCRIPTION
Utilizing caching to increase CI speed: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows

Also splits up the unit tests from E2E so that unit and E2E run in parellel. Because integration tests complete faster, this means we can add a lot more integration tests without impacting the CI completion time.

CI checks won't pass until we edit the repository rules to reflect the updates github action names

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
