### PR TITLE
fix(ci): allow releases to be trigged via changes to github workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,8 @@ on:
       - main
     paths:
     - 'packages/**'
-name: release-please
+    - '.github/workflows/*'
+name: Create release PR
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Overview
Allow release please based release to occur via changes to github workflows. This is important as we can then trigger release by simply altering the 'release as' setting.


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
