### PR TITLE
fix(composer): black screen on Matterport scene

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -174,7 +174,7 @@
         "lines": 76.32,
         "statements": 75.63,
         "functions": 75.34,
-        "branches": 61.11,
+        "branches": 61,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/components/WebGLCanvasManager.tsx
+++ b/packages/scene-composer/src/components/WebGLCanvasManager.tsx
@@ -40,6 +40,7 @@ export const WebGLCanvasManager: React.FC = () => {
   const { gl } = useThree();
   const domRef = useRef<HTMLElement>(gl.domElement.parentElement);
   const environmentPreset = getSceneProperty(KnownSceneProperty.EnvironmentPreset);
+  const matterportModelId = getSceneProperty(KnownSceneProperty.MatterportModelId);
   const rootNodeRefs = document.rootNodeRefs;
   const [startingPointerPosition, setStartingPointerPosition] = useState<THREE.Vector2>(new THREE.Vector2());
 
@@ -121,6 +122,7 @@ export const WebGLCanvasManager: React.FC = () => {
               rotation={[THREE.MathUtils.degToRad(270), 0, 0]}
               onPointerUp={onPointerUp}
               onPointerDown={onPointerDown}
+              renderOrder={matterportModelId ? 1 : undefined}
             >
               <planeGeometry args={[1000, 1000]} />
               <meshBasicMaterial colorWrite={false} />

--- a/packages/scene-composer/src/components/panels/SettingsPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SettingsPanel.tsx
@@ -134,7 +134,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
         </ExpandableInfoSection>
       )}
 
-      {matterportEnabled && (
+      {matterportEnabled && isEditing && (
         <ExpandableInfoSection
           title={intl.formatMessage({
             description: 'ExpandableInfoSection Title',


### PR DESCRIPTION
## Overview
- Fixed the black screen issue with Matterport Scene
When navigating in the scene with Matterport space the floor turns black before moving. This is due to the ground plane mesh inserted by WebGLCanvasManager which writes to the depth buffer but is otherwise invisible. Due to quirks of render order sorting, sometimes it gets rendered before the Matterport model mesh, which causes portions below the ground plane to be discarded by depth testing.

Setting its renderOrder to a value greater than zero i.e. 1 so it’s never rendered before the Matterport mesh when scene is using a Matterport space otherwise leave the default render order.

- Also, updated to not show the 3rd Party Resources section in Viewer mode

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
