### PR TITLE
refactor(Dashboard): remove iot prefix from dashboard widget types

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/gestures/index.spec.tsx
+++ b/packages/dashboard/src/components/internalDashboard/gestures/index.spec.tsx
@@ -62,7 +62,7 @@ it('sets the active gesture to move when moving a selected widget', () => {
     () =>
       useGestures({
         dashboardConfiguration: MockDashboardFactory.get(),
-        selectedWidgets: [{ id: 'widget-1', x: 0, y: 0, z: 0, height: 1, width: 1, type: 'iot-kpi', properties: {} }],
+        selectedWidgets: [{ id: 'widget-1', x: 0, y: 0, z: 0, height: 1, width: 1, type: 'kpi', properties: {} }],
         cellSize: 1,
       }),
     { wrapper: ({ children }) => <TestProvider children={children} /> }
@@ -88,7 +88,7 @@ it('sets the active gesture to resize when moving an anchor', () => {
     () =>
       useGestures({
         dashboardConfiguration: MockDashboardFactory.get(),
-        selectedWidgets: [{ id: 'widget-1', x: 0, y: 0, z: 0, height: 1, width: 1, type: 'iot-kpi', properties: {} }],
+        selectedWidgets: [{ id: 'widget-1', x: 0, y: 0, z: 0, height: 1, width: 1, type: 'kpi', properties: {} }],
         cellSize: 1,
       }),
     { wrapper: ({ children }) => <TestProvider children={children} /> }
@@ -114,7 +114,7 @@ it('sets the active gesture to select when moving on the grid', () => {
     () =>
       useGestures({
         dashboardConfiguration: MockDashboardFactory.get(),
-        selectedWidgets: [{ id: 'widget-1', x: 0, y: 0, z: 0, height: 1, width: 1, type: 'iot-kpi', properties: {} }],
+        selectedWidgets: [{ id: 'widget-1', x: 0, y: 0, z: 0, height: 1, width: 1, type: 'kpi', properties: {} }],
         cellSize: 1,
       }),
     { wrapper: ({ children }) => <TestProvider children={children} /> }
@@ -140,7 +140,7 @@ it('resets the active gesture after the gesture ends', () => {
     () =>
       useGestures({
         dashboardConfiguration: MockDashboardFactory.get(),
-        selectedWidgets: [{ id: 'widget-1', x: 0, y: 0, z: 0, height: 1, width: 1, type: 'iot-kpi', properties: {} }],
+        selectedWidgets: [{ id: 'widget-1', x: 0, y: 0, z: 0, height: 1, width: 1, type: 'kpi', properties: {} }],
         cellSize: 1,
       }),
     { wrapper: ({ children }) => <TestProvider children={children} /> }

--- a/packages/dashboard/src/components/palette/index.test.tsx
+++ b/packages/dashboard/src/components/palette/index.test.tsx
@@ -59,7 +59,7 @@ describe('Component Palette', () => {
     expect(store.getState().dashboardConfiguration.widgets).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          type: 'iot-line',
+          type: 'line-chart',
         }),
       ])
     );
@@ -74,7 +74,7 @@ describe('Component Palette', () => {
     expect(store.getState().dashboardConfiguration.widgets).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          type: 'iot-line',
+          type: 'line-chart',
         }),
         expect.objectContaining({
           type: 'text',

--- a/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/axisSettingSection/index.tsx
@@ -16,7 +16,7 @@ import './index.css';
 export type AxisWidget = LineChartWidget | ScatterChartWidget | BarChartWidget;
 
 export const isAxisSettingsSupported = (widget: Widget): widget is AxisWidget =>
-  ['iot-line', 'iot-scatter', 'iot-bar'].some((t) => t === widget.type);
+  ['line-chart', 'scatter-chart', 'bar-chart'].some((t) => t === widget.type);
 
 const defaultAxisSetting: AxisSettings = {
   yAxisLabel: '',

--- a/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/propertiesAlarmSection/index.tsx
@@ -47,7 +47,7 @@ const defaultOnDeleteQuery: PropertiesAlarmsSectionProps['onDeleteAssetQuery'] =
     updateSiteWiseAssetQuery({ assets });
   };
 export const isPropertiesAndAlarmsSupported = (widget: Widget): widget is QueryWidget =>
-  ['iot-line', 'iot-scatter', 'iot-bar', 'iot-table', 'iot-kpi', 'iot-status'].some((t) => t === widget.type);
+  ['line-chart', 'scatter-chart', 'bar-chart', 'table', 'kpi', 'status'].some((t) => t === widget.type);
 
 const GeneralPropertiesAlarmsSection: FC<PropertiesAlarmsSectionProps> = ({
   onDeleteAssetQuery = defaultOnDeleteQuery,
@@ -166,7 +166,7 @@ export const TablePropertiesAlarmsSection: FC<QueryWidget> = (widget) => {
 };
 
 export const PropertiesAlarmsSection: React.FC<PropertiesAlarmsSectionProps> = (props) => {
-  const isTableWidget = props.type === 'iot-table';
+  const isTableWidget = props.type === 'table';
   return isTableWidget ? <TablePropertiesAlarmsSection {...props} /> : <GeneralPropertiesAlarmsSection {...props} />;
 };
 export default PropertiesAlarmsSection;

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
@@ -31,12 +31,12 @@ export type ThresholdWidget =
 type AnnotationWidget = LineChartWidget | ScatterChartWidget | BarChartWidget;
 
 export const isThresholdsSupported = (widget: Widget): widget is ThresholdWidget =>
-  ['iot-kpi', 'iot-status', 'iot-line', 'iot-scatter', 'iot-bar', 'iot-table'].some((t) => t === widget.type);
+  ['kpi', 'status', 'line-chart', 'scatter-chart', 'bar-chart', 'table'].some((t) => t === widget.type);
 
 const isAnnotationsSupported = (widget: Widget): widget is AnnotationWidget =>
-  ['iot-line', 'iot-scatter', 'iot-bar'].some((t) => t === widget.type);
+  ['line-chart', 'scatter-chart', 'bar-chart'].some((t) => t === widget.type);
 
-const widgetsSupportsContainOp: string[] = ['iot-kpi', 'iot-status', 'iot-table'];
+const widgetsSupportsContainOp: string[] = ['kpi', 'status', 'table'];
 
 const defaultMessages = {
   header: 'Thresholds',

--- a/packages/dashboard/src/customization/widgets/barChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/plugin.tsx
@@ -7,7 +7,7 @@ import type { BarChartWidget } from '../types';
 
 export const barChartPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
-    registerWidget<BarChartWidget>('iot-bar', {
+    registerWidget<BarChartWidget>('bar-chart', {
       render: (widget) => (
         <MultiQueryWidget {...widget}>
           <BarChartWidgetComponent {...widget} />

--- a/packages/dashboard/src/customization/widgets/kpi/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/kpi/plugin.tsx
@@ -7,7 +7,7 @@ import type { KPIWidget } from '../types';
 
 export const kpiPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
-    registerWidget<KPIWidget>('iot-kpi', {
+    registerWidget<KPIWidget>('kpi', {
       render: (widget) => (
         <SingleQueryWidget {...widget}>
           <KPIWidgetComponent {...widget} />

--- a/packages/dashboard/src/customization/widgets/lineChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/lineChart/plugin.tsx
@@ -7,7 +7,7 @@ import type { LineChartWidget } from '../types';
 
 export const lineChartPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
-    registerWidget<LineChartWidget>('iot-line', {
+    registerWidget<LineChartWidget>('line-chart', {
       render: (widget) => (
         <MultiQueryWidget {...widget}>
           <LineChartWidgetComponent {...widget} />

--- a/packages/dashboard/src/customization/widgets/scatterChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/scatterChart/plugin.tsx
@@ -7,7 +7,7 @@ import type { ScatterChartWidget } from '../types';
 
 export const scatterChartPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
-    registerWidget<ScatterChartWidget>('iot-scatter', {
+    registerWidget<ScatterChartWidget>('scatter-chart', {
       render: (widget) => (
         <MultiQueryWidget {...widget}>
           <ScatterChartWidgetComponent {...widget} />

--- a/packages/dashboard/src/customization/widgets/status/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/status/plugin.tsx
@@ -7,7 +7,7 @@ import type { StatusWidget } from '../types';
 
 export const statusPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
-    registerWidget<StatusWidget>('iot-status', {
+    registerWidget<StatusWidget>('status', {
       render: (widget) => (
         <SingleQueryWidget {...widget}>
           <StatusWidgetComponent {...widget} />

--- a/packages/dashboard/src/customization/widgets/table/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/table/plugin.tsx
@@ -44,7 +44,7 @@ const tableOnDropAsset: onDropHandler = (item, widget: TableWidget) => {
 };
 export const tablePlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
-    registerWidget<TableWidget>('iot-table', {
+    registerWidget<TableWidget>('table', {
       render: (widget: TableWidget) => (
         <MultiQueryWidgetComponent {...widget} onDropHandler={tableOnDropAsset}>
           <TableWidgetComponent {...widget} />


### PR DESCRIPTION
## Overview
Switch over widget types to match final API for widget configuration

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
