### PR TITLE
refactor(Dashboard): remove hasEditPermissions and alter action btn s…

### DIFF
--- a/packages/dashboard/src/components/actions/index.tsx
+++ b/packages/dashboard/src/components/actions/index.tsx
@@ -11,19 +11,11 @@ export type ActionsProps = {
   messageOverrides: DashboardMessages;
   grid: DashboardState['grid'];
   readOnly: boolean;
-  hasEditPermission: boolean;
   dashboardConfiguration: DashboardState['dashboardConfiguration'];
   onSave?: (dashboard: SaveableDashboard) => void;
 };
 
-const Actions: React.FC<ActionsProps> = ({
-  grid,
-  dashboardConfiguration,
-  messageOverrides,
-  hasEditPermission,
-  readOnly,
-  onSave,
-}) => {
+const Actions: React.FC<ActionsProps> = ({ grid, dashboardConfiguration, messageOverrides, readOnly, onSave }) => {
   const dispatch = useDispatch();
 
   const handleOnSave = () => {
@@ -39,22 +31,18 @@ const Actions: React.FC<ActionsProps> = ({
     dispatch(onToggleReadOnly());
   };
 
-  if (!onSave && !hasEditPermission) return <></>;
-
   return (
     <div className='actions iot-dashboard-toolbar-actions'>
       <h1 className='iot-dashboard-toolbar-title'>{messageOverrides.toolbar.actions.title}</h1>
       <div className='button-actions'>
         {onSave && (
-          <Button variant='primary' onClick={handleOnSave} data-test-id='actions-save-dashboard-btn'>
+          <Button onClick={handleOnSave} data-test-id='actions-save-dashboard-btn'>
             {messageOverrides.toolbar.actions.save}
           </Button>
         )}
-        {hasEditPermission && (
-          <Button variant='primary' onClick={handleOnReadOnly} data-test-id='actions-toggle-read-only-btn'>
-            {readOnly ? 'Edit' : 'Preview'}
-          </Button>
-        )}
+        <Button onClick={handleOnReadOnly} data-test-id='actions-toggle-read-only-btn'>
+          {readOnly ? 'Edit' : 'Preview'}
+        </Button>
       </div>
     </div>
   );

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -28,13 +28,11 @@ export type DashboardProps = {
   messageOverrides?: RecursivePartial<DashboardMessages>;
   onSave?: (dashboard: SaveableDashboard) => void;
   dashboardClientConfiguration: DashboardClientConfiguration;
-  hasEditPermission?: boolean;
 } & PickRequiredOptional<DashboardState, 'dashboardConfiguration', 'readOnly' | 'grid'>;
 
 const Dashboard: React.FC<DashboardProps> = ({
   messageOverrides,
   onSave,
-  hasEditPermission = true,
   dashboardClientConfiguration,
   ...dashboardState
 }) => {
@@ -49,11 +47,7 @@ const Dashboard: React.FC<DashboardProps> = ({
               enableKeyboardEvents: true,
             }}
           >
-            <InternalDashboard
-              onSave={onSave}
-              hasEditPermission={hasEditPermission}
-              messageOverrides={merge(messageOverrides, DefaultDashboardMessages)}
-            />
+            <InternalDashboard onSave={onSave} messageOverrides={merge(messageOverrides, DefaultDashboardMessages)} />
           </DndProvider>
         </Provider>
       </QueryContext.Provider>

--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -38,7 +38,7 @@ describe('InternalDashboard', () => {
               enableKeyboardEvents: true,
             }}
           >
-            <InternalDashboard hasEditPermission={true} messageOverrides={DefaultDashboardMessages} />
+            <InternalDashboard messageOverrides={DefaultDashboardMessages} />
           </DndProvider>
         </Provider>
       );
@@ -77,7 +77,7 @@ describe('InternalDashboard', () => {
               enableKeyboardEvents: true,
             }}
           >
-            <InternalDashboard hasEditPermission={true} messageOverrides={DefaultDashboardMessages} onSave={onSave} />
+            <InternalDashboard messageOverrides={DefaultDashboardMessages} onSave={onSave} />
           </DndProvider>
         </Provider>
       );
@@ -117,7 +117,7 @@ describe('InternalDashboard', () => {
               enableKeyboardEvents: true,
             }}
           >
-            <InternalDashboard hasEditPermission={true} messageOverrides={DefaultDashboardMessages} />
+            <InternalDashboard messageOverrides={DefaultDashboardMessages} />
           </DndProvider>
         </Provider>
       );
@@ -151,7 +151,7 @@ describe('InternalDashboard', () => {
               enableKeyboardEvents: true,
             }}
           >
-            <InternalDashboard hasEditPermission={true} messageOverrides={DefaultDashboardMessages} />
+            <InternalDashboard messageOverrides={DefaultDashboardMessages} />
           </DndProvider>
         </Provider>
       );
@@ -165,42 +165,6 @@ describe('InternalDashboard', () => {
       const foundButton = wrapper(actionsContainer).findButton('[data-test-id="actions-toggle-read-only-btn"]');
       foundButton?.click();
     });
-
-    const dashboard = container.querySelector('.iot-dashboard-panes-area');
-    expect(dashboard).toBeFalsy();
-  });
-
-  it('cannot toggle to edit mode if no edit permissions', function () {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-
-    const args = {
-      readOnly: true,
-      dashboardConfiguration: {
-        widgets: [],
-        viewport: { duration: '5m' },
-      },
-    };
-    const root = createRoot(container);
-
-    act(() => {
-      root.render(
-        <Provider store={configureDashboardStore(args)}>
-          <DndProvider
-            backend={TouchBackend}
-            options={{
-              enableMouseEvents: true,
-              enableKeyboardEvents: true,
-            }}
-          >
-            <InternalDashboard hasEditPermission={false} messageOverrides={DefaultDashboardMessages} />
-          </DndProvider>
-        </Provider>
-      );
-    });
-
-    const actionsContainer = container.querySelector('.button-actions');
-    expect(actionsContainer).toBeFalsy();
 
     const dashboard = container.querySelector('.iot-dashboard-panes-area');
     expect(dashboard).toBeFalsy();

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -48,11 +48,10 @@ import './index.css';
 
 type InternalDashboardProps = {
   messageOverrides: DashboardMessages;
-  hasEditPermission: boolean;
   onSave?: (dashboard: SaveableDashboard) => void;
 };
 
-const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides, hasEditPermission, onSave }) => {
+const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides, onSave }) => {
   /**
    * Store variables
    */
@@ -181,7 +180,6 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
         <div className='iot-dashboard-toolbar iot-dashboard-toolbar-overlay'>
           <ViewportSelection messageOverrides={messageOverrides} />
           <Actions
-            hasEditPermission={hasEditPermission}
             messageOverrides={messageOverrides}
             readOnly={readOnly}
             onSave={onSave}
@@ -206,7 +204,6 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
         <ComponentPalette messageOverrides={messageOverrides} />
         <ViewportSelection messageOverrides={messageOverrides} />
         <Actions
-          hasEditPermission={hasEditPermission}
           readOnly={readOnly}
           messageOverrides={messageOverrides}
           onSave={onSave}

--- a/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.test.tsx
@@ -59,7 +59,7 @@ const renderDashboardAndPressKey = ({ key, meta }: { key: string; meta: boolean 
             enableKeyboardEvents: true,
           }}
         >
-          <InternalDashboard hasEditPermission={true} messageOverrides={DefaultDashboardMessages} />
+          <InternalDashboard messageOverrides={DefaultDashboardMessages} />
         </DndProvider>
       </Provider>
     );

--- a/packages/dashboard/src/components/palette/index.test.tsx
+++ b/packages/dashboard/src/components/palette/index.test.tsx
@@ -30,7 +30,7 @@ const renderDashboard = (state?: RecursivePartial<DashboardState>) => {
           enableKeyboardEvents: true,
         }}
       >
-        <InternalDashboard hasEditPermission={false} messageOverrides={DefaultDashboardMessages} />
+        <InternalDashboard messageOverrides={DefaultDashboardMessages} />
       </DndProvider>
     </Provider>
   );

--- a/packages/dashboard/stories/dashboard/sitewise-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/sitewise-dashboard.stories.tsx
@@ -40,7 +40,6 @@ const args = {
     viewport: { duration: '5m' },
   },
   query,
-  hasEditPermission: true,
   onSave: (dashboard) => {
     window.localStorage.setItem('dashboard', JSON.stringify(dashboard));
     console.log(dashboard);
@@ -69,7 +68,6 @@ const readOnlyArgs: DashboardProps = {
     ],
   },
   readOnly: true,
-  hasEditPermission: false,
 } as DashboardProps;
 
 export const ReadOnly: ComponentStory<typeof Dashboard> = () => {


### PR DESCRIPTION
Addresses https://github.com/awslabs/iot-app-kit/issues/792

Also removes hasEditPermissions prop, instead a dashboard that has no edit permissions will use a `DashboardView` component.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
