### PR TITLE
fix(react-components): fix binding styles in `useTimeSeriesData` hook

### DIFF
--- a/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.spec.ts
+++ b/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.spec.ts
@@ -175,3 +175,26 @@ it('returns thresholds from time series data provider', () => {
 
   expect(timeSeriesData.thresholds).toEqual([THRESHOLD]);
 });
+
+it('update datastream styles when styles change', () => {
+  const DATA_STREAM: DataStream = { refId: 'ref-id', id: 'abc', data: [], resolution: 0, name: 'my-name' };
+  const TIME_SERIES_DATA: TimeSeriesData = {
+    dataStreams: [DATA_STREAM],
+    viewport: { duration: '5m' },
+    annotations: {},
+  };
+
+  const queries = [mockTimeSeriesDataQuery([TIME_SERIES_DATA])];
+  let styles = { 'ref-id': { color: 'red' } };
+  const { rerender, result } = renderHook(() =>
+    useTimeSeriesData({
+      queries,
+      viewport: { duration: '5m' },
+      styles,
+    })
+  );
+  styles = { 'ref-id': { color: 'green' } };
+  rerender();
+
+  expect(result.current.dataStreams[0]).toEqual(expect.objectContaining({ color: 'green' }));
+});

--- a/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.ts
+++ b/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.ts
@@ -61,13 +61,8 @@ export const useTimeSeriesData = ({
           const timeSeriesData = combineTimeSeriesData(timeSeriesDataCollection, viewport);
 
           setTimeSeriesData({
+            ...timeSeriesData,
             viewport,
-            annotations: timeSeriesData.annotations,
-            dataStreams: bindStylesToDataStreams({
-              dataStreams: timeSeriesData.dataStreams,
-              styleSettings: styles,
-              assignDefaultColors: false,
-            }),
           });
         },
       });
@@ -94,5 +89,11 @@ export const useTimeSeriesData = ({
     prevViewport.current = viewport;
   }, [viewport]);
 
-  return { dataStreams: timeSeriesData?.dataStreams || [], thresholds: getThresholds(timeSeriesData?.annotations) };
+  const styledDataStreams = bindStylesToDataStreams({
+    dataStreams: timeSeriesData?.dataStreams || [],
+    styleSettings: styles,
+    assignDefaultColors: false,
+  });
+
+  return { dataStreams: styledDataStreams, thresholds: getThresholds(timeSeriesData?.annotations) };
 };


### PR DESCRIPTION
## Overview
Move binding styles out of side effect so it always applies the latest style settings.

fixes: #793 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
