### PR TITLE
fix(composer): temporarily remove view cursor svg

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/viewpoint/ViewCursorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/viewpoint/ViewCursorWidget.tsx
@@ -16,7 +16,9 @@ export const ViewCursorWidget = () => {
   const { addingWidget, cursorVisible, cursorStyle, setAddingWidget, setCursorVisible, setCursorStyle } =
     useEditorState(sceneComposerId);
   const svg = cursorStyle === 'edit' ? ViewCursorEditSvgString : ViewCursorMoveSvgString;
-  const data = useLoader(SVGLoader, getDataUri(svg));
+  // TODO: fix loading view cursor SVG
+  // const data = useLoader(SVGLoader, getDataUri(svg));
+  const data = useLoader(SVGLoader, '');
 
   const esc = useCallback(() => {
     window.addEventListener('keyup', (e: KeyboardEvent) => {


### PR DESCRIPTION
## Overview
View cursor svg is not rendered properly and will cause error in console. This change is to remove the svg for now, and fix for the svg will be in a different task.

There is no UI change by this PR since the cursor svg is not rendered correctly without this change.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
