### PR TITLE
chore(dashboard): correct import of `act` to remove warnings

### DIFF
--- a/packages/dashboard/src/components/contextMenu/index.test.tsx
+++ b/packages/dashboard/src/components/contextMenu/index.test.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 
-import { act } from 'react-dom/test-utils';
+import { act, render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
-import { render } from '@testing-library/react';
 import UserEvent from '@testing-library/user-event';
 
+import type { ContextMenuProps } from './index';
 import ContextMenu from './index';
 import { DefaultDashboardMessages } from '~/messages';
 import { DASHBOARD_CONTAINER_ID } from '../grid/getDashboardPosition';
 import { configureDashboardStore } from '~/store';
-import type { ContextMenuProps } from './index';
 
 const renderContextMenu = (args: ContextMenuProps, open?: boolean) => {
   const ret: { container: HTMLElement | null } = {

--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -1,9 +1,9 @@
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { createRoot } from 'react-dom/client';
 
+import type { DashboardProps } from './index';
 import Dashboard from './index';
 import React from 'react';
-import type { DashboardProps } from './index';
 
 describe('Dashboard', () => {
   it('should render', function () {

--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import { DndProvider } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
 
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 
 import wrapper from '@cloudscape-design/components/test-utils/dom';
 

--- a/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.test.tsx
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import { DndProvider } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
 
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 
 import InternalDashboard from './index';
 import { configureDashboardStore } from '../../store';
@@ -12,9 +12,7 @@ import { DefaultDashboardMessages } from '../../messages';
 
 import {
   onBringWidgetsToFrontAction,
-  // onCopyWidgetsAction,
   onDeleteWidgetsAction,
-  // onPasteWidgetsAction,
   onSelectWidgetsAction,
   onSendWidgetsToBackAction,
 } from '../../store/actions';

--- a/packages/dashboard/src/components/palette/index.test.tsx
+++ b/packages/dashboard/src/components/palette/index.test.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
 import { screen } from '@testing-library/dom';
-import { render } from '@testing-library/react';
-
-import { act } from 'react-dom/test-utils';
-
-import { fireEvent } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';

--- a/packages/dashboard/src/components/resizablePanes/index.test.tsx
+++ b/packages/dashboard/src/components/resizablePanes/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { createRoot } from 'react-dom/client';
 
 import { ResizablePanes } from './index';

--- a/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/baseSettingSection/index.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act, render, screen } from '@testing-library/react';
 import createWrapper from '@cloudscape-design/components/test-utils/dom';
 import userEvent from '@testing-library/user-event';
 import { MOCK_KPI_WIDGET } from '../../../../../testing/mocks';

--- a/packages/dashboard/src/components/viewportSelection/index.test.tsx
+++ b/packages/dashboard/src/components/viewportSelection/index.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 
 import wrapper from '@cloudscape-design/components/test-utils/dom';
 
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 
 import { screen } from '@testing-library/dom';
 


### PR DESCRIPTION
## Overview
Incorrect importing causes following error:
```
//import {act} from "react-dom/test-utils" 
 console.error
    Warning: An update to Menu inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
```

Correct it to 
```
import { act } from '@testing-library/react';
```

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
