### PR TITLE
feat(composer): implement add overlay from menu

### DIFF
--- a/packages/scene-composer/src/components/toolbars/common/ItemContainer.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/common/ItemContainer.spec.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { setFeatureConfig } from '../../../common/GlobalSettings';
+import { COMPOSER_FEATURES } from '../../../interfaces';
+
+import { ItemContainer } from './ItemContainer';
+import { ToolbarItemOptions } from './types';
+
+describe('ItemContainer', () => {
+  const onClick = jest.fn();
+  const baseItem: ToolbarItemOptions = {
+    label: 'item1',
+    uuid: 'item1-uuid',
+  };
+
+  const itemWithSubItems: ToolbarItemOptions = {
+    label: 'item1',
+    text: 'item1 text',
+    icon: { name: 'add-plus' },
+    uuid: 'item1-uuid',
+    subItems: [
+      {
+        label: 'item2',
+        text: 'item2 text',
+        icon: { name: 'add-plus' },
+        uuid: 'item2-uuid',
+      },
+      {
+        label: 'item3',
+        text: 'item3 text',
+        uuid: 'item3-uuid',
+        subItems: [
+          {
+            label: 'item4',
+            text: 'item4 text',
+            uuid: 'item4-uuid',
+            isSelected: true,
+          },
+          {
+            label: 'item5',
+            text: 'item5 text',
+            uuid: 'item5-uuid',
+          },
+        ],
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    setFeatureConfig({});
+  });
+
+  it('should render properly and trigger onClick when clicking on item', () => {
+    const { container } = render(<ItemContainer item={baseItem} type='action-select' onItemClick={onClick} />);
+    expect(container).toMatchSnapshot();
+
+    fireEvent.pointerUp(screen.getByTestId(baseItem.uuid));
+
+    expect(onClick).toBeCalledTimes(1);
+    expect(onClick).toBeCalledWith(baseItem);
+  });
+
+  it('should render properly and trigger onClick when clicking on sub item', () => {
+    const { container } = render(<ItemContainer item={itemWithSubItems} type='action-select' onItemClick={onClick} />);
+    expect(container).toMatchSnapshot();
+
+    fireEvent.pointerUp(screen.getByTestId('item5-uuid'));
+
+    expect(onClick).toBeCalledTimes(1);
+    expect(onClick).toBeCalledWith(itemWithSubItems.subItems![1].subItems![1]);
+  });
+
+  it('should not render when feature is not enabled', () => {
+    const { container } = render(
+      <ItemContainer item={{ ...baseItem, feature: { name: COMPOSER_FEATURES.FOR_TESTS } }} type='action-select' />,
+    );
+    expect(container).toMatchInlineSnapshot('<div />');
+  });
+
+  it('should render when feature is enabled', () => {
+    setFeatureConfig({ [COMPOSER_FEATURES.FOR_TESTS]: true });
+
+    const { container } = render(
+      <ItemContainer item={{ ...baseItem, feature: { name: COMPOSER_FEATURES.FOR_TESTS } }} type='action-select' />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/toolbars/common/ItemContainer.tsx
+++ b/packages/scene-composer/src/components/toolbars/common/ItemContainer.tsx
@@ -1,0 +1,150 @@
+import { isEmpty } from 'lodash';
+import React, { ReactNode, useCallback, useState } from 'react';
+
+import { getGlobalSettings } from '../../../common/GlobalSettings';
+
+import {
+  Icon,
+  SubMenuIconContainer,
+  ToolbarItemContainer,
+  ToolbarItemIcon,
+  ToolbarItemMenu,
+  ToolbarItemText,
+} from './styledComponents';
+import { ToolbarItemOptions, ToolbarItemOrientation, ToolbarItemType } from './types';
+
+interface ToolbarItemContainerProps {
+  item: ToolbarItemOptions;
+  type: ToolbarItemType;
+  children?: ReactNode;
+  onPointerDown?: React.PointerEventHandler<HTMLDivElement>;
+  onPointerEnter?: React.PointerEventHandler<HTMLDivElement>;
+  onPointerLeave?: React.PointerEventHandler<HTMLDivElement>;
+  onPointerUp?: React.PointerEventHandler<HTMLDivElement>;
+  orientation?: ToolbarItemOrientation;
+  onItemClick?: (item: ToolbarItemOptions) => void;
+  disableSelectedStyle?: boolean;
+}
+
+// Solves forwardRef with props and eslint issue. Explictly setting the props type (twice) silences eslint
+// error "'XXX' is missing in props validation." See https://stackoverflow.com/a/66948051
+export const ItemContainer = React.forwardRef<HTMLDivElement, ToolbarItemContainerProps>(
+  (
+    {
+      children,
+      item,
+      onPointerDown,
+      onPointerEnter,
+      onPointerLeave,
+      onPointerUp,
+      orientation,
+      onItemClick,
+      type,
+      disableSelectedStyle,
+    }: ToolbarItemContainerProps,
+    ref,
+  ) => {
+    const [hoveredItemId, setHoveredItemId] = useState<string>('');
+
+    const pointerDown = useCallback(
+      (e) => {
+        if (e.pointerType !== 'mouse' && type !== 'button') {
+          setHoveredItemId(item.uuid);
+        }
+        onPointerDown?.(e);
+      },
+      [type, item.uuid, onPointerDown],
+    );
+
+    const pointerUp = useCallback(
+      (e) => {
+        onPointerUp?.(e);
+        onItemClick?.(item);
+        e.stopPropagation();
+      },
+      [item, onPointerUp],
+    );
+
+    const pointerEnter = useCallback(
+      (e) => {
+        if (e.pointerType === 'mouse' && type !== 'button') {
+          setHoveredItemId(item.uuid);
+        }
+        onPointerEnter?.(e);
+      },
+      [type, item.uuid, onPointerEnter],
+    );
+
+    const pointerLeave = useCallback(
+      (e) => {
+        if (e.pointerType === 'mouse' && type !== 'button') {
+          setHoveredItemId('');
+        }
+        onPointerLeave?.(e);
+      },
+      [type, onPointerLeave],
+    );
+
+    if (item.feature) {
+      const featureEnabled = getGlobalSettings().featureConfig[item.feature.name];
+      if (!featureEnabled) {
+        return null;
+      }
+    }
+
+    return (
+      <ToolbarItemContainer
+        isDisabled={item.isDisabled}
+        isSelected={!disableSelectedStyle && item.isSelected}
+        onPointerDown={pointerDown}
+        onPointerEnter={pointerEnter}
+        onPointerLeave={pointerLeave}
+        onPointerUp={pointerUp}
+        data-testid={item.uuid}
+        ref={ref}
+      >
+        {item.icon && (
+          <ToolbarItemIcon>
+            <span role='img' aria-label={item.label} title={item.label}>
+              <Icon {...item.icon} variant={item.isDisabled ? 'disabled' : 'normal'} />
+            </span>
+          </ToolbarItemIcon>
+        )}
+        {item.text && (
+          <ToolbarItemText
+            color={item.isDisabled ? 'text-status-inactive' : 'inherit'}
+            leftPadding={item.icon ? 0 : undefined}
+            variant='small'
+          >
+            {item.text}
+          </ToolbarItemText>
+        )}
+        {!isEmpty(item.subItems) && (
+          <SubMenuIconContainer>
+            <Icon name='caret-right-filled' />
+          </SubMenuIconContainer>
+        )}
+        {!isEmpty(item.subItems) && (
+          <ToolbarItemMenu isOpen={hoveredItemId === item.uuid} orientation={orientation}>
+            {item.subItems?.map((subItem) => {
+              return (
+                <ItemContainer
+                  key={subItem.uuid}
+                  onPointerDown={onPointerDown}
+                  onPointerEnter={onPointerEnter}
+                  onPointerLeave={onPointerLeave}
+                  onPointerUp={onPointerUp}
+                  onItemClick={onItemClick}
+                  item={subItem}
+                  type={type}
+                />
+              );
+            })}
+          </ToolbarItemMenu>
+        )}
+
+        {children}
+      </ToolbarItemContainer>
+    );
+  },
+);

--- a/packages/scene-composer/src/components/toolbars/common/ToolbarItem.tsx
+++ b/packages/scene-composer/src/components/toolbars/common/ToolbarItem.tsx
@@ -1,114 +1,42 @@
-import React, { Fragment, ReactNode, useEffect, useRef, useState } from 'react';
+import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 
 import { CornerTriangleSvg } from '../../../assets/svgs';
-import { getGlobalSettings } from '../../../common/GlobalSettings';
 
-import {
-  CornerAdornment,
-  Icon,
-  ToolbarItemContainer,
-  ToolbarItemIcon,
-  ToolbarItemMenu,
-  ToolbarItemText,
-} from './styledComponents';
-import { FeatureDefinition, ToolbarItemOptions } from './types';
+import { ItemContainer } from './ItemContainer';
+import { CornerAdornment, ToolbarItemMenu } from './styledComponents';
+import { ToolbarItemOptions, ToolbarItemOrientation, ToolbarItemType } from './types';
 
 interface ToolbarItemProps<T extends ToolbarItemOptions> {
-  items: T | T[];
-  type: 'button' | 'action-select' | 'mode-select';
+  items: T[];
+  type: ToolbarItemType;
   initialSelectedItem?: T;
-  isDisabled?: boolean;
   onClick?: (item: T) => void;
-  orientation?: 'horizontal' | 'vertical';
+  orientation?: ToolbarItemOrientation;
 }
-
-interface ToolbarItemContainerProps extends ToolbarItemOptions {
-  children?: ReactNode;
-  onPointerDown?: React.PointerEventHandler<HTMLDivElement>;
-  onPointerEnter?: React.PointerEventHandler<HTMLDivElement>;
-  onPointerLeave?: React.PointerEventHandler<HTMLDivElement>;
-  onPointerUp?: React.PointerEventHandler<HTMLDivElement>;
-  feature?: FeatureDefinition;
-}
-
-// Solves forwardRef with props and eslint issue. Explictly setting the props type (twice) silences eslint
-// error "'XXX' is missing in props validation." See https://stackoverflow.com/a/66948051
-const ItemContainer = React.forwardRef<HTMLDivElement, ToolbarItemContainerProps>(
-  (
-    {
-      children,
-      icon,
-      isDisabled,
-      isSelected,
-      label,
-      onPointerDown,
-      onPointerEnter,
-      onPointerLeave,
-      onPointerUp,
-      text,
-      uuid,
-      feature,
-    }: ToolbarItemContainerProps,
-    ref,
-  ) => {
-    if (feature) {
-      const featureEnabled = getGlobalSettings().featureConfig[feature.name];
-      if (!featureEnabled) {
-        return null;
-      }
-    }
-    return (
-      <ToolbarItemContainer
-        isDisabled={isDisabled}
-        isSelected={isSelected}
-        onPointerDown={onPointerDown}
-        onPointerEnter={onPointerEnter}
-        onPointerLeave={onPointerLeave}
-        onPointerUp={onPointerUp}
-        data-testid={uuid}
-        ref={ref}
-      >
-        {icon && (
-          <ToolbarItemIcon>
-            <span role='img' aria-label={label} title={label}>
-              <Icon {...icon} variant={isDisabled ? 'disabled' : 'normal'} />
-            </span>
-          </ToolbarItemIcon>
-        )}
-        {text && (
-          <ToolbarItemText
-            color={isDisabled ? 'text-status-inactive' : 'inherit'}
-            leftPadding={icon ? 0 : undefined}
-            variant='small'
-          >
-            {text}
-          </ToolbarItemText>
-        )}
-        {children}
-      </ToolbarItemContainer>
-    );
-  },
-);
 
 export function ToolbarItem<T extends ToolbarItemOptions>({
   initialSelectedItem,
-  isDisabled,
   items,
   onClick,
   orientation,
   type,
 }: ToolbarItemProps<T>) {
-  const [selectedItem, setSelectedItem] = useState(initialSelectedItem ?? (Array.isArray(items) ? items[0] : items));
+  const [selectedItem, setSelectedItem] = useState(initialSelectedItem ?? items[0]);
   const [showMenu, setShowMenu] = useState<boolean>();
   const itemContainerRef = useRef<HTMLDivElement | null>(null);
 
   function handleItemClick(item: T) {
-    onClick && onClick(item);
+    type === 'mode-select' && setSelectedItem(item);
+    onClick?.(item);
   }
 
   useEffect(() => {
     initialSelectedItem && setSelectedItem(initialSelectedItem);
   }, [initialSelectedItem]);
+
+  useEffect(() => {
+    items.length === 1 && setSelectedItem(items[0]);
+  }, [items]);
 
   // When using a touch device, hide ToolbarItemMenu if clicking somewhere outside of it
   useEffect(() => {
@@ -123,24 +51,19 @@ export function ToolbarItem<T extends ToolbarItemOptions>({
     return () => document.removeEventListener('pointerdown', handlePointerDown);
   }, [showMenu]);
 
-  if (selectedItem) {
-    const { text, ...selectedItemProps } = selectedItem;
-    let subItems: JSX.Element[] | undefined;
-
-    if (Array.isArray(items) && items.length > 1) {
-      subItems = items.reduce<JSX.Element[]>((accum, item, index) => {
+  const menuItemComponents: JSX.Element[] | undefined = useMemo(() => {
+    if (items.length > 1) {
+      return items.reduce<JSX.Element[]>((accum, item, index) => {
         if ((type === 'action-select' && index > 0) || type !== 'action-select') {
           accum.push(
             <ItemContainer
-              isDisabled={item.isDisabled}
-              isSelected={item === selectedItem}
               key={item.uuid}
+              onItemClick={handleItemClick as (item: ToolbarItemOptions) => void}
               onPointerUp={() => {
-                type === 'mode-select' && setSelectedItem(item);
-                handleItemClick(item);
                 setShowMenu(false);
               }}
-              {...item}
+              item={item}
+              type={type}
             />,
           );
         }
@@ -148,42 +71,42 @@ export function ToolbarItem<T extends ToolbarItemOptions>({
         return accum;
       }, []);
     }
+    return undefined;
+  }, [items, setShowMenu, handleItemClick, type]);
 
-    return (
-      <ItemContainer
-        isDisabled={isDisabled || selectedItem.isDisabled}
-        onPointerDown={({ pointerType }) => {
-          if (pointerType !== 'mouse' && type !== 'button') {
-            setShowMenu(true);
-          }
-        }}
-        onPointerEnter={({ pointerType }) => {
-          if (pointerType === 'mouse' && type !== 'button') {
-            setShowMenu(true);
-          }
-        }}
-        onPointerLeave={({ pointerType }) => {
-          if (pointerType === 'mouse' && type !== 'button') {
-            setShowMenu(false);
-          }
-        }}
-        onPointerUp={() => {
-          type === 'button' && handleItemClick(selectedItem);
-        }}
-        {...selectedItemProps}
-        ref={itemContainerRef}
-      >
-        {type !== 'button' && subItems && (
-          <Fragment>
-            <CornerAdornment>{CornerTriangleSvg}</CornerAdornment>
-            <ToolbarItemMenu isOpen={showMenu} orientation={orientation}>
-              {subItems}
-            </ToolbarItemMenu>
-          </Fragment>
-        )}
-      </ItemContainer>
-    );
-  }
-
-  return null;
+  return selectedItem ? (
+    <ItemContainer
+      onPointerDown={({ pointerType }) => {
+        if (pointerType !== 'mouse' && type !== 'button') {
+          setShowMenu(true);
+        }
+      }}
+      onPointerEnter={({ pointerType }) => {
+        if (pointerType === 'mouse' && type !== 'button') {
+          setShowMenu(true);
+        }
+      }}
+      onPointerLeave={({ pointerType }) => {
+        if (pointerType === 'mouse' && type !== 'button') {
+          setShowMenu(false);
+        }
+      }}
+      onPointerUp={() => {
+        type === 'button' && handleItemClick(selectedItem);
+      }}
+      item={{ ...selectedItem, text: undefined }} // don't display text for first level toolbar item
+      type={type}
+      disableSelectedStyle
+      ref={itemContainerRef}
+    >
+      {type !== 'button' && menuItemComponents && (
+        <Fragment>
+          <CornerAdornment>{CornerTriangleSvg}</CornerAdornment>
+          <ToolbarItemMenu isOpen={showMenu} orientation={orientation}>
+            {menuItemComponents}
+          </ToolbarItemMenu>
+        </Fragment>
+      )}
+    </ItemContainer>
+  ) : null;
 }

--- a/packages/scene-composer/src/components/toolbars/common/__snapshots__/ItemContainer.spec.tsx.snap
+++ b/packages/scene-composer/src/components/toolbars/common/__snapshots__/ItemContainer.spec.tsx.snap
@@ -1,0 +1,362 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ItemContainer should render properly and trigger onClick when clicking on item 1`] = `
+.c0 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  min-width: 40px;
+  height: 40px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  pointer-events: initial;
+  background-color: colorBackgroundDropdownItemDefault;
+  border-top: 1px solid colorBorderDividerDefault;
+}
+
+.c0:hover {
+  background-color: colorBackgroundDropdownItemHover;
+}
+
+.c0:first-of-type {
+  border-top: 0;
+}
+
+<div>
+  <div
+    class="c0"
+    data-testid="item1-uuid"
+  />
+</div>
+`;
+
+exports[`ItemContainer should render properly and trigger onClick when clicking on sub item 1`] = `
+.c2 {
+  shape-rendering: geometricPrecision;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.c0 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  min-width: 40px;
+  height: 40px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  pointer-events: initial;
+  background-color: colorBackgroundDropdownItemDefault;
+  border-top: 1px solid colorBorderDividerDefault;
+}
+
+.c0:hover {
+  background-color: colorBackgroundDropdownItemHover;
+}
+
+.c0:first-of-type {
+  border-top: 0;
+}
+
+.c7 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  min-width: 40px;
+  height: 40px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: default;
+  pointer-events: none;
+  background-color: colorBackgroundItemSelected;
+  border-top: 1px solid colorBorderDividerDefault;
+}
+
+.c7:first-of-type {
+  border-top: 0;
+}
+
+.c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+}
+
+.c5 {
+  display: none;
+  position: absolute;
+  left: 100%;
+  top: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  background-color: colorBackgroundDropdownItemDefault;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 1;
+}
+
+.c5 > div {
+  border-top: 1px solid colorBorderDividerDefault;
+}
+
+.c5 > div:first-of-type {
+  border-top: 0;
+}
+
+.c3 {
+  padding: 0 20px 0 0px;
+  white-space: nowrap;
+}
+
+.c6 {
+  padding: 0 20px 0 20px;
+  white-space: nowrap;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  padding-right: 6px;
+}
+
+<div>
+  <div
+    class="c0"
+    data-testid="item1-uuid"
+  >
+    <div
+      class="c1"
+    >
+      <span
+        aria-label="item1"
+        role="img"
+        title="item1"
+      >
+        <div
+          class="c2"
+          data-mocked="Icon"
+          name="add-plus"
+          variant="normal"
+        />
+      </span>
+    </div>
+    <div
+      class="c3"
+      color="inherit"
+      data-mocked="Box"
+      leftpadding="0"
+      variant="small"
+    >
+      item1 text
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c2"
+        data-mocked="Icon"
+        name="caret-right-filled"
+      />
+    </div>
+    <div
+      class="c5"
+    >
+      <div
+        class="c0"
+        data-testid="item2-uuid"
+      >
+        <div
+          class="c1"
+        >
+          <span
+            aria-label="item2"
+            role="img"
+            title="item2"
+          >
+            <div
+              class="c2"
+              data-mocked="Icon"
+              name="add-plus"
+              variant="normal"
+            />
+          </span>
+        </div>
+        <div
+          class="c3"
+          color="inherit"
+          data-mocked="Box"
+          leftpadding="0"
+          variant="small"
+        >
+          item2 text
+        </div>
+      </div>
+      <div
+        class="c0"
+        data-testid="item3-uuid"
+      >
+        <div
+          class="c6"
+          color="inherit"
+          data-mocked="Box"
+          variant="small"
+        >
+          item3 text
+        </div>
+        <div
+          class="c4"
+        >
+          <div
+            class="c2"
+            data-mocked="Icon"
+            name="caret-right-filled"
+          />
+        </div>
+        <div
+          class="c5"
+        >
+          <div
+            class="c7"
+            data-testid="item4-uuid"
+          >
+            <div
+              class="c6"
+              color="inherit"
+              data-mocked="Box"
+              variant="small"
+            >
+              item4 text
+            </div>
+          </div>
+          <div
+            class="c0"
+            data-testid="item5-uuid"
+          >
+            <div
+              class="c6"
+              color="inherit"
+              data-mocked="Box"
+              variant="small"
+            >
+              item5 text
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ItemContainer should render when feature is enabled 1`] = `
+.c0 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  min-width: 40px;
+  height: 40px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  pointer-events: initial;
+  background-color: colorBackgroundDropdownItemDefault;
+  border-top: 1px solid colorBorderDividerDefault;
+}
+
+.c0:hover {
+  background-color: colorBackgroundDropdownItemHover;
+}
+
+.c0:first-of-type {
+  border-top: 0;
+}
+
+<div>
+  <div
+    class="c0"
+    data-testid="item1-uuid"
+  />
+</div>
+`;

--- a/packages/scene-composer/src/components/toolbars/common/styledComponents.ts
+++ b/packages/scene-composer/src/components/toolbars/common/styledComponents.ts
@@ -89,7 +89,7 @@ export const ToolbarItemMenu = styled.div<{
 }>`
   display: none;
   position: absolute;
-  left: 41px;
+  left: 100%;
   top: 0;
   flex-direction: ${({ orientation }) => (orientation === 'horizontal' ? 'row' : 'column')};
   background-color: ${colorBackgroundDropdownItemDefault};
@@ -128,4 +128,12 @@ export const ToolbarItemText = styled(Box)<{ leftPadding?: number; rightPadding?
   padding: 0 ${({ rightPadding = DEFAULT_TEXT_PADDING }) => rightPadding}px 0
     ${({ leftPadding = DEFAULT_TEXT_PADDING }) => leftPadding}px;
   white-space: nowrap;
+`;
+
+export const SubMenuIconContainer = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  justify-content: flex-end;
+  padding-right: 6px;
 `;

--- a/packages/scene-composer/src/components/toolbars/common/types.ts
+++ b/packages/scene-composer/src/components/toolbars/common/types.ts
@@ -17,4 +17,9 @@ export type ToolbarItemOptions = {
   text?: string;
   uuid: string;
   feature?: FeatureDefinition;
+  subItems?: ToolbarItemOptions[];
 };
+
+export type ToolbarItemType = 'button' | 'action-select' | 'mode-select';
+
+export type ToolbarItemOrientation = 'horizontal' | 'vertical';

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/CancelMenuItem.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/CancelMenuItem.tsx
@@ -12,11 +12,13 @@ export function CancelMenuItem() {
 
   return (
     <ToolbarItem
-      items={{
-        label: intl.formatMessage({ defaultMessage: 'Cancel', description: 'Menu Item label' }),
-        icon: { name: 'close' },
-        uuid: 'cancel',
-      }}
+      items={[
+        {
+          label: intl.formatMessage({ defaultMessage: 'Cancel', description: 'Menu Item label' }),
+          icon: { name: 'close' },
+          uuid: 'cancel',
+        },
+      ]}
       type='button'
       onClick={() => setAddingWidget(undefined)}
     />

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/HistoryItemGroup.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/HistoryItemGroup.tsx
@@ -11,7 +11,7 @@ export function HistoryItemGroup() {
   const sceneComposerId = useContext(sceneComposerIdContext);
   const [redo, undo] = useStore(sceneComposerId)((state) => [state.redo, state.undo]);
   const undoStore = useStore(sceneComposerId)((state) => state.undoStore);
-  const [undoState, setUndoSate] = useState<UndoStoreState>();
+  const [undoState, setUndoSate] = useState<UndoStoreState | undefined>(undoStore?.getState());
   const isRedoEnabled = (undoState?.futureStates && undoState.futureStates.length > 0) || false;
   const isUndoEnabled = (undoState?.prevStates && undoState.prevStates.length > 0) || false;
   const intl = useIntl();
@@ -23,23 +23,27 @@ export function HistoryItemGroup() {
   return (
     <ToolbarItemGroup>
       <ToolbarItem
-        items={{
-          label: intl.formatMessage({ defaultMessage: 'Undo', description: 'Menu Item label' }),
-          icon: { name: 'undo' },
-          uuid: 'undo',
-        }}
+        items={[
+          {
+            label: intl.formatMessage({ defaultMessage: 'Undo', description: 'Menu Item label' }),
+            icon: { name: 'undo' },
+            uuid: 'undo',
+            isDisabled: !isUndoEnabled,
+          },
+        ]}
         type='button'
-        isDisabled={!isUndoEnabled}
         onClick={() => undo && undo()}
       />
       <ToolbarItem
-        items={{
-          label: intl.formatMessage({ defaultMessage: 'Redo', description: 'Menu Item label' }),
-          icon: { isMirrored: true, name: 'undo' },
-          uuid: 'redo',
-        }}
+        items={[
+          {
+            label: intl.formatMessage({ defaultMessage: 'Redo', description: 'Menu Item label' }),
+            icon: { isMirrored: true, name: 'undo' },
+            uuid: 'redo',
+            isDisabled: !isRedoEnabled,
+          },
+        ]}
         type='button'
-        isDisabled={!isRedoEnabled}
         onClick={() => redo && redo()}
       />
     </ToolbarItemGroup>

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.tsx
@@ -45,17 +45,20 @@ export function ObjectItemGroup() {
       icon: { scale: 1.06, svg: TranslateIconSvg },
       uuid: TransformTypes.Translate,
       mode: 'translate',
+      isSelected: transformControlMode === 'translate',
     },
     {
       icon: { scale: 1.06, svg: RotateIconSvg },
       uuid: TransformTypes.Rotate,
       mode: 'rotate',
+      isSelected: transformControlMode === 'rotate',
     },
     {
       icon: { scale: 1.06, svg: ScaleIconSvg },
       uuid: TransformTypes.Scale,
       mode: 'scale',
       isDisabled: isTagComponent,
+      isSelected: transformControlMode === 'scale',
     },
   ].map(
     (item) =>
@@ -74,18 +77,20 @@ export function ObjectItemGroup() {
 
   const translatedItems = useMemo(() => {
     return transformSelectorItems;
-  }, [intl, isTagComponent]);
+  }, [intl, isTagComponent, transformControlMode]);
 
   return (
     <ToolbarItemGroup>
       <ToolbarItem
-        items={{
-          label: intl.formatMessage({ defaultMessage: 'Delete', description: 'Toolbar label' }),
-          icon: { svg: DeleteSvg },
-          uuid: 'delete',
-        }}
+        items={[
+          {
+            label: intl.formatMessage({ defaultMessage: 'Delete', description: 'Toolbar label' }),
+            icon: { svg: DeleteSvg },
+            uuid: 'delete',
+            isDisabled: isDeleteDisabled,
+          },
+        ]}
         type='button'
-        isDisabled={isDeleteDisabled}
         onClick={() => {
           if (removeSceneNode && selectedSceneNodeRef) {
             removeSceneNode(selectedSceneNodeRef);

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/SceneItemGroup.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/SceneItemGroup.tsx
@@ -62,11 +62,17 @@ export function SceneItemGroup({ isViewing = false }: SceneItemGroupProps) {
     return cameraControlItems(intl).find((item) => item.mode === cameraControlsType) ?? cameraControlItemsOptions[0];
   }, [cameraControlItems, cameraControlsType]);
 
+  const items = useMemo(() => {
+    const rawItems = cameraControlItems(intl);
+    rawItems.forEach((item) => (item.isSelected = item.mode === cameraControlsType));
+    return rawItems;
+  }, [cameraControlsType]);
+
   return (
     <ToolbarItemGroup>
       {!isViewing && <AddObjectMenu />}
       <ToolbarItem
-        items={cameraControlItems(intl)}
+        items={items}
         initialSelectedItem={initialSelectedItem}
         type='mode-select'
         onClick={(selectedItem) => setCameraControlsType(selectedItem.mode)}

--- a/packages/scene-composer/src/interfaces/feature.ts
+++ b/packages/scene-composer/src/interfaces/feature.ts
@@ -13,6 +13,7 @@ export enum COMPOSER_FEATURES {
   TagResize = 'TagResize',
   SubModelMovement = 'SubModelMovement',
   SubModelChildren = 'SubModelChildren',
+  Overlay = 'Overlay',
 }
 
 export type FeatureConfig = Partial<Record<COMPOSER_FEATURES, boolean>>;

--- a/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
+++ b/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
@@ -1701,6 +1701,37 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
   border-top: 0;
 }
 
+.c17 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  min-width: 40px;
+  height: 40px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: default;
+  pointer-events: none;
+  background-color: colorBackgroundItemSelected;
+  border-top: 1px solid colorBorderDividerDefault;
+}
+
+.c17:first-of-type {
+  border-top: 0;
+}
+
 .c11 {
   position: relative;
   display: -webkit-box;
@@ -1738,7 +1769,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
 .c16 {
   display: none;
   position: absolute;
-  left: 41px;
+  left: 100%;
   top: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1759,7 +1790,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
   border-top: 0;
 }
 
-.c17 {
+.c18 {
   padding: 0 20px 0 0px;
   white-space: nowrap;
 }
@@ -1783,7 +1814,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
   background-color: colorBackgroundDropdownItemDefault;
 }
 
-.c18 {
+.c19 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1936,8 +1967,11 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
                   className="c16"
                 >
                   <div
-                    className="c12"
+                    className="c17"
                     data-testid="camera-controls-orbit"
+                    onPointerDown={[Function]}
+                    onPointerEnter={[Function]}
+                    onPointerLeave={[Function]}
                     onPointerUp={[Function]}
                   >
                     <div
@@ -1987,7 +2021,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
                       </span>
                     </div>
                     <div
-                      className="c17"
+                      className="c18"
                       color="inherit"
                       data-mocked="Box"
                       leftPadding={0}
@@ -1999,6 +2033,9 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
                   <div
                     className="c12"
                     data-testid="camera-controls-pan"
+                    onPointerDown={[Function]}
+                    onPointerEnter={[Function]}
+                    onPointerLeave={[Function]}
                     onPointerUp={[Function]}
                   >
                     <div
@@ -2033,7 +2070,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
                       </span>
                     </div>
                     <div
-                      className="c17"
+                      className="c18"
                       color="inherit"
                       data-mocked="Box"
                       leftPadding={0}
@@ -2048,7 +2085,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
           </div>
         </div>
         <div
-          className="c18"
+          className="c19"
           style={
             Object {
               "height": "100%",
@@ -2296,6 +2333,37 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
   border-top: 0;
 }
 
+.c19 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  min-width: 40px;
+  height: 40px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: default;
+  pointer-events: none;
+  background-color: colorBackgroundItemSelected;
+  border-top: 1px solid colorBorderDividerDefault;
+}
+
+.c19:first-of-type {
+  border-top: 0;
+}
+
 .c13 {
   position: relative;
   display: -webkit-box;
@@ -2333,7 +2401,7 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
 .c18 {
   display: none;
   position: absolute;
-  left: 41px;
+  left: 100%;
   top: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -2354,7 +2422,7 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
   border-top: 0;
 }
 
-.c19 {
+.c20 {
   padding: 0 20px 0 0px;
   white-space: nowrap;
 }
@@ -2378,7 +2446,7 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
   background-color: colorBackgroundDropdownItemDefault;
 }
 
-.c20 {
+.c21 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2571,8 +2639,11 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
                   className="c18"
                 >
                   <div
-                    className="c14"
+                    className="c19"
                     data-testid="camera-controls-orbit"
+                    onPointerDown={[Function]}
+                    onPointerEnter={[Function]}
+                    onPointerLeave={[Function]}
                     onPointerUp={[Function]}
                   >
                     <div
@@ -2622,7 +2693,7 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
                       </span>
                     </div>
                     <div
-                      className="c19"
+                      className="c20"
                       color="inherit"
                       data-mocked="Box"
                       leftPadding={0}
@@ -2634,6 +2705,9 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
                   <div
                     className="c14"
                     data-testid="camera-controls-pan"
+                    onPointerDown={[Function]}
+                    onPointerEnter={[Function]}
+                    onPointerLeave={[Function]}
                     onPointerUp={[Function]}
                   >
                     <div
@@ -2668,7 +2742,7 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
                       </span>
                     </div>
                     <div
-                      className="c19"
+                      className="c20"
                       color="inherit"
                       data-mocked="Box"
                       leftPadding={0}
@@ -2683,7 +2757,7 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
           </div>
         </div>
         <div
-          className="c20"
+          className="c21"
           style={
             Object {
               "height": "100%",

--- a/packages/scene-composer/tests/components/toolbars/common/ToolbarItem.spec.tsx
+++ b/packages/scene-composer/tests/components/toolbars/common/ToolbarItem.spec.tsx
@@ -8,8 +8,20 @@ import { ToolbarItem } from '../../../../src/components/toolbars/common/ToolbarI
 describe('ToolbarItem', () => {
   const testMenuItem = {
     label: 'Test Item 1',
-    text: { name: 'item1' },
+    text: 'item1',
     uuid: 'item1',
+  };
+  const testMenuItemWithSubItem = {
+    label: 'Test Item 2',
+    text: 'item2',
+    uuid: 'item2',
+    subItems: [
+      {
+        label: 'Test sub item 1',
+        text: 'sub item 1',
+        uuid: 'sub-item1',
+      },
+    ],
   };
   const setSelectedItem = jest.fn();
   const setShowMenu = jest.fn();
@@ -21,7 +33,7 @@ describe('ToolbarItem', () => {
   it('should show menu on pointerDown', () => {
     jest.spyOn(React, 'useState').mockReturnValueOnce([testMenuItem, setSelectedItem]);
     jest.spyOn(React, 'useState').mockReturnValueOnce([false, setShowMenu]);
-    render(<ToolbarItem items={testMenuItem as any} type='action-select' />);
+    render(<ToolbarItem items={[testMenuItem]} type='action-select' />);
 
     fireEvent.pointerDown(screen.getByTestId('item1'));
 
@@ -31,10 +43,20 @@ describe('ToolbarItem', () => {
   it('should hide menu on pointerDown outside', () => {
     jest.spyOn(React, 'useState').mockReturnValueOnce([testMenuItem, setSelectedItem]);
     jest.spyOn(React, 'useState').mockReturnValueOnce([true, setShowMenu]);
-    render(<ToolbarItem items={testMenuItem as any} type='action-select' />);
+    render(<ToolbarItem items={[testMenuItem]} type='action-select' />);
 
     fireEvent.pointerDown(document.body);
 
     expect(setShowMenu).toBeCalledWith(false);
+  });
+
+  it('should trigger onClick when clicking on sub menu item', () => {
+    const onClick = jest.fn();
+    render(<ToolbarItem items={[testMenuItem, testMenuItemWithSubItem]} type='action-select' onClick={onClick} />);
+
+    fireEvent.pointerUp(screen.getByTestId('sub-item1'));
+
+    expect(onClick).toBeCalledTimes(1);
+    expect(onClick).toBeCalledWith(testMenuItemWithSubItem.subItems[0]);
   });
 });

--- a/packages/scene-composer/tests/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
+++ b/packages/scene-composer/tests/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
@@ -17,6 +17,7 @@ import {
   DEFAULT_LIGHT_SETTINGS_MAP,
   IAnchorComponent,
   ICameraComponent,
+  IDataOverlayComponent,
   ILightComponent,
   IModelRefComponent,
   IMotionIndicatorComponent,
@@ -219,5 +220,71 @@ describe('AddObjectMenu', () => {
     });
     expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
     expect(mockMetricRecorder.recordClick).toBeCalledWith('add-object-motion-indicator');
+  });
+
+  it('should not see add overlay item when feature is not enabled', () => {
+    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: false });
+
+    render(<AddObjectMenu />);
+
+    expect(screen.queryByTestId('add-overlay-menu')).toBeNull();
+  });
+
+  it('should call setAddingWidget when adding a data overlay', () => {
+    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true, [COMPOSER_FEATURES.ENHANCED_EDITING]: true });
+    const component: IDataOverlayComponent = {
+      type: KnownComponentType.DataOverlay,
+      valueDataBindings: [],
+      subType: Component.DataOverlaySubType.OverlayPanel,
+      dataRows: [
+        {
+          rowType: Component.DataOverlayRowType.Markdown,
+          content: '',
+        },
+      ],
+    };
+
+    render(<AddObjectMenu />);
+    const sut = screen.getByTestId('add-object-data-overlay');
+    fireEvent.pointerUp(sut);
+    expect(setAddingWidget).toBeCalledWith({
+      type: KnownComponentType.DataOverlay,
+      node: {
+        name: 'DataOverlay',
+        components: [component],
+        parentRef: selectedSceneNodeRef,
+      },
+    });
+    expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
+    expect(mockMetricRecorder.recordClick).toBeCalledWith('add-object-data-overlay');
+  });
+
+  it('should call setAddingWidget when adding a annotation', () => {
+    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true, [COMPOSER_FEATURES.ENHANCED_EDITING]: true });
+    const component: IDataOverlayComponent = {
+      type: KnownComponentType.DataOverlay,
+      valueDataBindings: [],
+      subType: Component.DataOverlaySubType.TextAnnotation,
+      dataRows: [
+        {
+          rowType: Component.DataOverlayRowType.Markdown,
+          content: '',
+        },
+      ],
+    };
+
+    render(<AddObjectMenu />);
+    const sut = screen.getByTestId('add-object-annotation');
+    fireEvent.pointerUp(sut);
+    expect(setAddingWidget).toBeCalledWith({
+      type: KnownComponentType.DataOverlay,
+      node: {
+        name: 'Annotation',
+        components: [component],
+        parentRef: selectedSceneNodeRef,
+      },
+    });
+    expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
+    expect(mockMetricRecorder.recordClick).toBeCalledWith('add-object-annotation');
   });
 });

--- a/packages/scene-composer/tests/components/toolbars/floatingToolbar/items/HistoryItemGroup.spec.tsx
+++ b/packages/scene-composer/tests/components/toolbars/floatingToolbar/items/HistoryItemGroup.spec.tsx
@@ -3,13 +3,31 @@ import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 
 import { HistoryItemGroup } from '../../../../../src/components/toolbars/floatingToolbar/items';
+import { useStore } from '../../../../../src/store';
+import { createUndoStore } from '../../../../../src/store/middlewares';
 
 jest.mock('../../../../../src/components/toolbars/common/ToolbarItem', () => ({
   ToolbarItem: 'ToolbarItem',
 }));
 
 describe('HistoryItemGroup', () => {
-  it('should render correctly', () => {
+  it('should render correctly with undo enabled', () => {
+    const undoStore = createUndoStore();
+    useStore('default').setState({ undoStore });
+
+    undoStore.setState({ prevStates: [{}] });
+    let container;
+    act(() => {
+      container = renderer.create(<HistoryItemGroup />);
+    });
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render correctly with redo enabled', () => {
+    const undoStore = createUndoStore();
+    useStore('default').setState({ undoStore });
+
+    undoStore.setState({ futureStates: [{}] });
     let container;
     act(() => {
       container = renderer.create(<HistoryItemGroup />);

--- a/packages/scene-composer/tests/components/toolbars/floatingToolbar/items/__snapshots__/HistoryItemGroup.spec.tsx.snap
+++ b/packages/scene-composer/tests/components/toolbars/floatingToolbar/items/__snapshots__/HistoryItemGroup.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HistoryItemGroup should render correctly 1`] = `
+exports[`HistoryItemGroup should render correctly with redo enabled 1`] = `
 .c0 {
   position: relative;
   display: -webkit-box;
@@ -21,30 +21,90 @@ exports[`HistoryItemGroup should render correctly 1`] = `
   className="c0"
 >
   <ToolbarItem
-    isDisabled={true}
     items={
-      Object {
-        "icon": Object {
-          "name": "undo",
+      Array [
+        Object {
+          "icon": Object {
+            "name": "undo",
+          },
+          "isDisabled": true,
+          "label": "Undo",
+          "uuid": "undo",
         },
-        "label": "Undo",
-        "uuid": "undo",
-      }
+      ]
     }
     onClick={[Function]}
     type="button"
   />
   <ToolbarItem
-    isDisabled={true}
     items={
-      Object {
-        "icon": Object {
-          "isMirrored": true,
-          "name": "undo",
+      Array [
+        Object {
+          "icon": Object {
+            "isMirrored": true,
+            "name": "undo",
+          },
+          "isDisabled": false,
+          "label": "Redo",
+          "uuid": "redo",
         },
-        "label": "Redo",
-        "uuid": "redo",
-      }
+      ]
+    }
+    onClick={[Function]}
+    type="button"
+  />
+</div>
+`;
+
+exports[`HistoryItemGroup should render correctly with undo enabled 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-top: 3px solid colorBorderDividerDefault;
+}
+
+.c0:first-of-type {
+  border-top: 0;
+}
+
+<div
+  className="c0"
+>
+  <ToolbarItem
+    items={
+      Array [
+        Object {
+          "icon": Object {
+            "name": "undo",
+          },
+          "isDisabled": false,
+          "label": "Undo",
+          "uuid": "undo",
+        },
+      ]
+    }
+    onClick={[Function]}
+    type="button"
+  />
+  <ToolbarItem
+    items={
+      Array [
+        Object {
+          "icon": Object {
+            "isMirrored": true,
+            "name": "undo",
+          },
+          "isDisabled": true,
+          "label": "Redo",
+          "uuid": "redo",
+        },
+      ]
     }
     onClick={[Function]}
     type="button"

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -143,6 +143,10 @@
     "note": "Form Field label",
     "text": "Model Path"
   },
+  "8W3SiU": {
+    "note": "Menu Item label",
+    "text": "Overlay"
+  },
   "8YlbtM": {
     "note": "Form field label",
     "text": "Near"
@@ -202,6 +206,10 @@
   "DVJ3oz": {
     "note": "view options dropdown button text",
     "text": "View Options"
+  },
+  "DlaPGB": {
+    "note": "Menu Item label",
+    "text": "Data overlay"
   },
   "DsNVlc": {
     "note": "Input error message",
@@ -351,6 +359,10 @@
     "note": "Menu Item",
     "text": "Pan"
   },
+  "OgOwr7": {
+    "note": "Menu Item",
+    "text": "Data overlay"
+  },
   "OpGIbY": {
     "note": "Scene Icon types in a dropdown menu",
     "text": "Error"
@@ -451,6 +463,10 @@
     "note": "checkbox option",
     "text": "Snap to floor"
   },
+  "WEMQNi": {
+    "note": "Menu Item label",
+    "text": "Annotation"
+  },
   "WVVCRr": {
     "note": "Form Field label",
     "text": "Unit of Measure"
@@ -462,6 +478,10 @@
   "X4zSHQ": {
     "note": "Form Field label",
     "text": "Distance"
+  },
+  "X7gllM": {
+    "note": "Menu Item",
+    "text": "Annotation"
   },
   "XXnvtK": {
     "note": "Error message",
@@ -742,6 +762,10 @@
   "rDIRVn": {
     "note": "Menu Item label",
     "text": "Motion indicator"
+  },
+  "rH0oex": {
+    "note": "Menu Item",
+    "text": "Add overlay"
   },
   "rKeM3X": {
     "note": "Form Field label",


### PR DESCRIPTION
## Overview
- Implement the basic add menu item for overlay and annotation. Final UX is still pending.
- Fixed selected mode menu item not displayed correctly issue 
- 
<img width="1098" alt="add-overlay" src="https://user-images.githubusercontent.com/9315598/227411254-68883e2f-ddf3-42f3-90be-ec629c832039.png">

<img width="248" alt="selected-camera-control" src="https://user-images.githubusercontent.com/9315598/227411275-6c2fb018-95bc-4a09-946e-8e7b74a534f8.png">

<img width="262" alt="selected-transform" src="https://user-images.githubusercontent.com/9315598/227411294-bfe1415c-f931-4d7f-9e7b-fe3d45d891c9.png">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
