### PR TITLE
chore: setup husky, update package-lock to remove react-app dependencies

### DIFF
--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -9,9 +9,21 @@ on:
       - synchronize
 
 jobs:
+  commit:
+    name: Commit message lint
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 3
+      - name: Install commit lint config
+        run: npm i @commitlint/config-conventional
+      - name: Validate current commit (last commit) with commitlint
+        run: npx commitlint --from ${{ github.event.after }}~1 --verbose
+
   main:
     name: Validate PR title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit ${1}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/package.json
+++ b/package.json
@@ -34,9 +34,12 @@
     "pack": "turbo run pack",
     "versionup:patch": "turbo run version --no-git-tag-version patch",
     "versionup:minor": "turbo run version --no-git-tag-version minor",
-    "versionup:major": "turbo run version --no-git-tag-version major"
+    "versionup:major": "turbo run version --no-git-tag-version major",
+    "prepare": "husky install"
   },
   "devDependencies": {
+    "@commitlint/cli": "^17.4.4",
+    "@commitlint/config-conventional": "^17.4.4",
     "@jest/core": "26.6.3",
     "@playwright/test": "^1.31.2",
     "@testing-library/dom": "^7.22.2",
@@ -76,6 +79,7 @@
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "husky": "^8.0.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "26.6.3",
     "jest-cli": "26.6.3",


### PR DESCRIPTION
## Overview
- enforce conventional commit at time of making a commit
- enforce conventional commit on CI
- update package-lock to account for removal of react-app from workspace

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
