### PR TITLE
feat(dashboard): add onUpdateWidget middleware for widget handling da…

### DIFF
--- a/packages/dashboard/src/customization/api.ts
+++ b/packages/dashboard/src/customization/api.ts
@@ -3,6 +3,7 @@ import { AnyWidget } from '~/types';
 import { ComponentLibraryComponentMap, ComponentLibraryComponentOrdering } from './componentLibraryComponentMap';
 import { WidgetComponentMap } from './widgetComponentMap';
 import { WidgetPropertiesGeneratorMap } from './widgetPropertiesGeneratorMap';
+import { DashboardAction } from '~/store/actions';
 
 type RenderFunc<T extends AnyWidget> = (widget: T) => React.ReactElement;
 
@@ -14,6 +15,7 @@ type WidgetRegistrationOptions<T extends AnyWidget> = {
   };
   properties?: () => T['properties'];
   initialSize?: Pick<AnyWidget, 'height' | 'width'>;
+  onUpdateWidget?: <W extends AnyWidget>(widget: W) => W;
 };
 type RegisterWidget = <T extends AnyWidget>(type: string, options: WidgetRegistrationOptions<T>) => void;
 
@@ -24,7 +26,7 @@ export const registerWidget: RegisterWidget = <T extends AnyWidget>(
   type: string,
   options: WidgetRegistrationOptions<T>
 ) => {
-  const { render, componentLibrary, properties, initialSize } = options;
+  const { render, componentLibrary, properties, initialSize, onUpdateWidget } = options;
   WidgetComponentMap[type] = render;
 
   if (componentLibrary) {
@@ -37,6 +39,7 @@ export const registerWidget: RegisterWidget = <T extends AnyWidget>(
     WidgetPropertiesGeneratorMap[type] = {
       properties,
       initialSize,
+      onUpdateWidget,
     };
   }
 };

--- a/packages/dashboard/src/customization/widgetPropertiesGeneratorMap.ts
+++ b/packages/dashboard/src/customization/widgetPropertiesGeneratorMap.ts
@@ -1,4 +1,4 @@
-import { AnyWidget } from '../types';
+import { AnyWidget } from '~/types';
 
 /**
  * map of widget type to a generator func to create properties when this widget is dropped into the grid
@@ -11,5 +11,6 @@ export const WidgetPropertiesGeneratorMap: {
     //eslint-disable-next-line
     properties?: () => Record<any, any>;
     initialSize?: Pick<AnyWidget, 'height' | 'width'>;
+    onUpdateWidget?: <W extends AnyWidget>(widget: W) => W;
   };
 } = {};

--- a/packages/dashboard/src/store/actions/updateWidget/index.ts
+++ b/packages/dashboard/src/store/actions/updateWidget/index.ts
@@ -8,14 +8,20 @@ import { DashboardState } from '../../state';
 type UpdateWidgetsActionPayload = {
   widgets: AnyWidget[];
 };
+
 export interface UpdateWidgetsAction extends Action {
   type: 'UPDATE_WIDGET';
   payload: UpdateWidgetsActionPayload;
+  applyUpdateWidget?: boolean;
 }
 
-export const onUpdateWidgetsAction = (payload: UpdateWidgetsActionPayload): UpdateWidgetsAction => ({
+export const onUpdateWidgetsAction = (
+  payload: UpdateWidgetsActionPayload,
+  applyUpdateWidget = true
+): UpdateWidgetsAction => ({
   type: 'UPDATE_WIDGET',
   payload,
+  applyUpdateWidget,
 });
 
 export const updateWidgets = (state: DashboardState, action: UpdateWidgetsAction): DashboardState => {

--- a/packages/dashboard/src/store/index.ts
+++ b/packages/dashboard/src/store/index.ts
@@ -6,9 +6,9 @@ import { DashboardAction } from './actions';
 import { DashboardState, initialState } from './state';
 import { dashboardReducer } from './reducer';
 import { RecursivePartial } from '~/types';
+import { updateWidgetMiddleware } from '~/store/updateWidgetMiddleware';
 
 export type DashboardStore = Store<DashboardState, DashboardAction>;
-
 export const configureDashboardStore = (preloadedState?: RecursivePartial<DashboardState>) => {
   const mergedState = merge(initialState, preloadedState);
 
@@ -23,6 +23,7 @@ export const configureDashboardStore = (preloadedState?: RecursivePartial<Dashbo
           initialState.dashboardConfiguration.viewport) as DashboardState['dashboardConfiguration']['viewport'],
       },
     },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(updateWidgetMiddleware),
   });
 
   return store;

--- a/packages/dashboard/src/store/updateWidgetMiddleware.spec.ts
+++ b/packages/dashboard/src/store/updateWidgetMiddleware.spec.ts
@@ -1,0 +1,52 @@
+import { DashboardAction, onUpdateWidgetsAction } from './actions';
+import { WidgetPropertiesGeneratorMap } from '../customization/widgetPropertiesGeneratorMap';
+import { MOCK_KPI_WIDGET } from '../../testing/mocks';
+import { updateWidgetMiddleware } from './updateWidgetMiddleware';
+import { MiddlewareAPI } from 'redux';
+
+describe('updateWidgetMiddleware', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const dispatch = jest.fn();
+  const store = {
+    dispatch,
+  };
+
+  const mockOnUpdateWidget = jest.fn((widget) => ({ ...widget, id: 'Widget got touched' }));
+  WidgetPropertiesGeneratorMap[MOCK_KPI_WIDGET.type] = {
+    onUpdateWidget: mockOnUpdateWidget,
+  };
+  const callMiddleware = (action: DashboardAction) => {
+    return updateWidgetMiddleware(store as unknown as MiddlewareAPI)(dispatch)(action);
+  };
+
+  it('does not call onUpdateWidget function if applyUpdateWidget flag is set to false', () => {
+    const action = onUpdateWidgetsAction({ widgets: [MOCK_KPI_WIDGET] }, false);
+    callMiddleware(action);
+    expect(mockOnUpdateWidget).not.toHaveBeenCalled();
+  });
+
+  it('does not change action if applyUpdateWidget flag is set to false', () => {
+    const updateWidgetsAction = onUpdateWidgetsAction({ widgets: [MOCK_KPI_WIDGET] }, false);
+    callMiddleware(updateWidgetsAction);
+    expect(dispatch).toHaveBeenCalledWith(updateWidgetsAction);
+  });
+
+  it('only calls onUpdateWidget function if applyUpdateWidget flag is set to true', () => {
+    const action = onUpdateWidgetsAction({ widgets: [MOCK_KPI_WIDGET] }, true);
+    callMiddleware(action);
+    expect(mockOnUpdateWidget).toHaveBeenCalled();
+  });
+
+  it('does change action result if applyUpdateWidget flag is set to true', () => {
+    const action = onUpdateWidgetsAction({ widgets: [MOCK_KPI_WIDGET] }, true);
+    callMiddleware(action);
+    expect(dispatch).toHaveBeenCalledWith({
+      ...action,
+      payload: {
+        ...action.payload,
+        widgets: [{ ...MOCK_KPI_WIDGET, id: 'Widget got touched' }],
+      },
+    });
+  });
+});

--- a/packages/dashboard/src/store/updateWidgetMiddleware.ts
+++ b/packages/dashboard/src/store/updateWidgetMiddleware.ts
@@ -1,0 +1,24 @@
+import { Dispatch, Middleware } from 'redux';
+import { DashboardAction } from '~/store/actions';
+import { DashboardState } from '~/store/state';
+import { WidgetPropertiesGeneratorMap } from '~/customization/widgetPropertiesGeneratorMap';
+
+export const updateWidgetMiddleware: Middleware<unknown, DashboardState, Dispatch<DashboardAction>> =
+  () => (next: Dispatch<DashboardAction>) => (action: DashboardAction) => {
+    if ('applyUpdateWidget' in action && action.applyUpdateWidget && action.payload?.widgets) {
+      return next({
+        ...action,
+        payload: {
+          ...action.payload,
+          widgets: action.payload.widgets.map((widget) => {
+            const widgetPropertiesGenerator = WidgetPropertiesGeneratorMap[widget.type];
+            if (widgetPropertiesGenerator?.onUpdateWidget) {
+              return widgetPropertiesGenerator.onUpdateWidget(widget);
+            }
+            return widget;
+          }),
+        },
+      });
+    }
+    return next(action);
+  };


### PR DESCRIPTION
…shboard action by themselves.

## Overview
Add `onUpdateWidget` function to `WidgetRegistrationOptions`. When any action with `widgets` filed and `applyUpdateWidget` flag is dispatched, `onUpdateWidget` will be called. This allows users to handle widget updates in a customized way.
For example, if KPI widget registered as 
```
export const kpiPlugin: DashboardPlugin = {
  install: ({ registerWidget }) => {
    registerWidget<KPIWidget>('iot-kpi', {
      ....
      onUpdateWidget: (widget) => {
        console.log(widget);
        return widget;
      },
    });
  },
};
```
It would log widget states to console on wiget state changes.
![chrome-capture-2023-2-9](https://user-images.githubusercontent.com/11740421/224177401-92b8bbba-fb43-47b3-8159-0b0d55c422e0.gif)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
