### PR TITLE
feat(resource explorer): allow dashboard to only show asset name

### DIFF
--- a/packages/dashboard/src/components/resourceExplorer/stencil/index.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/stencil/index.tsx
@@ -3,7 +3,7 @@ import { ResourceExplorer } from '@iot-app-kit/react-components';
 import { ResourceExplorerPanel } from '../components/panel';
 import { DefaultDashboardMessages } from '../../../messages';
 import type { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
-import type { DescribeAssetResponse } from '@aws-sdk/client-iotsitewise';
+import type { AssetSummary, DescribeAssetResponse } from '@aws-sdk/client-iotsitewise';
 import type { TableProps, NonCancelableCustomEvent } from '@cloudscape-design/components';
 
 import './style.css';
@@ -14,6 +14,14 @@ interface StencilResourceExplorerProps {
   treeQuery: SiteWiseQuery['assetTree']['fromRoot'];
 }
 
+const DEFAULT_COLUMNS = [
+  {
+    sortingField: 'name',
+    id: 'name',
+    header: 'Asset Name',
+    cell: ({ name }: AssetSummary) => name,
+  },
+];
 export const StencilResourceExplorer: React.FC<StencilResourceExplorerProps> = ({ treeQuery }) => {
   const [currentBranchId, setCurrentBranchId] = useState<string | undefined>(undefined);
 
@@ -28,7 +36,11 @@ export const StencilResourceExplorer: React.FC<StencilResourceExplorerProps> = (
   return (
     <div className='stencil-resource-explorer'>
       <div className='stencil-resource-explorer-tree'>
-        <ResourceExplorer query={treeQuery()} onSelectionChange={onSelectionChange} />
+        <ResourceExplorer
+          query={treeQuery()}
+          onSelectionChange={onSelectionChange}
+          columnDefinitions={DEFAULT_COLUMNS}
+        />
       </div>
 
       <div className='stencil-resource-explorer-assets'>


### PR DESCRIPTION
## Overview
update default column definitions in `iot-resource-explorer.tsx`

fixes: #756 
<img width="401" alt="image" src="https://user-images.githubusercontent.com/11740421/227625553-66b9093e-44b1-48cd-8c3c-a4e54921adcd.png">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
