### PR TITLE
feat(Matterport): add Tag Sync button to setting

### DIFF
--- a/packages/scene-composer/public/CookieFactoryWaterTankMatterportTag.scene.json
+++ b/packages/scene-composer/public/CookieFactoryWaterTankMatterportTag.scene.json
@@ -1,0 +1,387 @@
+{
+  "specVersion": "1.0",
+  "version": "1",
+  "unit": "meters",
+  "properties": {
+    "environmentPreset": "neutral",
+    "dataBindingConfig": {
+      "template": {
+        "sel_entity": "room1",
+        "sel_comp": "temperatureSensor2"
+      },
+      "fieldMapping": {
+        "entityId": [
+          "sel_entity"
+        ],
+        "componentName": [
+          "sel_comp"
+        ]
+      }
+    }
+  },
+  "nodes": [
+    {
+      "name": "Water Tank",
+      "transform": {
+        "position": [
+          1,
+          0,
+          0
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {},
+      "children": [
+        3,
+        4,
+        5,
+        6
+      ],
+      "components": [
+        {
+          "type": "ModelRef",
+          "uri": "CookieFactoryWaterTank.glb",
+          "modelType": "GLB",
+          "unitOfMeasure": "meters"
+        }
+      ],
+      "properties": {}
+    },
+    {
+      "name": "directional light",
+      "transform": {
+        "position": [
+          -5,
+          10,
+          10
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {},
+      "components": [
+        {
+          "type": "Light",
+          "lightType": "Directional",
+          "lightSettings": {
+            "color": 16777215,
+            "intensity": 1,
+            "castShadow": true
+          }
+        }
+      ],
+      "properties": {}
+    },
+    {
+      "name": "ambient light",
+      "transform": {
+        "position": [
+          10,
+          10,
+          10
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {},
+      "components": [
+        {
+          "type": "Light",
+          "lightType": "Ambient",
+          "lightSettings": {
+            "color": 16777215,
+            "intensity": 0.2
+          }
+        }
+      ],
+      "properties": {}
+    },
+    {
+      "name": "FlowMeter",
+      "transform": {
+        "position": [
+          -2.84068441,
+          0.2972502,
+          2.24821067
+        ],
+        "rotation": [
+          -1.5707963800073816,
+          0,
+          0
+        ],
+        "scale": [
+          100,
+          100,
+          100
+        ]
+      },
+      "transformConstraint": {
+        "snapToFloor": true
+      },
+      "components": [
+        {
+          "parentRef": "9A99B442-CBE4-4E34-836D-97B75A14D3AE",
+          "selector": "FlowMeter",
+          "type": "SubModelRef"
+        },
+        {
+          "type": "ModelShader",
+          "ruleBasedMapId": "AlwaysOn",
+          "valueDataBinding": {
+            "dataBindingContext": {
+              "entityId": "room1",
+              "componentName": "temperatureSensor1",
+              "propertyName": "temperature"
+            },
+            "dataFrameLabel": "componentName%3DtemperatureSensor1%26entityId%3Droom1%26propertyName%3Dtemperature"
+          }
+        }
+      ],
+      "properties": []
+    },
+    {
+      "name": "Main Pipe",
+      "transform": {
+        "position": [
+          -3.358429,
+          0.362605572,
+          2.33630419
+        ],
+        "rotation": [
+          -1.570796386794904,
+          1.5707963267948966,
+          0
+        ],
+        "scale": [
+          68.8637543,
+          68.8637543,
+          228.8157
+        ]
+      },
+      "transformConstraint": {
+        "snapToFloor": true
+      },
+      "components": [
+        {
+          "parentRef": "9A99B442-CBE4-4E34-836D-97B75A14D3AE",
+          "selector": "water-pipe1_2",
+          "type": "SubModelRef"
+        }
+      ],
+      "properties": []
+    },
+    {
+      "name": "MotionIndicator",
+      "transform": {
+        "position": [
+          -0.3991522671243042,
+          0.21967330077570077,
+          0.24360373492770346
+        ],
+        "rotation": [
+          -1.0775517822498457,
+          0.5574545669687746,
+          1.529595848679834
+        ],
+        "scale": [
+          0.5,
+          0.05,
+          0
+        ]
+      },
+      "transformConstraint": {},
+      "components": [
+        {
+          "type": "MotionIndicator",
+          "shape": "LinearCylinder",
+          "valueDataBindings": {
+            "foregroundColor": {}
+          },
+          "config": {
+            "numOfRepeatInY": 1,
+            "backgroundColorOpacity": 1,
+            "defaultSpeed": "0.5",
+            "defaultForegroundColor": "#0cee37"
+          }
+        }
+      ],
+      "properties": {}
+    },
+    {
+      "name": "SupplyTank",
+      "transform": {
+        "position": [
+          -4.34547043,
+          0,
+          0.008664846
+        ],
+        "scale": [
+          100,
+          100,
+          100
+        ],
+        "rotation": [
+          -1.5707962667948967,
+          2.999999998420933e-8,
+          -1.5707962667948967
+        ]
+      },
+      "transformConstraint": {
+        "snapToFloor": true
+      },
+      "components": [
+        {
+          "type": "SubModelRef",
+          "parentRef": "9A99B442-CBE4-4E34-836D-97B75A14D3AE",
+          "selector": "SupplyTank"
+        },
+        {
+          "type": "ModelShader",
+          "ruleBasedMapId": "TransparencyOn",
+          "valueDataBinding": {
+            "dataBindingContext": {
+              "entityId": "room1",
+              "componentName": "temperatureSensor1",
+              "propertyName": "temperature"
+            },
+            "dataFrameLabel": "componentName%3DtemperatureSensor1%26entityId%3Droom1%26propertyName%3Dtemperature"
+          }
+        }
+      ],
+      "properties": []
+    },
+    {
+      "name": "Matterport Sync will Delete",
+      "transform": {
+        "position": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ]
+      },
+      "transformConstraint": {
+        "snapToFloor": true
+      },
+      "components": [
+        {
+          "type": "Tag"
+        }
+      ],
+      "properties": {
+        "matterportId": "delete"
+      }
+    }
+  ],
+  "rootNodeIndexes": [
+    0,
+    1,
+    2,
+    7
+  ],
+  "cameras": [],
+  "rules": {
+    "sampleAlarmIconRule": {
+      "statements": [
+        {
+          "expression": "alarm_status == 'ACTIVE'",
+          "target": "iottwinmaker.common.icon:Error"
+        },
+        {
+          "expression": "alarm_status == 'ACKNOWLEDGED'",
+          "target": "iottwinmaker.common.icon:Warning"
+        },
+        {
+          "expression": "alarm_status == 'SNOOZE_DISABLED'",
+          "target": "iottwinmaker.common.icon:Warning"
+        },
+        {
+          "expression": "alarm_status == 'NORMAL'",
+          "target": "iottwinmaker.common.icon:Info"
+        }
+      ]
+    },
+    "sampleTimeSeriesIconRule": {
+      "statements": [
+        {
+          "expression": "temperature >= 20",
+          "target": "iottwinmaker.common.icon:Error"
+        },
+        {
+          "expression": "temperature >= 30",
+          "target": "iottwinmaker.common.icon:Warning"
+        },
+        {
+          "expression": "temperature < 30",
+          "target": "iottwinmaker.common.icon:Info"
+        }
+      ]
+    },
+    "sampleTimeSeriesColorRule": {
+      "statements": [
+        {
+          "expression": "temperature >= 37",
+          "target": "iottwinmaker.common.color:#ff0000"
+        },
+        {
+          "expression": "temperature >= 20",
+          "target": "iottwinmaker.common.color:#ffff00"
+        },
+        {
+          "expression": "temperature < 20",
+          "target": "iottwinmaker.common.color:#00ff00"
+        }
+      ]
+    },
+    "AlwaysOn": {
+      "statements": [
+        {
+          "expression": "1 == 1",
+          "target": "iottwinmaker.common.color:#d13212"
+        }
+      ]
+    },
+    "TransparencyOn": {
+      "statements": [
+        {
+          "expression": "1 == 1",
+          "target": "iottwinmaker.common.opacity:0.32"
+        }
+      ]
+    }
+  }
+}

--- a/packages/scene-composer/src/common/GlobalSettings.ts
+++ b/packages/scene-composer/src/common/GlobalSettings.ts
@@ -1,4 +1,5 @@
 import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
+import { MpSdk } from '@matterport/r3f/dist';
 
 import { DracoDecoderConfig, GetSceneObjectFunction } from '../interfaces/sceneViewer';
 import { COMPOSER_FEATURES, FeatureConfig } from '../interfaces';
@@ -12,6 +13,7 @@ const globalSettings: {
   featureConfig: FeatureConfig;
   getSceneObjectFunction: GetSceneObjectFunction | undefined;
   twinMakerSceneMetadataModule: TwinMakerSceneMetadataModule | undefined;
+  matterportSdks: Record<string, MpSdk>;
 } = {
   debugMode: false,
   dracoDecoder: { enable: true },
@@ -21,6 +23,7 @@ const globalSettings: {
   featureConfig: {},
   getSceneObjectFunction: undefined,
   twinMakerSceneMetadataModule: undefined,
+  matterportSdks: {},
 };
 
 const changeSubscribers = [] as Function[];
@@ -61,6 +64,15 @@ export const setGetSceneObjectFunction = (getSceneObjectFunction: GetSceneObject
 export const setTwinMakerSceneMetadataModule = (twinMakerSceneMetadataModule: TwinMakerSceneMetadataModule) => {
   globalSettings.twinMakerSceneMetadataModule = twinMakerSceneMetadataModule;
   notifySubscribers();
+};
+
+export const setMatterportSdk = (sceneId: string, sdk: MpSdk): void => {
+  globalSettings.matterportSdks[sceneId] = sdk;
+  notifySubscribers();
+};
+
+export const getMatterportSdk = (sceneId: string): MpSdk | undefined => {
+  return globalSettings.matterportSdks[sceneId];
 };
 
 export const getGlobalSettings = () => {

--- a/packages/scene-composer/src/components/panels/scene-settings/MatterportIntegration.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/MatterportIntegration.tsx
@@ -12,6 +12,8 @@ import {
   getUpdatedSceneInfoForConnection,
 } from '../../../utils/matterportIntegrationUtils';
 
+import { MatterportTagSync } from './MatterportTagSync';
+
 export const MatterportIntegration: React.FC = () => {
   const intl = useIntl();
   const sceneComposerId = useContext(sceneComposerIdContext);
@@ -163,6 +165,7 @@ export const MatterportIntegration: React.FC = () => {
             </SpaceBetween>
           </div>
         )}
+        {matterportModelId && <MatterportTagSync />}
       </SpaceBetween>
     </React.Fragment>
   );

--- a/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.spec.tsx
@@ -1,0 +1,203 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { MpSdk } from '@matterport/r3f/dist';
+
+import { ISceneNodeInternal, useStore } from '../../../store';
+import { MattertagItem, TagItem } from '../../../utils/matterportTagUtils';
+
+const getMatterTagsMock = jest.fn();
+const getTagsMock = jest.fn();
+jest.mock('../../../hooks/useMatterportObserver', () => {
+  return jest.fn(() => ({
+    mattertagObserver: {
+      getMattertags: getMatterTagsMock,
+    },
+    tagObserver: {
+      getTags: getTagsMock,
+    },
+  }));
+});
+
+const handleAddMatterportTagMock = jest.fn();
+const handleUpdateMatterportTagMock = jest.fn();
+const handleRemoveMatterportTagMock = jest.fn();
+jest.mock('../../../hooks/useMatterportTags', () => {
+  return jest.fn(() => ({
+    handleAddMatterportTag: handleAddMatterportTagMock,
+    handleUpdateMatterportTag: handleUpdateMatterportTagMock,
+    handleRemoveMatterportTag: handleRemoveMatterportTagMock,
+  }));
+});
+
+import { MatterportTagSync } from './MatterportTagSync';
+
+describe('MatterportIntegration', () => {
+  const getComponentRefByTypeMock = jest.fn();
+  const getSceneNodeByRefMock = jest.fn();
+
+  const baseState = {
+    getComponentRefByType: getComponentRefByTypeMock,
+    getSceneNodeByRef: getSceneNodeByRefMock,
+  };
+
+  const testInternalNode: ISceneNodeInternal = {
+    ref: '',
+    name: 'name1',
+    transform: {
+      position: [0, 0, 0],
+      rotation: [0, 0, 0],
+      scale: [1, 1, 1],
+    },
+    transformConstraint: {},
+    components: [],
+    childRefs: [],
+    properties: {
+      matterportId: 'id1',
+    },
+  };
+
+  const testMattertagItem: MattertagItem = {
+    sid: '',
+    enabled: true,
+    anchorPosition: { x: 0, y: 0, z: 0 },
+    stemVector: { x: 0, y: 0, z: 0 },
+    stemVisible: true,
+    label: 'initialLabel',
+    description: 'initial test tag',
+    media: {
+      type: 'mattertag.media.none' as MpSdk.Mattertag.MediaType,
+      src: '',
+    },
+    color: { r: 0, g: 0, b: 0 },
+    floorIndex: 0,
+    floorInfo: {
+      id: 'testFloorid',
+      sequence: 0,
+    },
+  };
+  const testTagItem: TagItem = {
+    id: '',
+    anchorPosition: { x: 0, y: 0, z: 0 },
+    discPosition: { x: 0, y: 0, z: 0 },
+    stemVector: { x: 0, y: 0, z: 0 },
+    stemHeight: 1,
+    stemVisible: true,
+    label: 'initialLabel',
+    description: 'initial test tag',
+    color: { r: 0, g: 0, b: 0 },
+    roomId: '',
+    attachments: [],
+    keywords: [],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render correctly', async () => {
+    useStore('default').setState(baseState);
+    const { container } = render(<MatterportTagSync />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should sync mattertags by deleting id1, updating id2, and adding id3', async () => {
+    useStore('default').setState(baseState);
+
+    getComponentRefByTypeMock.mockImplementation(() => {
+      const deletableTag: Record<string, string[]> = {
+        ref1: [],
+        ref2: [],
+        'ref3:': [],
+      };
+      return deletableTag;
+    });
+
+    const node1: ISceneNodeInternal = { ...testInternalNode };
+    const node2: ISceneNodeInternal = {
+      ...testInternalNode,
+      properties: {
+        matterportId: 'id2',
+      },
+    };
+    const node3: ISceneNodeInternal = {
+      ...testInternalNode,
+      properties: {},
+    };
+
+    getSceneNodeByRefMock.mockImplementation((ref: string) => {
+      const nodeLookup = {
+        ref1: node1,
+        ref2: node2,
+        ref3: node3,
+      };
+      return nodeLookup[ref];
+    });
+
+    const matterTag2 = { ...testMattertagItem, sid: 'id2' };
+    const matterTag3 = { ...testMattertagItem, sid: 'id2' };
+    getMatterTagsMock.mockImplementation(() => {
+      const mattertags: Array<[string, MpSdk.Mattertag.ObservableMattertagData]> = [
+        ['id2', matterTag2],
+        ['id3', matterTag3],
+      ];
+      return mattertags;
+    });
+    getTagsMock.mockImplementation(() => undefined);
+    const rendered = render(<MatterportTagSync />);
+
+    fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+
+    expect(getComponentRefByTypeMock).toBeCalled();
+    expect(handleAddMatterportTagMock).toBeCalledWith('id3', matterTag3);
+    expect(handleUpdateMatterportTagMock).toBeCalledWith('ref2', node2, matterTag2);
+    expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
+  });
+
+  it('should sync matterport tags by deleting id1, updating id2, and adding id3', async () => {
+    useStore('default').setState(baseState);
+
+    getComponentRefByTypeMock.mockImplementation(() => {
+      const deletableTag: Record<string, string[]> = {
+        ref1: [],
+        ref2: [],
+      };
+      return deletableTag;
+    });
+
+    const node1: ISceneNodeInternal = { ...testInternalNode };
+    const node2: ISceneNodeInternal = {
+      ...testInternalNode,
+      properties: {
+        matterportId: 'id2',
+      },
+    };
+
+    getSceneNodeByRefMock.mockImplementation((ref: string) => {
+      const nodeLookup = {
+        ref1: node1,
+        ref2: node2,
+      };
+      return nodeLookup[ref];
+    });
+
+    const tag2 = { ...testTagItem, sid: 'id2' };
+    const tag3 = { ...testTagItem, sid: 'id2' };
+    getMatterTagsMock.mockImplementation(() => undefined);
+    getTagsMock.mockImplementation(() => {
+      const tags: Array<[string, MpSdk.Tag.TagData]> = [
+        ['id2', tag2],
+        ['id3', tag3],
+      ];
+      return tags;
+    });
+    const rendered = render(<MatterportTagSync />);
+
+    fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+
+    expect(getComponentRefByTypeMock).toBeCalled();
+    expect(handleAddMatterportTagMock).toBeCalledWith('id3', tag2);
+    expect(handleUpdateMatterportTagMock).toBeCalledWith('ref2', node2, tag3);
+    expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.tsx
@@ -1,0 +1,79 @@
+import React, { useCallback } from 'react';
+import { useIntl } from 'react-intl';
+import { Button } from '@awsui/components-react';
+
+import { KnownComponentType } from '../../../interfaces';
+import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
+import useLifecycleLogging from '../../../logger/react-logger/hooks/useLifecycleLogging';
+import { ISceneNodeInternal, useStore } from '../../../store';
+import useMatterportTags from '../../../hooks/useMatterportTags';
+import useMatterportObserver from '../../../hooks/useMatterportObserver';
+
+export const MatterportTagSync: React.FC = () => {
+  useLifecycleLogging('MatterportTagSync');
+  const intl = useIntl();
+
+  const sceneComposerId = useSceneComposerId();
+  const getComponentRefByType = useStore(sceneComposerId)((state) => state.getComponentRefByType);
+  const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
+
+  const { handleAddMatterportTag, handleUpdateMatterportTag, handleRemoveMatterportTag } = useMatterportTags();
+  const { mattertagObserver, tagObserver } = useMatterportObserver();
+
+  const doSync = useCallback(() => {
+    const mattertags = mattertagObserver.getMattertags();
+    const tags = tagObserver.getTags();
+
+    const tagRecords = getComponentRefByType(KnownComponentType.Tag);
+    const oldTagMap: Record<string, { nodeRef: string; node: ISceneNodeInternal }> = {};
+    for (const key in tagRecords) {
+      const node = getSceneNodeByRef(key);
+      if (node?.properties.matterportId) {
+        oldTagMap[node.properties.matterportId] = { nodeRef: key, node: node };
+      }
+    }
+
+    if (mattertags) {
+      // matterport dictionary is a customer matterport type that doesn't inherit other javascript properties like
+      // enumerable so use this exact iterable for it only
+      for (const [key, value] of mattertags) {
+        if (oldTagMap[key]) {
+          handleUpdateMatterportTag(oldTagMap[key].nodeRef, oldTagMap[key].node, value);
+        } else {
+          handleAddMatterportTag(key, value);
+        }
+        delete oldTagMap[key];
+      }
+    }
+
+    if (tags) {
+      for (const [key, value] of tags) {
+        if (oldTagMap[key]) {
+          handleUpdateMatterportTag(oldTagMap[key].nodeRef, oldTagMap[key].node, value);
+        } else {
+          handleAddMatterportTag(key, value);
+        }
+        delete oldTagMap[key];
+      }
+    }
+
+    for (const key in oldTagMap) {
+      handleRemoveMatterportTag(oldTagMap[key].nodeRef);
+    }
+  }, [
+    getSceneNodeByRef,
+    mattertagObserver,
+    tagObserver,
+    handleAddMatterportTag,
+    handleUpdateMatterportTag,
+    handleRemoveMatterportTag,
+  ]);
+
+  return (
+    <React.Fragment>
+      <Button data-testid='matterport-tag-sync-button' onClick={doSync}>
+        {intl.formatMessage({ defaultMessage: 'Sync Matterport Tags', description: 'matterport tag sync button' })}
+      </Button>
+    </React.Fragment>
+  );
+};

--- a/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/MatterportIntegration.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/MatterportIntegration.spec.tsx.snap
@@ -41,6 +41,12 @@ exports[`MatterportIntegration should render correctly 1`] = `
         </div>
       </div>
     </div>
+    <div
+      data-mocked="Button"
+      data-testid="matterport-tag-sync-button"
+    >
+      Sync Matterport Tags
+    </div>
   </div>
 </div>
 `;

--- a/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/MatterportTagSync.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/MatterportTagSync.spec.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MatterportIntegration should render correctly 1`] = `
+<div>
+  <div
+    data-mocked="Button"
+    data-testid="matterport-tag-sync-button"
+  >
+    Sync Matterport Tags
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/hooks/useMatterportObserver.spec.tsx
+++ b/packages/scene-composer/src/hooks/useMatterportObserver.spec.tsx
@@ -1,0 +1,44 @@
+import { cleanup, renderHook } from '@testing-library/react-hooks';
+
+const matterTagSubscribe = jest.fn();
+const tagSubscribe = jest.fn();
+
+const matterportSdk = {
+  Mattertag: {
+    data: {
+      subscribe: matterTagSubscribe,
+    },
+  },
+  Tag: {
+    data: {
+      subscribe: tagSubscribe,
+    },
+  },
+};
+
+const getMatterportSdkMock = jest.fn();
+jest.mock('../common/GlobalSettings', () => {
+  return {
+    getMatterportSdk: getMatterportSdkMock,
+  };
+});
+getMatterportSdkMock.mockImplementation(() => {
+  return matterportSdk;
+});
+
+import useMatterportObserver from './useMatterportObserver';
+
+describe('useMatterportTags', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should subscribe to mattertag and tag', () => {
+    renderHook(() => useMatterportObserver()).result.current;
+
+    expect(matterTagSubscribe).toBeCalled();
+    expect(tagSubscribe).toBeCalled();
+
+    cleanup();
+  });
+});

--- a/packages/scene-composer/src/hooks/useMatterportObserver.ts
+++ b/packages/scene-composer/src/hooks/useMatterportObserver.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { MpSdk } from '@matterport/webcomponent';
+
+import { getMatterportSdk } from '../common/GlobalSettings';
+import { useSceneComposerId } from '../common/sceneComposerIdContext';
+import { MattertagObserver, TagObserver } from '../utils/matterportTagUtils';
+
+const useMatterportObserver = (): {
+  mattertagObserver: MattertagObserver;
+  tagObserver: TagObserver;
+} => {
+  const sceneComposerId = useSceneComposerId();
+  const matterportSdk = getMatterportSdk(sceneComposerId); //
+
+  const [mattertagObserver] = useState<MattertagObserver>(new MattertagObserver());
+  const [tagObserver] = useState<TagObserver>(new TagObserver());
+
+  useEffect(() => {
+    let mattertagSubscription: MpSdk.ISubscription | undefined = undefined;
+    let tagSubscription: MpSdk.ISubscription | undefined = undefined;
+    if (matterportSdk) {
+      if (matterportSdk.Mattertag) {
+        mattertagSubscription = matterportSdk.Mattertag.data.subscribe(mattertagObserver);
+      }
+      if (matterportSdk.Tag) {
+        tagSubscription = matterportSdk.Tag.data.subscribe(tagObserver);
+      }
+    }
+
+    return () => {
+      if (mattertagSubscription) {
+        mattertagSubscription.cancel();
+      }
+      if (tagSubscription) {
+        tagSubscription.cancel();
+      }
+    };
+  }, [matterportSdk]);
+
+  return { mattertagObserver, tagObserver };
+};
+
+export default useMatterportObserver;

--- a/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
+++ b/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
@@ -1,0 +1,151 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { MpSdk } from '@matterport/r3f/dist';
+
+import { IAnchorComponent, ISceneNode } from '../interfaces';
+import { ISceneNodeInternal, useStore } from '../store';
+import { MattertagItem, TagItem } from '../utils/matterportTagUtils';
+
+import useMatterportTags from './useMatterportTags';
+
+describe('useMatterportTags', () => {
+  const appendSceneNode = jest.fn();
+  const updateSceneNodeInternal = jest.fn();
+  const removeSceneNode = jest.fn();
+
+  const id = 'testMatterportId';
+
+  const mattertagItem: MattertagItem = {
+    sid: id,
+    enabled: true,
+    anchorPosition: { x: 1, y: 2, z: 3 },
+    stemVector: { x: 4, y: 5, z: 6 },
+    stemVisible: true,
+    label: 'initialLabel',
+    description: 'initial test tag',
+    media: {
+      type: 'mattertag.media.none' as MpSdk.Mattertag.MediaType,
+      src: '',
+    },
+    color: { r: 0, g: 0, b: 0 },
+    floorIndex: 0,
+    floorInfo: {
+      id: 'testFloorid',
+      sequence: 0,
+    },
+  };
+
+  const tagItem: TagItem = {
+    id: id,
+    anchorPosition: { x: 1, y: 2, z: 3 },
+    discPosition: { x: 7, y: 8, z: 9 },
+    stemVector: { x: 4, y: 5, z: 6 },
+    stemHeight: 1,
+    stemVisible: true,
+    label: 'initialLabel',
+    description: 'initial test tag',
+    color: { r: 10, g: 11, b: 12 },
+    roomId: '',
+    attachments: [],
+    keywords: [],
+  };
+
+  const anchorComponent: IAnchorComponent = {
+    type: 'Tag',
+    offset: [mattertagItem.stemVector.x, mattertagItem.stemVector.y, mattertagItem.stemVector.z],
+  };
+
+  const testNode = {
+    name: mattertagItem.label,
+    components: [anchorComponent],
+    transform: {
+      position: [mattertagItem.anchorPosition.x, mattertagItem.anchorPosition.y, mattertagItem.anchorPosition.z],
+      rotation: [0, 0, 0],
+      scale: [1, 1, 1],
+    },
+    properties: {
+      matterportId: id, //mattertag uses item.sid and tag uses item.id so we just us the collection key for both
+    },
+    //parentRef: getRefForParenting(),
+  } as ISceneNode;
+
+  const testInternalNode: ISceneNodeInternal = {
+    ...testNode,
+    ref: '',
+    name: testNode.name!,
+    transform: testNode.transform!,
+    transformConstraint: {},
+    components: [{ ...anchorComponent, ref: '' }],
+    childRefs: [],
+    properties: testNode.properties!,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useStore('default').setState({
+      appendSceneNode,
+      updateSceneNodeInternal,
+      removeSceneNode,
+    });
+    jest.clearAllMocks();
+  });
+
+  it('should add matterport mattertag', () => {
+    const { handleAddMatterportTag } = renderHook(() => useMatterportTags()).result.current;
+
+    handleAddMatterportTag(id, mattertagItem);
+    expect(appendSceneNode).toBeCalledWith(testNode);
+  });
+
+  it('should add matterport tag', () => {
+    const { handleAddMatterportTag } = renderHook(() => useMatterportTags()).result.current;
+
+    handleAddMatterportTag(id, tagItem);
+    expect(appendSceneNode).toBeCalledWith(testNode);
+  });
+
+  it('should update matterport mattertag', () => {
+    const { handleUpdateMatterportTag } = renderHook(() => useMatterportTags()).result.current;
+
+    handleUpdateMatterportTag('', testInternalNode, mattertagItem);
+    expect(updateSceneNodeInternal).toBeCalledWith('', {
+      name: mattertagItem.label,
+      transform: {
+        position: [mattertagItem.anchorPosition.x, mattertagItem.anchorPosition.y, mattertagItem.anchorPosition.z],
+      },
+      components: [
+        {
+          ...anchorComponent,
+          ref: '',
+          offset: [mattertagItem.stemVector.x, mattertagItem.stemVector.y, mattertagItem.stemVector.z],
+        },
+      ],
+    });
+  });
+
+  it('should update matterport tag', () => {
+    const { handleUpdateMatterportTag } = renderHook(() => useMatterportTags()).result.current;
+
+    handleUpdateMatterportTag('', testInternalNode, tagItem);
+    expect(updateSceneNodeInternal).toBeCalledWith('', {
+      name: tagItem.label,
+      transform: {
+        position: [tagItem.anchorPosition.x, tagItem.anchorPosition.y, tagItem.anchorPosition.z],
+      },
+      components: [
+        {
+          ...anchorComponent,
+          ref: '',
+          offset: [tagItem.stemVector.x, tagItem.stemVector.y, tagItem.stemVector.z],
+        },
+      ],
+    });
+  });
+
+  it('should delete matterport mattertag or tag', () => {
+    const { handleRemoveMatterportTag } = renderHook(() => useMatterportTags()).result.current;
+
+    handleRemoveMatterportTag('deleteMe');
+    expect(removeSceneNode).toBeCalledWith('deleteMe');
+  });
+});

--- a/packages/scene-composer/src/hooks/useMatterportTags.ts
+++ b/packages/scene-composer/src/hooks/useMatterportTags.ts
@@ -1,0 +1,91 @@
+import { useCallback } from 'react';
+
+import { useSceneComposerId } from '../common/sceneComposerIdContext';
+import { IAnchorComponent, ISceneNode, KnownComponentType } from '../interfaces';
+import { IAnchorComponentInternal, ISceneNodeInternal, useStore } from '../store';
+import { MattertagItem, TagItem } from '../utils/matterportTagUtils';
+import { RecursivePartial } from '../utils/typeUtils';
+
+const addTag = (
+  addSceneNode: (node: ISceneNode, parentRef?: string) => Readonly<ISceneNode>,
+  id: string,
+  item: MattertagItem | TagItem,
+) => {
+  const anchorComponent: IAnchorComponent = {
+    type: KnownComponentType.Tag,
+    offset: [item.stemVector.x, item.stemVector.y, item.stemVector.z],
+  };
+  const node = {
+    name: item.label,
+    components: [anchorComponent],
+    transform: {
+      position: [item.anchorPosition.x, item.anchorPosition.y, item.anchorPosition.z],
+      rotation: [0, 0, 0],
+      scale: [1, 1, 1],
+    },
+    properties: {
+      matterportId: id, //mattertag uses item.sid and tag uses item.id so we just us the collection key for both
+    },
+  } as ISceneNode;
+  addSceneNode(node);
+};
+
+const updateTag = (
+  updateSceneNode: (ref: string, partial: RecursivePartial<ISceneNodeInternal>, isTransient?: boolean) => void,
+  ref: string,
+  node: ISceneNodeInternal,
+  item: MattertagItem | TagItem,
+) => {
+  // assume only one tag per node which is same assumption as findComponentByType
+  const components = [...node.components];
+  const tagIndex = node.components.findIndex((elem) => elem.type === KnownComponentType.Tag);
+  if (tagIndex !== -1) {
+    components[tagIndex] = {
+      ...components[tagIndex],
+      offset: [item.stemVector.x, item.stemVector.y, item.stemVector.z],
+    } as IAnchorComponentInternal;
+  }
+  updateSceneNode(ref, {
+    name: item.label,
+    transform: {
+      position: [item.anchorPosition.x, item.anchorPosition.y, item.anchorPosition.z],
+    },
+    components: components,
+  });
+};
+
+const useMatterportTags = (): {
+  handleAddMatterportTag: (id: string, item: MattertagItem | TagItem) => void;
+  handleUpdateMatterportTag: (ref: string, node: ISceneNodeInternal, item: MattertagItem | TagItem) => void;
+  handleRemoveMatterportTag: (nodeRef: string) => void;
+} => {
+  const sceneComposerId = useSceneComposerId();
+  const appendSceneNode = useStore(sceneComposerId)((state) => state.appendSceneNode);
+  const updateSceneNodeInternal = useStore(sceneComposerId)((state) => state.updateSceneNodeInternal);
+  const removeSceneNode = useStore(sceneComposerId)((state) => state.removeSceneNode);
+
+  const handleAddMatterportTag = useCallback(
+    (id: string, item: MattertagItem | TagItem) => {
+      addTag(appendSceneNode, id, item);
+    },
+    [appendSceneNode],
+  );
+
+  const handleUpdateMatterportTag = useCallback(
+    (ref: string, node: ISceneNodeInternal, item: MattertagItem | TagItem) => {
+      updateTag(updateSceneNodeInternal, ref, node, item);
+    },
+    [updateSceneNodeInternal],
+  );
+
+  const handleRemoveMatterportTag = useCallback(
+    (nodeRef: string) => {
+      removeSceneNode(nodeRef);
+    },
+    [removeSceneNode],
+  );
+
+  return { handleAddMatterportTag, handleUpdateMatterportTag, handleRemoveMatterportTag };
+};
+
+export default useMatterportTags;

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
@@ -5,6 +5,7 @@ import { Canvas, ThreeEvent } from '@react-three/fiber';
 import { useContextBridge } from '@react-three/drei/core/useContextBridge';
 import { MatterportViewer, MpSdk } from '@matterport/r3f/dist';
 
+import { setMatterportSdk } from '../../common/GlobalSettings';
 import LoggingContext from '../../logger/react-logger/contexts/logging';
 import MessageModal from '../../components/MessageModal';
 import { MenuBar } from '../../components/MenuBar';
@@ -46,6 +47,7 @@ const R3FWrapper = (props: {
   children?: any;
   sceneLoaded?: boolean;
 }) => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
   const ContextBridge = useContextBridge(LoggingContext, sceneComposerIdContext, ThemeContext);
 
   if (!props.sceneLoaded) {
@@ -67,6 +69,7 @@ const R3FWrapper = (props: {
           //  <Other2DComponents/>
           // <MpSdkContext.Provider/>
           console.log('MatterportViewer SDK ready!', matterportSdk);
+          setMatterportSdk(sceneComposerId, matterportSdk);
         }}
         style={{ width: '100%', height: '100%' }}
         search={0}
@@ -111,7 +114,7 @@ const SceneLayout: FC<SceneLayoutProps> = ({
     .valueDataBindingProvider;
   const ContextBridge = useContextBridge(LoggingContext, sceneComposerIdContext, ThemeContext);
   const intl = useIntl();
-  const { sceneLoaded, getSceneProperty } = useSceneDocument(sceneComposerId);
+  const { sceneLoaded } = useSceneDocument(sceneComposerId);
 
   const renderDisplayRef = useRef<HTMLDivElement>(null!);
 

--- a/packages/scene-composer/src/utils/matterportTagUtils.ts
+++ b/packages/scene-composer/src/utils/matterportTagUtils.ts
@@ -1,0 +1,29 @@
+import { MpSdk } from '@matterport/r3f/dist';
+
+export type TagItem = MpSdk.Tag.TagData;
+export class TagObserver implements MpSdk.IMapObserver<TagItem> {
+  tagCollection: MpSdk.Dictionary<TagItem> | undefined;
+  constructor() {
+    this.tagCollection = undefined;
+  }
+  onCollectionUpdated(collection: MpSdk.Dictionary<TagItem>): void {
+    this.tagCollection = collection;
+  }
+  getTags(): MpSdk.Dictionary<TagItem> | undefined {
+    return this.tagCollection;
+  }
+}
+
+export type MattertagItem = MpSdk.Mattertag.ObservableMattertagData;
+export class MattertagObserver implements MpSdk.IMapObserver<MattertagItem> {
+  tagCollection: MpSdk.Dictionary<MattertagItem> | undefined;
+  constructor() {
+    this.tagCollection = undefined;
+  }
+  onCollectionUpdated(collection: MpSdk.Dictionary<MattertagItem>): void {
+    this.tagCollection = collection;
+  }
+  getMattertags(): MpSdk.Dictionary<MattertagItem> | undefined {
+    return this.tagCollection;
+  }
+}

--- a/packages/scene-composer/stories/Matterport.stories.mdx
+++ b/packages/scene-composer/stories/Matterport.stories.mdx
@@ -45,7 +45,7 @@ export const Template = (args) => {
   <Story name='Editor'
     height='500px'
     parameters={{ controls: { include: ['matterportModelId', 'matterportApplicationKey', 'onSelectionChanged', 'onWidgetClick'], hideNoControlsWarning: true }}}
-    args={{ ...defaultArgs, scene: 'CookieFactoryWaterTank', mode: 'Editing' }}>
+    args={{ ...defaultArgs, scene: 'CookieFactoryWaterTankMatterportTag', mode: 'Editing' }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -779,6 +779,10 @@
     "note": "Progress Bar description",
     "text": "{fileSize} downloaded"
   },
+  "ty9k3i": {
+    "note": "matterport tag sync button",
+    "text": "Sync Matterport Tags"
+  },
   "tz4SMZ": {
     "note": "Panel Tab title",
     "text": "Settings"


### PR DESCRIPTION
## Overview
Add Tag Sync button to Matterport Settings panel in TwinMaker Scene Editor

## Verifying Changes
The scene viewer doesn't update as you change a Matterport scene so the easiest way to verify is:
Have a TwinMaker Scene with a fake Matterport Tag imported into already (tag with properties {matterportId: 'someId'} that isn't in your Matterport space
A Matterport space with 2+ tags
Use the Sync button -
 the fake Matterport tag should be deleted
 the other tags should get added
Manually delete a tag
Manually enter some data bindings on one of the new imported tags
Use the Sync button
Verify: the manually deleted tag returns, verify the added bindings aren't ovewritten when the tag updates

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
