### PR TITLE
feat(react-comp): sync viewports using @iot-app-kit/charts pckg

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -95,7 +95,7 @@
     "@cloudscape-design/components": "^3.0.228",
     "@cloudscape-design/design-tokens": "^3.0.9",
     "@cloudscape-design/global-styles": "^1.0.7",
-    "@iot-app-kit-visualizations/core": "^1.2.0",
+    "@iot-app-kit/charts-core": "^1.6.0",
     "@iot-app-kit/components": "^4.0.0",
     "@iot-app-kit/core": "^4.0.0",
     "@iot-app-kit/core-util": "*",

--- a/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
+++ b/packages/dashboard/src/components/sidePanel/sections/thresholdsSection/thresholdsSection.tsx
@@ -17,7 +17,7 @@ import type {
 } from '~/customization/widgets/types';
 import type { Widget } from '~/types';
 import type { ThresholdWithId } from '~/customization/settings';
-import type { Annotations } from '@iot-app-kit-visualizations/core';
+import type { Annotations } from '@iot-app-kit/charts-core';
 import { COMPARISON_OPERATOR } from '@iot-app-kit/core';
 
 export type ThresholdWidget =

--- a/packages/dashboard/src/customization/widgets/barChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { BarChart } from '@iot-app-kit/react-components';
-import { Axis } from '@iot-app-kit-visualizations/core';
+import { Axis } from '@iot-app-kit/charts-core';
 
 import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';

--- a/packages/dashboard/src/customization/widgets/lineChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineChart/component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { LineChart } from '@iot-app-kit/react-components';
-import { Axis } from '@iot-app-kit-visualizations/core';
+import { Axis } from '@iot-app-kit/charts-core';
 
 import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';

--- a/packages/dashboard/src/customization/widgets/scatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/scatterChart/component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { ScatterChart } from '@iot-app-kit/react-components';
-import { Axis } from '@iot-app-kit-visualizations/core';
+import { Axis } from '@iot-app-kit/charts-core';
 
 import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';

--- a/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
+++ b/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
@@ -5,7 +5,7 @@ import { DashboardState } from '~/store/state';
 import { StatusTimelineWidget } from '../types';
 import { useQueries } from '~/components/dashboard/queryContext';
 import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
-import { Axis } from '@iot-app-kit-visualizations/core';
+import { Axis } from '@iot-app-kit/charts-core';
 
 const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (widget) => {
   const viewport = useSelector((state: DashboardState) => state.dashboardConfiguration.viewport);

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -9,7 +9,7 @@ import type {
   ThresholdWithId,
 } from '../settings';
 import type { TableColumnDefinition, TableItem } from '@iot-app-kit/react-components/src';
-import type { Annotations } from '@iot-app-kit-visualizations/core';
+import type { Annotations } from '@iot-app-kit/charts-core';
 
 export type QueryConfig<S, T> = {
   source: S;

--- a/packages/dashboard/testing/mocks/index.ts
+++ b/packages/dashboard/testing/mocks/index.ts
@@ -1,6 +1,6 @@
 import type { TimeSeriesData } from '@iot-app-kit/core';
 import { DATA_TYPE } from '@iot-app-kit/core';
-import type { DataPoint } from '@iot-app-kit-visualizations/core';
+import type { DataPoint } from '@iot-app-kit/charts-core';
 import random from 'lodash/random';
 import {
   KPIWidget,

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -81,8 +81,8 @@
   "dependencies": {
     "@cloudscape-design/collection-hooks": "^1.0.19",
     "@cloudscape-design/components": "^3.0.228",
-    "@iot-app-kit-visualizations/core": "^1.2.0",
-    "@iot-app-kit-visualizations/react": "^1.2.0",
+    "@iot-app-kit/charts-core": "^1.6.0",
+    "@iot-app-kit/charts": "^1.6.0",
     "@iot-app-kit/components": "4.0.0",
     "@iot-app-kit/core": "4.0.0",
     "@iot-app-kit/source-iottwinmaker": "4.0.0",

--- a/packages/react-components/src/components.ts
+++ b/packages/react-components/src/components.ts
@@ -4,7 +4,7 @@ import { createReactComponent } from './stencil-generated';
 import type { JSX } from '@iot-app-kit/components';
 
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
-const { defineCustomElements: defineSynchroChartsElements } = require('@iot-app-kit-visualizations/core/dist/loader');
+const { defineCustomElements: defineSynchroChartsElements } = require('@iot-app-kit/charts-core/dist/loader');
 defineCustomElements();
 defineSynchroChartsElements()
 

--- a/packages/react-components/src/components/bar-chart/barChart.spec.tsx
+++ b/packages/react-components/src/components/bar-chart/barChart.spec.tsx
@@ -18,10 +18,10 @@ it('renders', async () => {
   ]);
 
   const { container } = render(<BarChart queries={[query]} viewport={VIEWPORT} />);
-  const chart = container.querySelector('sc-bar-chart');
+  const chart = container.querySelector('iot-app-kit-vis-bar-chart');
 
   expect(chart).not.toBeNull();
 
-  expect(chart).toHaveProperty('viewport', VIEWPORT);
+  expect(chart).toHaveProperty('viewport.duration', VIEWPORT.duration);
   expect(chart).toHaveProperty('dataStreams', [DATA_STREAM]);
 });

--- a/packages/react-components/src/components/bar-chart/barChart.tsx
+++ b/packages/react-components/src/components/bar-chart/barChart.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { StyleSettingsMap, Threshold, TimeSeriesDataQuery, Viewport } from '@iot-app-kit/core';
-import { BarChart as BarChartBase } from '@iot-app-kit-visualizations/react';
-import type { Annotations, Axis, DataStream as DataStreamViz } from '@iot-app-kit-visualizations/core';
-import { YAnnotation } from '@iot-app-kit-visualizations/core';
+import { BarChart as BarChartBase } from '@iot-app-kit/charts';
+import type { Annotations, Axis, DataStream as DataStreamViz, YAnnotation } from '@iot-app-kit/charts-core';
 import { useTimeSeriesData } from '../../hooks/useTimeSeriesData';
 import { useViewport } from '../../hooks/useViewport';
 import { DEFAULT_VIEWPORT } from '../../common/constants';
@@ -43,7 +42,7 @@ export const BarChart = ({
     },
     styles,
   });
-  const { viewport } = useViewport();
+  const { viewport, setViewport, group, lastUpdatedBy } = useViewport();
   const allThresholds = [...queryThresholds, ...thresholds];
 
   const utilizedViewport = passedInViewport || viewport || DEFAULT_VIEWPORT; // explicitly passed in viewport overrides viewport group
@@ -52,7 +51,8 @@ export const BarChart = ({
     <BarChartBase
       widgetId=''
       dataStreams={dataStreams as DataStreamViz[]}
-      viewport={utilizedViewport}
+      viewport={{ ...utilizedViewport, group, lastUpdatedBy }}
+      setViewport={setViewport}
       annotations={{ y: allThresholds as YAnnotation[], thresholdOptions }}
       {...rest}
     />

--- a/packages/react-components/src/components/line-chart/lineChart.spec.tsx
+++ b/packages/react-components/src/components/line-chart/lineChart.spec.tsx
@@ -18,10 +18,10 @@ it('renders', async () => {
   ]);
 
   const { container } = render(<LineChart queries={[query]} viewport={VIEWPORT} />);
-  const chart = container.querySelector('sc-line-chart');
+  const chart = container.querySelector('iot-app-kit-vis-line-chart');
 
   expect(chart).not.toBeNull();
 
-  expect(chart).toHaveProperty('viewport', VIEWPORT);
+  expect(chart).toHaveProperty('viewport.duration', VIEWPORT.duration);
   expect(chart).toHaveProperty('dataStreams', [DATA_STREAM]);
 });

--- a/packages/react-components/src/components/line-chart/lineChart.tsx
+++ b/packages/react-components/src/components/line-chart/lineChart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSettingsMap, Threshold, TimeSeriesDataQuery, Viewport } from '@iot-app-kit/core';
-import { LineChart as LineChartBase } from '@iot-app-kit-visualizations/react';
-import type { Annotations, Axis, DataStream as DataStreamViz, YAnnotation } from '@iot-app-kit-visualizations/core';
+import { LineChart as LineChartBase } from '@iot-app-kit/charts';
+import type { Annotations, Axis, DataStream as DataStreamViz, YAnnotation } from '@iot-app-kit/charts-core';
 import { useTimeSeriesData } from '../../hooks/useTimeSeriesData';
 import { useViewport } from '../../hooks/useViewport';
 import { DEFAULT_VIEWPORT } from '../../common/constants';
@@ -33,7 +33,7 @@ export const LineChart = ({
     },
     styles,
   });
-  const { viewport } = useViewport();
+  const { viewport, setViewport, group, lastUpdatedBy } = useViewport();
   const allThresholds = [...queryThresholds, ...thresholds];
 
   const utilizedViewport = passedInViewport || viewport || DEFAULT_VIEWPORT; // explicitly passed in viewport overrides viewport group
@@ -42,7 +42,8 @@ export const LineChart = ({
     <LineChartBase
       widgetId=''
       dataStreams={dataStreams as DataStreamViz[]}
-      viewport={utilizedViewport}
+      viewport={{ ...utilizedViewport, group, lastUpdatedBy }}
+      setViewport={setViewport}
       annotations={{ y: allThresholds as YAnnotation[], thresholdOptions }}
       {...rest}
     />

--- a/packages/react-components/src/components/scatter-chart/scatterChart.spec.tsx
+++ b/packages/react-components/src/components/scatter-chart/scatterChart.spec.tsx
@@ -18,10 +18,10 @@ it('renders', async () => {
   ]);
 
   const { container } = render(<ScatterChart queries={[query]} viewport={VIEWPORT} />);
-  const chart = container.querySelector('sc-scatter-chart');
+  const chart = container.querySelector('iot-app-kit-vis-scatter-chart');
 
   expect(chart).not.toBeNull();
 
-  expect(chart).toHaveProperty('viewport', VIEWPORT);
+  expect(chart).toHaveProperty('viewport.duration', VIEWPORT.duration);
   expect(chart).toHaveProperty('dataStreams', [DATA_STREAM]);
 });

--- a/packages/react-components/src/components/scatter-chart/scatterChart.tsx
+++ b/packages/react-components/src/components/scatter-chart/scatterChart.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { StyleSettingsMap, Threshold, TimeSeriesDataQuery, Viewport } from '@iot-app-kit/core';
-import { ScatterChart as ScatterChartBase } from '@iot-app-kit-visualizations/react';
-import type { Annotations, Axis, DataStream as DataStreamViz } from '@iot-app-kit-visualizations/core';
-import { YAnnotation } from '@iot-app-kit-visualizations/core';
+import { ScatterChart as ScatterChartBase } from '@iot-app-kit/charts';
+import type { Annotations, Axis, DataStream as DataStreamViz } from '@iot-app-kit/charts-core';
+import { YAnnotation } from '@iot-app-kit/charts-core';
 import { useTimeSeriesData } from '../../hooks/useTimeSeriesData';
 import { useViewport } from '../../hooks/useViewport';
 import { DEFAULT_VIEWPORT } from '../../common/constants';
@@ -34,7 +34,7 @@ export const ScatterChart = ({
     },
     styles,
   });
-  const { viewport } = useViewport();
+  const { viewport, setViewport, group, lastUpdatedBy } = useViewport();
   const allThresholds = [...queryThresholds, ...thresholds];
 
   const utilizedViewport = passedInViewport || viewport || DEFAULT_VIEWPORT; // explicitly passed in viewport overrides viewport group
@@ -43,8 +43,9 @@ export const ScatterChart = ({
     <ScatterChartBase
       widgetId=''
       dataStreams={dataStreams as DataStreamViz[]}
-      viewport={utilizedViewport}
+      viewport={{ ...utilizedViewport, group, lastUpdatedBy }}
       annotations={{ y: allThresholds as YAnnotation[], thresholdOptions }}
+      setViewport={setViewport}
       {...rest}
     />
   );

--- a/packages/react-components/src/components/status-timeline/statusTimeline.spec.tsx
+++ b/packages/react-components/src/components/status-timeline/statusTimeline.spec.tsx
@@ -18,10 +18,10 @@ it('renders', async () => {
   ]);
 
   const { container } = render(<StatusTimeline queries={[query]} viewport={VIEWPORT} />);
-  const chart = container.querySelector('sc-status-timeline');
+  const chart = container.querySelector('iot-app-kit-vis-status-timeline');
 
   expect(chart).not.toBeNull();
 
-  expect(chart).toHaveProperty('viewport', VIEWPORT);
+  expect(chart).toHaveProperty('viewport.duration', VIEWPORT.duration);
   expect(chart).toHaveProperty('dataStreams', [DATA_STREAM]);
 });

--- a/packages/react-components/src/components/status-timeline/statusTimeline.tsx
+++ b/packages/react-components/src/components/status-timeline/statusTimeline.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { StyleSettingsMap, Threshold, TimeSeriesDataQuery, Viewport } from '@iot-app-kit/core';
-import { StatusTimeline as StatusTimelineBaseWrongType, LineChart } from '@iot-app-kit-visualizations/react';
-import type { DataStream as DataStreamViz, Annotations, Axis, LegendConfig } from '@iot-app-kit-visualizations/core';
+import { StatusTimeline as StatusTimelineBaseWrongType, LineChart } from '@iot-app-kit/charts';
+import type { DataStream as DataStreamViz, Annotations, Axis, LegendConfig } from '@iot-app-kit/charts-core';
 import { useTimeSeriesData } from '../../hooks/useTimeSeriesData';
 import { useViewport } from '../../hooks/useViewport';
 import { DEFAULT_VIEWPORT } from '../../common/constants';
 
-// TODO: Remove this type assertion - iot-app-kit-visualizations has the wrong type for StatusTimeline
+// TODO: Remove this type assertion - iot-app-kit/charts has the wrong type for StatusTimeline
 const StatusTimelineBase: typeof LineChart = StatusTimelineBaseWrongType as unknown as typeof LineChart;
 
 export const StatusTimeline = ({
@@ -36,7 +36,7 @@ export const StatusTimeline = ({
     },
     styles,
   });
-  const { viewport } = useViewport();
+  const { viewport, setViewport, group, lastUpdatedBy } = useViewport();
   const allThresholds = [...queryThresholds, ...thresholds];
 
   const utilizedViewport = passedInViewport || viewport || DEFAULT_VIEWPORT; // explicitly passed in viewport overrides viewport group
@@ -45,8 +45,9 @@ export const StatusTimeline = ({
     <StatusTimelineBase
       widgetId=''
       dataStreams={dataStreams as DataStreamViz[]}
-      viewport={utilizedViewport}
+      viewport={{ ...utilizedViewport, group, lastUpdatedBy }}
       annotations={{ y: allThresholds } as Annotations}
+      setViewport={setViewport}
       {...rest}
     />
   );

--- a/packages/react-components/src/components/time-sync/index.tsx
+++ b/packages/react-components/src/components/time-sync/index.tsx
@@ -1,8 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import React, { createContext, useCallback, useEffect, useState, useRef } from 'react';
-import { viewportManager } from '@iot-app-kit/core';
+import { Viewport, viewportManager } from '@iot-app-kit/core';
 import type { ReactNode } from 'react';
-import type { Viewport } from '@iot-app-kit/core';
 
 export interface IViewportContext {
   viewport?: Viewport;

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -14,7 +14,7 @@ export { Kpi } from './components/kpi/kpi';
 export { StatusTimeline } from './components/status-timeline';
 export { Status } from './components/status/status';
 
-export { WebglContext } from '@iot-app-kit-visualizations/react';
+export { WebglContext } from '@iot-app-kit/charts';
 export { TimeSync } from './components/time-sync';
 
 export { useViewport } from './hooks/useViewport';

--- a/packages/react-components/stories/chart/chart.stories.tsx
+++ b/packages/react-components/stories/chart/chart.stories.tsx
@@ -43,11 +43,11 @@ export const LineChartExample: ComponentStory<typeof LineChart> = () => {
   );
 };
 
-export const MultipleLineChartExample: ComponentStory<typeof LineChart> = () => {
+export const MultipleBarChartExample: ComponentStory<typeof LineChart> = () => {
   return (
     <div id='story-container' style={{ width: '500px', height: '300px' }}>
       <TimeSync>
-        <LineChart queries={[MOCK_TIME_SERIES_DATA_QUERY]} />
+        <BarChart queries={[MOCK_TIME_SERIES_DATA_AGGREGATED_QUERY]} />
         <LineChart queries={[MOCK_TIME_SERIES_DATA_QUERY]} />
         <ViewportConsumer />
       </TimeSync>


### PR DESCRIPTION
## Overview
pass through the `setViewport` function (from the `useViewports` hook) into the @iot-app-kit/charts package, which will set the viewport on Gesture and will prevent re render if `lastUpdatedBy` is set to be `chart-gesture`

![viewport](https://user-images.githubusercontent.com/28601414/227573435-025926b2-801b-44c6-a315-a29cb30fc0a1.gif)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
