### PR TITLE
style(Dashboard): remove white border in dashboards edit view

### DIFF
--- a/packages/dashboard/src/components/widgets/widget.css
+++ b/packages/dashboard/src/components/widgets/widget.css
@@ -9,11 +9,13 @@
 }
 
 .widget-editable {
-  border: var(--selection-border-width) solid var(--selection-bg-color);
+  /* Keeps widget in line with widget when selected */
+  padding: var(--selection-border-width);
 }
 
 .widget-editable:hover {
   border: var(--selection-border-width) solid var(--selection-color-secondary);
+  padding: 0; /* removes padding that was present to keep aligned when border is added on hover */
   cursor: all-scroll;
   border-radius: var(--selection-radius-small);
 }


### PR DESCRIPTION
## Overview
style tweak to remove white borders around widgets in edit mode, replaced with a padding to keep the spacing consistent

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
