### PR TITLE
ci(e2e): speed up e2e CI by not building storybook on build

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run integration tests
         uses: cypress-io/github-action@v5
         with:
-          command: npx turbo run test:integration
+          command: npx turbo run test:integration --filter=packages/components
       # after the test run completes
       # store videos and any screenshots
       - uses: actions/upload-artifact@v1

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -17,8 +17,8 @@
     "directory": "packages/react-components"
   },
   "scripts": {
-    "build": "npm run clean && npm run compile && build-storybook",
-    "clean": "rm -rf dist",
+    "build": "npm run clean && npm run compile",
+    "clean": "rm -rf dist && rm -rf storybook-static",
     "compile": "tsc",
     "dev": "npm-watch build",
     "rollup": "rollup -c",


### PR DESCRIPTION
## Overview
Speed up CI across multiple jobs, ~40% increase in speed of e2e github action

- fix `clean` script in react-components to remove storybook artifacts
- remove unecessary storybook building on build script, preventing additional build times in CI
- scope down e2e run to prevent other packages from building

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
