### PR TITLE
fix(Dashboard): dashboard API changes for onSave etc.

### DIFF
--- a/packages/dashboard/src/components/actions/index.tsx
+++ b/packages/dashboard/src/components/actions/index.tsx
@@ -4,27 +4,24 @@ import { useDispatch } from 'react-redux';
 import { Button, SpaceBetween, FormField } from '@cloudscape-design/components';
 import { onToggleReadOnly } from '~/store/actions';
 import type { DashboardMessages } from '~/messages';
-import type { DashboardState, SaveableDashboard } from '~/store/state';
+import type { DashboardState } from '~/store/state';
 import { isEqual, pick } from 'lodash';
+import { DashboardSave } from '~/types';
 
 export type ActionsProps = {
   messageOverrides: DashboardMessages;
   grid: DashboardState['grid'];
   readOnly: boolean;
   dashboardConfiguration: DashboardState['dashboardConfiguration'];
-  onSave?: (dashboard: SaveableDashboard) => void;
+  onSave?: DashboardSave;
 };
 
-const Actions: React.FC<ActionsProps> = ({ grid, dashboardConfiguration, messageOverrides, readOnly, onSave }) => {
+const Actions: React.FC<ActionsProps> = ({ dashboardConfiguration, messageOverrides, readOnly, onSave }) => {
   const dispatch = useDispatch();
 
   const handleOnSave = () => {
     if (!onSave) return;
-    const { height, width, cellSize, stretchToFit } = grid;
-    onSave({
-      grid: { height, width, cellSize, stretchToFit },
-      dashboardConfiguration,
-    });
+    onSave(dashboardConfiguration);
   };
 
   const handleOnReadOnly = () => {
@@ -34,14 +31,8 @@ const Actions: React.FC<ActionsProps> = ({ grid, dashboardConfiguration, message
   return (
     <FormField label={messageOverrides.toolbar.actions.title}>
       <SpaceBetween size='s' direction='horizontal'>
-        {onSave && (
-          <Button onClick={handleOnSave} data-test-id='actions-save-dashboard-btn'>
-            {messageOverrides.toolbar.actions.save}
-          </Button>
-        )}
-        <Button onClick={handleOnReadOnly} data-test-id='actions-toggle-read-only-btn'>
-          {readOnly ? 'Edit' : 'Preview'}
-        </Button>
+        {onSave && <Button onClick={handleOnSave}>{messageOverrides.toolbar.actions.save}</Button>}
+        <Button onClick={handleOnReadOnly}>{readOnly ? 'Edit' : 'Preview'}</Button>
       </SpaceBetween>
     </FormField>
   );

--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -7,11 +7,12 @@ import React from 'react';
 it('renders', function () {
   const { queryByText } = render(
     <Dashboard
+      onSave={() => Promise.resolve()}
       dashboardConfiguration={{
         widgets: [],
         viewport: { duration: '5m' },
       }}
-      dashboardClientConfiguration={{
+      clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
         iotSiteWiseClient: createMockSiteWiseSDK(),
       }}

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -2,18 +2,14 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { DndProvider } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
-import { merge } from 'lodash';
 
 import InternalDashboard from '../internalDashboard';
 
 import { configureDashboardStore } from '~/store';
-import { DefaultDashboardMessages } from '~/messages';
 
 import { setupDashboardPlugins } from '~/customization/api';
 import plugins from '~/customization/pluginsConfiguration';
-import type { DashboardState, SaveableDashboard } from '~/store/state';
-import type { PickRequiredOptional, RecursivePartial, DashboardClientConfiguration } from '~/types';
-import type { DashboardMessages } from '~/messages';
+import type { DashboardClientConfiguration, DashboardConfiguration, DashboardSave } from '~/types';
 import { ClientContext } from './clientContext';
 import { QueryContext } from './queryContext';
 import { getClients } from './getClients';
@@ -25,20 +21,15 @@ import '../../styles/variables.css';
 setupDashboardPlugins(plugins);
 
 export type DashboardProps = {
-  messageOverrides?: RecursivePartial<DashboardMessages>;
-  onSave?: (dashboard: SaveableDashboard) => void;
-  dashboardClientConfiguration: DashboardClientConfiguration;
-} & PickRequiredOptional<DashboardState, 'dashboardConfiguration', 'readOnly' | 'grid'>;
+  onSave: DashboardSave;
+  clientConfiguration: DashboardClientConfiguration;
+  dashboardConfiguration: DashboardConfiguration;
+};
 
-const Dashboard: React.FC<DashboardProps> = ({
-  messageOverrides,
-  onSave,
-  dashboardClientConfiguration,
-  ...dashboardState
-}) => {
+const Dashboard: React.FC<DashboardProps> = ({ onSave, clientConfiguration, ...dashboardState }) => {
   return (
-    <ClientContext.Provider value={getClients(dashboardClientConfiguration)}>
-      <QueryContext.Provider value={getQueries(dashboardClientConfiguration)}>
+    <ClientContext.Provider value={getClients(clientConfiguration)}>
+      <QueryContext.Provider value={getQueries(clientConfiguration)}>
         <Provider store={configureDashboardStore({ ...dashboardState })}>
           <DndProvider
             backend={TouchBackend}
@@ -47,7 +38,7 @@ const Dashboard: React.FC<DashboardProps> = ({
               enableKeyboardEvents: true,
             }}
           >
-            <InternalDashboard onSave={onSave} messageOverrides={merge(messageOverrides, DefaultDashboardMessages)} />
+            <InternalDashboard onSave={onSave} />
           </DndProvider>
         </Provider>
       </QueryContext.Provider>

--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -4,11 +4,8 @@ import { DndProvider } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
 import { render, fireEvent, screen } from '@testing-library/react';
 
-import noop from 'lodash/noop';
-
 import InternalDashboard from './index';
 import { configureDashboardStore } from '~/store';
-import { DefaultDashboardMessages } from '~/messages';
 import { DashboardConfiguration } from '~/types';
 
 const EMPTY_DASHBOARD: DashboardConfiguration = {
@@ -17,7 +14,7 @@ const EMPTY_DASHBOARD: DashboardConfiguration = {
 };
 
 it('saves when the save button is pressed with default grid settings provided', function () {
-  const onSave = jest.fn();
+  const onSave = jest.fn().mockImplementation(() => Promise.resolve());
 
   render(
     <Provider store={configureDashboardStore({ dashboardConfiguration: EMPTY_DASHBOARD })}>
@@ -28,18 +25,14 @@ it('saves when the save button is pressed with default grid settings provided', 
           enableKeyboardEvents: true,
         }}
       >
-        <InternalDashboard messageOverrides={DefaultDashboardMessages} onSave={onSave} />
+        <InternalDashboard onSave={onSave} />
       </DndProvider>
     </Provider>
   );
 
   fireEvent.click(screen.getByRole('button', { name: /save/i }));
 
-  expect(onSave).toBeCalledWith(
-    expect.objectContaining({
-      dashboardConfiguration: EMPTY_DASHBOARD,
-    })
-  );
+  expect(onSave).toBeCalledWith(EMPTY_DASHBOARD);
 });
 
 it('renders preview mode', function () {
@@ -56,7 +49,7 @@ it('renders preview mode', function () {
           enableKeyboardEvents: true,
         }}
       >
-        <InternalDashboard messageOverrides={DefaultDashboardMessages} />
+        <InternalDashboard />
       </DndProvider>
     </Provider>
   );
@@ -81,7 +74,7 @@ it('toggles to preview mode and hides the component library', function () {
           enableKeyboardEvents: true,
         }}
       >
-        <InternalDashboard messageOverrides={DefaultDashboardMessages} onSave={noop} />
+        <InternalDashboard onSave={() => Promise.resolve()} />
       </DndProvider>
     </Provider>
   );

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -37,26 +37,25 @@ import { toGridPosition } from '~/util/position';
 import { useGestures } from './gestures';
 import { useKeyboardShortcuts } from './keyboardShortcuts';
 
-import type { Position, Widget } from '~/types';
-import type { DashboardMessages } from '~/messages';
+import type { DashboardSave, Position, Widget } from '~/types';
 import type { ContextMenuProps } from '../contextMenu';
 import type { DropEvent, GridProps } from '../grid';
 import type { WidgetsProps } from '../widgets/list';
 import type { UserSelectionProps } from '../userSelection';
-import type { DashboardState, SaveableDashboard } from '~/store/state';
+import type { DashboardState } from '~/store/state';
 import { useSelectedWidgets } from '~/hooks/useSelectedWidgets';
 
 import '@iot-app-kit/components/styles.css';
 import './index.css';
+import { DefaultDashboardMessages } from '~/messages';
 
 type InternalDashboardProps = {
-  messageOverrides: DashboardMessages;
-  onSave?: (dashboard: SaveableDashboard) => void;
+  onSave?: DashboardSave;
 };
 
 const Divider = () => <div className='divider' />;
 
-const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides, onSave }) => {
+const InternalDashboard: React.FC<InternalDashboardProps> = ({ onSave }) => {
   /**
    * Store variables
    */
@@ -159,7 +158,7 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
     readOnly,
     dashboardConfiguration,
     selectedWidgets,
-    messageOverrides,
+    messageOverrides: DefaultDashboardMessages,
     cellSize,
     dragEnabled: grid.enabled,
   };
@@ -169,7 +168,7 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
   };
 
   const contextMenuProps: ContextMenuProps = {
-    messageOverrides,
+    messageOverrides: DefaultDashboardMessages,
     copyWidgets,
     pasteWidgets,
     deleteWidgets,
@@ -185,10 +184,11 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
         <div className='dashboard-toolbar'>
           <Box float='right' padding='s'>
             <SpaceBetween size='s' direction='horizontal'>
-              <ViewportSelection messageOverrides={messageOverrides} />
-              <Divider />
+              <ViewportSelection key='1' messageOverrides={DefaultDashboardMessages} />
+              <Divider key='2' />
               <Actions
-                messageOverrides={messageOverrides}
+                key='3'
+                messageOverrides={DefaultDashboardMessages}
                 readOnly={readOnly}
                 onSave={onSave}
                 dashboardConfiguration={dashboardConfiguration}
@@ -207,18 +207,19 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
 
   return (
     <div className='dashboard'>
-      <CustomDragLayer messageOverrides={messageOverrides} />
+      <CustomDragLayer messageOverrides={DefaultDashboardMessages} />
       <div className='dashboard-toolbar'>
         <Box float='left' padding='s'>
-          <ComponentPalette messageOverrides={messageOverrides} />
+          <ComponentPalette messageOverrides={DefaultDashboardMessages} />
         </Box>
         <Box float='right' padding='s'>
           <SpaceBetween size='s' direction='horizontal'>
-            <ViewportSelection messageOverrides={messageOverrides} />
-            <Divider />
+            <ViewportSelection key='1' messageOverrides={DefaultDashboardMessages} />
+            <Divider key='2' />
             <Actions
+              key='3'
               readOnly={readOnly}
-              messageOverrides={messageOverrides}
+              messageOverrides={DefaultDashboardMessages}
               onSave={onSave}
               dashboardConfiguration={dashboardConfiguration}
               grid={grid}
@@ -238,7 +239,7 @@ const InternalDashboard: React.FC<InternalDashboardProps> = ({ messageOverrides,
             <WebglContext viewFrame={viewFrame} />
           </div>
         }
-        rightPane={<SidePanel messageOverrides={messageOverrides} />}
+        rightPane={<SidePanel messageOverrides={DefaultDashboardMessages} />}
       />
     </div>
   );

--- a/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.test.tsx
@@ -8,7 +8,6 @@ import { act } from '@testing-library/react';
 
 import InternalDashboard from './index';
 import { configureDashboardStore } from '../../store';
-import { DefaultDashboardMessages } from '../../messages';
 
 import {
   onBringWidgetsToFrontAction,
@@ -59,7 +58,7 @@ const renderDashboardAndPressKey = ({ key, meta }: { key: string; meta: boolean 
             enableKeyboardEvents: true,
           }}
         >
-          <InternalDashboard messageOverrides={DefaultDashboardMessages} />
+          <InternalDashboard />
         </DndProvider>
       </Provider>
     );

--- a/packages/dashboard/src/components/palette/index.test.tsx
+++ b/packages/dashboard/src/components/palette/index.test.tsx
@@ -7,7 +7,6 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import { DASHBOARD_CONTAINER_ID } from '../grid/getDashboardPosition';
 import InternalDashboard from '../internalDashboard';
-import { DefaultDashboardMessages } from '../../messages';
 
 import { configureDashboardStore } from '../../store';
 import { setupDashboardPlugins } from '../../customization/api';
@@ -29,7 +28,7 @@ const renderDashboard = (state?: RecursivePartial<DashboardState>) => {
           enableKeyboardEvents: true,
         }}
       >
-        <InternalDashboard messageOverrides={DefaultDashboardMessages} />
+        <InternalDashboard />
       </DndProvider>
     </Provider>
   );

--- a/packages/dashboard/src/store/state.ts
+++ b/packages/dashboard/src/store/state.ts
@@ -15,16 +15,6 @@ export type DashboardState = {
   dashboardConfiguration: DashboardConfiguration;
 };
 
-export type SaveableDashboard = {
-  grid: {
-    width: number;
-    height: number;
-    cellSize: number;
-    stretchToFit: boolean;
-  };
-  dashboardConfiguration: DashboardConfiguration;
-};
-
 export const initialState: DashboardState = {
   grid: {
     enabled: true,

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -20,6 +20,8 @@ export type DashboardIotSiteWiseQueries = {
 
 export type DashboardClientConfiguration = DashboardIotSiteWiseClients | DashboardClientCredentials;
 
+export type DashboardSave = (config: DashboardConfiguration) => Promise<void>;
+
 export type Widget<T extends Record<string, unknown> = Record<string, unknown>> = {
   type: string;
   id: string;

--- a/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
@@ -14,7 +14,7 @@ export default {
   },
 } as ComponentMeta<typeof Dashboard>;
 
-const dashboardClientConfiguration: DashboardClientConfiguration = {
+const clientConfiguration: DashboardClientConfiguration = {
   iotSiteWiseClient: createMockSiteWiseSDK(),
   iotEventsClient: createMockIoTEventsSDK(),
 };
@@ -22,12 +22,12 @@ const dashboardClientConfiguration: DashboardClientConfiguration = {
 export const Empty: ComponentStory<typeof Dashboard> = () => (
   <Dashboard
     {...{
-      dashboardClientConfiguration,
+      clientConfiguration,
       dashboardConfiguration: {
         widgets: [],
         viewport: { duration: '5m' },
       },
-      onSave: () => {},
+      onSave: () => Promise.resolve(),
     }}
   />
 );
@@ -35,22 +35,23 @@ export const Empty: ComponentStory<typeof Dashboard> = () => (
 export const SingleWidget: ComponentStory<typeof Dashboard> = () => (
   <Dashboard
     {...{
-      dashboardClientConfiguration,
+      clientConfiguration,
       dashboardConfiguration: {
         widgets: [
           {
-            componentTag: 'iot-line-chart',
+            type: 'iot-line-chart',
+            id: 'some id',
             height: 15,
             width: 27,
             x: 5,
             y: 5,
             z: 0,
-            assets: [],
+            properties: {},
           },
         ],
         viewport: { duration: '5m' },
       },
-      onSave: () => {},
+      onSave: () => Promise.resolve(),
     }}
   />
 );

--- a/packages/dashboard/stories/dashboard/sitewise-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/sitewise-dashboard.stories.tsx
@@ -2,17 +2,14 @@ import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import Dashboard, { DashboardProps } from '../../src/components/dashboard';
-import { query, REGION } from '../../testing/siteWiseQueries';
-
-import { MockWidgetFactory } from '../../testing/mocks';
-import { SaveableDashboard } from '../../src/store/state';
+import { REGION } from '../../testing/siteWiseQueries';
 
 import { getEnvCredentials } from '../../testing/getEnvCredentials';
 import { DashboardClientConfiguration } from '../../src/types';
 
 const getDashboardProps = (defaultProps: DashboardProps): DashboardProps => {
   const cachedDashboard = window.localStorage.getItem('dashboard');
-  const dashboard = cachedDashboard ? (JSON.parse(cachedDashboard) as SaveableDashboard) : defaultProps;
+  const dashboard = cachedDashboard ? JSON.parse(cachedDashboard) : defaultProps;
 
   return {
     ...defaultProps,
@@ -28,48 +25,21 @@ export default {
   },
 } as ComponentMeta<typeof Dashboard>;
 
-const dashboardClientConfiguration: DashboardClientConfiguration = {
+const clientConfiguration: DashboardClientConfiguration = {
   awsCredentials: getEnvCredentials(),
   awsRegion: REGION,
 };
 
 const args = {
-  dashboardClientConfiguration,
+  clientConfiguration,
   dashboardConfiguration: {
     widgets: [],
     viewport: { duration: '5m' },
   },
-  query,
   onSave: (dashboard) => {
     window.localStorage.setItem('dashboard', JSON.stringify(dashboard));
-    console.log(dashboard);
+    return Promise.resolve();
   },
 } as DashboardProps;
 
 export const Main: ComponentStory<typeof Dashboard> = () => <Dashboard {...getDashboardProps(args)} />;
-
-const readOnlyArgs: DashboardProps = {
-  dashboardClientConfiguration,
-  grid: {
-    height: 100,
-    width: 100,
-    cellSize: 10,
-    stretchToFit: false,
-  },
-  query,
-  dashboardConfiguration: {
-    viewport: { duration: '5m' },
-    widgets: [
-      MockWidgetFactory.getTextWidget({ x: 0, y: 0, width: 30, height: 2 }),
-      MockWidgetFactory.getKpiWidget({ x: 0, y: 3, width: 30, height: 20 }),
-      MockWidgetFactory.getKpiWidget({ x: 31, y: 3, width: 30, height: 20 }),
-      MockWidgetFactory.getLineChartWidget({ x: 0, y: 24, width: 30, height: 30 }),
-      MockWidgetFactory.getLineChartWidget({ x: 31, y: 24, width: 30, height: 30 }),
-    ],
-  },
-  readOnly: true,
-} as DashboardProps;
-
-export const ReadOnly: ComponentStory<typeof Dashboard> = () => {
-  return <Dashboard {...getDashboardProps(readOnlyArgs)} />;
-};

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@iot-app-kit/ts-config/react-library.json",
   "include": [
-    "./src"
+    "./src",
+    "./stories"
   ],
   "compilerOptions": {
     "baseUrl": ".",


### PR DESCRIPTION
## Overview
    - remove unused query param from storybook that caused redux errors
    - update onSave prop type for dashboard to return promise
    - remove deprecated internationlization
    - fix key warnings on various UX elements
    - enable typescript on storybook, fix ts errors

Addresses https://github.com/awslabs/iot-app-kit/issues/806

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
