### PR TITLE
fix(dashboard): remove widget background color

### DIFF
--- a/packages/dashboard/src/components/widgets/widget.css
+++ b/packages/dashboard/src/components/widgets/widget.css
@@ -2,7 +2,6 @@
 
 .widget {
   position: absolute;
-  background-color: var(--selection-bg-color);
   height: 100%;
   user-select: none;
   box-sizing: border-box;


### PR DESCRIPTION
## Overview
Set all widgets to have no background color by default. Fixes #651.
<img width="369" alt="image" src="https://user-images.githubusercontent.com/11740421/225389894-ac0df7fb-3bbe-407b-bb19-c2ecb04485e6.png">

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
