### PR TITLE
ci(commit-lint): enforce commit to be conventional

### DIFF
--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -11,3 +11,11 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Install commit lint config
+        run: npm i @commitlint/config-conventional
+      - name: Validate current commit (last commit) with commitlint
+        run: npx commitlint --from HEAD~1 --verbose


### PR DESCRIPTION
## Overview
Enforce conventional commits on latest commit message within CI

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
