### PR TITLE
fix(dashboard): remove chart suffix from empty states

### DIFF
--- a/packages/dashboard/src/customization/widgets/kpi/component.tsx
+++ b/packages/dashboard/src/customization/widgets/kpi/component.tsx
@@ -39,7 +39,7 @@ const KPIWidgetEmptyStateComponent: React.FC = () => {
         </Box>
 
         <Box variant='p' color='text-status-inactive' margin={{ bottom: 's', horizontal: 's' }}>
-          Add a property or alarm to populate KPI chart
+          Add a property or alarm to populate KPI
         </Box>
       </div>
     </div>

--- a/packages/dashboard/src/customization/widgets/status/component.tsx
+++ b/packages/dashboard/src/customization/widgets/status/component.tsx
@@ -39,7 +39,7 @@ const StatusWidgetEmptyStateComponent: React.FC = () => {
         </Box>
 
         <Box variant='p' color='text-status-inactive' margin={{ bottom: 's', horizontal: 's' }}>
-          Add a property or alarm to populate status chart
+          Add a property or alarm to populate status
         </Box>
       </div>
     </div>


### PR DESCRIPTION
## Overview
Removes the 'chart' suffix from empty state lines.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
