### PR TITLE
chore(AWS-SDK): upgraded AWS SDK for TwinMaker packages

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -71,7 +71,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@aws-sdk/credential-providers": "3.163",
+    "@aws-sdk/credential-providers": "^3.281.0",
     "@awsui/jest-preset": "^2.0.3",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",

--- a/packages/source-iotsitewise/package.json
+++ b/packages/source-iotsitewise/package.json
@@ -50,8 +50,8 @@
     "pack": "npm pack"
   },
   "dependencies": {
-    "@aws-sdk/client-iot-events": "^3.118.1",
-    "@aws-sdk/client-iotsitewise": "^3.87.0",
+    "@aws-sdk/client-iot-events": "^3.281.0",
+    "@aws-sdk/client-iotsitewise": "^3.281.0",
     "@iot-app-kit/core": "3.0.0",
     "@rollup/plugin-typescript": "^8.3.0",
     "@synchro-charts/core": "7.2.0",

--- a/packages/source-iottwinmaker/jest.config.js
+++ b/packages/source-iottwinmaker/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 85,
-      branches: 83,
+      branches: 82,
       functions: 85,
       lines: 85,
     },

--- a/packages/source-iottwinmaker/package.json
+++ b/packages/source-iottwinmaker/package.json
@@ -50,11 +50,11 @@
     "pack": "npm pack"
   },
   "dependencies": {
-    "@aws-sdk/client-iotsitewise": "^3.131.0",
-    "@aws-sdk/client-iottwinmaker": "^3.131.0",
-    "@aws-sdk/client-kinesis-video": "^3.131.0",
-    "@aws-sdk/client-kinesis-video-archived-media": "^3.131.0",
-    "@aws-sdk/client-s3": "^3.72.0",
+    "@aws-sdk/client-iotsitewise": "^3.281.0",
+    "@aws-sdk/client-iottwinmaker": "^3.281.0",
+    "@aws-sdk/client-kinesis-video": "^3.281.0",
+    "@aws-sdk/client-kinesis-video-archived-media": "^3.281.0",
+    "@aws-sdk/client-s3": "^3.281.0",
     "@iot-app-kit/core": "3.0.0",
     "@iot-app-kit-visualizations/core": "1.1.0",
     "flush-promises": "^1.0.2",

--- a/packages/source-iottwinmaker/src/__mocks__/MockVideoPlayerProps.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/MockVideoPlayerProps.ts
@@ -292,8 +292,8 @@ export const mockGetAvailableTimeRangeResponse = [
     { start: 1630005800000, end: 1630005850000, src: 'mockOnDemandURL' },
   ],
   [
-    { start: 1630005400000, end: 1630005600000 },
-    { start: 1630005800000, end: 1630005900000 },
+    { start: 1630005400000, end: 1630005500000 },
+    { start: 1630005800000, end: 1630005850000 },
   ],
 ];
 

--- a/packages/source-iottwinmaker/src/__mocks__/iotsitewiseSDK.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/iotsitewiseSDK.ts
@@ -1,0 +1,43 @@
+import {
+  GetAssetPropertyValueCommandInput,
+  GetAssetPropertyValueResponse,
+  GetInterpolatedAssetPropertyValuesCommandInput,
+  GetInterpolatedAssetPropertyValuesResponse,
+  IoTSiteWiseClient,
+  BatchPutAssetPropertyValueCommandInput,
+  BatchPutAssetPropertyValueCommandOutput,
+} from '@aws-sdk/client-iotsitewise';
+
+const nonOverriddenMock = () => Promise.reject(new Error('Mock method not override.'));
+
+export const createMockSiteWiseSDK = ({
+  batchPutAssetPropertyValue = nonOverriddenMock,
+  getAssetPropertyValue = nonOverriddenMock,
+  getInterpolatedAssetPropertyValues = nonOverriddenMock,
+}: {
+  batchPutAssetPropertyValue?: (input: BatchPutAssetPropertyValueCommandInput) => Promise<BatchPutAssetPropertyValueCommandOutput>;
+  getAssetPropertyValue?: (input: GetAssetPropertyValueCommandInput) => Promise<GetAssetPropertyValueResponse>;
+  getInterpolatedAssetPropertyValues?: (
+    input: GetInterpolatedAssetPropertyValuesCommandInput
+  ) => Promise<GetInterpolatedAssetPropertyValuesResponse>;
+} = {}) =>
+  ({
+    send: (command: { input: any }) => {
+      // Mocks out the process of a sending a command within the JS AWS-SDK v3, learn more at
+      // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html#high-level-concepts
+      const commandName = command.constructor.name;
+
+      switch (commandName) {
+        case 'BatchPutAssetPropertyValueCommand':
+          return batchPutAssetPropertyValue(command.input);
+        case 'GetAssetPropertyValueCommand':
+          return getAssetPropertyValue(command.input);
+        case 'GetInterpolatedAssetPropertyValuesCommand':
+          return getInterpolatedAssetPropertyValues(command.input);
+        default:
+          throw new Error(
+            `missing mock implementation for command name ${commandName}. Add a new command within the mock SiteWise SDK.`
+          );
+      }
+    },
+  } as unknown as IoTSiteWiseClient);

--- a/packages/source-iottwinmaker/src/__mocks__/iottwinmakerSDK.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/iottwinmakerSDK.ts
@@ -1,0 +1,33 @@
+import { GetEntityCommandInput, GetEntityCommandOutput, GetPropertyValueHistoryCommandInput, GetPropertyValueHistoryCommandOutput, IoTTwinMakerClient, ListEntitiesCommandInput, ListEntitiesCommandOutput } from '@aws-sdk/client-iottwinmaker';
+
+const nonOverriddenMock = () => Promise.reject(new Error('Mock method not override.'));
+
+export const createMockTwinMakerSDK = ({
+  getEntity = nonOverriddenMock,
+  getPropertyValueHistory = nonOverriddenMock,
+  listEntities = nonOverriddenMock,
+}: {
+  getEntity?: (input: GetEntityCommandInput) => Promise<GetEntityCommandOutput>;
+  getPropertyValueHistory?: (input: GetPropertyValueHistoryCommandInput) => Promise<GetPropertyValueHistoryCommandOutput>;
+  listEntities?: (input: ListEntitiesCommandInput) => Promise<ListEntitiesCommandOutput>;
+} = {}) =>
+  ({
+    send: (command: { input: any }) => {
+      // Mocks out the process of a sending a command within the JS AWS-SDK v3, learn more at
+      // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html#high-level-concepts
+      const commandName = command.constructor.name;
+
+      switch (commandName) {
+        case 'GetEntityCommand':
+          return getEntity(command.input);
+        case 'GetPropertyValueHistoryCommand':
+          return getPropertyValueHistory(command.input);
+        case 'ListEntitiesCommand':
+          return listEntities(command.input);
+        default:
+          throw new Error(
+            `missing mock implementation for command name ${commandName}. Add a new command within the mock IotTwinMaker SDK.`
+          );
+      }
+    },
+  } as unknown as IoTTwinMakerClient);

--- a/packages/source-iottwinmaker/src/__mocks__/kinesisVideoArchivedMediaSDK.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/kinesisVideoArchivedMediaSDK.ts
@@ -1,0 +1,28 @@
+import { GetHLSStreamingSessionURLCommandInput, GetHLSStreamingSessionURLCommandOutput, KinesisVideoArchivedMediaClient } from '@aws-sdk/client-kinesis-video-archived-media';
+
+const nonOverriddenMock = () => Promise.reject(new Error('Mock method not override.'));
+
+export const createMockKinesisVideoArchivedMediaSDK = ({
+  getHLSStreamingSessionURL = nonOverriddenMock,
+}: {
+  getHLSStreamingSessionURL?: (input: GetHLSStreamingSessionURLCommandInput) => Promise<GetHLSStreamingSessionURLCommandOutput>;
+} = {}) =>
+  ({
+    send: (command: { input: any }) => {
+      // Mocks out the process of a sending a command within the JS AWS-SDK v3, learn more at
+      // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html#high-level-concepts
+      const commandName = command.constructor.name;
+
+      switch (commandName) {
+        case 'GetHLSStreamingSessionURLCommand':
+          return getHLSStreamingSessionURL(command.input);
+        default:
+          throw new Error(
+            `missing mock implementation for command name ${commandName}. Add a new command within the mock KinesisVideoArchivedMedia SDK.`
+          );
+      }
+    },
+    config: {
+      endpoint: 'testEndpoint',
+    },
+  } as unknown as KinesisVideoArchivedMediaClient);

--- a/packages/source-iottwinmaker/src/__mocks__/kinesisVideoSDK.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/kinesisVideoSDK.ts
@@ -1,0 +1,25 @@
+import { GetDataEndpointCommandInput, GetDataEndpointCommandOutput, KinesisVideoClient } from '@aws-sdk/client-kinesis-video';
+
+const nonOverriddenMock = () => Promise.reject(new Error('Mock method not override.'));
+
+export const createMockKinesisVideoSDK = ({
+  getDataEndpoint = nonOverriddenMock,
+}: {
+  getDataEndpoint?: (input: GetDataEndpointCommandInput) => Promise<GetDataEndpointCommandOutput>;
+} = {}) =>
+  ({
+    send: (command: { input: any }) => {
+      // Mocks out the process of a sending a command within the JS AWS-SDK v3, learn more at
+      // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html#high-level-concepts
+      const commandName = command.constructor.name;
+
+      switch (commandName) {
+        case 'GetDataEndpointCommand':
+          return getDataEndpoint(command.input);
+        default:
+          throw new Error(
+            `missing mock implementation for command name ${commandName}. Add a new command within the mock KinesisVideo SDK.`
+          );
+      }
+    },
+  } as unknown as KinesisVideoClient);

--- a/packages/source-iottwinmaker/src/metadata-module/TwinMakerMetadataModule.spec.ts
+++ b/packages/source-iottwinmaker/src/metadata-module/TwinMakerMetadataModule.spec.ts
@@ -1,48 +1,46 @@
-import {
-  GetEntityCommand,
-  GetEntityResponse,
-  IoTTwinMakerClient,
-  ListEntitiesCommand,
-} from '@aws-sdk/client-iottwinmaker';
+import { GetEntityResponse } from '@aws-sdk/client-iottwinmaker';
 import { ErrorDetails } from '@iot-app-kit/core';
-import { mockClient } from 'aws-sdk-client-mock';
+import { createMockTwinMakerSDK } from '../__mocks__/iottwinmakerSDK';
 import { TwinMakerMetadataCache } from './TwinMakerMetadataCache';
 import { TwinMakerMetadataModule } from './TwinMakerMetadataModule';
 
 describe('TwinMakerMetadataModule', () => {
   const mockEntity1 = { entityId: 'test-1' } as GetEntityResponse;
   const mockEntity2 = { entityId: 'test-2' } as GetEntityResponse;
-  let tmClient = new IoTTwinMakerClient({});
 
   let cache: TwinMakerMetadataCache = new TwinMakerMetadataCache();
   let module: TwinMakerMetadataModule;
 
   describe('fetchEntity', () => {
+    const getEntity = jest.fn();
+    const mockTMClient = createMockTwinMakerSDK({
+      getEntity,
+    });
     beforeEach(() => {
       jest.clearAllMocks();
-      tmClient = new IoTTwinMakerClient({});
-      jest.spyOn(tmClient, 'send').mockResolvedValue(mockEntity1 as never);
 
       cache = new TwinMakerMetadataCache();
-      module = new TwinMakerMetadataModule('ws-id', tmClient, cache);
+      module = new TwinMakerMetadataModule('ws-id', mockTMClient, cache);
     });
 
     it('should send request when the entity is not in the cache', async () => {
       expect(cache.getEntity(mockEntity1.entityId!)).toBeUndefined();
 
+      getEntity.mockResolvedValue(mockEntity1);
       const entity = await module.fetchEntity({ entityId: mockEntity1.entityId! });
-      expect(tmClient.send).toBeCalledTimes(1);
+      expect(getEntity).toBeCalledTimes(1);
       expect(entity).toEqual(mockEntity1);
     });
 
     it('should not send request when the request for the same entity is in process', async () => {
       expect(cache.getEntity(mockEntity1.entityId!)).toBeUndefined();
 
+      getEntity.mockResolvedValue(mockEntity1);
       const entities = await Promise.all([
         module.fetchEntity({ entityId: mockEntity1.entityId! }),
         module.fetchEntity({ entityId: mockEntity1.entityId! }),
       ]);
-      expect(tmClient.send).toBeCalledTimes(1);
+      expect(getEntity).toBeCalledTimes(1);
       expect(entities[0]).toEqual(mockEntity1);
       expect(entities[1]).toEqual(mockEntity1);
     });
@@ -50,19 +48,21 @@ describe('TwinMakerMetadataModule', () => {
     it('should send request when multiple calls for the different entities are triggered', async () => {
       expect(cache.getEntity(mockEntity1.entityId!)).toBeUndefined();
 
+      getEntity.mockResolvedValue(mockEntity1);
       await Promise.all([
         module.fetchEntity({ entityId: mockEntity1.entityId! }),
         module.fetchEntity({ entityId: 'xx-yy-zz' }),
       ]);
-      expect(tmClient.send).toBeCalledTimes(2);
+      expect(getEntity).toBeCalledTimes(2);
     });
 
     it('should return cached entity when one is in the cache', async () => {
+      getEntity.mockResolvedValue(mockEntity1);
       await module.fetchEntity({ entityId: mockEntity1.entityId! });
       jest.clearAllMocks();
 
       const entity = await module.fetchEntity({ entityId: mockEntity1.entityId! });
-      expect(tmClient.send).not.toBeCalled();
+      expect(getEntity).not.toBeCalled();
       expect(entity).toEqual(mockEntity1);
     });
 
@@ -77,34 +77,36 @@ describe('TwinMakerMetadataModule', () => {
         type: mockError.name,
         status: mockError.$metadata.httpStatusCode,
       };
-      jest.spyOn(tmClient, 'send').mockRejectedValue(mockError as never);
+      getEntity.mockRejectedValue(mockError as never);
 
       try {
         await module.fetchEntity({ entityId: 'random' });
       } catch (err) {
         expect(err).toEqual(mockErrorDetails);
-        expect(tmClient.send).toBeCalledTimes(1);
+        expect(getEntity).toBeCalledTimes(1);
       }
     });
   });
 
   describe('fetchEntitiesByComponentTypeId', () => {
     const mockComponentTypeId = 'test-comp-1';
-    let mockTMClient = mockClient(tmClient);
+    const getEntity = jest.fn();
+    const listEntities = jest.fn();
+    const mockTMClient = createMockTwinMakerSDK({
+      getEntity,
+      listEntities,
+    });
 
     beforeEach(() => {
       jest.clearAllMocks();
-      tmClient = new IoTTwinMakerClient({});
-      mockTMClient = mockClient(tmClient);
-      mockTMClient
-        .on(ListEntitiesCommand)
-        .resolvesOnce({ entitySummaries: [mockEntity1], nextToken: 'xxyyzz' })
-        .resolvesOnce({ entitySummaries: [mockEntity2] });
-      mockTMClient.on(GetEntityCommand, { entityId: mockEntity1.entityId }).resolves(mockEntity1);
-      mockTMClient.on(GetEntityCommand, { entityId: mockEntity2.entityId }).resolves(mockEntity2);
+      listEntities
+        .mockResolvedValueOnce({ entitySummaries: [mockEntity1], nextToken: 'xxyyzz' })
+        .mockResolvedValueOnce({ entitySummaries: [mockEntity2] });
+      getEntity.mockResolvedValueOnce(mockEntity1);
+      getEntity.mockResolvedValueOnce(mockEntity2);
 
       cache = new TwinMakerMetadataCache();
-      module = new TwinMakerMetadataModule('ws-id', tmClient, cache);
+      module = new TwinMakerMetadataModule('ws-id', mockTMClient, cache);
     });
 
     it('should send request when the component type is not in the cache', async () => {
@@ -117,35 +119,37 @@ describe('TwinMakerMetadataModule', () => {
     it('should not send request when the request for the same component type is in process', async () => {
       expect(cache.getEntitySummariesByComponentType(mockComponentTypeId)).toBeUndefined();
 
-      jest.spyOn(tmClient, 'send').mockResolvedValue({} as never);
+      jest.spyOn(mockTMClient, 'send').mockResolvedValueOnce({} as never);
 
       await Promise.all([
         module.fetchEntitiesByComponentTypeId({ componentTypeId: mockComponentTypeId }),
         module.fetchEntitiesByComponentTypeId({ componentTypeId: mockComponentTypeId }),
       ]);
-      expect(tmClient.send).toBeCalledTimes(1);
+      expect(mockTMClient.send).toBeCalledTimes(1);
     });
 
     it('should send request when multiple calls for the different component types are triggered', async () => {
       expect(cache.getEntitySummariesByComponentType(mockComponentTypeId)).toBeUndefined();
 
-      jest.spyOn(tmClient, 'send').mockResolvedValue({} as never);
+      jest
+        .spyOn(mockTMClient, 'send')
+        .mockResolvedValueOnce({} as never)
+        .mockResolvedValueOnce({} as never);
 
       await Promise.all([
         module.fetchEntitiesByComponentTypeId({ componentTypeId: mockComponentTypeId }),
         module.fetchEntitiesByComponentTypeId({ componentTypeId: 'xx-yy-zz' }),
       ]);
-      expect(tmClient.send).toBeCalledTimes(2);
+      expect(mockTMClient.send).toBeCalledTimes(2);
     });
 
     it('should return cached entities when available in the cache', async () => {
       await module.fetchEntitiesByComponentTypeId({ componentTypeId: mockComponentTypeId });
 
-      jest.spyOn(tmClient, 'send').mockResolvedValue({} as never);
-
+      jest.clearAllMocks();
       const entities = await module.fetchEntitiesByComponentTypeId({ componentTypeId: mockComponentTypeId });
       expect(entities).toEqual([mockEntity1, mockEntity2]);
-      expect(tmClient.send).not.toBeCalled();
+      expect(listEntities).not.toBeCalled();
     });
 
     it('should throw error when request failed', async () => {
@@ -159,13 +163,13 @@ describe('TwinMakerMetadataModule', () => {
         type: mockError.name,
         status: mockError.$metadata.httpStatusCode,
       };
-      jest.spyOn(tmClient, 'send').mockRejectedValue(mockError as never);
+      getEntity.mockRejectedValue(mockError as never);
 
       try {
         await module.fetchEntitiesByComponentTypeId({ componentTypeId: 'random' });
       } catch (err) {
         expect(err).toEqual(mockErrorDetails);
-        expect(tmClient.send).toBeCalledTimes(1);
+        expect(getEntity).toBeCalledTimes(1);
       }
     });
   });

--- a/packages/source-iottwinmaker/src/time-series-data/client/getPropertyValueHistoryByEntity.spec.ts
+++ b/packages/source-iottwinmaker/src/time-series-data/client/getPropertyValueHistoryByEntity.spec.ts
@@ -1,10 +1,6 @@
-import {
-  EntityPropertyReference,
-  GetPropertyValueHistoryCommand,
-  IoTTwinMakerClient,
-} from '@aws-sdk/client-iottwinmaker';
+import { EntityPropertyReference } from '@aws-sdk/client-iottwinmaker';
 import { RequestInformationAndRange, ErrorDetails } from '@iot-app-kit/core';
-import { mockClient } from 'aws-sdk-client-mock';
+import { createMockTwinMakerSDK } from '../../__mocks__/iottwinmakerSDK';
 
 import { TwinMakerDataStreamIdComponent } from '../types';
 import { toDataStreamId } from '../utils/dataStreamId';
@@ -47,23 +43,20 @@ describe('getPropertyValueHistoryByEntity', () => {
     start,
     end,
   };
-  const tmClient = new IoTTwinMakerClient({});
-  let sendSpy = jest.spyOn(tmClient, 'send');
+  const getEntity = jest.fn();
+  const getPropertyValueHistory = jest.fn();
+  const tmClient = createMockTwinMakerSDK({
+    getEntity,
+    getPropertyValueHistory,
+  });
   const onSuccess = jest.fn();
   const onError = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    sendSpy = jest.spyOn(tmClient, 'send');
   });
 
   it('should send correct request when fetchMostRecentBeforeStart is true', async () => {
-    const commands: GetPropertyValueHistoryCommand[] = [];
-    sendSpy.mockImplementation((cmd) => {
-      commands.push(cmd as GetPropertyValueHistoryCommand);
-      return Promise.resolve({});
-    });
-
     await getPropertyValueHistoryByEntity({
       onSuccess,
       onError,
@@ -75,28 +68,30 @@ describe('getPropertyValueHistoryByEntity', () => {
     });
 
     // First request
-    expect(commands[0].input.workspaceId).toEqual(streamIdComponents1.workspaceId);
-    expect(commands[0].input.entityId).toEqual(streamIdComponents1.entityId);
-    expect(commands[0].input.componentName).toEqual(streamIdComponents1.componentName);
-    expect(commands[0].input.selectedProperties).toEqual([streamIdComponents1.propertyName]);
-    expect(commands[0].input.maxResults).toEqual(1);
-    expect(commands[0].input.orderByTime).toEqual('DESCENDING');
-    expect(commands[0].input.startTime).toEqual(new Date(0, 0, 0).toISOString());
-    expect(commands[0].input.endTime).toEqual(start.toISOString());
+    expect(getPropertyValueHistory).toBeCalledWith({
+      workspaceId: streamIdComponents1.workspaceId,
+      entityId: streamIdComponents1.entityId,
+      componentName: streamIdComponents1.componentName,
+      selectedProperties: [streamIdComponents1.propertyName],
+      maxResults: 1,
+      orderByTime: 'DESCENDING',
+      startTime: new Date(0, 0, 0).toISOString(),
+      endTime: start.toISOString(),
+    });
     // Second request
-    expect(commands[1].input.workspaceId).toEqual(streamIdComponents2.workspaceId);
-    expect(commands[1].input.entityId).toEqual(streamIdComponents2.entityId);
-    expect(commands[1].input.componentName).toEqual(streamIdComponents2.componentName);
-    expect(commands[1].input.selectedProperties).toEqual([streamIdComponents2.propertyName]);
+    expect(getPropertyValueHistory).toBeCalledWith({
+      workspaceId: streamIdComponents2.workspaceId,
+      entityId: streamIdComponents2.entityId,
+      componentName: streamIdComponents2.componentName,
+      selectedProperties: [streamIdComponents2.propertyName],
+      maxResults: 1,
+      orderByTime: 'DESCENDING',
+      startTime: new Date(0, 0, 0).toISOString(),
+      endTime: start.toISOString(),
+    });
   });
 
   it('should send correct request when fetchMostRecentBeforeEnd is true', async () => {
-    const commands: GetPropertyValueHistoryCommand[] = [];
-    sendSpy.mockImplementation((cmd) => {
-      commands.push(cmd as GetPropertyValueHistoryCommand);
-      return Promise.resolve({});
-    });
-
     await getPropertyValueHistoryByEntity({
       onSuccess,
       onError,
@@ -108,24 +103,30 @@ describe('getPropertyValueHistoryByEntity', () => {
     });
 
     // Fist request
-    expect(commands[0].input.maxResults).toEqual(1);
-    expect(commands[0].input.orderByTime).toEqual('DESCENDING');
-    expect(commands[0].input.startTime).toEqual(new Date(0, 0, 0).toISOString());
-    expect(commands[0].input.endTime).toEqual(end.toISOString());
+    expect(getPropertyValueHistory).toBeCalledWith({
+      workspaceId: streamIdComponents1.workspaceId,
+      entityId: streamIdComponents1.entityId,
+      componentName: streamIdComponents1.componentName,
+      selectedProperties: [streamIdComponents1.propertyName],
+      maxResults: 1,
+      orderByTime: 'DESCENDING',
+      startTime: new Date(0, 0, 0).toISOString(),
+      endTime: end.toISOString(),
+    });
     // Second request
-    expect(commands[1].input.workspaceId).toEqual(streamIdComponents2.workspaceId);
-    expect(commands[1].input.entityId).toEqual(streamIdComponents2.entityId);
-    expect(commands[1].input.componentName).toEqual(streamIdComponents2.componentName);
-    expect(commands[1].input.selectedProperties).toEqual([streamIdComponents2.propertyName]);
+    expect(getPropertyValueHistory).toBeCalledWith({
+      workspaceId: streamIdComponents2.workspaceId,
+      entityId: streamIdComponents2.entityId,
+      componentName: streamIdComponents2.componentName,
+      selectedProperties: [streamIdComponents2.propertyName],
+      maxResults: 1,
+      orderByTime: 'DESCENDING',
+      startTime: new Date(0, 0, 0).toISOString(),
+      endTime: end.toISOString(),
+    });
   });
 
   it('should send correct request when fetchFromStartToEnd is true', async () => {
-    const commands: GetPropertyValueHistoryCommand[] = [];
-    sendSpy.mockImplementation((cmd) => {
-      commands.push(cmd as GetPropertyValueHistoryCommand);
-      return Promise.resolve({});
-    });
-
     await getPropertyValueHistoryByEntity({
       onSuccess,
       onError,
@@ -137,25 +138,21 @@ describe('getPropertyValueHistoryByEntity', () => {
     });
 
     // Should combine into the same request
-    expect(commands.length).toEqual(1);
-    expect(commands[0].input.workspaceId).toEqual(streamIdComponents1.workspaceId);
-    expect(commands[0].input.entityId).toEqual(streamIdComponents1.entityId);
-    expect(commands[0].input.componentName).toEqual(streamIdComponents1.componentName);
-    expect(commands[0].input.selectedProperties).toEqual([
-      streamIdComponents1.propertyName,
-      streamIdComponents2.propertyName,
-    ]);
-    expect(commands[0].input.maxResults).toEqual(undefined);
-    expect(commands[0].input.orderByTime).toEqual('ASCENDING');
-    expect(commands[0].input.startTime).toEqual(start.toISOString());
-    expect(commands[0].input.endTime).toEqual(end.toISOString());
+    expect(getPropertyValueHistory).toBeCalledTimes(1);
+    expect(getPropertyValueHistory).toBeCalledWith({
+      workspaceId: streamIdComponents1.workspaceId,
+      entityId: streamIdComponents1.entityId,
+      componentName: streamIdComponents1.componentName,
+      selectedProperties: [streamIdComponents1.propertyName, streamIdComponents2.propertyName],
+      orderByTime: 'ASCENDING',
+      startTime: start.toISOString(),
+      endTime: end.toISOString(),
+    });
   });
 
   it('should trigger onSuccess with correct dataStream response', async () => {
-    const tmClientMock = mockClient(tmClient);
-    tmClientMock
-      .on(GetPropertyValueHistoryCommand)
-      .resolvesOnce({
+    getPropertyValueHistory
+      .mockResolvedValueOnce({
         nextToken: '11223344',
         propertyValues: [
           {
@@ -171,7 +168,7 @@ describe('getPropertyValueHistoryByEntity', () => {
           },
         ],
       })
-      .resolvesOnce({
+      .mockResolvedValueOnce({
         nextToken: undefined,
         propertyValues: [
           {
@@ -277,8 +274,7 @@ describe('getPropertyValueHistoryByEntity', () => {
       type: mockError.name,
       status: mockError.$metadata.httpStatusCode,
     };
-    const tmClientMock = mockClient(tmClient);
-    tmClientMock.on(GetPropertyValueHistoryCommand).rejects(mockError);
+    getPropertyValueHistory.mockRejectedValue(mockError);
 
     await getPropertyValueHistoryByEntity({
       onSuccess,

--- a/packages/source-iottwinmaker/src/video-data/utils/sitewiseUtils.spec.ts
+++ b/packages/source-iottwinmaker/src/video-data/utils/sitewiseUtils.spec.ts
@@ -1,31 +1,28 @@
+import { BatchPutAssetPropertyErrorEntry, GetAssetPropertyValueCommandOutput } from '@aws-sdk/client-iotsitewise';
 import {
-  BatchPutAssetPropertyErrorEntry,
-  BatchPutAssetPropertyValueCommand,
-  GetAssetPropertyValueCommand,
-  GetAssetPropertyValueCommandOutput,
-  GetInterpolatedAssetPropertyValuesCommand,
-  IoTSiteWiseClient,
-} from '@aws-sdk/client-iotsitewise';
-import { mockClient } from 'aws-sdk-client-mock';
-import { getAssetPropertyValue, getLastValueBeforeTimestamp, triggerVideoUploadRequest } from './sitewiseUtils';
+  getAssetPropertyValue as getAssetPropertyValueFn,
+  getLastValueBeforeTimestamp,
+  triggerVideoUploadRequest,
+} from './sitewiseUtils';
 import {
   batchPutAssetPropertyResponse,
   mockAssetId,
-  mockAWSCredentials,
   mockGetAssetPropertyValueRequest,
   mockGetInterpolatedAssetPropertyValuesResponse,
   mockPropertyId,
 } from '../../__mocks__/MockVideoPlayerProps';
+import { createMockSiteWiseSDK } from '../../__mocks__/iotsitewiseSDK';
 import { GetLastValueBeforeTimestampRequest, TriggerVideoUploadRequest } from '../types';
 
 describe('SitewiseUtils for Video Player', () => {
-  const sitewiseClient = new IoTSiteWiseClient({
-    ...{
-      region: 'abc',
-    },
-    credentials: mockAWSCredentials,
+  const batchPutAssetPropertyValue = jest.fn();
+  const getAssetPropertyValue = jest.fn();
+  const getInterpolatedAssetPropertyValues = jest.fn();
+  const siteWiseClientMock = createMockSiteWiseSDK({
+    batchPutAssetPropertyValue,
+    getAssetPropertyValue,
+    getInterpolatedAssetPropertyValues,
   });
-  const siteWiseClientMock = mockClient(sitewiseClient);
 
   it('getAssetPropertyValue() - Check return value for String type', async () => {
     const mockGetAssetPropertyValue: GetAssetPropertyValueCommandOutput = {
@@ -39,9 +36,9 @@ describe('SitewiseUtils for Video Player', () => {
       },
       $metadata: {},
     };
-    siteWiseClientMock.on(GetAssetPropertyValueCommand).resolves(mockGetAssetPropertyValue);
+    getAssetPropertyValue.mockResolvedValue(mockGetAssetPropertyValue);
     const expectedResult = '200';
-    const propertyValue = await getAssetPropertyValue(mockGetAssetPropertyValueRequest, sitewiseClient);
+    const propertyValue = await getAssetPropertyValueFn(mockGetAssetPropertyValueRequest, siteWiseClientMock);
     expect(propertyValue).toEqual(expectedResult);
   });
 
@@ -57,9 +54,9 @@ describe('SitewiseUtils for Video Player', () => {
       },
       $metadata: {},
     };
-    siteWiseClientMock.on(GetAssetPropertyValueCommand).resolves(mockGetAssetPropertyValue);
+    getAssetPropertyValue.mockResolvedValue(mockGetAssetPropertyValue);
     const expectedResult = 200.0;
-    const propertyValue = await getAssetPropertyValue(mockGetAssetPropertyValueRequest, sitewiseClient);
+    const propertyValue = await getAssetPropertyValueFn(mockGetAssetPropertyValueRequest, siteWiseClientMock);
     expect(propertyValue).toEqual(expectedResult);
   });
 
@@ -75,9 +72,9 @@ describe('SitewiseUtils for Video Player', () => {
       },
       $metadata: {},
     };
-    siteWiseClientMock.on(GetAssetPropertyValueCommand).resolves(mockGetAssetPropertyValue);
+    getAssetPropertyValue.mockResolvedValue(mockGetAssetPropertyValue);
     const expectedResult = 200;
-    const propertyValue = await getAssetPropertyValue(mockGetAssetPropertyValueRequest, sitewiseClient);
+    const propertyValue = await getAssetPropertyValueFn(mockGetAssetPropertyValueRequest, siteWiseClientMock);
     expect(propertyValue).toEqual(expectedResult);
   });
 
@@ -93,36 +90,34 @@ describe('SitewiseUtils for Video Player', () => {
       },
       $metadata: {},
     };
-    siteWiseClientMock.on(GetAssetPropertyValueCommand).resolves(mockGetAssetPropertyValue);
+    getAssetPropertyValue.mockResolvedValue(mockGetAssetPropertyValue);
     const expectedResult = true;
-    const propertyValue = await getAssetPropertyValue(mockGetAssetPropertyValueRequest, sitewiseClient);
+    const propertyValue = await getAssetPropertyValueFn(mockGetAssetPropertyValueRequest, siteWiseClientMock);
     expect(propertyValue).toEqual(expectedResult);
   });
 
   it('Test return value from getLastValueBeforeTimestamp', async () => {
-    siteWiseClientMock
-      .on(GetInterpolatedAssetPropertyValuesCommand)
-      .resolves(mockGetInterpolatedAssetPropertyValuesResponse);
+    getInterpolatedAssetPropertyValues.mockResolvedValue(mockGetInterpolatedAssetPropertyValuesResponse);
     const expectedResult = new Date(1630005400000);
     const mockGetLastValueBeforeTimestampRequest: GetLastValueBeforeTimestampRequest = {
       assetId: mockAssetId,
       propertyId: mockPropertyId,
       timestamp: new Date(1630004199000),
     };
-    const propertyValue = await getLastValueBeforeTimestamp(mockGetLastValueBeforeTimestampRequest, sitewiseClient);
+    const propertyValue = await getLastValueBeforeTimestamp(mockGetLastValueBeforeTimestampRequest, siteWiseClientMock);
     expect(propertyValue).toEqual(expectedResult);
   });
 
   it('Test triggerVideoUploadRequest with start and end time', async () => {
     const expectedErrorEntries = [{ entryId: 'test', errors: [] }] as BatchPutAssetPropertyErrorEntry[];
-    siteWiseClientMock.on(BatchPutAssetPropertyValueCommand).resolves(batchPutAssetPropertyResponse);
+    batchPutAssetPropertyValue.mockResolvedValue(batchPutAssetPropertyResponse);
     const mockTriggerVideoUploadRequest: TriggerVideoUploadRequest = {
       assetId: mockAssetId,
       propertyId: mockPropertyId,
       startTimestamp: '1630005400',
       endTimestamp: '1630005444',
     };
-    const result = await triggerVideoUploadRequest(mockTriggerVideoUploadRequest, sitewiseClient);
+    const result = await triggerVideoUploadRequest(mockTriggerVideoUploadRequest, siteWiseClientMock);
     expect(result).toEqual(expectedErrorEntries);
   });
 });

--- a/packages/source-iottwinmaker/src/video-data/utils/twinmakerUtils.spec.ts
+++ b/packages/source-iottwinmaker/src/video-data/utils/twinmakerUtils.spec.ts
@@ -1,13 +1,7 @@
-import {
-  GetPropertyValueHistoryCommand,
-  GetPropertyValueHistoryCommandOutput,
-  IoTTwinMakerClient,
-} from '@aws-sdk/client-iottwinmaker';
-import { mockClient } from 'aws-sdk-client-mock';
+import { GetPropertyValueHistoryCommandOutput } from '@aws-sdk/client-iottwinmaker';
 import { Primitive } from '../../common/types';
 import { createPropertyIndentifierKey, generateEntityRefKey, getSinglePropertyValueHistory } from './twinmakerUtils';
 import {
-  mockAWSCredentials,
   mockComponentName,
   mockEntityId,
   mockEntityPropertyReference,
@@ -15,15 +9,13 @@ import {
   mockGetPropertyValueHistoryRequest,
   mockPropertyId,
 } from '../../__mocks__/MockVideoPlayerProps';
+import { createMockTwinMakerSDK } from '../../__mocks__/iottwinmakerSDK';
 
 describe('TwinMakerUtils for Video Player', () => {
-  const twinMakerClient = new IoTTwinMakerClient({
-    ...{
-      region: 'abc',
-    },
-    credentials: mockAWSCredentials,
+  const getPropertyValueHistory = jest.fn();
+  const twinMakerClientMock = createMockTwinMakerSDK({
+    getPropertyValueHistory,
   });
-  const twinMakerClientMock = mockClient(twinMakerClient);
 
   it('getSinglePropertyValueHistory() - Check return value for String type', async () => {
     const mockGetPropertyValueHistoryResponse: GetPropertyValueHistoryCommandOutput = {
@@ -52,7 +44,7 @@ describe('TwinMakerUtils for Video Player', () => {
       ],
       $metadata: {},
     };
-    twinMakerClientMock.on(GetPropertyValueHistoryCommand).resolves(mockGetPropertyValueHistoryResponse);
+    getPropertyValueHistory.mockResolvedValue(mockGetPropertyValueHistoryResponse);
     const mockDataId = createPropertyIndentifierKey(mockEntityId, mockComponentName, mockPropertyId);
     const expectedResult: {
       [id: string]: {
@@ -67,7 +59,7 @@ describe('TwinMakerUtils for Video Player', () => {
     };
     const propertyValueHistory = await getSinglePropertyValueHistory(
       mockGetPropertyValueHistoryRequest,
-      twinMakerClient
+      twinMakerClientMock
     );
     setTimeout(() => {
       expect(propertyValueHistory).toEqual(expectedResult);
@@ -101,7 +93,7 @@ describe('TwinMakerUtils for Video Player', () => {
       ],
       $metadata: {},
     };
-    twinMakerClientMock.on(GetPropertyValueHistoryCommand).resolves(mockGetPropertyValueHistoryResponse);
+    getPropertyValueHistory.mockResolvedValue(mockGetPropertyValueHistoryResponse);
     const mockDataId = createPropertyIndentifierKey(mockEntityId, mockComponentName, mockPropertyId);
     const expectedResult: {
       [id: string]: {
@@ -116,7 +108,7 @@ describe('TwinMakerUtils for Video Player', () => {
     };
     const propertyValueHistory = await getSinglePropertyValueHistory(
       mockGetPropertyValueHistoryRequest,
-      twinMakerClient
+      twinMakerClientMock
     );
     setTimeout(() => {
       expect(propertyValueHistory).toEqual(expectedResult);
@@ -150,7 +142,7 @@ describe('TwinMakerUtils for Video Player', () => {
       ],
       $metadata: {},
     };
-    twinMakerClientMock.on(GetPropertyValueHistoryCommand).resolves(mockGetPropertyValueHistoryResponse);
+    getPropertyValueHistory.mockResolvedValue(mockGetPropertyValueHistoryResponse);
     const mockDataId = createPropertyIndentifierKey(mockEntityId, mockComponentName, mockPropertyId);
     const expectedResult: {
       [id: string]: {
@@ -165,7 +157,7 @@ describe('TwinMakerUtils for Video Player', () => {
     };
     const propertyValueHistory = await getSinglePropertyValueHistory(
       mockGetPropertyValueHistoryRequest,
-      twinMakerClient
+      twinMakerClientMock
     );
     setTimeout(() => {
       expect(propertyValueHistory).toEqual(expectedResult);
@@ -199,7 +191,7 @@ describe('TwinMakerUtils for Video Player', () => {
       ],
       $metadata: {},
     };
-    twinMakerClientMock.on(GetPropertyValueHistoryCommand).resolves(mockGetPropertyValueHistoryResponse);
+    getPropertyValueHistory.mockResolvedValue(mockGetPropertyValueHistoryResponse);
     const mockDataId = createPropertyIndentifierKey(mockEntityId, mockComponentName, mockPropertyId);
     const expectedResult: {
       [id: string]: {
@@ -214,7 +206,7 @@ describe('TwinMakerUtils for Video Player', () => {
     };
     const propertyValueHistory = await getSinglePropertyValueHistory(
       mockGetPropertyValueHistoryRequest,
-      twinMakerClient
+      twinMakerClientMock
     );
     setTimeout(() => {
       expect(propertyValueHistory).toEqual(expectedResult);
@@ -248,7 +240,7 @@ describe('TwinMakerUtils for Video Player', () => {
       ],
       $metadata: {},
     };
-    twinMakerClientMock.on(GetPropertyValueHistoryCommand).resolves(mockGetPropertyValueHistoryResponse);
+    getPropertyValueHistory.mockResolvedValue(mockGetPropertyValueHistoryResponse);
     const mockDataId = createPropertyIndentifierKey(mockEntityId, mockComponentName, mockPropertyId);
     const expectedResult: {
       [id: string]: {
@@ -263,7 +255,7 @@ describe('TwinMakerUtils for Video Player', () => {
     };
     const propertyValueHistory = await getSinglePropertyValueHistory(
       mockGetPropertyValueHistoryRequest,
-      twinMakerClient
+      twinMakerClientMock
     );
     setTimeout(() => {
       expect(propertyValueHistory).toEqual(expectedResult);


### PR DESCRIPTION
## Overview
Upgraded the AWS SDK for scene-composer and source-iottwinmaker packages

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
