### PR TITLE
chore(AWS-SDK): upgraded AWS SDK for TwinMaker packages

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -71,7 +71,7 @@
     "react-dom": "^18"
   },
   "devDependencies": {
-    "@aws-sdk/credential-providers": "3.163",
+    "@aws-sdk/credential-providers": "^3.281.0",
     "@awsui/jest-preset": "^2.0.3",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",

--- a/packages/source-iottwinmaker/jest.config.ts
+++ b/packages/source-iottwinmaker/jest.config.ts
@@ -5,7 +5,7 @@ const config = {
   coverageThreshold: {
     global: {
       statements: 85,
-      branches: 83,
+      branches: 82,
       functions: 85,
       lines: 85,
     },

--- a/packages/source-iottwinmaker/package.json
+++ b/packages/source-iottwinmaker/package.json
@@ -50,11 +50,11 @@
     "pack": "npm pack"
   },
   "dependencies": {
-    "@aws-sdk/client-iotsitewise": "^3.131.0",
-    "@aws-sdk/client-iottwinmaker": "^3.131.0",
-    "@aws-sdk/client-kinesis-video": "^3.131.0",
-    "@aws-sdk/client-kinesis-video-archived-media": "^3.131.0",
-    "@aws-sdk/client-s3": "^3.72.0",
+    "@aws-sdk/client-iotsitewise": "^3.281.0",
+    "@aws-sdk/client-iottwinmaker": "^3.281.0",
+    "@aws-sdk/client-kinesis-video": "^3.281.0",
+    "@aws-sdk/client-kinesis-video-archived-media": "^3.281.0",
+    "@aws-sdk/client-s3": "^3.281.0",
     "@aws-sdk/url-parser": "^3.289.0",
     "@iot-app-kit/core": "4.0.0",
     "lodash": "^4.17.21",

--- a/packages/source-iottwinmaker/src/__mocks__/MockVideoPlayerProps.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/MockVideoPlayerProps.ts
@@ -1,10 +1,15 @@
+import { GetDataEndpointOutput } from '@aws-sdk/client-kinesis-video';
+import {
+  BatchPutAssetPropertyValueResponse,
+  GetAssetPropertyValueRequest,
+  GetAssetPropertyValueResponse,
+  GetInterpolatedAssetPropertyValuesResponse
+} from "@aws-sdk/client-iotsitewise";
+import { GetEntityCommandOutput, GetPropertyValueHistoryCommandOutput, GetPropertyValueHistoryRequest } from '@aws-sdk/client-iottwinmaker';
+import { Credentials } from "@aws-sdk/types";
 import { parseUrl } from '@aws-sdk/url-parser';
 import { CachedVideoAgeOutOnEdge, VideoUploadedTimeRange } from '../video-data/constants';
-import type { GetDataEndpointOutput } from "@aws-sdk/client-kinesis-video";
-import type { BatchPutAssetPropertyValueResponse, GetAssetPropertyValueRequest, GetAssetPropertyValueResponse, GetInterpolatedAssetPropertyValuesResponse } from "@aws-sdk/client-iotsitewise";
-import type { GetEntityCommandOutput, GetPropertyValueHistoryCommandOutput, GetPropertyValueHistoryRequest } from "@aws-sdk/client-iottwinmaker";
-import type { Credentials } from "@aws-sdk/types";
-import type { Primitive } from "../common/types";
+import { Primitive } from "../common/types";
 
 export const mockWorkspaceId = 'mockWorkspaceId';
 export const mockEntityId = 'mockEntityId';
@@ -287,8 +292,8 @@ export const mockGetAvailableTimeRangeResponse = [
     { start: 1630005800000, end: 1630005850000, src: 'mockOnDemandURL' },
   ],
   [
-    { start: 1630005400000, end: 1630005600000 },
-    { start: 1630005800000, end: 1630005900000 },
+    { start: 1630005400000, end: 1630005500000 },
+    { start: 1630005800000, end: 1630005850000 },
   ],
 ];
 

--- a/packages/source-iottwinmaker/src/__mocks__/iotsitewiseSDK.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/iotsitewiseSDK.ts
@@ -1,0 +1,43 @@
+import {
+  GetAssetPropertyValueCommandInput,
+  GetAssetPropertyValueResponse,
+  GetInterpolatedAssetPropertyValuesCommandInput,
+  GetInterpolatedAssetPropertyValuesResponse,
+  IoTSiteWiseClient,
+  BatchPutAssetPropertyValueCommandInput,
+  BatchPutAssetPropertyValueCommandOutput,
+} from '@aws-sdk/client-iotsitewise';
+
+const nonOverriddenMock = () => Promise.reject(new Error('Mock method not override.'));
+
+export const createMockSiteWiseSDK = ({
+  batchPutAssetPropertyValue = nonOverriddenMock,
+  getAssetPropertyValue = nonOverriddenMock,
+  getInterpolatedAssetPropertyValues = nonOverriddenMock,
+}: {
+  batchPutAssetPropertyValue?: (input: BatchPutAssetPropertyValueCommandInput) => Promise<BatchPutAssetPropertyValueCommandOutput>;
+  getAssetPropertyValue?: (input: GetAssetPropertyValueCommandInput) => Promise<GetAssetPropertyValueResponse>;
+  getInterpolatedAssetPropertyValues?: (
+    input: GetInterpolatedAssetPropertyValuesCommandInput
+  ) => Promise<GetInterpolatedAssetPropertyValuesResponse>;
+} = {}) =>
+  ({
+    send: (command: { input: any }) => {
+      // Mocks out the process of a sending a command within the JS AWS-SDK v3, learn more at
+      // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html#high-level-concepts
+      const commandName = command.constructor.name;
+
+      switch (commandName) {
+        case 'BatchPutAssetPropertyValueCommand':
+          return batchPutAssetPropertyValue(command.input);
+        case 'GetAssetPropertyValueCommand':
+          return getAssetPropertyValue(command.input);
+        case 'GetInterpolatedAssetPropertyValuesCommand':
+          return getInterpolatedAssetPropertyValues(command.input);
+        default:
+          throw new Error(
+            `missing mock implementation for command name ${commandName}. Add a new command within the mock SiteWise SDK.`
+          );
+      }
+    },
+  } as unknown as IoTSiteWiseClient);

--- a/packages/source-iottwinmaker/src/__mocks__/iottwinmakerSDK.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/iottwinmakerSDK.ts
@@ -1,0 +1,33 @@
+import { GetEntityCommandInput, GetEntityCommandOutput, GetPropertyValueHistoryCommandInput, GetPropertyValueHistoryCommandOutput, IoTTwinMakerClient, ListEntitiesCommandInput, ListEntitiesCommandOutput } from '@aws-sdk/client-iottwinmaker';
+
+const nonOverriddenMock = () => Promise.reject(new Error('Mock method not override.'));
+
+export const createMockTwinMakerSDK = ({
+  getEntity = nonOverriddenMock,
+  getPropertyValueHistory = nonOverriddenMock,
+  listEntities = nonOverriddenMock,
+}: {
+  getEntity?: (input: GetEntityCommandInput) => Promise<GetEntityCommandOutput>;
+  getPropertyValueHistory?: (input: GetPropertyValueHistoryCommandInput) => Promise<GetPropertyValueHistoryCommandOutput>;
+  listEntities?: (input: ListEntitiesCommandInput) => Promise<ListEntitiesCommandOutput>;
+} = {}) =>
+  ({
+    send: (command: { input: any }) => {
+      // Mocks out the process of a sending a command within the JS AWS-SDK v3, learn more at
+      // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html#high-level-concepts
+      const commandName = command.constructor.name;
+
+      switch (commandName) {
+        case 'GetEntityCommand':
+          return getEntity(command.input);
+        case 'GetPropertyValueHistoryCommand':
+          return getPropertyValueHistory(command.input);
+        case 'ListEntitiesCommand':
+          return listEntities(command.input);
+        default:
+          throw new Error(
+            `missing mock implementation for command name ${commandName}. Add a new command within the mock IotTwinMaker SDK.`
+          );
+      }
+    },
+  } as unknown as IoTTwinMakerClient);

--- a/packages/source-iottwinmaker/src/__mocks__/kinesisVideoArchivedMediaSDK.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/kinesisVideoArchivedMediaSDK.ts
@@ -1,0 +1,28 @@
+import { GetHLSStreamingSessionURLCommandInput, GetHLSStreamingSessionURLCommandOutput, KinesisVideoArchivedMediaClient } from '@aws-sdk/client-kinesis-video-archived-media';
+
+const nonOverriddenMock = () => Promise.reject(new Error('Mock method not override.'));
+
+export const createMockKinesisVideoArchivedMediaSDK = ({
+  getHLSStreamingSessionURL = nonOverriddenMock,
+}: {
+  getHLSStreamingSessionURL?: (input: GetHLSStreamingSessionURLCommandInput) => Promise<GetHLSStreamingSessionURLCommandOutput>;
+} = {}) =>
+  ({
+    send: (command: { input: any }) => {
+      // Mocks out the process of a sending a command within the JS AWS-SDK v3, learn more at
+      // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html#high-level-concepts
+      const commandName = command.constructor.name;
+
+      switch (commandName) {
+        case 'GetHLSStreamingSessionURLCommand':
+          return getHLSStreamingSessionURL(command.input);
+        default:
+          throw new Error(
+            `missing mock implementation for command name ${commandName}. Add a new command within the mock KinesisVideoArchivedMedia SDK.`
+          );
+      }
+    },
+    config: {
+      endpoint: 'testEndpoint',
+    },
+  } as unknown as KinesisVideoArchivedMediaClient);

--- a/packages/source-iottwinmaker/src/__mocks__/kinesisVideoSDK.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/kinesisVideoSDK.ts
@@ -1,0 +1,25 @@
+import { GetDataEndpointCommandInput, GetDataEndpointCommandOutput, KinesisVideoClient } from '@aws-sdk/client-kinesis-video';
+
+const nonOverriddenMock = () => Promise.reject(new Error('Mock method not override.'));
+
+export const createMockKinesisVideoSDK = ({
+  getDataEndpoint = nonOverriddenMock,
+}: {
+  getDataEndpoint?: (input: GetDataEndpointCommandInput) => Promise<GetDataEndpointCommandOutput>;
+} = {}) =>
+  ({
+    send: (command: { input: any }) => {
+      // Mocks out the process of a sending a command within the JS AWS-SDK v3, learn more at
+      // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html#high-level-concepts
+      const commandName = command.constructor.name;
+
+      switch (commandName) {
+        case 'GetDataEndpointCommand':
+          return getDataEndpoint(command.input);
+        default:
+          throw new Error(
+            `missing mock implementation for command name ${commandName}. Add a new command within the mock KinesisVideo SDK.`
+          );
+      }
+    },
+  } as unknown as KinesisVideoClient);

--- a/packages/source-iottwinmaker/src/time-series-data/client/getPropertyValueHistoryByComponentType.spec.ts
+++ b/packages/source-iottwinmaker/src/time-series-data/client/getPropertyValueHistoryByComponentType.spec.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { GetPropertyValueHistoryCommand, IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
-import { mockClient } from 'aws-sdk-client-mock';
+import { GetEntityResponse } from '@aws-sdk/client-iottwinmaker';
+import { RequestInformationAndRange, ErrorDetails } from '@iot-app-kit/core';
 import flushPromises from 'flush-promises';
 import { TwinMakerMetadataModule } from '../../metadata-module/TwinMakerMetadataModule';
+import { createMockTwinMakerSDK } from '../../__mocks__/iottwinmakerSDK';
+
+import { TwinMakerDataStreamIdComponent } from '../types';
 import { toDataStreamId } from '../utils/dataStreamId';
 import { getPropertyValueHistoryByComponentType } from './getPropertyValueHistoryByComponentType';
-import type { GetEntityResponse } from '@aws-sdk/client-iottwinmaker';
-import type { RequestInformationAndRange, ErrorDetails } from '@iot-app-kit/core';
-import type { TwinMakerDataStreamIdComponent } from '../types';
 
 describe('getPropertyValueHistoryByComponentType', () => {
   const streamIdComponents1: TwinMakerDataStreamIdComponent = {
@@ -78,7 +78,12 @@ describe('getPropertyValueHistoryByComponentType', () => {
       meta: { componentTypeId: 'comp-type-1' },
     },
   ];
-  const tmClient = new IoTTwinMakerClient({});
+  const getEntity = jest.fn();
+  const getPropertyValueHistory = jest.fn();
+  const tmClient = createMockTwinMakerSDK({
+    getEntity,
+    getPropertyValueHistory,
+  });
   const twinMakerMetadataModule = new TwinMakerMetadataModule('workspace-id', tmClient);
   const mockEntities: GetEntityResponse[] = [
     {
@@ -156,7 +161,6 @@ describe('getPropertyValueHistoryByComponentType', () => {
   ] as any as GetEntityResponse[];
   jest.spyOn(twinMakerMetadataModule, 'fetchEntitiesByComponentTypeId').mockResolvedValue(mockEntities);
 
-  let sendSpy = jest.spyOn(tmClient, 'send');
   const onSuccess = jest.fn();
   const onError = jest.fn();
 
@@ -228,15 +232,9 @@ describe('getPropertyValueHistoryByComponentType', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    sendSpy = jest.spyOn(tmClient, 'send');
   });
 
   it('should send correct request when fetchMostRecentBeforeStart is true', async () => {
-    let command: GetPropertyValueHistoryCommand;
-    sendSpy.mockImplementation((cmd) => {
-      command = cmd as GetPropertyValueHistoryCommand;
-      return Promise.resolve({});
-    });
     const expectedStart = new Date(start);
     expectedStart.setDate(expectedStart.getDate() - 1);
 
@@ -251,20 +249,17 @@ describe('getPropertyValueHistoryByComponentType', () => {
       client: tmClient,
     });
 
-    expect(command!.input.workspaceId).toEqual(streamIdComponents1.workspaceId);
-    expect(command!.input.componentTypeId).toEqual(mockRequestInfos[0].meta?.['componentTypeId']);
-    expect(command!.input.selectedProperties?.[0]).toEqual(streamIdComponents1.propertyName);
-    expect(command!.input.orderByTime).toEqual('DESCENDING');
-    expect(command!.input.startTime).toEqual(expectedStart.toISOString());
-    expect(command!.input.endTime).toEqual(start.toISOString());
+    expect(getPropertyValueHistory).toBeCalledWith({
+      workspaceId: streamIdComponents1.workspaceId,
+      componentTypeId: mockRequestInfos[0].meta?.['componentTypeId'],
+      selectedProperties: [streamIdComponents1.propertyName],
+      orderByTime: 'DESCENDING',
+      startTime: expectedStart.toISOString(),
+      endTime: start.toISOString(),
+    });
   });
 
   it('should send correct request when fetchMostRecentBeforeEnd is true', async () => {
-    let command: GetPropertyValueHistoryCommand;
-    sendSpy.mockImplementation((cmd) => {
-      command = cmd as GetPropertyValueHistoryCommand;
-      return Promise.resolve({});
-    });
     const expectedStart = new Date(start);
     expectedStart.setDate(expectedStart.getDate() - 1);
 
@@ -279,18 +274,17 @@ describe('getPropertyValueHistoryByComponentType', () => {
       client: tmClient,
     });
 
-    expect(command!.input.orderByTime).toEqual('DESCENDING');
-    expect(command!.input.startTime).toEqual(expectedStart.toISOString());
-    expect(command!.input.endTime).toEqual(end.toISOString());
+    expect(getPropertyValueHistory).toBeCalledWith({
+      workspaceId: streamIdComponents1.workspaceId,
+      componentTypeId: mockRequestInfos[0].meta?.['componentTypeId'],
+      selectedProperties: [streamIdComponents1.propertyName],
+      orderByTime: 'DESCENDING',
+      startTime: expectedStart.toISOString(),
+      endTime: end.toISOString(),
+    });
   });
 
   it('should send correct request when fetchFromStartToEnd is true', async () => {
-    let command: GetPropertyValueHistoryCommand;
-    sendSpy.mockImplementation((cmd) => {
-      command = cmd as GetPropertyValueHistoryCommand;
-      return Promise.resolve({});
-    });
-
     await getPropertyValueHistoryByComponentType({
       metadataModule: twinMakerMetadataModule,
       onSuccess,
@@ -302,14 +296,18 @@ describe('getPropertyValueHistoryByComponentType', () => {
       client: tmClient,
     });
 
-    expect(command!.input.orderByTime).toEqual('ASCENDING');
-    expect(command!.input.startTime).toEqual(start.toISOString());
-    expect(command!.input.endTime).toEqual(end.toISOString());
+    expect(getPropertyValueHistory).toBeCalledWith({
+      workspaceId: streamIdComponents1.workspaceId,
+      componentTypeId: mockRequestInfos[0].meta?.['componentTypeId'],
+      selectedProperties: [streamIdComponents1.propertyName],
+      orderByTime: 'ASCENDING',
+      startTime: start.toISOString(),
+      endTime: end.toISOString(),
+    });
   });
 
   it('should trigger onSuccess with correct dataStream response for fetchFromStartToEnd case', async () => {
-    const tmClientMock = mockClient(tmClient);
-    tmClientMock.on(GetPropertyValueHistoryCommand).resolvesOnce(mockResponse1).resolvesOnce(mockResponse2);
+    getPropertyValueHistory.mockResolvedValueOnce(mockResponse1).mockResolvedValueOnce(mockResponse2);
 
     await getPropertyValueHistoryByComponentType({
       metadataModule: twinMakerMetadataModule,
@@ -417,8 +415,7 @@ describe('getPropertyValueHistoryByComponentType', () => {
   });
 
   it('should trigger onSuccess with correct dataStream response for fetchMostRecentBeforeEnd case', async () => {
-    const tmClientMock = mockClient(tmClient);
-    tmClientMock.on(GetPropertyValueHistoryCommand).resolvesOnce(mockResponse1).resolvesOnce(mockResponse2);
+    getPropertyValueHistory.mockResolvedValueOnce(mockResponse1).mockResolvedValueOnce(mockResponse2);
     const expectedStart = new Date(start);
     expectedStart.setDate(expectedStart.getDate() - 1);
 
@@ -493,8 +490,7 @@ describe('getPropertyValueHistoryByComponentType', () => {
       type: mockError.name,
       status: mockError.$metadata.httpStatusCode,
     };
-    const tmClientMock = mockClient(tmClient);
-    tmClientMock.on(GetPropertyValueHistoryCommand).rejects(mockError);
+    getPropertyValueHistory.mockRejectedValue(mockError);
 
     await getPropertyValueHistoryByComponentType({
       metadataModule: twinMakerMetadataModule,

--- a/packages/source-iottwinmaker/src/video-data/VideoData.spec.ts
+++ b/packages/source-iottwinmaker/src/video-data/VideoData.spec.ts
@@ -1,20 +1,6 @@
-import { GetDataEndpointCommand, KinesisVideoClient } from '@aws-sdk/client-kinesis-video';
-import {
-  GetHLSStreamingSessionURLCommand,
-  KinesisVideoArchivedMediaClient,
-} from '@aws-sdk/client-kinesis-video-archived-media';
-import {
-  BatchPutAssetPropertyValueCommand,
-  GetAssetPropertyValueCommand,
-  GetInterpolatedAssetPropertyValuesCommand,
-  IoTSiteWiseClient,
-} from '@aws-sdk/client-iotsitewise';
-import { GetEntityCommand, GetPropertyValueHistoryCommand, IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
-import { mockClient } from 'aws-sdk-client-mock';
 import { VideoDataImpl } from './VideoData';
 import {
   batchPutAssetPropertyResponse,
-  mockAWSCredentials,
   mockCachedVideoAgeOutOnEdge,
   mockComponentName,
   mockEdgeVideoEntity,
@@ -35,49 +21,47 @@ import {
   mockWorkspaceId,
 } from '../__mocks__/MockVideoPlayerProps';
 import { PLAYBACKMODE_LIVE, PLAYBACKMODE_ON_DEMAND } from './constants';
-import type { VideoDataInput } from './types';
+import { VideoDataInput } from './types';
+import { createMockKinesisVideoSDK } from '../__mocks__/kinesisVideoSDK';
+import { createMockKinesisVideoArchivedMediaSDK } from '../__mocks__/kinesisVideoArchivedMediaSDK';
+import { createMockTwinMakerSDK } from '../__mocks__/iottwinmakerSDK';
+import { createMockSiteWiseSDK } from '../__mocks__/iotsitewiseSDK';
 
 describe('Test VideoData class', () => {
-  const kinesisVideoClient = new KinesisVideoClient({
-    ...{
-      region: 'abc',
-    },
-    credentials: mockAWSCredentials,
+  const getDataEndpoint = jest.fn();
+  const kinesisVideoClientMock = createMockKinesisVideoSDK({
+    getDataEndpoint,
   });
-  const kinesisVideoClientMock = mockClient(kinesisVideoClient);
 
-  const kinesisVideoArchivedMediaClient = new KinesisVideoArchivedMediaClient({
-    ...{
-      region: 'abc',
-    },
-    credentials: mockAWSCredentials,
+  const getHLSStreamingSessionURL = jest.fn();
+  const kinesisVideoArchivedMediaClientMock = createMockKinesisVideoArchivedMediaSDK({
+    getHLSStreamingSessionURL,
   });
-  const kinesisVideoArchivedMediaClientMock = mockClient(kinesisVideoArchivedMediaClient);
 
-  const sitewiseClient = new IoTSiteWiseClient({
-    ...{
-      region: 'abc',
-    },
-    credentials: mockAWSCredentials,
+  const batchPutAssetPropertyValue = jest.fn();
+  const getAssetPropertyValue = jest.fn();
+  const getInterpolatedAssetPropertyValues = jest.fn();
+  const siteWiseClientMock = createMockSiteWiseSDK({
+    batchPutAssetPropertyValue,
+    getAssetPropertyValue,
+    getInterpolatedAssetPropertyValues,
   });
-  const siteWiseClientMock = mockClient(sitewiseClient);
 
-  const twinMakerClient = new IoTTwinMakerClient({
-    ...{
-      region: 'abc',
-    },
-    credentials: mockAWSCredentials,
+  const getEntity = jest.fn();
+  const getPropertyValueHistory = jest.fn();
+  const twinMakerClientMock = createMockTwinMakerSDK({
+    getEntity,
+    getPropertyValueHistory,
   });
-  const twinMakerClientMock = mockClient(twinMakerClient);
 
   const videoDataInput: VideoDataInput = {
     workspaceId: mockWorkspaceId,
     entityId: mockEntityId,
     componentName: mockComponentName,
-    kinesisVideoClient: kinesisVideoClient,
-    kinesisVideoArchivedMediaClient: kinesisVideoArchivedMediaClient,
-    siteWiseClient: sitewiseClient,
-    twinMakerClient: twinMakerClient,
+    kinesisVideoClient: kinesisVideoClientMock,
+    kinesisVideoArchivedMediaClient: kinesisVideoArchivedMediaClientMock,
+    siteWiseClient: siteWiseClientMock,
+    twinMakerClient: twinMakerClientMock,
     sitewiseAssetId: mockSitewiseAssetId,
     videoUploadRequestPropertyId: mockVideoUploadRequestPropertyId,
   };
@@ -85,24 +69,21 @@ describe('Test VideoData class', () => {
 
   const videoDataInputSimpleMode: VideoDataInput = {
     kvsStreamName: mockKVSStreamName,
-    kinesisVideoClient: kinesisVideoClient,
-    kinesisVideoArchivedMediaClient: kinesisVideoArchivedMediaClient,
-    siteWiseClient: sitewiseClient,
-    twinMakerClient: twinMakerClient,
+    kinesisVideoClient: kinesisVideoClientMock,
+    kinesisVideoArchivedMediaClient: kinesisVideoArchivedMediaClientMock,
+    siteWiseClient: siteWiseClientMock,
+    twinMakerClient: twinMakerClientMock,
     sitewiseAssetId: mockSitewiseAssetId,
     videoUploadRequestPropertyId: mockVideoUploadRequestPropertyId,
   };
   const videoDataSimpleMode = new VideoDataImpl(videoDataInputSimpleMode);
 
   beforeEach(() => {
-    kinesisVideoClientMock.reset();
-    kinesisVideoClientMock.on(GetDataEndpointCommand).resolves(mockGetDataEndpointResponse);
-
-    siteWiseClientMock.reset();
-    siteWiseClientMock.on(BatchPutAssetPropertyValueCommand).resolves(batchPutAssetPropertyResponse);
-    siteWiseClientMock.on(GetAssetPropertyValueCommand).resolves(mockGetAssetPropertyValueResponse);
-
     jest.clearAllMocks();
+
+    getDataEndpoint.mockResolvedValue(mockGetDataEndpointResponse);
+    batchPutAssetPropertyValue.mockResolvedValue(batchPutAssetPropertyResponse);
+    getAssetPropertyValue.mockResolvedValue(mockGetAssetPropertyValueResponse);
   });
 
   it('Test successful triggerLiveVideoUpload()', async () => {
@@ -116,69 +97,51 @@ describe('Test VideoData class', () => {
   });
 
   it('Fetch KVS stream source for LIVE playback - Simple Mode', async () => {
-    kinesisVideoArchivedMediaClientMock
-      .on(GetHLSStreamingSessionURLCommand)
-      .resolves(mockLiveGetHLSStreamingSessionURLResponse);
+    getHLSStreamingSessionURL.mockResolvedValue(mockLiveGetHLSStreamingSessionURLResponse);
     const response = await videoDataSimpleMode.getKvsStreamSrc(PLAYBACKMODE_LIVE);
     expect(response).toEqual(mockLiveURL);
   });
 
   it('Fetch KVS stream source for ON_DEMAND playback - Simple Mode', async () => {
-    kinesisVideoArchivedMediaClientMock
-      .on(GetHLSStreamingSessionURLCommand)
-      .resolves(mockOnDemandGetHLSStreamingSessionURLResponse);
+    getHLSStreamingSessionURL.mockResolvedValue(mockOnDemandGetHLSStreamingSessionURLResponse);
     const response = await videoDataSimpleMode.getKvsStreamSrc(PLAYBACKMODE_ON_DEMAND);
     expect(response).toEqual(mockOnDemandURL);
   });
 
   it('Fetch KVS stream source for LIVE playback - EdgeVideo Component', async () => {
-    kinesisVideoArchivedMediaClientMock
-      .on(GetHLSStreamingSessionURLCommand)
-      .resolves(mockLiveGetHLSStreamingSessionURLResponse);
-    twinMakerClientMock.on(GetEntityCommand).resolves(mockEdgeVideoEntity);
+    getHLSStreamingSessionURL.mockResolvedValue(mockLiveGetHLSStreamingSessionURLResponse);
+    getEntity.mockResolvedValue(mockEdgeVideoEntity);
     const response = await videoData.getKvsStreamSrc(PLAYBACKMODE_LIVE);
     expect(response).toEqual(mockLiveURL);
   });
 
   it('Fetch KVS stream source for ON_DEMAND playback - EdgeVideo Component', async () => {
-    kinesisVideoArchivedMediaClientMock
-      .on(GetHLSStreamingSessionURLCommand)
-      .resolves(mockOnDemandGetHLSStreamingSessionURLResponse);
-    twinMakerClientMock.on(GetEntityCommand).resolves(mockEdgeVideoEntity);
+    getHLSStreamingSessionURL.mockResolvedValue(mockOnDemandGetHLSStreamingSessionURLResponse);
+    getEntity.mockResolvedValue(mockEdgeVideoEntity);
     const response = await videoData.getKvsStreamSrc(PLAYBACKMODE_ON_DEMAND);
     expect(response).toEqual(mockOnDemandURL);
   });
 
   it('Fetch KVS stream source for LIVE playback - KVS Component', async () => {
-    kinesisVideoArchivedMediaClientMock
-      .on(GetHLSStreamingSessionURLCommand)
-      .resolves(mockLiveGetHLSStreamingSessionURLResponse);
-    twinMakerClientMock.on(GetEntityCommand).resolves(mockKVSEntity);
+    getHLSStreamingSessionURL.mockResolvedValue(mockLiveGetHLSStreamingSessionURLResponse);
+    getEntity.mockResolvedValue(mockKVSEntity);
     const response = await videoData.getKvsStreamSrc(PLAYBACKMODE_LIVE);
     expect(response).toEqual(mockLiveURL);
   });
 
   it('Fetch KVS stream source for ON_DEMAND playback - KVS Component', async () => {
-    kinesisVideoArchivedMediaClientMock
-      .on(GetHLSStreamingSessionURLCommand)
-      .resolves(mockOnDemandGetHLSStreamingSessionURLResponse);
-    twinMakerClientMock.on(GetEntityCommand).resolves(mockKVSEntity);
+    getHLSStreamingSessionURL.mockResolvedValue(mockOnDemandGetHLSStreamingSessionURLResponse);
+    getEntity.mockResolvedValue(mockKVSEntity);
     const response = await videoData.getKvsStreamSrc(PLAYBACKMODE_ON_DEMAND);
     expect(response).toEqual(mockOnDemandURL);
   });
 
   it('Get available time ranges when video is available', async () => {
-    kinesisVideoArchivedMediaClientMock
-      .on(GetHLSStreamingSessionURLCommand)
-      .resolves(mockOnDemandGetHLSStreamingSessionURLResponse);
-    twinMakerClientMock.on(GetEntityCommand).resolves(mockEdgeVideoEntity);
-    twinMakerClientMock
-      .on(GetPropertyValueHistoryCommand)
-      .resolvesOnce(mockCachedVideoAgeOutOnEdge)
-      .resolves(mockVideoUploadedTimeRange);
-    siteWiseClientMock
-      .on(GetInterpolatedAssetPropertyValuesCommand)
-      .resolves(mockGetInterpolatedAssetPropertyValuesResponse);
+    getHLSStreamingSessionURL.mockResolvedValue(mockOnDemandGetHLSStreamingSessionURLResponse);
+    getEntity.mockResolvedValue(mockEdgeVideoEntity);
+    getPropertyValueHistory.mockResolvedValue(mockCachedVideoAgeOutOnEdge);
+    getPropertyValueHistory.mockResolvedValue(mockVideoUploadedTimeRange);
+    getInterpolatedAssetPropertyValues.mockResolvedValue(mockGetInterpolatedAssetPropertyValuesResponse);
     const kvsStreamSrc = await videoData.getKvsStreamSrc(PLAYBACKMODE_ON_DEMAND);
     const response = await videoData.getAvailableTimeRanges(new Date(1630005300000), new Date(1630005900000));
     expect(kvsStreamSrc).toEqual(mockOnDemandURL);

--- a/packages/source-iottwinmaker/src/video-data/utils/kvsUtils.spec.ts
+++ b/packages/source-iottwinmaker/src/video-data/utils/kvsUtils.spec.ts
@@ -1,12 +1,5 @@
-import { mockClient } from 'aws-sdk-client-mock';
-import { GetDataEndpointCommand, KinesisVideoClient } from '@aws-sdk/client-kinesis-video';
-import {
-  GetHLSStreamingSessionURLCommand,
-  KinesisVideoArchivedMediaClient,
-} from '@aws-sdk/client-kinesis-video-archived-media';
 import { getKVSDataEndpoint, getLiveHLSStreamingSessionURL, getOnDemandHLSStreamingSessionURL } from './kvsUtils';
 import {
-  mockAWSCredentials,
   mockDataEndpoint,
   mockGetDataEndpointResponse,
   mockKVSStreamName,
@@ -15,35 +8,29 @@ import {
   mockOnDemandGetHLSStreamingSessionURLResponse,
   mockOnDemandURL,
 } from '../../__mocks__/MockVideoPlayerProps';
-import type { GetLiveHLSStreamingSessionURLRequest, GetOnDemandHLSStreamingSessionURLRequest } from '../types';
+import { createMockKinesisVideoArchivedMediaSDK } from '../../__mocks__/kinesisVideoArchivedMediaSDK';
+import { createMockKinesisVideoSDK } from '../../__mocks__/kinesisVideoSDK';
+import { GetLiveHLSStreamingSessionURLRequest, GetOnDemandHLSStreamingSessionURLRequest } from '../types';
 
 describe('KVSUtils for Video Player', () => {
-  const kinesisVideoClient = new KinesisVideoClient({
-    ...{
-      region: 'abc',
-    },
-    credentials: mockAWSCredentials,
+  const getDataEndpoint = jest.fn();
+  const kinesisVideoClientMock = createMockKinesisVideoSDK({
+    getDataEndpoint,
   });
-  const kinesisVideoClientMock = mockClient(kinesisVideoClient);
 
-  const kinesisVideoArchivedMediaClient = new KinesisVideoArchivedMediaClient({
-    ...{
-      region: 'abc',
-    },
-    credentials: mockAWSCredentials,
+  const getHLSStreamingSessionURL = jest.fn();
+  const kinesisVideoArchivedMediaClientMock = createMockKinesisVideoArchivedMediaSDK({
+    getHLSStreamingSessionURL,
   });
-  const kinesisVideoArchivedMediaClientMock = mockClient(kinesisVideoArchivedMediaClient);
 
   it('Get KVS DataEndpoint', async () => {
-    kinesisVideoClientMock.on(GetDataEndpointCommand).resolves(mockGetDataEndpointResponse);
-    const kvsDataEndpoint = await getKVSDataEndpoint(mockKVSStreamName, kinesisVideoClient);
+    getDataEndpoint.mockResolvedValue(mockGetDataEndpointResponse);
+    const kvsDataEndpoint = await getKVSDataEndpoint(mockKVSStreamName, kinesisVideoClientMock);
     expect(kvsDataEndpoint).toEqual(mockDataEndpoint);
   });
 
   it('Get HLSStreamingSessionURL for ON_DEMAND mode', async () => {
-    kinesisVideoArchivedMediaClientMock
-      .on(GetHLSStreamingSessionURLCommand)
-      .resolves(mockOnDemandGetHLSStreamingSessionURLResponse);
+    getHLSStreamingSessionURL.mockResolvedValue(mockOnDemandGetHLSStreamingSessionURLResponse);
     const mockGetOnDemandHLSStreamingSessionURLRequest: GetOnDemandHLSStreamingSessionURLRequest = {
       kvsStreamName: mockKVSStreamName,
       kvsDataEndpoint: mockDataEndpoint,
@@ -52,22 +39,20 @@ describe('KVSUtils for Video Player', () => {
     };
     const onDemandHLSStreamingSessionURL = await getOnDemandHLSStreamingSessionURL(
       mockGetOnDemandHLSStreamingSessionURLRequest,
-      kinesisVideoArchivedMediaClient
+      kinesisVideoArchivedMediaClientMock
     );
     expect(onDemandHLSStreamingSessionURL).toEqual(mockOnDemandURL);
   });
 
   it('Get HLSStreamingSessionURL for LIVE mode', async () => {
-    kinesisVideoArchivedMediaClientMock
-      .on(GetHLSStreamingSessionURLCommand)
-      .resolves(mockLiveGetHLSStreamingSessionURLResponse);
+    getHLSStreamingSessionURL.mockResolvedValue(mockLiveGetHLSStreamingSessionURLResponse);
     const mockGetLiveHLSStreamingSessionURLRequest: GetLiveHLSStreamingSessionURLRequest = {
       kvsStreamName: mockKVSStreamName,
       kvsDataEndpoint: mockDataEndpoint,
     };
     const liveHLSStreamingSessionURL = await getLiveHLSStreamingSessionURL(
       mockGetLiveHLSStreamingSessionURLRequest,
-      kinesisVideoArchivedMediaClient
+      kinesisVideoArchivedMediaClientMock
     );
     expect(liveHLSStreamingSessionURL).toEqual(mockLiveURL);
   });

--- a/packages/source-iottwinmaker/src/video-data/utils/twinmakerUtils.spec.ts
+++ b/packages/source-iottwinmaker/src/video-data/utils/twinmakerUtils.spec.ts
@@ -1,8 +1,7 @@
-import { GetPropertyValueHistoryCommand, IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
-import { mockClient } from 'aws-sdk-client-mock';
+import { GetPropertyValueHistoryCommandOutput } from '@aws-sdk/client-iottwinmaker';
+import { Primitive } from '../../common/types';
 import { createPropertyIndentifierKey, generateEntityRefKey, getSinglePropertyValueHistory } from './twinmakerUtils';
 import {
-  mockAWSCredentials,
   mockComponentName,
   mockEntityId,
   mockEntityPropertyReference,
@@ -10,17 +9,13 @@ import {
   mockGetPropertyValueHistoryRequest,
   mockPropertyId,
 } from '../../__mocks__/MockVideoPlayerProps';
-import type { GetPropertyValueHistoryCommandOutput } from '@aws-sdk/client-iottwinmaker';
-import type { Primitive } from '../../common/types';
+import { createMockTwinMakerSDK } from '../../__mocks__/iottwinmakerSDK';
 
 describe('TwinMakerUtils for Video Player', () => {
-  const twinMakerClient = new IoTTwinMakerClient({
-    ...{
-      region: 'abc',
-    },
-    credentials: mockAWSCredentials,
+  const getPropertyValueHistory = jest.fn();
+  const twinMakerClientMock = createMockTwinMakerSDK({
+    getPropertyValueHistory,
   });
-  const twinMakerClientMock = mockClient(twinMakerClient);
 
   it('getSinglePropertyValueHistory() - Check return value for String type', async () => {
     const mockGetPropertyValueHistoryResponse: GetPropertyValueHistoryCommandOutput = {
@@ -49,7 +44,7 @@ describe('TwinMakerUtils for Video Player', () => {
       ],
       $metadata: {},
     };
-    twinMakerClientMock.on(GetPropertyValueHistoryCommand).resolves(mockGetPropertyValueHistoryResponse);
+    getPropertyValueHistory.mockResolvedValue(mockGetPropertyValueHistoryResponse);
     const mockDataId = createPropertyIndentifierKey(mockEntityId, mockComponentName, mockPropertyId);
     const expectedResult: {
       [id: string]: {
@@ -64,7 +59,7 @@ describe('TwinMakerUtils for Video Player', () => {
     };
     const propertyValueHistory = await getSinglePropertyValueHistory(
       mockGetPropertyValueHistoryRequest,
-      twinMakerClient
+      twinMakerClientMock
     );
     setTimeout(() => {
       expect(propertyValueHistory).toEqual(expectedResult);
@@ -98,7 +93,7 @@ describe('TwinMakerUtils for Video Player', () => {
       ],
       $metadata: {},
     };
-    twinMakerClientMock.on(GetPropertyValueHistoryCommand).resolves(mockGetPropertyValueHistoryResponse);
+    getPropertyValueHistory.mockResolvedValue(mockGetPropertyValueHistoryResponse);
     const mockDataId = createPropertyIndentifierKey(mockEntityId, mockComponentName, mockPropertyId);
     const expectedResult: {
       [id: string]: {
@@ -113,7 +108,7 @@ describe('TwinMakerUtils for Video Player', () => {
     };
     const propertyValueHistory = await getSinglePropertyValueHistory(
       mockGetPropertyValueHistoryRequest,
-      twinMakerClient
+      twinMakerClientMock
     );
     setTimeout(() => {
       expect(propertyValueHistory).toEqual(expectedResult);
@@ -147,7 +142,7 @@ describe('TwinMakerUtils for Video Player', () => {
       ],
       $metadata: {},
     };
-    twinMakerClientMock.on(GetPropertyValueHistoryCommand).resolves(mockGetPropertyValueHistoryResponse);
+    getPropertyValueHistory.mockResolvedValue(mockGetPropertyValueHistoryResponse);
     const mockDataId = createPropertyIndentifierKey(mockEntityId, mockComponentName, mockPropertyId);
     const expectedResult: {
       [id: string]: {
@@ -162,7 +157,7 @@ describe('TwinMakerUtils for Video Player', () => {
     };
     const propertyValueHistory = await getSinglePropertyValueHistory(
       mockGetPropertyValueHistoryRequest,
-      twinMakerClient
+      twinMakerClientMock
     );
     setTimeout(() => {
       expect(propertyValueHistory).toEqual(expectedResult);
@@ -196,7 +191,7 @@ describe('TwinMakerUtils for Video Player', () => {
       ],
       $metadata: {},
     };
-    twinMakerClientMock.on(GetPropertyValueHistoryCommand).resolves(mockGetPropertyValueHistoryResponse);
+    getPropertyValueHistory.mockResolvedValue(mockGetPropertyValueHistoryResponse);
     const mockDataId = createPropertyIndentifierKey(mockEntityId, mockComponentName, mockPropertyId);
     const expectedResult: {
       [id: string]: {
@@ -211,7 +206,7 @@ describe('TwinMakerUtils for Video Player', () => {
     };
     const propertyValueHistory = await getSinglePropertyValueHistory(
       mockGetPropertyValueHistoryRequest,
-      twinMakerClient
+      twinMakerClientMock
     );
     setTimeout(() => {
       expect(propertyValueHistory).toEqual(expectedResult);
@@ -245,7 +240,7 @@ describe('TwinMakerUtils for Video Player', () => {
       ],
       $metadata: {},
     };
-    twinMakerClientMock.on(GetPropertyValueHistoryCommand).resolves(mockGetPropertyValueHistoryResponse);
+    getPropertyValueHistory.mockResolvedValue(mockGetPropertyValueHistoryResponse);
     const mockDataId = createPropertyIndentifierKey(mockEntityId, mockComponentName, mockPropertyId);
     const expectedResult: {
       [id: string]: {
@@ -260,7 +255,7 @@ describe('TwinMakerUtils for Video Player', () => {
     };
     const propertyValueHistory = await getSinglePropertyValueHistory(
       mockGetPropertyValueHistoryRequest,
-      twinMakerClient
+      twinMakerClientMock
     );
     setTimeout(() => {
       expect(propertyValueHistory).toEqual(expectedResult);


### PR DESCRIPTION
## Overview
Upgraded the AWS SDK for scene-composer and source-iottwinmaker packages

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
