### PR TITLE
chore(dashboard): remove redundent AnyWidget type and use default Widget type instead

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/gestures/index.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/index.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { DashboardState } from '~/store/state';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { DragEvent, PointClickEvent } from '../../grid';
 import { determineTargetGestures } from './determineTargetGestures';
 import { Gesture } from './types';
@@ -10,7 +10,7 @@ import { useSelectionGestures } from './useSelection';
 
 type GestureHooksProps = {
   dashboardConfiguration: DashboardState['dashboardConfiguration'];
-  selectedWidgets: AnyWidget[];
+  selectedWidgets: Widget[];
   cellSize: DashboardState['grid']['cellSize'];
 };
 

--- a/packages/dashboard/src/components/internalDashboard/gestures/useMove.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useMove.ts
@@ -2,14 +2,14 @@ import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { onMoveWidgetsAction } from '~/store/actions';
 import { DashboardState } from '~/store/state';
-import { Position, AnyWidget } from '~/types';
+import { Position, Widget } from '~/types';
 import { toGridPosition } from '~/util/position';
 import { DragEvent } from '../../grid';
 import { Gesture } from './types';
 
 type MoveHooksProps = {
   setActiveGesture: React.Dispatch<React.SetStateAction<Gesture>>;
-  selectedWidgets: AnyWidget[];
+  selectedWidgets: Widget[];
   cellSize: DashboardState['grid']['cellSize'];
 };
 

--- a/packages/dashboard/src/components/internalDashboard/gestures/useResize.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useResize.ts
@@ -1,15 +1,15 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Anchor, onResizeWidgetsAction } from '~/store/actions';
 import { DashboardState } from '~/store/state';
-import { Position, AnyWidget } from '~/types';
+import { Position, Widget } from '~/types';
 import { toGridPosition } from '~/util/position';
 import { DragEvent } from '../../grid';
 import { Gesture } from './types';
 
 type ResizeHooksProps = {
   setActiveGesture: React.Dispatch<React.SetStateAction<Gesture>>;
-  selectedWidgets: AnyWidget[];
+  selectedWidgets: Widget[];
   cellSize: DashboardState['grid']['cellSize'];
 };
 

--- a/packages/dashboard/src/components/internalDashboard/gestures/useSelection.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useSelection.ts
@@ -1,8 +1,8 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { onSelectWidgetsAction } from '~/store/actions';
 import { DashboardState } from '~/store/state';
-import { Position, AnyWidget, Selection } from '~/types';
+import { Position, Selection, Widget } from '~/types';
 import { getSelectedWidgets, pointSelect, selectedRect } from '~/util/select';
 import { DragEvent } from '../../grid';
 import { Gesture } from './types';
@@ -15,7 +15,7 @@ type SelectionHooksProps = {
 
 export const useSelectionGestures = ({ setActiveGesture, dashboardConfiguration, cellSize }: SelectionHooksProps) => {
   const dispatch = useDispatch();
-  const selectWidgets = (widgets: AnyWidget[], union: boolean) => {
+  const selectWidgets = (widgets: Widget[], union: boolean) => {
     dispatch(
       onSelectWidgetsAction({
         widgets,

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -4,7 +4,7 @@ import Box from '@cloudscape-design/components/box';
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 import { WebglContext } from '@iot-app-kit/react-components';
 
-import { AnyWidget, Position } from '~/types';
+import { Position, Widget } from '~/types';
 import { selectedRect } from '~/util/select';
 import { DashboardMessages } from '~/messages';
 
@@ -30,9 +30,9 @@ import {
   onBringWidgetsToFrontAction,
   onCopyWidgetsAction,
   onCreateWidgetsAction,
+  onDeleteWidgetsAction,
   onPasteWidgetsAction,
   onSendWidgetsToBackAction,
-  onDeleteWidgetsAction,
 } from '~/store/actions';
 import { DashboardState, SaveableDashboard } from '~/store/state';
 import { widgetCreator } from '~/store/actions/createWidget/presets';
@@ -71,7 +71,7 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({
   const [viewFrame, setViewFrameElement] = useState<HTMLDivElement | undefined>(undefined);
 
   const dispatch = useDispatch();
-  const createWidgets = (widgets: AnyWidget[]) =>
+  const createWidgets = (widgets: Widget[]) =>
     dispatch(
       onCreateWidgetsAction({
         widgets,
@@ -132,7 +132,7 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({
 
     const { x, y } = toGridPosition(position, cellSize);
 
-    const widget: AnyWidget = {
+    const widget: Widget = {
       ...widgetPresets,
       x: Math.floor(x),
       y: Math.floor(y),

--- a/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.tsx
@@ -10,13 +10,13 @@ import {
 } from '@cloudscape-design/components';
 import ExpandableSectionHeader from '../../shared/expandableSectionHeader';
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { useWidgetLense } from '../../utils/useWidgetLense';
 import { BarChartWidget, LineChartWidget, ScatterChartWidget } from '~/customization/widgets/types';
 import { merge } from 'lodash';
 import { AxisSettings } from '../../../../customization/settings';
 
-export const isAxisSettingsSupported = (widget: AnyWidget): boolean =>
+export const isAxisSettingsSupported = (widget: Widget): boolean =>
   ['iot-line', 'iot-scatter', 'iot-bar'].some((t) => t === widget.type);
 
 export type AxisWidget = LineChartWidget | ScatterChartWidget | BarChartWidget;

--- a/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.tsx
@@ -3,7 +3,7 @@ import { BaseChangeDetail } from '@cloudscape-design/components/input/interfaces
 import { ExpandableSection, Grid, Input } from '@cloudscape-design/components';
 
 import { trimWidgetPosition } from '~/util/trimWidgetPosition';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { useWidgetLense } from '../../utils/useWidgetLense';
 
 const defaultMessages = {
@@ -14,23 +14,23 @@ const defaultMessages = {
   title: 'Size and position',
 };
 
-export const BaseSettings: FC<AnyWidget> = (widget) => {
-  const [x, updateX] = useWidgetLense<AnyWidget, number>(
+export const BaseSettings: FC<Widget> = (widget) => {
+  const [x, updateX] = useWidgetLense<Widget, number>(
     widget,
     (w) => w.x,
     (w, x) => ({ ...w, x })
   );
-  const [y, updateY] = useWidgetLense<AnyWidget, number>(
+  const [y, updateY] = useWidgetLense<Widget, number>(
     widget,
     (w) => w.y,
     (w, y) => ({ ...w, y })
   );
-  const [width, updateWidth] = useWidgetLense<AnyWidget, number>(
+  const [width, updateWidth] = useWidgetLense<Widget, number>(
     widget,
     (w) => w.width,
     (w, width) => ({ ...w, width })
   );
-  const [height, updateHeight] = useWidgetLense<AnyWidget, number>(
+  const [height, updateHeight] = useWidgetLense<Widget, number>(
     widget,
     (w) => w.height,
     (w, height) => ({ ...w, height })
@@ -46,7 +46,7 @@ export const BaseSettings: FC<AnyWidget> = (widget) => {
     updateHeight(Math.round(parseFloat(value)));
   const gridDefinition = [{ colspan: 2 }, { colspan: 4 }, { colspan: 2 }, { colspan: 4 }];
 
-  const formattedValue = trimWidgetPosition({ x, y, width, height } as AnyWidget);
+  const formattedValue = trimWidgetPosition({ x, y, width, height } as Widget);
   return (
     <ExpandableSection headerText={defaultMessages.title} defaultExpanded>
       <Grid gridDefinition={gridDefinition}>

--- a/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.tsx
@@ -9,9 +9,9 @@ import ExpandableSectionHeader from '../../shared/expandableSectionHeader';
 import { PropertyComponent } from './propertyComponent';
 import { useWidgetLense } from '../../utils/useWidgetLense';
 import { StyleSettingsMap } from '@iot-app-kit/core';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 
-export const isPropertiesAndAlarmsSupported = (widget: AnyWidget): boolean =>
+export const isPropertiesAndAlarmsSupported = (widget: Widget): boolean =>
   ['iot-line', 'iot-scatter', 'iot-bar', 'iot-table', 'iot-kpi', 'iot-status'].some((t) => t === widget.type);
 
 export type PropertiesAlarmsSectionProps = {

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
@@ -19,7 +19,7 @@ import {
   StatusWidget,
   TableWidget,
 } from '~/customization/widgets/types';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 
 export type ThresholdWidget =
   | KPIWidget
@@ -29,7 +29,7 @@ export type ThresholdWidget =
   | BarChartWidget
   | TableWidget;
 
-export const isThresholdsSupported = (widget: AnyWidget): boolean =>
+export const isThresholdsSupported = (widget: Widget): boolean =>
   ['iot-kpi', 'iot-status', 'iot-line', 'iot-scatter', 'iot-bar', 'iot-table'].some((t) => t === widget.type);
 
 const widgetsSupportsContainOp: string[] = ['iot-kpi', 'iot-status', 'iot-table'];

--- a/packages/dashboard/src/components/sidePanel/utils/useWidgetLense.ts
+++ b/packages/dashboard/src/components/sidePanel/utils/useWidgetLense.ts
@@ -1,8 +1,8 @@
 import { useCallback, useMemo } from 'react';
 import { useWidgetActions } from '~/customization/hooks/useWidgetActions';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 
-export const useWidgetLense = <W extends AnyWidget, T>(
+export const useWidgetLense = <W extends Widget, T>(
   widget: W,
   selector: (widget: W) => T,
   updater: (widget: W, value: T) => W

--- a/packages/dashboard/src/components/widgets/dynamicWidget.tsx
+++ b/packages/dashboard/src/components/widgets/dynamicWidget.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { WidgetsMessages } from '~/messages';
 import { WidgetComponentMap } from '~/customization/widgetComponentMap';
 
@@ -21,7 +21,7 @@ const IconX: React.FC = () => (
 );
 
 export type DynamicWidgetProps = {
-  widget: AnyWidget;
+  widget: Widget;
   widgetsMessages: WidgetsMessages;
 };
 
@@ -29,7 +29,7 @@ export const getDragLayerProps = ({
   widget,
   widgetsMessages,
 }: {
-  widget: AnyWidget;
+  widget: Widget;
   widgetsMessages: WidgetsMessages;
 }): DynamicWidgetProps => ({
   widget,

--- a/packages/dashboard/src/components/widgets/list.tsx
+++ b/packages/dashboard/src/components/widgets/list.tsx
@@ -4,7 +4,7 @@ import map from 'lodash/map';
 import includes from 'lodash/includes';
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 
-import { AnyWidget, DashboardConfiguration } from '~/types';
+import { DashboardConfiguration, Widget } from '~/types';
 import WidgetComponent from './widget';
 import SelectionBox from './selectionBox';
 import { DashboardMessages } from '~/messages';
@@ -15,7 +15,7 @@ export type WidgetsProps = {
   readOnly: boolean;
   query?: SiteWiseQuery;
   dashboardConfiguration: DashboardConfiguration;
-  selectedWidgets: AnyWidget[];
+  selectedWidgets: Widget[];
   cellSize: number;
   dragEnabled: boolean;
   messageOverrides: DashboardMessages;

--- a/packages/dashboard/src/components/widgets/selectionBox.tsx
+++ b/packages/dashboard/src/components/widgets/selectionBox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import SelectionBoxAnchor from './selectionBoxAnchor';
 import { gestureable } from '../internalDashboard/gestures/determineTargetGestures';
 import { getSelectionBox } from '~/util/getSelectionBox';
@@ -9,7 +9,7 @@ import './selectionBox.css';
 import { useLayers } from '../internalDashboard/useLayers';
 
 export type SelectionBoxProps = {
-  selectedWidgets: AnyWidget[];
+  selectedWidgets: Widget[];
   cellSize: number;
   dragEnabled: boolean;
 };

--- a/packages/dashboard/src/components/widgets/widget.tsx
+++ b/packages/dashboard/src/components/widgets/widget.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 import { DashboardMessages } from '~/messages';
 
-import { DashboardConfiguration, AnyWidget } from '~/types';
+import { DashboardConfiguration, Widget } from '~/types';
 import { gestureable, idable } from '../internalDashboard/gestures/determineTargetGestures';
 import DynamicWidgetComponent from './dynamicWidget';
 
@@ -14,7 +14,7 @@ export type WidgetProps = {
   query?: SiteWiseQuery;
   isSelected: boolean;
   cellSize: number;
-  widget: AnyWidget;
+  widget: Widget;
   viewport: DashboardConfiguration['viewport'];
   messageOverrides: DashboardMessages;
 };

--- a/packages/dashboard/src/customization/api.ts
+++ b/packages/dashboard/src/customization/api.ts
@@ -1,26 +1,26 @@
 import React from 'react';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { ComponentLibraryComponentMap, ComponentLibraryComponentOrdering } from './componentLibraryComponentMap';
 import { WidgetComponentMap } from './widgetComponentMap';
 import { WidgetPropertiesGeneratorMap } from './widgetPropertiesGeneratorMap';
 
-type RenderFunc<T extends AnyWidget> = (widget: T) => React.ReactElement;
+type RenderFunc<T extends Widget> = (widget: T) => React.ReactElement;
 
-type WidgetRegistrationOptions<T extends AnyWidget> = {
+type WidgetRegistrationOptions<T extends Widget> = {
   render: RenderFunc<T>;
   componentLibrary?: {
     name: string;
     icon: React.FC;
   };
   properties?: () => T['properties'];
-  initialSize?: Pick<AnyWidget, 'height' | 'width'>;
+  initialSize?: Pick<Widget, 'height' | 'width'>;
 };
-type RegisterWidget = <T extends AnyWidget>(type: string, options: WidgetRegistrationOptions<T>) => void;
+type RegisterWidget = <T extends Widget>(type: string, options: WidgetRegistrationOptions<T>) => void;
 
 /**
  * function to register a new widget type in the dashboard
  */
-export const registerWidget: RegisterWidget = <T extends AnyWidget>(
+export const registerWidget: RegisterWidget = <T extends Widget>(
   type: string,
   options: WidgetRegistrationOptions<T>
 ) => {

--- a/packages/dashboard/src/customization/hooks/useIsSelected.ts
+++ b/packages/dashboard/src/customization/hooks/useIsSelected.ts
@@ -3,7 +3,7 @@ import includes from 'lodash/includes';
 import map from 'lodash/map';
 
 import { DashboardState } from '~/store/state';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { useCallback } from 'react';
 
 /**
@@ -12,7 +12,7 @@ import { useCallback } from 'react';
  * used to determine if this widget is in the selection
  *
  */
-export const useIsSelected = <T extends AnyWidget>(widget: T) => {
+export const useIsSelected = <T extends Widget>(widget: T) => {
   const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
 
   const isSelected = useCallback(

--- a/packages/dashboard/src/customization/hooks/useWidgetActions.ts
+++ b/packages/dashboard/src/customization/hooks/useWidgetActions.ts
@@ -1,7 +1,7 @@
 import { useDispatch } from 'react-redux';
 
 import { onUpdateWidgetsAction } from '~/store/actions';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 
 /**
  * Helper hook that can be exposed to consumers making their own widget components
@@ -9,7 +9,7 @@ import { AnyWidget } from '~/types';
  * used to update itself in the store
  *
  */
-export const useWidgetActions = <T extends AnyWidget>() => {
+export const useWidgetActions = <T extends Widget>() => {
   const dispatch = useDispatch();
 
   const update = (widget: T) =>

--- a/packages/dashboard/src/customization/widgetPropertiesGeneratorMap.ts
+++ b/packages/dashboard/src/customization/widgetPropertiesGeneratorMap.ts
@@ -1,4 +1,4 @@
-import { AnyWidget } from '../types';
+import { Widget } from '~/types';
 
 /**
  * map of widget type to a generator func to create properties when this widget is dropped into the grid
@@ -6,10 +6,11 @@ import { AnyWidget } from '../types';
  * also the initial size of that widget in real pixels
  *
  */
-export const WidgetPropertiesGeneratorMap: {
+
+type WidgetPropertiesGenerator<W extends Widget = Widget> = {
   [key in string]: {
-    //eslint-disable-next-line
-    properties?: () => Record<any, any>;
-    initialSize?: Pick<AnyWidget, 'height' | 'width'>;
+    properties?: () => W['properties'];
+    initialSize?: Pick<W, 'height' | 'width'>;
   };
-} = {};
+};
+export const WidgetPropertiesGeneratorMap: WidgetPropertiesGenerator = {};

--- a/packages/dashboard/src/store/actions/bringToFront/index.spec.ts
+++ b/packages/dashboard/src/store/actions/bringToFront/index.spec.ts
@@ -1,10 +1,10 @@
 import { bringWidgetsToFront } from '.';
 import { DashboardState, initialState } from '../../state';
 
-import { MockWidgetFactory, MOCK_KPI_WIDGET } from '../../../../testing/mocks';
-import { AnyWidget } from '~/types';
+import { MOCK_KPI_WIDGET, MockWidgetFactory } from '../../../../testing/mocks';
+import { Widget } from '~/types';
 
-const setupDashboardState = (widgets: AnyWidget[] = [], selectedWidgets: AnyWidget[] = []): DashboardState => ({
+const setupDashboardState = (widgets: Widget[] = [], selectedWidgets: Widget[] = []): DashboardState => ({
   ...initialState,
   dashboardConfiguration: {
     ...initialState.dashboardConfiguration,

--- a/packages/dashboard/src/store/actions/copyWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/copyWidgets/index.spec.ts
@@ -2,9 +2,9 @@ import { copyWidgets, onCopyWidgetsAction } from '.';
 import { DashboardState, initialState } from '../../state';
 
 import { MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET, MOCK_SCATTER_CHART_WIDGET } from '../../../../testing/mocks';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 
-const setupDashboardState = (widgets: AnyWidget[] = [], pasteCounter = 0): DashboardState => ({
+const setupDashboardState = (widgets: Widget[] = [], pasteCounter = 0): DashboardState => ({
   ...initialState,
   dashboardConfiguration: {
     ...initialState.dashboardConfiguration,

--- a/packages/dashboard/src/store/actions/copyWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/copyWidgets/index.ts
@@ -2,12 +2,13 @@ import { Action } from 'redux';
 
 import intersectionBy from 'lodash/intersectionBy';
 
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { DashboardState } from '../../state';
 
 type CopyWidgetsActionPayload = {
-  widgets: AnyWidget[];
+  widgets: Widget[];
 };
+
 export interface CopyWidgetsAction extends Action {
   type: 'COPY_WIDGETS';
   payload: CopyWidgetsActionPayload;

--- a/packages/dashboard/src/store/actions/createWidget/index.ts
+++ b/packages/dashboard/src/store/actions/createWidget/index.ts
@@ -1,13 +1,14 @@
 import { Action } from 'redux';
 
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
 import { trimWidgetPosition } from '~/util/trimWidgetPosition';
 import { DashboardState } from '../../state';
 
 type CreateWidgetsActionPayload = {
-  widgets: AnyWidget[];
+  widgets: Widget[];
 };
+
 export interface CreateWidgetsAction extends Action {
   type: 'CREATE_WIDGETS';
   payload: CreateWidgetsActionPayload;

--- a/packages/dashboard/src/store/actions/createWidget/presets/index.ts
+++ b/packages/dashboard/src/store/actions/createWidget/presets/index.ts
@@ -1,5 +1,5 @@
 import { nanoid } from '@reduxjs/toolkit';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { DashboardState } from '~/store/state';
 import { WidgetPropertiesGeneratorMap } from '~/customization/widgetPropertiesGeneratorMap';
 
@@ -11,7 +11,7 @@ const BASE_POSITION = {
 
 export const widgetCreator =
   (gridState: DashboardState['grid']) =>
-  (type: string): AnyWidget => {
+  (type: string): Widget => {
     const { width, height, cellSize } = gridState;
 
     const { properties, initialSize } = WidgetPropertiesGeneratorMap[type];

--- a/packages/dashboard/src/store/actions/deleteWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/deleteWidgets/index.spec.ts
@@ -1,10 +1,10 @@
 import { deleteWidgets, onDeleteWidgetsAction } from './index';
 import { DashboardState, initialState } from '../../state';
 
-import { MockWidgetFactory, MOCK_KPI_WIDGET } from '../../../../testing/mocks';
-import { AnyWidget } from '~/types';
+import { MOCK_KPI_WIDGET, MockWidgetFactory } from '../../../../testing/mocks';
+import { Widget } from '~/types';
 
-const setupDashboardState = (widgets: AnyWidget[] = []): DashboardState => ({
+const setupDashboardState = (widgets: Widget[] = []): DashboardState => ({
   ...initialState,
   dashboardConfiguration: {
     ...initialState.dashboardConfiguration,

--- a/packages/dashboard/src/store/actions/deleteWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/deleteWidgets/index.ts
@@ -1,11 +1,12 @@
 import { Action } from 'redux';
 
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { DashboardState } from '../../state';
 
 type DeleteWidgetsActionPayload = {
-  widgets: AnyWidget[];
+  widgets: Widget[];
 };
+
 export interface DeleteWidgetsAction extends Action {
   type: 'DELETE_WIDGETS';
   payload: DeleteWidgetsActionPayload;

--- a/packages/dashboard/src/store/actions/moveWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/moveWidgets/index.spec.ts
@@ -1,10 +1,10 @@
 import { moveWidgets, onMoveWidgetsAction } from './index';
 import { DashboardState, initialState } from '../../state';
 
-import { MockWidgetFactory, MOCK_KPI_WIDGET } from '../../../../testing/mocks';
-import { AnyWidget } from '~/types';
+import { MOCK_KPI_WIDGET, MockWidgetFactory } from '../../../../testing/mocks';
+import { Widget } from '~/types';
 
-const setupDashboardState = (widgets: AnyWidget[] = []): DashboardState => ({
+const setupDashboardState = (widgets: Widget[] = []): DashboardState => ({
   ...initialState,
   grid: {
     ...initialState.grid,

--- a/packages/dashboard/src/store/actions/moveWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/moveWidgets/index.ts
@@ -1,15 +1,16 @@
 import { Action } from 'redux';
 
-import { Position, AnyWidget } from '~/types';
+import { Position, Widget } from '~/types';
 import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
 import { trimWidgetPosition } from '~/util/trimWidgetPosition';
 import { DashboardState } from '../../state';
 
 type MoveWidgetsActionPayload = {
-  widgets: AnyWidget[];
+  widgets: Widget[];
   vector: Position;
   complete?: boolean;
 };
+
 export interface MoveWidgetsAction extends Action {
   type: 'MOVE_WIDGETS';
   payload: MoveWidgetsActionPayload;

--- a/packages/dashboard/src/store/actions/pasteWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/pasteWidgets/index.spec.ts
@@ -1,10 +1,10 @@
-import { pasteWidgets, onPasteWidgetsAction } from '.';
+import { onPasteWidgetsAction, pasteWidgets } from '.';
 import { DashboardState, initialState } from '../../state';
 
 import { MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET } from '../../../../testing/mocks';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 
-const setupDashboardState = (widgets: AnyWidget[] = [], copiedWidgets: AnyWidget[] = []): DashboardState => ({
+const setupDashboardState = (widgets: Widget[] = [], copiedWidgets: Widget[] = []): DashboardState => ({
   ...initialState,
   dashboardConfiguration: {
     ...initialState.dashboardConfiguration,

--- a/packages/dashboard/src/store/actions/resizeWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/resizeWidgets/index.spec.ts
@@ -1,12 +1,10 @@
-import { MockWidgetFactory } from '../../../../testing/mocks';
+import { MOCK_KPI_WIDGET, MockWidgetFactory } from '../../../../testing/mocks';
 import { onResizeWidgetsAction, resizeWidgets } from './index';
 
 import { DashboardState, initialState } from '../../state';
+import { Widget } from '~/types';
 
-import { MOCK_KPI_WIDGET } from '../../../../testing/mocks';
-import { AnyWidget } from '~/types';
-
-const setupDashboardState = (widgets: AnyWidget[] = []): DashboardState => ({
+const setupDashboardState = (widgets: Widget[] = []): DashboardState => ({
   ...initialState,
   grid: {
     ...initialState.grid,

--- a/packages/dashboard/src/store/actions/resizeWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/resizeWidgets/index.ts
@@ -1,5 +1,5 @@
 import { Action } from 'redux';
-import { Position, Rect, AnyWidget } from '~/types';
+import { Position, Rect, Widget } from '~/types';
 import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
 import { getSelectionBox } from '~/util/getSelectionBox';
 import { trimWidgetPosition } from '~/util/trimWidgetPosition';
@@ -11,20 +11,21 @@ const MIN_WIDTH = 2;
 export type Anchor = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left' | 'left' | 'right' | 'top' | 'bottom';
 
 type ResizeProps = {
-  widgets: AnyWidget[];
+  widgets: Widget[];
   selectedWidgetIds: string[];
   vector: Position;
   selectionBox: Rect;
 };
 
-type Resizer = (props: ResizeProps) => AnyWidget[];
+type Resizer = (props: ResizeProps) => Widget[];
 
 type ResizeWidgetsActionPayload = {
   anchor: Anchor;
-  widgets: AnyWidget[];
+  widgets: Widget[];
   vector: Position;
   complete?: boolean;
 };
+
 export interface ResizeWidgetsAction extends Action {
   type: 'RESIZE_WIDGETS';
   payload: ResizeWidgetsActionPayload;

--- a/packages/dashboard/src/store/actions/selectWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/selectWidgets/index.ts
@@ -1,13 +1,14 @@
 import { Action } from 'redux';
 import uniqBy from 'lodash/uniqBy';
 
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { DashboardState } from '../../state';
 
 type SelectWidgetsActionPayload = {
-  widgets: AnyWidget[];
+  widgets: Widget[];
   union: boolean;
 };
+
 export interface SelectWidgetsAction extends Action {
   type: 'SELECT_WIDGETS';
   payload: SelectWidgetsActionPayload;

--- a/packages/dashboard/src/store/actions/sendToBack/index.spec.ts
+++ b/packages/dashboard/src/store/actions/sendToBack/index.spec.ts
@@ -1,9 +1,9 @@
 import { sendWidgetsToBack } from '.';
-import { MockWidgetFactory, MOCK_KPI_WIDGET } from '../../../../testing/mocks';
-import { AnyWidget } from '~/types';
+import { MOCK_KPI_WIDGET, MockWidgetFactory } from '../../../../testing/mocks';
+import { Widget } from '~/types';
 import { DashboardState, initialState } from '../../state';
 
-const setupDashboardState = (widgets: AnyWidget[] = [], selectedWidgets: AnyWidget[] = []): DashboardState => ({
+const setupDashboardState = (widgets: Widget[] = [], selectedWidgets: Widget[] = []): DashboardState => ({
   ...initialState,
   dashboardConfiguration: {
     ...initialState.dashboardConfiguration,

--- a/packages/dashboard/src/store/actions/toggleReadOnly/index.spec.ts
+++ b/packages/dashboard/src/store/actions/toggleReadOnly/index.spec.ts
@@ -2,9 +2,9 @@ import { toggleReadOnly } from '.';
 import { DashboardState, initialState } from '../../state';
 
 import { MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET } from '../../../../testing/mocks';
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 
-const setupDashboardState = (widgets: AnyWidget[] = [], pasteCounter = 0): DashboardState => ({
+const setupDashboardState = (widgets: Widget[] = [], pasteCounter = 0): DashboardState => ({
   ...initialState,
   dashboardConfiguration: {
     ...initialState.dashboardConfiguration,

--- a/packages/dashboard/src/store/actions/updateWidget/index.spec.ts
+++ b/packages/dashboard/src/store/actions/updateWidget/index.spec.ts
@@ -1,10 +1,10 @@
-import { updateWidgets, onUpdateWidgetsAction } from '.';
+import { onUpdateWidgetsAction, updateWidgets } from '.';
 import { DashboardState, initialState } from '../../state';
 
-import { MockWidgetFactory, MOCK_TEXT_WIDGET } from '../../../../testing/mocks';
-import { AnyWidget } from '~/types';
+import { MOCK_TEXT_WIDGET, MockWidgetFactory } from '../../../../testing/mocks';
+import { Widget } from '~/types';
 
-const setupDashboardState = (widgets: AnyWidget[] = []): DashboardState => ({
+const setupDashboardState = (widgets: Widget[] = []): DashboardState => ({
   ...initialState,
   dashboardConfiguration: {
     ...initialState.dashboardConfiguration,

--- a/packages/dashboard/src/store/actions/updateWidget/index.ts
+++ b/packages/dashboard/src/store/actions/updateWidget/index.ts
@@ -1,13 +1,14 @@
 import { Action } from 'redux';
 
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
 import { trimWidgetPosition } from '~/util/trimWidgetPosition';
 import { DashboardState } from '../../state';
 
 type UpdateWidgetsActionPayload = {
-  widgets: AnyWidget[];
+  widgets: Widget[];
 };
+
 export interface UpdateWidgetsAction extends Action {
   type: 'UPDATE_WIDGET';
   payload: UpdateWidgetsActionPayload;

--- a/packages/dashboard/src/store/state.ts
+++ b/packages/dashboard/src/store/state.ts
@@ -1,4 +1,4 @@
-import { AnyWidget, DashboardConfiguration } from '~/types';
+import { DashboardConfiguration, Widget } from '~/types';
 
 export type DashboardState = {
   grid: {
@@ -9,8 +9,8 @@ export type DashboardState = {
     stretchToFit: boolean;
   };
   readOnly: boolean;
-  selectedWidgets: AnyWidget[];
-  copiedWidgets: AnyWidget[];
+  selectedWidgets: Widget[];
+  copiedWidgets: Widget[];
   pasteCounter: number;
   dashboardConfiguration: DashboardConfiguration;
 };

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -1,7 +1,6 @@
 import { Viewport } from '@iot-app-kit/core';
 
-//eslint-disable-next-line
-export type Widget<T extends Record<any, any>> = {
+export type Widget<T extends Record<string, unknown> = Record<string, unknown>> = {
   type: string;
   id: string;
   x: number;
@@ -12,11 +11,8 @@ export type Widget<T extends Record<any, any>> = {
   properties: T;
 };
 
-//eslint-disable-next-line
-export type AnyWidget = Widget<Record<any, any>>;
-
 export type DashboardConfiguration = {
-  widgets: AnyWidget[];
+  widgets: Widget[];
   viewport: Viewport;
 };
 

--- a/packages/dashboard/src/util/constrainWidgetPositionToGrid.ts
+++ b/packages/dashboard/src/util/constrainWidgetPositionToGrid.ts
@@ -1,6 +1,6 @@
-import { Rect, AnyWidget } from '~/types';
+import { Rect, Widget } from '~/types';
 
-export const constrainWidgetPositionToGrid = (gridRect: Rect, widget: AnyWidget): AnyWidget => ({
+export const constrainWidgetPositionToGrid = (gridRect: Rect, widget: Widget): Widget => ({
   ...widget,
   x: Math.min(gridRect.width - widget.width, Math.max(gridRect.x, widget.x)),
   y: Math.min(gridRect.height - widget.height, Math.max(gridRect.y, widget.y)),

--- a/packages/dashboard/src/util/getSelectionBox.ts
+++ b/packages/dashboard/src/util/getSelectionBox.ts
@@ -1,7 +1,7 @@
-import { Rect, AnyWidget } from '~/types';
+import { Rect, Widget } from '~/types';
 
 // Returns the smallest rectangle which can contain all the selected widgets
-export const getSelectionBox = (selectedWidgets: AnyWidget[]): Rect | null => {
+export const getSelectionBox = (selectedWidgets: Widget[]): Rect | null => {
   if (selectedWidgets.length === 0) {
     return null;
   }

--- a/packages/dashboard/src/util/select.ts
+++ b/packages/dashboard/src/util/select.ts
@@ -1,7 +1,7 @@
 import last from 'lodash/last';
 import sortBy from 'lodash/sortBy';
 
-import { AnyWidget, DashboardConfiguration, Position, Rect, Selection } from '~/types';
+import { DashboardConfiguration, Position, Rect, Selection, Widget } from '~/types';
 import { isContained } from './isContained';
 
 export const getSelectedWidgets = ({
@@ -55,7 +55,7 @@ export const pointSelect = ({
   position: Position;
   cellSize: number;
   dashboardConfiguration: DashboardConfiguration;
-}): AnyWidget | undefined => {
+}): Widget | undefined => {
   /**
    * TODO edge case where bottom most pixel on a widget does not pick up the intersection
    * and the top most pixel above a widget picks up the intersection

--- a/packages/dashboard/src/util/trimWidgetPosition.ts
+++ b/packages/dashboard/src/util/trimWidgetPosition.ts
@@ -1,6 +1,6 @@
-import { AnyWidget } from '~/types';
+import { Widget } from '~/types';
 
-export const trimWidgetPosition = (widget: AnyWidget): AnyWidget => {
+export const trimWidgetPosition = (widget: Widget): Widget => {
   return {
     ...widget,
     x: Math.round(widget.x),

--- a/packages/dashboard/testing/mocks.ts
+++ b/packages/dashboard/testing/mocks.ts
@@ -12,7 +12,7 @@ import {
 /**
  * Shared mocks for testing purposes
  */
-import { AnyWidget, DashboardConfiguration } from '../src/types';
+import { DashboardConfiguration, Widget } from '../src/types';
 
 import {
   DEMO_TURBINE_ASSET_1,
@@ -23,8 +23,8 @@ import {
 } from './siteWiseQueries';
 
 export const createMockWidget =
-  (baseWidget: AnyWidget) =>
-  (partialWidget?: Partial<AnyWidget>): AnyWidget => ({
+  (baseWidget: Widget) =>
+  (partialWidget?: Partial<Widget>): Widget => ({
     ...baseWidget,
     ...partialWidget,
     id: partialWidget?.id ?? Math.random().toFixed(20),
@@ -190,7 +190,7 @@ export const MockWidgetFactory = {
   getTextWidget: createMockWidget(MOCK_TEXT_WIDGET),
 };
 
-export const getRandomWidget = (partialWidget?: Partial<AnyWidget>): AnyWidget => {
+export const getRandomWidget = (partialWidget?: Partial<Widget>): Widget => {
   switch (random(0, 3)) {
     default:
     case 0:


### PR DESCRIPTION
## Overview
1. Update `Widget<T extends Record<any, any>>` to `Widget<T extends Record<string, unknown> = Record<string, unknown>>`
2. AnyWidget is redundent and unnecessary after the first change. Replace all `AnyWidget` with `Widget`.
3. Remove unnecessary `//eslint-disable-next-line` comment.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
