### PR TITLE
build: update turborepo pipeline, filter tasks by changes since last …

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ main ]
   schedule:
     - cron: '40 16 * * 4'
@@ -43,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -20,7 +20,7 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
       - name: Install
         run:
-          npm ci --prefer-offline --no-audit
+          npm ci --prefer-offline --no-audit --no-fund
 
       - run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -1,0 +1,18 @@
+name: "Lint PR"
+
+on:
+  pull_request:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ !needs.release-please.outputs.releases_created }}
     steps:
       - name: Fetching the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: release-please--branches--main
           fetch-depth: 2

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -12,16 +12,12 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
       - name: Install
         run:
-          npm ci --prefer-offline --no-audit
-
-      - name: Build
-        run:
-          npm run build
+          npm ci --prefer-offline --no-audit --no-fund
 
       - name: Run integration tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
         with:
-          command: npm run test:integration
+          command: npx turbo run test:integration
       # after the test run completes
       # store videos and any screenshots
       - uses: actions/upload-artifact@v1
@@ -39,4 +35,3 @@ jobs:
         with:
           name: cypress-snapshots
           path: packages/components/cypress/snapshots
-

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 3
       - uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -13,11 +15,10 @@ jobs:
 
       - name: Install
         run:
-          npm ci --prefer-offline --no-audit
-
-      - name: Build
-        run:
-          npm run build
+          npm ci --prefer-offline --no-audit --no-fund
 
       - name: Run unit tests
-        run: npm test
+        run: npx turbo run test --filter='...[${{ github.event.after }}^]'
+
+      - name: Run lints
+        run: npm run test:rest

--- a/package.json
+++ b/package.json
@@ -11,13 +11,12 @@
     "npm": ">=8.7.0"
   },
   "workspaces": [
-    "examples/*",
     "packages/*"
   ],
   "scripts": {
     "bootstrap": "npm install && npm run build",
     "start": "cd packages/components && npm start",
-    "build": "turbo run build --filter='./packages/*'",
+    "build": "turbo run build",
     "clean": "git clean -dxf -e /.idea -e /.vscode -e creds.json",
     "dev": "turbo run dev",
     "fix": "npm-run-all -p fix:eslint fix:stylelint",
@@ -26,9 +25,10 @@
     "test": "npm-run-all -p test:unit test:eslint test:stylelint test:git",
     "test:integration": "turbo run test:integration",
     "test:ui": "turbo run test:ui --filter='./packages/dashboard'",
-    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=40",
-    "test:stylelint": "stylelint '**/*.css' --max-warnings 0",
     "test:unit": "turbo run test",
+    "test:rest": "npm-run-all -p test:eslint test:stylelint test:git",
+    "test:eslint": "eslint --ext .js,.ts,.tsx . --max-warnings=39",
+    "test:stylelint": "stylelint '**/*.css' --max-warnings 0",
     "test:git": "git diff --exit-code",
     "release": "npm run build",
     "pack": "turbo run pack",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -118,10 +118,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 67.19,
-        "statements": 67.11,
-        "functions": 61.72,
-        "branches": 46.66,
+        "lines": 77.12,
+        "statements": 77.33,
+        "functions": 76.11,
+        "branches": 59.73,
         "branchesTrue": 100
       }
     }

--- a/turbo.json
+++ b/turbo.json
@@ -3,28 +3,36 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "outputMode": "new-only"
     },
     "dev": {
-      "dependsOn": []
+      "dependsOn": [],
+      "outputMode": "new-only"
     },
     "pack": {
-      "dependsOn": []
+      "dependsOn": [],
+      "outputMode": "new-only"
     },
     "test": {
-      "dependsOn": []
+      "dependsOn": ["build"],
+      "outputMode": "new-only"
     },
     "test:integration": {
-      "dependsOn": []
+      "dependsOn": ["build"],
+      "outputMode": "new-only"
     },
     "test:ui": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "outputMode": "new-only"
     },
     "start": {
-      "dependsOn": []
+      "dependsOn": [],
+      "outputMode": "new-only"
     },
     "version": {
-      "dependsOn": []
+      "dependsOn": [],
+      "outputMode": "new-only"
     }
   }
 }


### PR DESCRIPTION
This PR seeks to improve the developer experience by increasing the speed of the CI process.

- update turborepo to accurately reflect which tasks depends on build
- setup github actions to only execute tasks based on what has changed in the latest commit
- remove reac-app from the workspace as its in a broken state that won't build.
- prevent excessive output from cached turborepo tasks
- Update github actions to use the latest version

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
