### PR TITLE
fix(aws-sdk): fix the build failure due to internal dependencies

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -71,7 +71,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@aws-sdk/credential-providers": "^3.281.0",
+    "@aws-sdk/credential-providers": "3.281.0",
     "@awsui/jest-preset": "^2.0.3",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",

--- a/packages/source-iotsitewise/package.json
+++ b/packages/source-iotsitewise/package.json
@@ -50,8 +50,8 @@
     "pack": "npm pack"
   },
   "dependencies": {
-    "@aws-sdk/client-iot-events": "^3.281.0",
-    "@aws-sdk/client-iotsitewise": "^3.281.0",
+    "@aws-sdk/client-iot-events": "3.281.0",
+    "@aws-sdk/client-iotsitewise": "3.281.0",
     "@iot-app-kit/core": "3.0.0",
     "@rollup/plugin-typescript": "^8.3.0",
     "@synchro-charts/core": "7.2.0",

--- a/packages/source-iottwinmaker/package.json
+++ b/packages/source-iottwinmaker/package.json
@@ -50,11 +50,11 @@
     "pack": "npm pack"
   },
   "dependencies": {
-    "@aws-sdk/client-iotsitewise": "^3.281.0",
-    "@aws-sdk/client-iottwinmaker": "^3.281.0",
-    "@aws-sdk/client-kinesis-video": "^3.281.0",
-    "@aws-sdk/client-kinesis-video-archived-media": "^3.281.0",
-    "@aws-sdk/client-s3": "^3.281.0",
+    "@aws-sdk/client-iotsitewise": "3.281.0",
+    "@aws-sdk/client-iottwinmaker": "3.281.0",
+    "@aws-sdk/client-kinesis-video": "3.281.0",
+    "@aws-sdk/client-kinesis-video-archived-media": "3.281.0",
+    "@aws-sdk/client-s3": "3.281.0",
     "@iot-app-kit/core": "3.0.0",
     "@iot-app-kit-visualizations/core": "1.1.0",
     "flush-promises": "^1.0.2",
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
-    "aws-sdk-client-mock": "^1.0.0",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
     "eslint-config-iot-app-kit": "3.0.0",


### PR DESCRIPTION
## Overview
Fix for the build failure due to internal dependencies of vs.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
