### PR TITLE
refactor(dashboard): refactor constant types to help enforce static t…

### DIFF
--- a/packages/core/src/common/constants.ts
+++ b/packages/core/src/common/constants.ts
@@ -1,18 +1,18 @@
-import type { DataType, StreamType, ComparisonOperator, StatusIconType } from '../data-module/types';
+import type { ComparisonOperator, DataType, StatusIconType, StreamType } from '../data-module/types';
 
-export const DATA_TYPE: { [dataType: string]: DataType } = {
+export const DATA_TYPE: { [dataType in DataType]: DataType } = {
   NUMBER: 'NUMBER',
   BOOLEAN: 'BOOLEAN',
   STRING: 'STRING',
 };
 
-export const STREAM_TYPE: { [streamType: string]: StreamType } = {
+export const STREAM_TYPE: { [streamType in StreamType]: StreamType } = {
   ALARM: 'ALARM',
   ANOMALY: 'ANOMALY',
   ALARM_THRESHOLD: 'ALARM_THRESHOLD',
 };
 
-export const COMPARISON_OPERATOR: { [comparisonOperator: string]: ComparisonOperator } = {
+export const COMPARISON_OPERATOR: { [comparisonOperator in ComparisonOperator]: ComparisonOperator } = {
   LT: 'LT',
   GT: 'GT',
   LTE: 'LTE',
@@ -21,7 +21,7 @@ export const COMPARISON_OPERATOR: { [comparisonOperator: string]: ComparisonOper
   CONTAINS: 'CONTAINS',
 };
 
-export const STATUS_ICON_TYPE: { [statusIconType: string]: StatusIconType } = {
+export const STATUS_ICON_TYPE: { [statusIconType in StatusIconType]: StatusIconType } = {
   error: 'error',
   active: 'active',
   normal: 'normal',

--- a/packages/core/src/mockWidgetProperties.ts
+++ b/packages/core/src/mockWidgetProperties.ts
@@ -1,4 +1,4 @@
-import { STATUS_ICON_TYPE, COMPARISON_OPERATOR, DATA_TYPE, STREAM_TYPE } from './common/constants';
+import { COMPARISON_OPERATOR, DATA_TYPE, STATUS_ICON_TYPE, STREAM_TYPE } from './common/constants';
 import { DAY_IN_MS } from './common/time';
 import type { Threshold } from './common/types';
 import type { DataStream } from './data-module/types';
@@ -54,7 +54,7 @@ export const ALARM_STREAM: DataStream<string> = {
   dataType: DATA_TYPE.STRING,
   name: 'alarm stream',
   color: 'red',
-  streamType: STREAM_TYPE.alarm,
+  streamType: STREAM_TYPE.ALARM,
   resolution: 0,
   data: [
     {
@@ -67,8 +67,8 @@ export const ALARM_STREAM: DataStream<string> = {
 export const ALARM_THRESHOLD: Threshold<string> = {
   value: ALARM,
   color: 'orange',
-  comparisonOperator: COMPARISON_OPERATOR.EQUAL,
-  icon: STATUS_ICON_TYPE.ACTIVE,
+  comparisonOperator: COMPARISON_OPERATOR.EQ,
+  icon: STATUS_ICON_TYPE.active,
 };
 
 export const STRING_STREAM_1: DataStream<string> = {

--- a/packages/react-components/src/components/shared-components/StatusIcon/StatusIcon.tsx
+++ b/packages/react-components/src/components/shared-components/StatusIcon/StatusIcon.tsx
@@ -15,6 +15,6 @@ export const StatusIcon: React.FC<{
   name: StatusIconType;
   color?: string; // hex color
   size?: number; // pixels
-}> = ({ name = STATUS_ICON_TYPE.NORMAL, color, size }) => (
+}> = ({ name = STATUS_ICON_TYPE.normal, color, size }) => (
   <Icon data-testid={`status-icon-${name}`}>{getIcons(name, color, size)}</Icon>
 );

--- a/packages/react-components/src/components/table/tableBase.spec.tsx
+++ b/packages/react-components/src/components/table/tableBase.spec.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import type { DataStream, Viewport } from '@iot-app-kit/core';
 import { COMPARISON_OPERATOR, STATUS_ICON_TYPE } from '@iot-app-kit/core';
 import { createTableItems } from './createTableItems';
 import { TableBase } from './tableBase';
 import { DEFAULT_TABLE_MESSAGES } from './messages';
 import { render } from '@testing-library/react';
-import type { DataStream, Viewport } from '@iot-app-kit/core';
 import type { TableColumnDefinition, TableItem } from './types';
 
 const dataStreamId = 'datastream-1';
@@ -100,7 +100,7 @@ it('renders icon and applies style when a datastream breaches threshold', async 
           color: 'red',
           value: 30,
           comparisonOperator: COMPARISON_OPERATOR.GT,
-          icon: STATUS_ICON_TYPE.ERROR,
+          icon: STATUS_ICON_TYPE.error,
           dataStreamIds: [dataStreamId],
         },
       ],


### PR DESCRIPTION
…yping checks

## Overview
Types of key in constants are too generic. Like 
```
export const DATA_TYPE: { [dataType: string]: DataType } = {
  NUMBER: 'NUMBER',
  BOOLEAN: 'BOOLEAN',
  STRING: 'STRING',
};
``` 
1. if we add new type in `DataType`, constant DATA_TYPE might be missing the new type but compiler won't warn on this
2. if user misused the constant like `DATA_TYPE.NUM`, compiler won't warn on this
3. typescript won't promote possible options of the constants.

This change will help resolve all of these.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
