### PR TITLE
refactor(Dashboard): change internal dashboard to utilize cloudscape …

### DIFF
--- a/packages/dashboard/jest-setup.js
+++ b/packages/dashboard/jest-setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/dashboard/jest.config.ts
+++ b/packages/dashboard/jest.config.ts
@@ -6,6 +6,7 @@ const config = {
     '\\.(css|scss)$': 'identity-obj-proxy',
     '~/(.*)': '<rootDir>/src/$1',
   },
+  setupFilesAfterEnv: ['<rootDir>/jest-setup.js'],
   roots: ['src'],
 };
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -29,6 +29,7 @@
     "clean": "rimraf dist",
     "start": "start-storybook -p 6006",
     "test": "jest --silent",
+    "test:watch": "jest --watch",
     "lint": "eslint . --max-warnings=0",
     "fix": "eslint --fix .",
     "test:ui": "npx playwright test"

--- a/packages/dashboard/src/components/actions/index.tsx
+++ b/packages/dashboard/src/components/actions/index.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { Button } from '@cloudscape-design/components';
+import { Button, SpaceBetween, FormField } from '@cloudscape-design/components';
 import { onToggleReadOnly } from '~/store/actions';
 import type { DashboardMessages } from '~/messages';
 import type { DashboardState, SaveableDashboard } from '~/store/state';
@@ -32,9 +32,8 @@ const Actions: React.FC<ActionsProps> = ({ grid, dashboardConfiguration, message
   };
 
   return (
-    <div className='actions iot-dashboard-toolbar-actions'>
-      <h1 className='iot-dashboard-toolbar-title'>{messageOverrides.toolbar.actions.title}</h1>
-      <div className='button-actions'>
+    <FormField label={messageOverrides.toolbar.actions.title}>
+      <SpaceBetween size='s' direction='horizontal'>
         {onSave && (
           <Button onClick={handleOnSave} data-test-id='actions-save-dashboard-btn'>
             {messageOverrides.toolbar.actions.save}
@@ -43,8 +42,8 @@ const Actions: React.FC<ActionsProps> = ({ grid, dashboardConfiguration, message
         <Button onClick={handleOnReadOnly} data-test-id='actions-toggle-read-only-btn'>
           {readOnly ? 'Edit' : 'Preview'}
         </Button>
-      </div>
-    </div>
+      </SpaceBetween>
+    </FormField>
   );
 };
 

--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -1,35 +1,24 @@
-import { act } from '@testing-library/react';
-import { createRoot } from 'react-dom/client';
-
+import { render } from '@testing-library/react';
 import { createMockIoTEventsSDK, createMockSiteWiseSDK } from '@iot-app-kit/testing-util';
 
-import type { DashboardProps } from './index';
 import Dashboard from './index';
 import React from 'react';
 
-describe('Dashboard', () => {
-  it('should render', function () {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-
-    const args: DashboardProps = {
-      dashboardClientConfiguration: {
-        iotEventsClient: createMockIoTEventsSDK(),
-        iotSiteWiseClient: createMockSiteWiseSDK(),
-      },
-      dashboardConfiguration: {
+it('renders', function () {
+  const { queryByText } = render(
+    <Dashboard
+      dashboardConfiguration={{
         widgets: [],
         viewport: { duration: '5m' },
-      },
-    };
+      }}
+      dashboardClientConfiguration={{
+        iotEventsClient: createMockIoTEventsSDK(),
+        iotSiteWiseClient: createMockSiteWiseSDK(),
+      }}
+    />
+  );
 
-    const root = createRoot(container);
-
-    act(() => {
-      root.render(<Dashboard {...args} />);
-    });
-
-    const dashboard = container.querySelector('.iot-dashboard');
-    expect(dashboard).toBeTruthy();
-  });
+  expect(queryByText(/component library/i)).toBeInTheDocument();
+  expect(queryByText(/actions/i)).toBeInTheDocument();
+  expect(queryByText(/time machine/i)).toBeInTheDocument();
 });

--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -1,96 +1,26 @@
 @import '../../styles/variables.css';
 
-.iot-dashboard {
+.dashboard {
   height: 100vh;
-  width: 100vw;
   display: flex;
   flex-direction: column;
 }
 
-.iot-dashboard-grid {
+.dashboard .divider {
+  width: 2px;
+  height: 70px;
+  background: var(--colors-light-grey);
+}
+
+.dashboard .display-area {
   height: 100%;
   width: 100%;
   overflow: auto;
-  position: relative;
-  z-index: var(--stack-order-grid);
 }
 
-.iot-dashboard-grid-with-overlay {
-  margin-top: var(--toolbar-overlay-height);
-  overflow: unset;
-}
-
-.iot-dashboard-panes-area {
-  flex: 1;
-  max-height: calc(100vh - var(--toolbar-overlay-height));
-}
-
-.iot-dashboard-toolbar {
+.dashboard .dashboard-toolbar {
   overflow-x: auto;
-  display: grid;
-  grid-template-rows: 0px 1fr 0px;
-  grid-template-columns: 0px 1fr max-content max-content 0px;
-  grid-template-areas: ". . . . ."
-                      ". components viewport actions ."
-                      ". . . . .";
-  grid-gap: 1rem;
+  overflow-y: hidden;
   border-bottom: var(--border-width-toolbar) solid var(--colors-light-grey);
-  z-index: var(--stack-order-grid-inputs);
   background-color: var(--colors-white);
-  box-sizing: border-box;
-}
-.iot-dashboard-toolbar-components {
-  grid-area: components;
-}
-.iot-dashboard-toolbar-viewport {
-  grid-area: viewport;
-}
-.iot-dashboard-toolbar-actions {
-  grid-area: actions;
-}
-
-.iot-dashboard-toolbar-overlay {
-  position: fixed;
-  left: 0;
-  right: 0;
-  box-sizing: border-box;
-}
-
-.iot-dashboard-toolbar > *:last-child {
-  border-left: 1px solid var(--colors-light-grey);
-  padding-left: 1rem;
-}
-
-.iot-dashboard-toolbar > *:first-child {
-  border: none;
-  padding-left: initial;
-}
-
-.button-actions {
-  display: flex;
-  align-items: flex-start;
-  flex-direction: row;
-  justify-content: center;
-  gap: var(--button-action-gap);
-}
-
-.iot-dashboard-toolbar-title {
-  font-size: var(--font-size-component-palette-title);
-  margin: 0;
-  margin-bottom: 0.5rem;
-}
-
-.dummy-content {
-  width: calc(100% - 40px);
-  height: calc(100% - 40px);
-  min-height: calc(100vh - 210px);
-  background-color: rgba(0 0 0 / 1%);
-  padding: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.iot-resource-explorer-pane {
-  height: 100%;
 }

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { WebglContext } from '@iot-app-kit/react-components';
+import Box from '@cloudscape-design/components/box';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
 import { selectedRect } from '~/util/select';
 /**
  * Component imports
@@ -50,6 +53,8 @@ type InternalDashboardProps = {
   messageOverrides: DashboardMessages;
   onSave?: (dashboard: SaveableDashboard) => void;
 };
+
+const Divider = () => <div className='divider' />;
 
 const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides, onSave }) => {
   /**
@@ -176,21 +181,24 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
 
   if (readOnly) {
     return (
-      <div className='iot-dashboard'>
-        <div className='iot-dashboard-toolbar iot-dashboard-toolbar-overlay'>
-          <ViewportSelection messageOverrides={messageOverrides} />
-          <Actions
-            messageOverrides={messageOverrides}
-            readOnly={readOnly}
-            onSave={onSave}
-            dashboardConfiguration={dashboardConfiguration}
-            grid={grid}
-          />
+      <div className='dashboard'>
+        <div className='dashboard-toolbar'>
+          <Box float='right' padding='s'>
+            <SpaceBetween size='s' direction='horizontal'>
+              <ViewportSelection messageOverrides={messageOverrides} />
+              <Divider />
+              <Actions
+                messageOverrides={messageOverrides}
+                readOnly={readOnly}
+                onSave={onSave}
+                dashboardConfiguration={dashboardConfiguration}
+                grid={grid}
+              />
+            </SpaceBetween>
+          </Box>
         </div>
-        <div className='iot-dashboard-grid iot-dashboard-grid-with-overlay'>
-          <Grid {...gridProps}>
-            <Widgets {...widgetsProps} />
-          </Grid>
+        <div className='display-area'>
+          <Widgets {...widgetsProps} />
         </div>
         <WebglContext />
       </div>
@@ -198,39 +206,40 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
   }
 
   return (
-    <div className='iot-dashboard'>
+    <div className='dashboard'>
       <CustomDragLayer messageOverrides={messageOverrides} />
-      <div className='iot-dashboard-toolbar'>
-        <ComponentPalette messageOverrides={messageOverrides} />
-        <ViewportSelection messageOverrides={messageOverrides} />
-        <Actions
-          readOnly={readOnly}
-          messageOverrides={messageOverrides}
-          onSave={onSave}
-          dashboardConfiguration={dashboardConfiguration}
-          grid={grid}
-        />
+      <div className='dashboard-toolbar'>
+        <Box float='left' padding='s'>
+          <ComponentPalette messageOverrides={messageOverrides} />
+        </Box>
+        <Box float='right' padding='s'>
+          <SpaceBetween size='s' direction='horizontal'>
+            <ViewportSelection messageOverrides={messageOverrides} />
+            <Divider />
+            <Actions
+              readOnly={readOnly}
+              messageOverrides={messageOverrides}
+              onSave={onSave}
+              dashboardConfiguration={dashboardConfiguration}
+              grid={grid}
+            />
+          </SpaceBetween>
+        </Box>
       </div>
-      <div className='iot-dashboard-panes-area'>
-        <ResizablePanes
-          leftPane={
-            <div className='iot-resource-explorer-pane'>
-              <ResourceExplorer />
-            </div>
-          }
-          centerPane={
-            <div className='iot-dashboard-grid' ref={(el) => setViewFrameElement(el || undefined)}>
-              <Grid {...gridProps}>
-                <ContextMenu {...contextMenuProps} />
-                <Widgets {...widgetsProps} />
-                {activeGesture === 'select' && <UserSelection {...selectionProps} />}
-              </Grid>
-              <WebglContext viewFrame={viewFrame} />
-            </div>
-          }
-          rightPane={<SidePanel messageOverrides={messageOverrides} />}
-        />
-      </div>
+      <ResizablePanes
+        leftPane={<ResourceExplorer />}
+        centerPane={
+          <div className='display-area' ref={(el) => setViewFrameElement(el || undefined)}>
+            <Grid {...gridProps}>
+              <ContextMenu {...contextMenuProps} />
+              <Widgets {...widgetsProps} />
+              {activeGesture === 'select' && <UserSelection {...selectionProps} />}
+            </Grid>
+            <WebglContext viewFrame={viewFrame} />
+          </div>
+        }
+        rightPane={<SidePanel messageOverrides={messageOverrides} />}
+      />
     </div>
   );
 };

--- a/packages/dashboard/src/components/palette/component.tsx
+++ b/packages/dashboard/src/components/palette/component.tsx
@@ -37,7 +37,7 @@ const PaletteComponent: React.FC<PaletteComponentProps> = ({ componentTag, name,
 
   return (
     <div ref={node} className={`palette-component ${isDragging ? 'palette-component-dragging' : ''}`}>
-      <div ref={dragRef} className='palette-component-draggable'>
+      <div aria-label={`add ${name} widget`} draggable ref={dragRef} className='palette-component-draggable'>
         <PaletteComponentIcon Icon={IconComponent} />
       </div>
       <h1 className='palette-component-name'>{name}</h1>

--- a/packages/dashboard/src/components/palette/index.css
+++ b/packages/dashboard/src/components/palette/index.css
@@ -1,6 +1,0 @@
-@import "../../styles/variables.css";
-
-.component-palette {
-  display: inline-flex;
-  column-gap: var(--spacing-component-palette-icon);
-}

--- a/packages/dashboard/src/components/palette/index.test.tsx
+++ b/packages/dashboard/src/components/palette/index.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/dom';
-import { act, fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -21,7 +20,7 @@ const renderDashboard = (state?: RecursivePartial<DashboardState>) => {
 
   const store = configureDashboardStore(state);
 
-  const { container } = render(
+  const renderResults = render(
     <Provider store={store}>
       <DndProvider
         backend={HTML5Backend}
@@ -35,19 +34,19 @@ const renderDashboard = (state?: RecursivePartial<DashboardState>) => {
     </Provider>
   );
 
-  return { container, store };
+  return { ...renderResults, store };
 };
 
 describe('Component Palette', () => {
   it('can drag widgets onto the grid', function () {
     const { container, store } = renderDashboard();
 
-    const draggableLine = screen.getByText('Line').previousElementSibling;
-    const draggableText = screen.getByText('Text').previousElementSibling;
+    const draggableLine = screen.getByLabelText(/add line widget/i);
+    const draggableText = screen.getByLabelText(/add text widget/i);
 
     const grid = container.querySelector(`#${DASHBOARD_CONTAINER_ID}`);
 
-    if (!draggableLine || !draggableText || !grid) throw new Error('could not get draggable elements for test');
+    if (!grid) throw new Error('could not get draggable elements for test');
 
     expect(store.getState().dashboardConfiguration.widgets).toHaveLength(0);
 
@@ -86,21 +85,20 @@ describe('Component Palette', () => {
   });
 
   it('does not add a widget if dropped outside of grid', function () {
-    const { container, store } = renderDashboard();
+    const { store } = renderDashboard();
 
-    const draggable = screen.getByText('Line').previousElementSibling;
+    const draggable = screen.getByLabelText(/add line widget/i);
 
-    const componentPalette = container.querySelector('.component-palette');
-
-    if (!draggable || !componentPalette) throw new Error('could not get draggable elements for test');
+    // Preview button is always visible, and outside of the grid area
+    const previewBtn = screen.getByRole('button', { name: /preview/i });
 
     expect(store.getState().dashboardConfiguration.widgets).toHaveLength(0);
 
     act(() => {
       fireEvent.dragStart(draggable);
-      fireEvent.dragEnter(componentPalette);
-      fireEvent.dragOver(componentPalette);
-      fireEvent.drop(componentPalette);
+      fireEvent.dragEnter(previewBtn);
+      fireEvent.dragOver(previewBtn);
+      fireEvent.drop(previewBtn);
     });
 
     expect(store.getState().dashboardConfiguration.widgets).toHaveLength(0);

--- a/packages/dashboard/src/components/palette/index.tsx
+++ b/packages/dashboard/src/components/palette/index.tsx
@@ -4,8 +4,9 @@ import {
   ComponentLibraryComponentOrdering,
 } from '~/customization/componentLibraryComponentMap';
 import PaletteComponent from './component';
+import FormField from '@cloudscape-design/components/form-field';
+import SpaceBetween from '@cloudscape-design/components/space-between';
 
-import './index.css';
 import type { DashboardMessages } from '~/messages';
 
 export type ComponentPaletteProps = {
@@ -14,17 +15,16 @@ export type ComponentPaletteProps = {
 
 const Palette: React.FC<ComponentPaletteProps> = ({ messageOverrides }) => {
   return (
-    <div className='iot-dashboard-toolbar-components'>
-      <h1 className='iot-dashboard-toolbar-title'>{messageOverrides.toolbar.componentLibrary.title}</h1>
-      <div className='component-palette'>
+    <FormField label={messageOverrides.toolbar.componentLibrary.title}>
+      <SpaceBetween size='xs' direction='horizontal'>
         {ComponentLibraryComponentOrdering.map((widgetType) => {
           const [name, iconComponent] = ComponentLibraryComponentMap[widgetType];
           return (
             <PaletteComponent key={widgetType} componentTag={widgetType} name={name} IconComponent={iconComponent} />
           );
         })}
-      </div>
-    </div>
+      </SpaceBetween>
+    </FormField>
   );
 };
 

--- a/packages/dashboard/src/components/resizablePanes/index.css
+++ b/packages/dashboard/src/components/resizablePanes/index.css
@@ -22,15 +22,9 @@
   overflow-y: auto;
 }
 
-.iot-resizable-panes-pane-center {
-  z-index: var(--stack-order-grid);
-}
-
 .iot-resizable-panes-handle {
   background-color: var(--colors-light-grey);
   cursor: ew-resize;
-  z-index: 2;
-  isolation: isolate;
 }
 
 .iot-resizable-panes-handle:hover {

--- a/packages/dashboard/src/components/resizablePanes/index.test.tsx
+++ b/packages/dashboard/src/components/resizablePanes/index.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { act } from '@testing-library/react';
-import { createRoot } from 'react-dom/client';
+import { render } from '@testing-library/react';
 
 import { ResizablePanes } from './index';
 
@@ -8,25 +7,17 @@ const leftPaneContent = `Warp core monitor`;
 const centerPaneContent = `Forward viewscreen`;
 const rightPaneContent = `Phaser controls`;
 
-describe('ResizablePanes', () => {
-  it('should render panes', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
+it('renders panes', () => {
+  const { container } = render(
+    <ResizablePanes
+      leftPane={<p>{leftPaneContent}</p>}
+      centerPane={<p>{centerPaneContent}</p>}
+      rightPane={<p>{rightPaneContent}</p>}
+    />
+  );
 
-    const root = createRoot(container);
-    act(() => {
-      root.render(
-        <ResizablePanes
-          leftPane={<p>{leftPaneContent}</p>}
-          centerPane={<p>{centerPaneContent}</p>}
-          rightPane={<p>{rightPaneContent}</p>}
-        />
-      );
-    });
-
-    const paraEls = document.querySelectorAll('p');
-    expect(paraEls[0].textContent).toEqual(leftPaneContent);
-    expect(paraEls[1].textContent).toEqual(centerPaneContent);
-    expect(paraEls[2].textContent).toEqual(rightPaneContent);
-  });
+  const paraEls = container.querySelectorAll('p');
+  expect(paraEls[0].textContent).toEqual(leftPaneContent);
+  expect(paraEls[1].textContent).toEqual(centerPaneContent);
+  expect(paraEls[2].textContent).toEqual(rightPaneContent);
 });

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.spec.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.spec.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { MOCK_TEXT_WIDGET } from '../../../../../testing/mocks';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureDashboardStore } from '~/store';
 import TextSettings from './text';
-import wrapper from '@cloudscape-design/components/test-utils/dom';
 import type { DashboardState } from '~/store/state';
 import type { TextWidget } from '~/customization/widgets/types';
 
@@ -28,42 +27,19 @@ const state: Partial<DashboardState> = {
   selectedWidgets: [widget],
 };
 
-const TestComponent = () => (
-  <Provider store={configureDashboardStore(state)}>
-    <TextSettings {...widget} />
-  </Provider>
-);
+it('renders font style settings reflecting the initial values passed in', () => {
+  render(
+    <Provider store={configureDashboardStore(state)}>
+      <TextSettings {...widget} />
+    </Provider>
+  );
 
-it('renders', () => {
-  expect(render(<TestComponent />));
-});
+  const bold = screen.queryByLabelText('toggle bold text');
+  expect(bold).toBeChecked();
 
-it('renders with font select', () => {
-  const elem = render(<TestComponent />).container;
-  expect(wrapper(elem).findSelect('[data-test-id="text-widget-setting-font"]'));
-});
+  const italic = screen.queryByLabelText('toggle italicize text');
+  expect(italic).toBeChecked();
 
-it('renders with font size select', () => {
-  const elem = render(<TestComponent />).container;
-  expect(wrapper(elem).findSelect('[data-test-id="text-widget-setting-font-size"]'));
-});
-
-it('renders with horizontal alignment select', () => {
-  const elem = render(<TestComponent />).container;
-  expect(wrapper(elem).findSelect('[data-test-id="text-widget-setting-horizontal-align"]'));
-});
-
-it('renders with vertical alignment select', () => {
-  const elem = render(<TestComponent />).container;
-  expect(wrapper(elem).findSelect('[data-test-id="text-widget-setting-vertical-align"]'));
-});
-
-it('renders with font style toggles with correct style', () => {
-  const elem = render(<TestComponent />).container;
-  const bold = elem.querySelector('[data-test-id="text-widget-setting-toggle-text-bold"]');
-  expect(bold?.className).toInclude('checked');
-  const italic = elem.querySelector('[data-test-id="text-widget-setting-toggle-text-italic"]');
-  expect(italic?.className).toInclude('checked');
-  const underline = elem.querySelector('[data-test-id="text-widget-setting-toggle-text-underline"]');
-  expect(underline?.className).not.toInclude('checked');
+  const underline = screen.queryByLabelText('toggle underline text');
+  expect(underline).not.toBeChecked();
 });

--- a/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/textSettingSection/text.tsx
@@ -34,7 +34,13 @@ const ButtonWithState: FC<ButtonWithStateProps> = ({
   ...others // passing other attributes like data-test-id
 }) => {
   return (
-    <div {...others} className={`text-button-toggle ${checked ? 'checked' : ''}`} onClick={onToggle}>
+    <div
+      role='checkbox'
+      aria-checked={checked}
+      {...others}
+      className={`text-button-toggle ${checked ? 'checked' : ''}`}
+      onClick={onToggle}
+    >
       {children}
     </div>
   );
@@ -142,24 +148,16 @@ const TextSettings: FC<TextWidget> = (widget) => {
 
         <label>{defaultMessages.style}</label>
         <SpaceBetween size='xxs' direction='horizontal'>
-          <ButtonWithState
-            checked={bold}
-            onToggle={() => toggleBold(!bold)}
-            data-test-id='text-widget-setting-toggle-text-bold'
-          >
+          <ButtonWithState aria-label='toggle bold text' checked={bold} onToggle={() => toggleBold(!bold)}>
             <b>B</b>
           </ButtonWithState>
-          <ButtonWithState
-            checked={italic}
-            onToggle={() => toggleItalic(!italic)}
-            data-test-id='text-widget-setting-toggle-text-italic'
-          >
+          <ButtonWithState aria-label='toggle italicize text' checked={italic} onToggle={() => toggleItalic(!italic)}>
             <i>I</i>
           </ButtonWithState>
           <ButtonWithState
+            aria-label='toggle underline text'
             checked={underline}
             onToggle={() => toggleUnderline(!underline)}
-            data-test-id='text-widget-setting-toggle-text-underline'
           >
             <u>U</u>
           </ButtonWithState>

--- a/packages/dashboard/src/components/viewportSelection/index.test.tsx
+++ b/packages/dashboard/src/components/viewportSelection/index.test.tsx
@@ -3,62 +3,50 @@ import { Provider } from 'react-redux';
 
 import wrapper from '@cloudscape-design/components/test-utils/dom';
 
-import { act } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 import { screen } from '@testing-library/dom';
 
 import ViewportSelection from './index';
 import { configureDashboardStore } from '~/store';
 import { DefaultDashboardMessages } from '~/messages';
-import { createRoot } from 'react-dom/client';
 
 const LAST_MINUTE = 0;
 const CUSTOM = 9;
-/**
- * expandToViewport uses portals which causes makes it difficult for the test to find the correct buttons
- * it is enabled by default for correct styling.
- */
-const TestComponent = () => {
-  const args = {
-    dashboardConfiguration: {
-      widgets: [],
-      viewport: { duration: '5m' },
-    },
-  };
-  return (
-    <Provider store={configureDashboardStore(args)}>
-      <ViewportSelection expandToViewport={false} messageOverrides={DefaultDashboardMessages} />;
-    </Provider>
-  );
-};
 
 describe('ViewportSelection', () => {
   it('should render', function () {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
+    render(
+      <Provider
+        store={configureDashboardStore({
+          dashboardConfiguration: {
+            widgets: [],
+            viewport: { duration: '5m' },
+          },
+        })}
+      >
+        <ViewportSelection expandToViewport={false} messageOverrides={DefaultDashboardMessages} />;
+      </Provider>
+    );
 
-    const root = createRoot(container);
-
-    act(() => {
-      root.render(<TestComponent />);
-    });
-
-    expect(screen.getByText('Last 5 minutes')).toBeTruthy();
+    expect(screen.getByText('Last 5 minutes')).toBeInTheDocument();
   });
 
   it('can select a relative duration', function () {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
+    const { container } = render(
+      <Provider
+        store={configureDashboardStore({
+          dashboardConfiguration: {
+            widgets: [],
+            viewport: { duration: '5m' },
+          },
+        })}
+      >
+        <ViewportSelection expandToViewport={false} messageOverrides={DefaultDashboardMessages} />;
+      </Provider>
+    );
 
-    const root = createRoot(container);
-
-    act(() => {
-      root.render(<TestComponent />);
-    });
-
-    const viewportSelection = container.querySelector('.viewport-selection');
-    if (!viewportSelection) throw new Error('viewport did not render');
-    const dateRangePicker = wrapper(viewportSelection).findDateRangePicker();
+    const dateRangePicker = wrapper(container).findDateRangePicker();
 
     act(() => {
       dateRangePicker?.openDropdown();
@@ -75,24 +63,24 @@ describe('ViewportSelection', () => {
       dateRangePicker?.findDropdown()?.findApplyButton().click();
     });
 
-    expect(screen.getByText('Last minute')).toBeTruthy();
+    expect(screen.getByText('Last minute')).toBeInTheDocument();
   });
 
   it('can select a relative custom duration', function () {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    document.body.style.height = '10000px';
-    document.body.style.width = '10000px';
+    const { container } = render(
+      <Provider
+        store={configureDashboardStore({
+          dashboardConfiguration: {
+            widgets: [],
+            viewport: { duration: '5m' },
+          },
+        })}
+      >
+        <ViewportSelection expandToViewport={false} messageOverrides={DefaultDashboardMessages} />;
+      </Provider>
+    );
 
-    const root = createRoot(container);
-
-    act(() => {
-      root.render(<TestComponent />);
-    });
-
-    const viewportSelection = container.querySelector('.viewport-selection');
-    if (!viewportSelection) throw new Error('viewport did not render');
-    const dateRangePicker = wrapper(viewportSelection).findDateRangePicker();
+    const dateRangePicker = wrapper(container).findDateRangePicker();
 
     act(() => {
       dateRangePicker?.openDropdown();
@@ -114,6 +102,6 @@ describe('ViewportSelection', () => {
       dateRangePicker?.findDropdown()?.findApplyButton().click();
     });
 
-    expect(screen.getByText('Last 15 minutes')).toBeTruthy();
+    expect(screen.getByText('Last 15 minutes')).toBeInTheDocument();
   });
 });

--- a/packages/dashboard/src/components/viewportSelection/index.tsx
+++ b/packages/dashboard/src/components/viewportSelection/index.tsx
@@ -3,6 +3,8 @@ import React, { memo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import DateRangePicker from '@cloudscape-design/components/date-range-picker';
+import FormField from '@cloudscape-design/components/form-field';
+
 import { onUpdateViewportAction } from '~/store/actions';
 import { DashboardState } from '~/store/state';
 
@@ -68,8 +70,7 @@ const ViewportSelection: React.FC<ViewportSelectionProps> = ({ expandToViewport 
     messageOverrides.viewport;
 
   return (
-    <div className='viewport-selection iot-dashboard-toolbar-viewport'>
-      <h1 className='iot-dashboard-toolbar-title'>{title}</h1>
+    <FormField label={title}>
       <DateRangePicker
         expandToViewport={expandToViewport}
         onChange={handleChangeDateRange}
@@ -80,7 +81,7 @@ const ViewportSelection: React.FC<ViewportSelectionProps> = ({ expandToViewport 
         i18nStrings={i18nStrings}
         placeholder={placeholder}
       />
-    </div>
+    </FormField>
   );
 };
 


### PR DESCRIPTION
## Overview

Utilize cloudscape over custom css. Removed uneeded CSS and uneeded DOM. Rewrote tests using best/better practices via testing library.

- initialize setup for jest-dom for assertions
- add test:watch command

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
