### PR TITLE
feat(composer): add overlay panel config editor

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -158,6 +158,7 @@
     "react-error-boundary": "^3.1.3",
     "react-intl": "5.24.1",
     "react-markdown": "^8.0.5",
+    "rehype-sanitize": "^5.0.1",
     "string-to-arraybuffer": "1.0.2",
     "styled-components": "^5.3.0",
     "three": "^0.131.0",

--- a/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.tsx
@@ -8,6 +8,7 @@ import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { Component } from '../../../models/SceneModels';
 
 import { DataBindingMapEditor } from './data-overlay/DataBindingMapEditor';
+import { DataOverlayPanelConfigEditor } from './data-overlay/DataOverlayPanelConfigEditor';
 
 export interface IDataOverlayComponentEditorProps extends IComponentEditorProps {
   component: IDataOverlayComponentInternal;
@@ -23,6 +24,7 @@ export const DataOverlayComponentEditor: React.FC<IDataOverlayComponentEditorPro
     (state) => state.getEditorConfig().valueDataBindingProvider,
   );
   const { formatMessage } = useIntl();
+  const subtype = component.subType;
 
   const onUpdateCallback = useCallback(
     (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean) => {
@@ -46,7 +48,7 @@ export const DataOverlayComponentEditor: React.FC<IDataOverlayComponentEditorPro
             row.rowType === Component.DataOverlayRowType.Markdown && (
               <FormField
                 key={index}
-                label={formatMessage({ defaultMessage: 'Markdown content', description: 'FormField label' })}
+                label={formatMessage({ defaultMessage: 'Markdown Content', description: 'FormField label' })}
               >
                 <Textarea
                   value={row.content}
@@ -59,6 +61,9 @@ export const DataOverlayComponentEditor: React.FC<IDataOverlayComponentEditorPro
               </FormField>
             ),
         )}
+      {subtype === Component.DataOverlaySubType.OverlayPanel && (
+        <DataOverlayPanelConfigEditor config={component.config} onUpdateCallback={onUpdateCallback} />
+      )}
     </SpaceBetween>
   );
 };

--- a/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditorSnap.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditorSnap.spec.tsx
@@ -17,6 +17,15 @@ jest.mock('./data-overlay/DataBindingMapEditor', () => {
     },
   };
 });
+jest.mock('./data-overlay/DataOverlayPanelConfigEditor', () => {
+  const originalModule = jest.requireActual('./data-overlay/DataOverlayPanelConfigEditor');
+  return {
+    ...originalModule,
+    DataOverlayPanelConfigEditor: (...props: unknown[]) => {
+      return <div data-testid='DataOverlayPanelConfigEditor'>{JSON.stringify(props)}</div>;
+    },
+  };
+});
 
 describe('DataOverlayComponentEditor', () => {
   const component: IDataOverlayComponentInternal = {
@@ -47,10 +56,23 @@ describe('DataOverlayComponentEditor', () => {
     getEditorConfig: jest.fn().mockReturnValue({ valueDataBindingProvider: mockProvider }),
   };
 
-  it('should render data rows', async () => {
+  it('should render data rows for text annotation', async () => {
     useStore('default').setState(baseState);
 
     const { container } = render(<DataOverlayComponentEditor node={node} component={component} />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render editor for overlay panel', async () => {
+    useStore('default').setState(baseState);
+
+    const { container } = render(
+      <DataOverlayComponentEditor
+        node={node}
+        component={{ ...component, subType: Component.DataOverlaySubType.OverlayPanel }}
+      />,
+    );
 
     expect(container).toMatchSnapshot();
   });

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/DataOverlayComponentEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/DataOverlayComponentEditorSnap.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DataOverlayComponentEditor should render data rows 1`] = `
+exports[`DataOverlayComponentEditor should render data rows for text annotation 1`] = `
 <div>
   <div
     data-mocked="SpaceBetween"
@@ -12,12 +12,40 @@ exports[`DataOverlayComponentEditor should render data rows 1`] = `
     </div>
     <div
       data-mocked="FormField"
-      label="Markdown content"
+      label="Markdown Content"
     >
       <div
         data-mocked="Textarea"
         value="markdown-content"
       />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataOverlayComponentEditor should render editor for overlay panel 1`] = `
+<div>
+  <div
+    data-mocked="SpaceBetween"
+  >
+    <div
+      data-testid="DataBindingMapEditor"
+    >
+      [{"valueDataBindingProvider":{},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"markdown-content"}],"valueDataBindings":[{"bindingName":"binding-1","valueDataBinding":{"dataBindingContext":"random-1"}}]}},{}]
+    </div>
+    <div
+      data-mocked="FormField"
+      label="Markdown Content"
+    >
+      <div
+        data-mocked="Textarea"
+        value="markdown-content"
+      />
+    </div>
+    <div
+      data-testid="DataOverlayPanelConfigEditor"
+    >
+      [{},{}]
     </div>
   </div>
 </div>

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataOverlayPanelConfigEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataOverlayPanelConfigEditor.spec.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import wrapper from '@awsui/components-react/test-utils/dom';
+
+import { DataOverlayPanelConfigEditor } from './DataOverlayPanelConfigEditor';
+
+jest.mock('@awsui/components-react', () => ({
+  ...jest.requireActual('@awsui/components-react'),
+}));
+
+describe('DataOverlayPanelConfigEditor', () => {
+  const config = {
+    isPinned: true,
+  };
+  const onUpdateCallbackMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should update when clicking checkbox', async () => {
+    const { container } = render(
+      <DataOverlayPanelConfigEditor config={config} onUpdateCallback={onUpdateCallbackMock} />,
+    );
+    const polarisWrapper = wrapper(container);
+
+    const pinnedCheckbox = polarisWrapper.findCheckbox('[data-testid="pinned-checkbox"]');
+    expect(pinnedCheckbox).not.toBeNull();
+
+    act(() => {
+      pinnedCheckbox!.findNativeInput().click();
+    });
+
+    expect(onUpdateCallbackMock).toBeCalledTimes(1);
+    expect(onUpdateCallbackMock).toBeCalledWith(
+      {
+        config: { isPinned: false },
+      },
+      false,
+    );
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataOverlayPanelConfigEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataOverlayPanelConfigEditor.tsx
@@ -1,0 +1,33 @@
+import React, { useCallback } from 'react';
+import { Checkbox, FormField } from '@awsui/components-react';
+import { useIntl } from 'react-intl';
+
+import { IDataOverlayComponentInternal } from '../../../../store';
+import { Component } from '../../../../models/SceneModels';
+
+interface IDataOverlayPanelConfigEditorProps {
+  config: Component.OverlayPanelConfig | undefined;
+  onUpdateCallback: (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean | undefined) => void;
+}
+
+export const DataOverlayPanelConfigEditor: React.FC<IDataOverlayPanelConfigEditorProps> = ({
+  config,
+  onUpdateCallback,
+}) => {
+  const { formatMessage } = useIntl();
+
+  const onPinnedChange = useCallback(
+    ({ detail: { checked } }) => {
+      onUpdateCallback({ config: { isPinned: checked } }, false);
+    },
+    [onUpdateCallback],
+  );
+
+  return (
+    <FormField label={formatMessage({ defaultMessage: 'Panel Config', description: 'FormField label' })}>
+      <Checkbox data-testid='pinned-checkbox' checked={config?.isPinned === true} onChange={onPinnedChange}>
+        {formatMessage({ defaultMessage: 'Open by default', description: 'checkbox option' })}
+      </Checkbox>
+    </FormField>
+  );
+};

--- a/packages/scene-composer/src/components/wrappers/ReactMarkdownWrapper.tsx
+++ b/packages/scene-composer/src/components/wrappers/ReactMarkdownWrapper.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import ReactMarkdown from 'react-markdown';
+import rehypeSanitize from 'rehype-sanitize';
 
 import './ReactMarkdownWrapper.scss';
 
@@ -9,7 +10,12 @@ export interface ReactMarkdownWrapperProps {
 }
 export const ReactMarkdownWrapper: FC<ReactMarkdownWrapperProps> = ({ content, className }) => {
   return (
-    <ReactMarkdown skipHtml className={`markdown-wrapper ${className}`} linkTarget='_blank'>
+    <ReactMarkdown
+      skipHtml
+      className={`markdown-wrapper ${className}`}
+      linkTarget='_blank'
+      rehypePlugins={[rehypeSanitize]}
+    >
       {content}
     </ReactMarkdown>
   );

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -551,6 +551,10 @@
     "note": "Form Field label",
     "text": "Decay"
   },
+  "fLNO7R": {
+    "note": "FormField label",
+    "text": "Panel Config"
+  },
   "fOCzxm": {
     "note": "Form Field label",
     "text": "Component Name"
@@ -558,6 +562,10 @@
   "fOhk5w": {
     "note": "Menu Item",
     "text": "3D Pan"
+  },
+  "fWrngr": {
+    "note": "FormField label",
+    "text": "Markdown Content"
   },
   "fdMW6X": {
     "note": "FormField label",
@@ -643,6 +651,10 @@
     "note": "Warning message",
     "text": "Warning"
   },
+  "lbVroy": {
+    "note": "checkbox option",
+    "text": "Open by default"
+  },
   "lbd69l": {
     "note": "Menu Item",
     "text": "Add light"
@@ -650,10 +662,6 @@
   "lnTuMX": {
     "note": "label",
     "text": "Selected"
-  },
-  "lxQp5c": {
-    "note": "FormField label",
-    "text": "Markdown content"
   },
   "mhM85K": {
     "note": "Form Field label",


### PR DESCRIPTION
## Overview
Add checkbox to control `isPinned` value for data overlay panel

<img width="1109" alt="overlay-panel-config-editor" src="https://user-images.githubusercontent.com/9315598/225175065-31826795-5729-4a43-8c28-a79ff9fd300d.png">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
