### PR TITLE
feat(composer): data binding variable support for data overlay

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayDataRow.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayDataRow.tsx
@@ -1,22 +1,80 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
+import { ITwinMakerEntityDataBindingContext } from '../../../interfaces';
 import { Component } from '../../../models/SceneModels';
+import { useStore } from '../../../store';
+import { dataBindingValuesProvider } from '../../../utils/dataBindingUtils';
+import { replaceBindingVariables } from '../../../utils/dataBindingVariableUtils';
 import { ReactMarkdownWrapper } from '../../wrappers/ReactMarkdownWrapper';
 import './styles.scss';
 
 export interface DataOverlayDataRowProps {
   rowData: Component.DataOverlayRow;
   overlayType: Component.DataOverlaySubType;
+  valueDataBindings: Component.ValueDataBindingNamedMap[];
 }
 
-export const DataOverlayDataRow = ({ rowData, overlayType }: DataOverlayDataRowProps): ReactElement => {
+export const DataOverlayDataRow = ({
+  rowData,
+  overlayType,
+  valueDataBindings,
+}: DataOverlayDataRowProps): ReactElement => {
+  const sceneComposerId = useSceneComposerId();
+  const dataInput = useStore(sceneComposerId)((state) => state.dataInput);
+  const dataBindingTemplate = useStore(sceneComposerId)((state) => state.dataBindingTemplate);
+  const isEditing = useStore(sceneComposerId)((state) => state.isEditing());
+
+  const [stringContent, setStringContent] = useState<string>('');
+
+  const bindingValuesMap: Record<string, string> = useMemo(() => {
+    const result = {};
+    valueDataBindings.forEach((binding) => {
+      if (!binding.valueDataBinding) {
+        return;
+      }
+      const values: Record<string, unknown> = dataBindingValuesProvider(
+        dataInput,
+        binding.valueDataBinding,
+        dataBindingTemplate,
+      );
+      result[binding.bindingName] =
+        values[(binding.valueDataBinding.dataBindingContext as ITwinMakerEntityDataBindingContext).propertyName];
+    });
+
+    return result;
+  }, [valueDataBindings, dataInput, dataBindingTemplate]);
+
+  const updateContentWithBindingVariables = useCallback(
+    (content: string) => {
+      // Show original content in editing mode
+      if (isEditing) {
+        setStringContent(content);
+        return;
+      }
+
+      setStringContent(replaceBindingVariables(content, bindingValuesMap));
+    },
+    [bindingValuesMap],
+  );
+
+  useEffect(() => {
+    switch (rowData.rowType) {
+      case Component.DataOverlayRowType.Markdown: {
+        updateContentWithBindingVariables((rowData as Component.DataOverlayMarkdownRow).content);
+        break;
+      }
+      default:
+        break;
+    }
+  }, [bindingValuesMap, rowData]);
+
   switch (rowData.rowType) {
     case Component.DataOverlayRowType.Markdown: {
-      const row = rowData as Component.DataOverlayMarkdownRow;
       return (
         <ReactMarkdownWrapper
           className={overlayType === Component.DataOverlaySubType.TextAnnotation ? 'annotation-row' : 'panel-row'}
-          content={row.content}
+          content={stringContent}
         />
       );
     }

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayRows.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayRows.tsx
@@ -18,7 +18,14 @@ export const DataOverlayRows = ({ component }: DataOverlayRowsProps): ReactEleme
       }`}
     >
       {component.dataRows.map((row, index) => {
-        return <DataOverlayDataRow rowData={row} overlayType={component.subType} key={index} />;
+        return (
+          <DataOverlayDataRow
+            rowData={row}
+            overlayType={component.subType}
+            key={index}
+            valueDataBindings={component.valueDataBindings}
+          />
+        );
       })}
     </div>
   );

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayDataRowSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayDataRowSnap.spec.tsx
@@ -3,28 +3,118 @@ import { render } from '@testing-library/react';
 
 import { Component } from '../../../../models/SceneModels';
 import { DataOverlayDataRow } from '../DataOverlayDataRow';
+import { useStore } from '../../../../store';
+import { IDataInput } from '../../../../interfaces';
 
 jest.mock('../../../wrappers/ReactMarkdownWrapper', () => ({
   ReactMarkdownWrapper: (...props: unknown[]) => <div data-testid='ReactMarkdownWrapper'>{JSON.stringify(props)}</div>,
 }));
 
 describe('DataOverlayDataRow', () => {
+  const valueDataBindings: Component.ValueDataBindingNamedMap[] = [
+    {
+      bindingName: 'binding-a',
+      valueDataBinding: {
+        dataBindingContext: {
+          entityId: 'entity-1',
+          componentName: 'comp-1',
+          propertyName: 'prop-1',
+        },
+      },
+    },
+  ];
+  const mockDataInput: IDataInput = {
+    dataFrames: [
+      {
+        dataFrameId: 'A',
+        fields: [
+          {
+            name: 'time',
+            valueType: 'time',
+            values: [111, 222],
+          },
+          {
+            name: 'prop-1',
+            valueType: 'number',
+            labels: {
+              ...(valueDataBindings[0].valueDataBinding?.dataBindingContext || {}),
+            },
+            values: [11, 22],
+          },
+        ],
+      },
+    ],
+    timeRange: { from: 111, to: 222 },
+  };
+  const isEditingMock = jest.fn();
+  const baseState = {
+    dataInput: mockDataInput,
+    dataBindingTemplate: undefined,
+    isEditing: isEditingMock,
+  };
+
   describe('Markdown', () => {
     const mockMarkdownRow: Component.DataOverlayMarkdownRow = {
       rowType: Component.DataOverlayRowType.Markdown,
       content: '# content',
     };
 
+    beforeEach(() => {
+      useStore('default').setState(baseState);
+    });
+
     it('should render markdown row for overlay panel correctly', () => {
       const { container } = render(
-        <DataOverlayDataRow rowData={mockMarkdownRow} overlayType={Component.DataOverlaySubType.OverlayPanel} />,
+        <DataOverlayDataRow
+          rowData={mockMarkdownRow}
+          overlayType={Component.DataOverlaySubType.OverlayPanel}
+          valueDataBindings={[]}
+        />,
       );
       expect(container).toMatchSnapshot();
     });
 
     it('should render markdown row for text annotation correctly', () => {
       const { container } = render(
-        <DataOverlayDataRow rowData={mockMarkdownRow} overlayType={Component.DataOverlaySubType.TextAnnotation} />,
+        <DataOverlayDataRow
+          rowData={mockMarkdownRow}
+          overlayType={Component.DataOverlaySubType.TextAnnotation}
+          valueDataBindings={[]}
+        />,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should render markdown row with data binding variable correctly in editing mode', () => {
+      const row: Component.DataOverlayMarkdownRow = {
+        rowType: Component.DataOverlayRowType.Markdown,
+        content: '# content ${binding-a}',
+      };
+      isEditingMock.mockReturnValue(true);
+
+      const { container } = render(
+        <DataOverlayDataRow
+          rowData={row}
+          overlayType={Component.DataOverlaySubType.TextAnnotation}
+          valueDataBindings={valueDataBindings}
+        />,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should render markdown row with data binding variable correctly in viewing mode', () => {
+      const row: Component.DataOverlayMarkdownRow = {
+        rowType: Component.DataOverlayRowType.Markdown,
+        content: '# content ${binding-a}',
+      };
+      isEditingMock.mockReturnValue(false);
+
+      const { container } = render(
+        <DataOverlayDataRow
+          rowData={row}
+          overlayType={Component.DataOverlaySubType.TextAnnotation}
+          valueDataBindings={valueDataBindings}
+        />,
       );
       expect(container).toMatchSnapshot();
     });

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayDataRowSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayDataRowSnap.spec.tsx.snap
@@ -19,3 +19,23 @@ exports[`DataOverlayDataRow Markdown should render markdown row for text annotat
   </div>
 </div>
 `;
+
+exports[`DataOverlayDataRow Markdown should render markdown row with data binding variable correctly in editing mode 1`] = `
+<div>
+  <div
+    data-testid="ReactMarkdownWrapper"
+  >
+    [{"className":"annotation-row","content":"# content \${binding-a}"},{}]
+  </div>
+</div>
+`;
+
+exports[`DataOverlayDataRow Markdown should render markdown row with data binding variable correctly in viewing mode 1`] = `
+<div>
+  <div
+    data-testid="ReactMarkdownWrapper"
+  >
+    [{"className":"annotation-row","content":"# content 22"},{}]
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayRowsSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayRowsSnap.spec.tsx.snap
@@ -8,12 +8,12 @@ exports[`DataOverlayRows should render overlay panel correctly 1`] = `
     <div
       data-testid="data-row"
     >
-      [{"rowData":{"rowType":"Markdown","content":"content 1"},"overlayType":"OverlayPanel"},{}]
+      [{"rowData":{"rowType":"Markdown","content":"content 1"},"overlayType":"OverlayPanel","valueDataBindings":[]},{}]
     </div>
     <div
       data-testid="data-row"
     >
-      [{"rowData":{"rowType":"Markdown","content":"content 2"},"overlayType":"OverlayPanel"},{}]
+      [{"rowData":{"rowType":"Markdown","content":"content 2"},"overlayType":"OverlayPanel","valueDataBindings":[]},{}]
     </div>
   </div>
 </div>
@@ -27,12 +27,12 @@ exports[`DataOverlayRows should render text annotation correctly 1`] = `
     <div
       data-testid="data-row"
     >
-      [{"rowData":{"rowType":"Markdown","content":"content 1"},"overlayType":"TextAnnotation"},{}]
+      [{"rowData":{"rowType":"Markdown","content":"content 1"},"overlayType":"TextAnnotation","valueDataBindings":[]},{}]
     </div>
     <div
       data-testid="data-row"
     >
-      [{"rowData":{"rowType":"Markdown","content":"content 2"},"overlayType":"TextAnnotation"},{}]
+      [{"rowData":{"rowType":"Markdown","content":"content 2"},"overlayType":"TextAnnotation","valueDataBindings":[]},{}]
     </div>
   </div>
 </div>

--- a/packages/scene-composer/src/interfaces/dataTypes.ts
+++ b/packages/scene-composer/src/interfaces/dataTypes.ts
@@ -37,6 +37,12 @@ export interface IValueDataBinding {
   dataBindingContext: unknown;
 }
 
+export interface ITwinMakerEntityDataBindingContext {
+  entityId: string;
+  componentName: string;
+  propertyName: string;
+}
+
 export interface INavLink {
   destination?: string;
   params?: Record<string, any>;

--- a/packages/scene-composer/src/utils/dataBindingUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingUtils.ts
@@ -78,7 +78,7 @@ export const dataBindingValuesProvider = (
   dataInput?: IDataInput,
   dataBinding?: IValueDataBinding,
   dataBindingTemplate?: IDataBindingTemplate,
-): Record<string, any> => {
+): Record<string, unknown> => {
   if (!dataBinding || !dataInput || !dataBinding.dataBindingContext) {
     return {};
   } else if (

--- a/packages/scene-composer/src/utils/dataBindingVariableUtils.spec.ts
+++ b/packages/scene-composer/src/utils/dataBindingVariableUtils.spec.ts
@@ -1,0 +1,49 @@
+import { replaceBindingVariables } from './dataBindingVariableUtils';
+
+describe('replaceBindingVariables', () => {
+  const bindingValuesMap: Record<string, string> = {
+    'binding a': '11',
+    'binding~!@#$%^&*()': '22',
+    '<随机>': '33',
+  };
+
+  it('should replace variable with value correctly', () => {
+    const original = 'abc ${binding a} def,.';
+    const expected = 'abc 11 def,.';
+
+    const result = replaceBindingVariables(original, bindingValuesMap);
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace variable containing special character with value correctly', () => {
+    const original = 'abc ${binding~!@#$%^&*()} def,.';
+    const expected = 'abc 22 def,.';
+
+    const result = replaceBindingVariables(original, bindingValuesMap);
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace variable in other language with value correctly', () => {
+    const original = 'abc ${<随机>} def,.';
+    const expected = 'abc 33 def,.';
+
+    const result = replaceBindingVariables(original, bindingValuesMap);
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace all variables with value correctly', () => {
+    const original = 'abc ${binding a} and ${binding a} and ${binding~!@#$%^&*()} or ${<随机>} def,.';
+    const expected = 'abc 11 and 11 and 22 or 33 def,.';
+
+    const result = replaceBindingVariables(original, bindingValuesMap);
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace variable with no data when value is not available', () => {
+    const original = 'abc ${binding randon} def,.';
+    const expected = 'abc - def,.';
+
+    const result = replaceBindingVariables(original, bindingValuesMap);
+    expect(result).toEqual(expected);
+  });
+});

--- a/packages/scene-composer/src/utils/dataBindingVariableUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingVariableUtils.ts
@@ -1,0 +1,18 @@
+// Match ${xyz} where xyz can be anything except new line, and as few as possible
+const bindingVariableRegex = /\$\{.+?\}/gi;
+const UNAVAILABLE_DATA = '-';
+
+export function replaceBindingVariables(content: string, bindingValuesMap: Record<string, string>): string {
+  let result = content;
+
+  const variableMatches = content.match(bindingVariableRegex) || [];
+  const variables = variableMatches.map((v: string) => v.substring(2, v.length - 1));
+  // Only support replace variable with their latest property value for now.
+  variables.forEach((variable, index) => {
+    // Display "-" when value not available
+    const value = bindingValuesMap[variable] || UNAVAILABLE_DATA;
+    result = result.replaceAll(variableMatches[index], value);
+  });
+
+  return result;
+}

--- a/packages/scene-composer/tests/scenes/scene_1.json
+++ b/packages/scene-composer/tests/scenes/scene_1.json
@@ -357,11 +357,32 @@
           "config": {
             "isPinned": true
           },
-          "valueDataBindings": [],
+          "valueDataBindings": [
+            {
+              "bindingName": "binding a",
+              "valueDataBinding" : {
+                "dataBindingContext": {
+                  "entityId": "room1",
+                  "componentName": "temperatureSensor1",
+                  "propertyName": "temperature"    
+                }
+              }
+            },
+            {
+              "bindingName": "binding b",
+              "valueDataBinding" : {
+                "dataBindingContext": {
+                  "entityId": "room2",
+                  "componentName": "temperatureSensor1",
+                  "propertyName": "temperature"    
+                }
+              }
+            }
+          ],
           "dataRows": [
             {
               "rowType": "Markdown",
-              "content": "## || Panel || \n ## [Click me](https://github.com/awslabs/iot-app-kit)"
+              "content": "## || Panel || \n ## [Click me](https://github.com/awslabs/iot-app-kit) \n ${binding a} ${binding b}xxxx"
             }
           ]
         }


### PR DESCRIPTION
## Overview
Implement the data binding variable support for data overlay.
User can input `${binding-name}` in overlay markdown/string content to display the latest property history value of that configured data binding

<img width="1225" alt="variable-editing" src="https://user-images.githubusercontent.com/9315598/226496048-c99d2cf2-3e94-49e1-ac1f-9e1d90f4a008.png">
<img width="1224" alt="variable-viewing" src="https://user-images.githubusercontent.com/9315598/226496085-ca3bbe84-30c0-4759-853f-9b3fd31a6245.png">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
