### PR TITLE
build(publish): manually setup for a nightly release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,52 +28,53 @@ jobs:
         with:
           package: './packages/core/package.json'
           token: ${{ secrets.NPM_TOKEN }}
+          tag: 'nightly'
 
       - name: Publish @iot-app-kit/components
         uses: JS-DevTools/npm-publish@v1
         with:
           package: './packages/components/package.json'
           token: ${{ secrets.NPM_TOKEN }}
+          tag: 'nightly'
 
       - name: Publish @iot-app-kit/source-iotsitewise
         uses: JS-DevTools/npm-publish@v1
         with:
           package: './packages/source-iotsitewise/package.json'
           token: ${{ secrets.NPM_TOKEN }}
+          tag: 'nightly'
 
       - name: Publish @iot-app-kit/related-table
         uses: JS-DevTools/npm-publish@v1
         with:
           package: './packages/related-table/package.json'
           token: ${{ secrets.NPM_TOKEN }}
+          tag: 'nightly'
 
       - name: Publish @iot-app-kit/react-components
         uses: JS-DevTools/npm-publish@v1
         with:
           package: './packages/react-components/package.json'
           token: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish @iot-app-kit/table
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          package: './packages/table/package.json'
-          token: ${{ secrets.NPM_TOKEN }}
+          tag: 'nightly'
 
       - name: Publish @iot-app-kit/source-iottwinmaker
         uses: JS-DevTools/npm-publish@v1
         with:
           package: './packages/source-iottwinmaker/package.json'
           token: ${{ secrets.NPM_TOKEN }}
+          tag: 'nightly'
 
       - name: Publish @iot-app-kit/dashboard
         uses: JS-DevTools/npm-publish@v1
         with:
           package: './packages/dashboard/package.json'
           token: ${{ secrets.NPM_TOKEN }}
-          tag: 'alpha'
+          tag: 'nightly'
 
       - name: Publish @iot-app-kit/scene-composer
         uses: JS-DevTools/npm-publish@v1
         with:
           package: './packages/scene-composer/package.json'
           token: ${{ secrets.NPM_TOKEN }}
+          tag: 'nightly'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,8 @@ jobs:
         id: release
         with:
           command: manifest
+          prerelease: true
+          release-as: 3.0.1-nightly
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
 


### PR DESCRIPTION
## Overview
Set up a pre-release in a semi-manual fashion.

pre-release is not well supported by release please, to unblock the sharing of development versions, this will release a `@nightly` tagged with versions set to 3.0.1-nightly.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
