### PR TITLE
fix(iot-app-kit): fix internal build failure

### DIFF
--- a/packages/source-iottwinmaker/package.json
+++ b/packages/source-iottwinmaker/package.json
@@ -51,7 +51,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-iotsitewise": "3.281.0",
-    "@aws-sdk/client-iottwinmaker": "file:libs/aws-sdk-client-iottwinmaker-v3.289.0.tgz",
     "@aws-sdk/client-kinesis-video": "3.281.0",
     "@aws-sdk/client-kinesis-video-archived-media": "3.281.0",
     "@aws-sdk/client-s3": "3.281.0",
@@ -69,6 +68,9 @@
     "eslint-config-iot-app-kit": "3.0.0",
     "npm-watch": "^0.11.0",
     "ts-jest": "^27.1.3"
+  },
+  "optionalDependencies": {
+    "@aws-sdk/client-iottwinmaker": "file:libs/aws-sdk-client-iottwinmaker-v3.289.0.tgz"
   },
   "bugs": {
     "url": "https://github.com/awslabs/iot-app-kit/issues"

--- a/packages/source-iottwinmaker/src/initialize.ts
+++ b/packages/source-iottwinmaker/src/initialize.ts
@@ -53,7 +53,7 @@ type IoTAppKitInitAuthInputs = {
   /**
    * The pre-configured Secrets Manager client
    */
-  secretsManagerClient: SecretsManagerClient;
+  secretsManagerClient?: SecretsManagerClient;
 };
 
 /**


### PR DESCRIPTION
## Overview
- Fix the build error due to client-iottwinmaker AWS SDK dependency
- Updated `secretsManagerClient` to be an optional parameter in `IoTAppKitInitAuthInputs` 

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
