### PR TITLE
fix(composer): fix default loading the mp scene

### DIFF
--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -234,7 +234,7 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
   }, [sceneContentUri]);
 
   useEffect(() => {
-    if (enableMatterportViewer && sceneMetadataModule && matterportModelId) {
+    if (sceneMetadataModule && matterportModelId) {
       sceneMetadataModule
         .getSceneInfo()
         .then((sceneInfo) => {
@@ -259,7 +259,7 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
     } else {
       setUpdatedExternalLibraryConfig({ ...externalLibraryConfig });
     }
-  }, [enableMatterportViewer, externalLibraryConfig, matterportModelId, sceneMetadataModule]);
+  }, [enableMatterportViewer, externalLibraryConfig, matterportModelId, sceneMetadataModule]); // enableMatterportViewer is required to trigger this once scene settings are updated
 
   // load scene content
   useLayoutEffect(() => {


### PR DESCRIPTION
## Overview
fix default loading the mp scene when user is not changing anything on the scene settings page

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
