### PR TITLE
fix(composer): fix error with rendering 3D tiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,12 @@
     "node": ">=16.0.0",
     "npm": ">=8.7.0"
   },
-  "workspaces": {
-    "packages": [
-      "examples/*",
-      "packages/*"
-    ]
-  },
+  "workspaces": [
+    "examples/*",
+    "packages/*"
+  ],
   "scripts": {
-    "bootstrap": "npm install -ws && npm run build",
+    "bootstrap": "npm install && npm run build",
     "start": "cd packages/components && npm start",
     "build": "turbo run build --filter='./packages/*'",
     "clean": "git clean -dxf -e /.idea -e /.vscode -e creds.json",

--- a/packages/scene-composer/src/three/tiles3d/TilesRendererBase.js
+++ b/packages/scene-composer/src/three/tiles3d/TilesRendererBase.js
@@ -64,6 +64,7 @@ export class TilesRendererBase extends BaseTilesRendererBase {
 
   // + Amazon --------
   constructor(url, twinMakerFetch) {
+    super(url);
     this.fetch = twinMakerFetch || window.fetch;
     // - Amazon --------
 


### PR DESCRIPTION
## Overview
- fix error with rendering 3D tiles
- fix local npm install issue

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
