### PR TITLE
fix(dashboard): constrain drag vector to border of dashboard

### DIFF
--- a/packages/dashboard/src/store/actions/moveWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/moveWidgets/index.spec.ts
@@ -1,8 +1,8 @@
 import { moveWidgets, onMoveWidgetsAction } from './index';
+import type { DashboardState } from '../../state';
 import { initialState } from '../../state';
 
 import { MOCK_KPI_WIDGET, MockWidgetFactory } from '../../../../testing/mocks';
-import type { DashboardState } from '../../state';
 import type { Widget } from '~/types';
 
 const setupDashboardState = (widgets: Widget[] = []): DashboardState => ({
@@ -169,6 +169,37 @@ describe('move', () => {
         expect.objectContaining({
           x: 1,
           y: 1,
+        }),
+      ])
+    );
+  });
+
+  it('does not move widget group out of the grid', () => {
+    const widget1 = MockWidgetFactory.getKpiWidget({ x: 0, y: 0, width: 5, height: 5 });
+    const widget2 = MockWidgetFactory.getKpiWidget({ x: 5, y: 5, width: 5, height: 5 });
+
+    const dashboardState = setupDashboardState([widget1, widget2]);
+    expect(
+      moveWidgets(
+        dashboardState,
+        onMoveWidgetsAction({
+          widgets: [widget1, widget2],
+          vector: { x: dashboardState.grid.width, y: dashboardState.grid.height },
+        })
+      ).dashboardConfiguration.widgets
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          x: 90,
+          y: 90,
+          width: 5,
+          height: 5,
+        }),
+        expect.objectContaining({
+          x: 95,
+          y: 95,
+          width: 5,
+          height: 5,
         }),
       ])
     );

--- a/packages/dashboard/src/store/actions/resizeWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/resizeWidgets/index.ts
@@ -1,14 +1,12 @@
-import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
 import { getSelectionBox } from '~/util/getSelectionBox';
 import { trimRectPosition } from '~/util/trimRectPosition';
 import type { Action } from 'redux';
 import type { Position, Widget } from '~/types';
 import type { DashboardState } from '../../state';
-import { resizeWidget } from '~/util/resizeWidget';
+import { transformWidget } from '~/util/transformWidget';
 import { resizeSelectionBox } from '~/util/resizeSelectionBox';
 
 export type Anchor = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left' | 'left' | 'right' | 'top' | 'bottom';
-
 type ResizeWidgetsActionPayload = {
   anchor: Anchor;
   widgets: Widget[];
@@ -35,17 +33,15 @@ export const resizeWidgets = (state: DashboardState, action: ResizeWidgetsAction
 
   if (!selectionBox) return state;
 
-  const newSelectionBox = constrainWidgetPositionToGrid(
-    {
-      x: 0,
-      y: 0,
-      width: state.grid.width,
-      height: state.grid.height,
-    },
-    resizeSelectionBox({ selectionBox, anchor, vector })
-  );
+  const newSelectionBox = resizeSelectionBox({
+    selectionBox,
+    anchor,
+    vector,
+    grid: state.grid,
+  });
+
   const resizer = (widget: Widget) =>
-    resizeWidget(widget, selectionBox, complete ? trimRectPosition(newSelectionBox) : newSelectionBox);
+    transformWidget(widget, selectionBox, complete ? trimRectPosition(newSelectionBox) : newSelectionBox);
 
   const updateWidgets = (widgets: Widget[]) =>
     widgets.map((widget) => {

--- a/packages/dashboard/src/util/moveSelectionBox.spec.ts
+++ b/packages/dashboard/src/util/moveSelectionBox.spec.ts
@@ -1,0 +1,26 @@
+import { moveSelectionBox } from '~/util/moveSelectionBox';
+
+import { DashboardState } from '~/store/state';
+
+const grid = {
+  width: 100,
+  height: 100,
+  cellSize: 1,
+} as DashboardState['grid'];
+describe('moveSelectionBox', () => {
+  const widget1 = { x: 0, y: 0, width: 10, height: 10 };
+
+  it('should move selection box', () => {
+    const selectionBox = widget1;
+    const vector = { x: 10, y: 10 };
+    const expected = { x: 10, y: 10, width: 10, height: 10 };
+    expect(moveSelectionBox({ selectionBox, vector, grid })).toEqual(expected);
+  });
+
+  it('should not move selection box if it is out of bounds', () => {
+    const selectionBox = widget1;
+    const vector = { x: 100, y: 100 };
+    const expected = { x: 90, y: 90, width: 10, height: 10 };
+    expect(moveSelectionBox({ selectionBox, vector, grid })).toEqual(expected);
+  });
+});

--- a/packages/dashboard/src/util/moveSelectionBox.ts
+++ b/packages/dashboard/src/util/moveSelectionBox.ts
@@ -1,0 +1,30 @@
+import { Position, Rect } from '~/types';
+import { DashboardState } from '~/store/state';
+
+export const moveSelectionBox: (params: {
+  selectionBox: Rect;
+  vector: Position;
+  grid: DashboardState['grid'];
+}) => Rect = ({ selectionBox, vector, grid }) => {
+  const newRect = { ...selectionBox };
+  if (newRect.x + vector.x < 0) {
+    vector.x = 0 - newRect.x;
+  }
+
+  if (newRect.x + newRect.width + vector.x > grid.width) {
+    vector.x = grid.width - newRect.x - newRect.width;
+  }
+
+  if (newRect.y + vector.y < 0) {
+    vector.y = 0 - newRect.y;
+  }
+
+  if (newRect.y + newRect.height + vector.y > grid.height) {
+    vector.y = grid.height - newRect.y - newRect.height;
+  }
+
+  newRect.x += vector.x;
+  newRect.y += vector.y;
+
+  return newRect;
+};

--- a/packages/dashboard/src/util/resizeSelectionBox.spec.ts
+++ b/packages/dashboard/src/util/resizeSelectionBox.spec.ts
@@ -1,12 +1,19 @@
 import { resizeSelectionBox } from '~/util/resizeSelectionBox';
 import type { Anchor } from '~/store/actions';
+import type { Rect } from '~/types';
+import type { DashboardState } from '~/store/state';
 
+const grid = {
+  width: 150,
+  height: 150,
+  cellSize: 1,
+} as DashboardState['grid'];
 it('should resize selection box on top anchor', () => {
   const curr = { x: 0, y: 0, width: 100, height: 100 };
   const anchor = 'top';
   const vector = { x: 10, y: 10 };
   const expected = { x: 0, y: 10, width: 100, height: 90 };
-  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector })).toEqual(expected);
+  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid })).toEqual(expected);
 });
 
 it('should resize selection box on top-left anchor', () => {
@@ -14,7 +21,7 @@ it('should resize selection box on top-left anchor', () => {
   const anchor = 'top-left';
   const vector = { x: 10, y: 10 };
   const expected = { x: 10, y: 10, width: 90, height: 90 };
-  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector })).toEqual(expected);
+  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid })).toEqual(expected);
 });
 
 it('should resize selection box on top-right anchor', () => {
@@ -22,7 +29,7 @@ it('should resize selection box on top-right anchor', () => {
   const anchor = 'top-right';
   const vector = { x: 10, y: 10 };
   const expected = { x: 0, y: 10, width: 110, height: 90 };
-  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector })).toEqual(expected);
+  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid })).toEqual(expected);
 });
 
 it('should resize selection box on bottom anchor', () => {
@@ -30,7 +37,7 @@ it('should resize selection box on bottom anchor', () => {
   const anchor = 'bottom';
   const vector = { x: 10, y: 10 };
   const expected = { x: 0, y: 0, width: 100, height: 110 };
-  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector })).toEqual(expected);
+  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid })).toEqual(expected);
 });
 
 it('should resize selection box on bottom-left anchor', () => {
@@ -38,7 +45,7 @@ it('should resize selection box on bottom-left anchor', () => {
   const anchor = 'bottom-left';
   const vector = { x: 10, y: 10 };
   const expected = { x: 10, y: 0, width: 90, height: 110 };
-  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector })).toEqual(expected);
+  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid })).toEqual(expected);
 });
 
 it('should resize selection box on bottom-right anchor', () => {
@@ -46,7 +53,7 @@ it('should resize selection box on bottom-right anchor', () => {
   const anchor = 'bottom-right';
   const vector = { x: 10, y: 10 };
   const expected = { x: 0, y: 0, width: 110, height: 110 };
-  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector })).toEqual(expected);
+  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid })).toEqual(expected);
 });
 
 it('should resize selection box on left anchor', () => {
@@ -54,7 +61,7 @@ it('should resize selection box on left anchor', () => {
   const anchor = 'left';
   const vector = { x: 10, y: 10 };
   const expected = { x: 10, y: 0, width: 90, height: 100 };
-  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector })).toEqual(expected);
+  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid })).toEqual(expected);
 });
 
 it('should resize selection box on right anchor', () => {
@@ -62,7 +69,7 @@ it('should resize selection box on right anchor', () => {
   const anchor = 'right';
   const vector = { x: 10, y: 10 };
   const expected = { x: 0, y: 0, width: 110, height: 100 };
-  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector })).toEqual(expected);
+  expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid })).toEqual(expected);
 });
 
 describe('should not vertically resize selection box below minimum width', () => {
@@ -71,7 +78,7 @@ describe('should not vertically resize selection box below minimum width', () =>
   leftAnchors.forEach((anchor) => {
     const vector = { x: 10, y: 10 };
     it(`should not resize selection box on ${anchor} anchor`, () => {
-      expect(resizeSelectionBox({ selectionBox: curr, anchor, vector }).width).toEqual(2);
+      expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid }).width).toEqual(2);
     });
   });
 
@@ -79,7 +86,7 @@ describe('should not vertically resize selection box below minimum width', () =>
   rightAnchors.forEach((anchor) => {
     const vector = { x: -10, y: 10 };
     it(`should not resize selection box on ${anchor} anchor`, () => {
-      expect(resizeSelectionBox({ selectionBox: curr, anchor, vector }).width).toEqual(2);
+      expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid }).width).toEqual(2);
     });
   });
 });
@@ -90,7 +97,7 @@ describe('should not horizontally resize selection box below minimum height', ()
   topAnchors.forEach((anchor) => {
     const vector = { x: 10, y: 10 };
     it(`should not resize selection box on ${anchor} anchor`, () => {
-      expect(resizeSelectionBox({ selectionBox: curr, anchor, vector }).height).toEqual(2);
+      expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid }).height).toEqual(2);
     });
   });
 
@@ -98,7 +105,44 @@ describe('should not horizontally resize selection box below minimum height', ()
   bottomAnchors.forEach((anchor) => {
     const vector = { x: 10, y: -10 };
     it(`should not resize selection box on ${anchor} anchor`, () => {
-      expect(resizeSelectionBox({ selectionBox: curr, anchor, vector }).height).toEqual(2);
+      expect(resizeSelectionBox({ selectionBox: curr, anchor, vector, grid }).height).toEqual(2);
     });
+  });
+});
+const withinGrid = (newRect: Rect, gridRect: Rect) => {
+  const { x, y, width, height } = newRect;
+  const { x: gridX, y: gridY, width: gridWidth, height: gridHeight } = gridRect;
+
+  return x >= gridX && y >= gridY && x + width <= gridX + gridWidth && y + height <= gridY + gridHeight;
+};
+describe('should not resize selection box beyond grid', () => {
+  const anchors: Anchor[] = ['top', 'top-left', 'top-right', 'bottom', 'bottom-left', 'bottom-right', 'left', 'right'];
+  const startingPoints = [
+    { x: 0, y: 0 },
+    { x: 90, y: 0 },
+    { x: 0, y: 90 },
+    { x: 90, y: 90 },
+  ];
+  const vectors = [
+    { x: 20, y: 20 },
+    { x: -20, y: 20 },
+    { x: 20, y: -20 },
+    { x: -20, y: -20 },
+  ];
+  type TestCase = { anchor: Anchor; startingPoint: typeof startingPoints[number]; vector: typeof vectors[number] };
+  const table: TestCase[] = anchors.flatMap((anchor) =>
+    startingPoints.flatMap((startingPoint) => vectors.map((vector) => ({ anchor, startingPoint, vector })))
+  );
+
+  it.concurrent.each(table)('on $anchor from $startingPoint with $vector', ({ anchor, startingPoint, vector }) => {
+    const curr = { x: startingPoint.x, y: startingPoint.y, width: 10, height: 10 };
+    const newRect = resizeSelectionBox({ selectionBox: curr, anchor, vector, grid });
+    expect(
+      withinGrid(newRect, {
+        x: 0,
+        y: 0,
+        ...grid,
+      })
+    ).toBe(true);
   });
 });

--- a/packages/dashboard/src/util/resizeSelectionBox.ts
+++ b/packages/dashboard/src/util/resizeSelectionBox.ts
@@ -1,5 +1,6 @@
 import type { Position, Rect } from '~/types';
 import type { Anchor } from '~/store/actions';
+import { DashboardState } from '~/store/state';
 
 const MIN_WIDTH = 2;
 const MIN_HEIGHT = 2;
@@ -12,19 +13,34 @@ const rectWithinMin = (rect: Rect): Rect => {
     height: Math.max(height, MIN_HEIGHT),
   };
 };
-export const resizeSelectionBox: (params: { selectionBox: Rect; anchor: Anchor; vector: Position }) => Rect = ({
+export const resizeSelectionBox: (params: {
+  selectionBox: Rect;
+  anchor: Anchor;
+  vector: Position;
+  grid: DashboardState['grid'];
+}) => Rect = ({
   selectionBox,
   anchor,
   vector,
+  grid = {
+    width: 100,
+    height: 100,
+  },
 }) => {
   const newRect = { ...selectionBox };
   if (anchor.includes('top')) {
+    if (newRect.y + vector.y < 0) {
+      vector.y = 0 - newRect.y;
+    }
     if (newRect.height - vector.y >= MIN_HEIGHT) {
       newRect.y += vector.y;
       newRect.height -= vector.y;
     }
   }
   if (anchor.includes('left')) {
+    if (newRect.x + vector.x < 0) {
+      vector.x = 0 - newRect.x;
+    }
     // don't allow the selection box to be smaller than the minimum width
     if (newRect.width - vector.x >= MIN_WIDTH) {
       newRect.x += vector.x;
@@ -32,9 +48,15 @@ export const resizeSelectionBox: (params: { selectionBox: Rect; anchor: Anchor; 
     }
   }
   if (anchor.includes('right')) {
+    if (newRect.x + newRect.width + vector.x > grid.width) {
+      vector.x = grid.width - newRect.x - newRect.width;
+    }
     newRect.width += vector.x;
   }
   if (anchor.includes('bottom')) {
+    if (newRect.y + newRect.height + vector.y > grid.height) {
+      vector.y = grid.height - newRect.y - newRect.height;
+    }
     newRect.height += vector.y;
   }
 

--- a/packages/dashboard/src/util/transformWidget.spec.ts
+++ b/packages/dashboard/src/util/transformWidget.spec.ts
@@ -1,11 +1,17 @@
-import { resizeWidget } from './resizeWidget';
+import { transformWidget } from './transformWidget';
 import { getSelectionBox } from './getSelectionBox';
 import { resizeSelectionBox } from './resizeSelectionBox';
 
 import type { Rect, Widget } from '~/types';
 import type { Anchor } from '~/store/actions';
+import type { DashboardState } from '~/store/state';
 
 const anchors: Anchor[] = ['top', 'top-left', 'top-right', 'bottom', 'bottom-left', 'bottom-right', 'left', 'right'];
+const grid = {
+  width: 100,
+  height: 100,
+  cellSize: 1,
+} as DashboardState['grid'];
 describe('resize single widget', () => {
   const baseWidget: Widget = {
     id: 'widget',
@@ -19,10 +25,10 @@ describe('resize single widget', () => {
   };
 
   const selectionBox: Rect = baseWidget;
-  const transformerToBeTested = (newSelectionBox: Rect) => resizeWidget(baseWidget, selectionBox, newSelectionBox);
+  const transformerToBeTested = (newSelectionBox: Rect) => transformWidget(baseWidget, selectionBox, newSelectionBox);
 
   anchors.forEach((anchor) => {
-    const newSelectionBox = resizeSelectionBox({ selectionBox: selectionBox, anchor, vector: { x: 10, y: 10 } });
+    const newSelectionBox = resizeSelectionBox({ selectionBox: selectionBox, anchor, vector: { x: 10, y: 10 }, grid });
     const expected: Rect = { ...baseWidget, ...newSelectionBox };
     const result = transformerToBeTested(newSelectionBox);
     const keys = ['x', 'y', 'width', 'height'] as (keyof Rect)[];
@@ -54,7 +60,7 @@ describe('resize multiple widgets', () => {
 
   const selectionBox = getSelectionBox(widgets)!;
   const transformerToBeTested = (newSelectionBox: Rect) => (widget: Widget) =>
-    resizeWidget(widget, selectionBox, newSelectionBox);
+    transformWidget(widget, selectionBox, newSelectionBox);
 
   anchors.forEach((anchor) => {
     const mapper = transformerToBeTested(
@@ -62,6 +68,7 @@ describe('resize multiple widgets', () => {
         selectionBox: selectionBox,
         anchor,
         vector: { x: 10, y: 10 },
+        grid,
       })
     );
     const result = widgets.map(mapper);

--- a/packages/dashboard/src/util/transformWidget.ts
+++ b/packages/dashboard/src/util/transformWidget.ts
@@ -1,6 +1,6 @@
 import type { Rect, Widget } from '~/types';
 
-export const resizeWidget: (widget: Widget, pre: Rect, curr: Rect) => Widget = (widget, prev, curr) => {
+export const transformWidget: (widget: Widget, pre: Rect, curr: Rect) => Widget = (widget, prev, curr) => {
   const offsetX = widget.x - prev.x;
   const offsetY = widget.y - prev.y;
 


### PR DESCRIPTION
## Overview
All drag vectors will be constrained in grid.
- if a vector moves from `10, -10 -> 10, 10`, it would be considered as `10, 0 -> 10, 10`. and the new vector is `0, 10`. which means cursor movements out of bound will be ignored.

![chrome-capture-2023-2-24](https://user-images.githubusercontent.com/11740421/227583341-0ed53821-590f-4fd9-b25c-81751dcf8ac5.gif)
- also fixes a strange behaviour on moving a group of widgets out of bound.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
