### PR TITLE
feat(react-comp): isThresholdBreached checks all comparison ops

### DIFF
--- a/packages/react-components/src/components/bar-chart/barChart.tsx
+++ b/packages/react-components/src/components/bar-chart/barChart.tsx
@@ -36,8 +36,8 @@ export const BarChart = ({
       /** Bar chart cannot visualize raw data, so customize the resolution breakpoints as the default resolution */
       resolution: {
         [0]: '1m',
-        [HOUR_IN_MS]: '1hr',
-        [DAY_IN_MS * 5]: '1day',
+        [HOUR_IN_MS]: '1h',
+        [DAY_IN_MS * 5]: '1d',
       },
     },
     styles,

--- a/packages/react-components/src/testing/mockWidgetProperties.ts
+++ b/packages/react-components/src/testing/mockWidgetProperties.ts
@@ -1,8 +1,6 @@
-import { DATA_TYPE } from '@iot-app-kit/core';
+import { DATA_TYPE, STATUS_ICON_TYPE, Threshold, DataStream, COMPARISON_OPERATOR } from '@iot-app-kit/core';
 import { DAY_IN_MS } from '../utils/time';
-import { COMPARISON_OPERATOR, StatusIconType } from '../common/constants';
 import { VIEWPORT } from '../utils/testUtil';
-import type { Threshold, DataStream } from '@iot-app-kit/core';
 
 export const START_DATE = new Date(2000, 0, 0);
 
@@ -98,7 +96,7 @@ const THRESHOLD_VALUE = 20;
 export const THRESHOLD: Threshold = {
   color: 'purple',
   value: THRESHOLD_VALUE,
-  comparisonOperator: COMPARISON_OPERATOR.LESS_THAN,
+  comparisonOperator: COMPARISON_OPERATOR.LT,
 };
 
 // since we have a 'less than' operation, it breaches if it is below the threshold value.
@@ -113,8 +111,8 @@ export const OK = 'ok';
 export const ALARM_THRESHOLD: Threshold<string> = {
   value: ALARM,
   color: 'orange',
-  comparisonOperator: COMPARISON_OPERATOR.EQUAL,
-  icon: StatusIconType.ACTIVE,
+  comparisonOperator: COMPARISON_OPERATOR.EQ,
+  icon: STATUS_ICON_TYPE.active,
 };
 
 export const WITHIN_VIEWPORT_DATE = new Date(2000, 0, 1);

--- a/packages/react-components/src/utils/thresholdUtils.ts
+++ b/packages/react-components/src/utils/thresholdUtils.ts
@@ -2,8 +2,7 @@ import { bisector } from 'd3-array';
 
 import { isValid } from './predicates';
 import { isNumeric } from './number';
-import { COMPARISON_OPERATOR } from '../common/constants';
-import type { Annotations, Threshold, Primitive } from '@iot-app-kit/core';
+import { COMPARISON_OPERATOR, Annotations, Threshold, Primitive } from '@iot-app-kit/core';
 
 /**
  * Returns only thresholds defined for number
@@ -102,20 +101,23 @@ export const isThresholdBreached = (value: Primitive, threshold: Threshold): boo
 
   if (typeof dataStreamValue === 'number' && typeof thresholdValue === 'number') {
     switch (thresholdComparison) {
-      case COMPARISON_OPERATOR.GREATER_THAN:
+      case COMPARISON_OPERATOR.GT:
         return dataStreamValue > thresholdValue;
 
-      case COMPARISON_OPERATOR.GREATER_THAN_EQUAL:
+      case COMPARISON_OPERATOR.GTE:
         return dataStreamValue >= thresholdValue;
 
-      case COMPARISON_OPERATOR.LESS_THAN:
+      case COMPARISON_OPERATOR.LT:
         return dataStreamValue < thresholdValue;
 
-      case COMPARISON_OPERATOR.LESS_THAN_EQUAL:
+      case COMPARISON_OPERATOR.LTE:
         return dataStreamValue <= thresholdValue;
 
-      case COMPARISON_OPERATOR.EQUAL:
+      case COMPARISON_OPERATOR.EQ:
         return dataStreamValue === thresholdValue;
+
+      case COMPARISON_OPERATOR.CONTAINS:
+        return false;
 
       default:
         throw new Error(`Unsupported number threshold comparison operator: ${thresholdComparison}`);
@@ -123,23 +125,39 @@ export const isThresholdBreached = (value: Primitive, threshold: Threshold): boo
   }
 
   if (typeof dataStreamValue === 'string' && typeof thresholdValue === 'string') {
-    if (thresholdComparison === COMPARISON_OPERATOR.EQUAL) {
-      return dataStreamValue === thresholdValue;
-    }
+    switch (thresholdComparison) {
+      case COMPARISON_OPERATOR.GT:
+      case COMPARISON_OPERATOR.GTE:
+      case COMPARISON_OPERATOR.LT:
+      case COMPARISON_OPERATOR.LTE:
+        return false;
 
-    if (thresholdComparison === COMPARISON_OPERATOR.CONTAINS) {
-      return dataStreamValue.includes(thresholdValue);
-    }
+      case COMPARISON_OPERATOR.EQ:
+        return dataStreamValue === thresholdValue;
 
-    throw new Error(`Unsupported string threshold comparison operator: ${thresholdComparison}`);
+      case COMPARISON_OPERATOR.CONTAINS:
+        return dataStreamValue.includes(thresholdValue);
+
+      default:
+        throw new Error(`Unsupported string threshold comparison operator: ${thresholdComparison}`);
+    }
   }
 
   if (typeof dataStreamValue === 'boolean' && typeof thresholdValue === 'boolean') {
-    if (thresholdComparison === COMPARISON_OPERATOR.EQUAL) {
-      return dataStreamValue === thresholdValue;
-    }
+    switch (thresholdComparison) {
+      case COMPARISON_OPERATOR.GT:
+      case COMPARISON_OPERATOR.GTE:
+      case COMPARISON_OPERATOR.LT:
+      case COMPARISON_OPERATOR.LTE:
+      case COMPARISON_OPERATOR.CONTAINS:
+        return false;
 
-    throw new Error(`Unsupported boolean threshold comparison operator: ${thresholdComparison}`);
+      case COMPARISON_OPERATOR.EQ:
+        return dataStreamValue === thresholdValue;
+
+      default:
+        throw new Error(`Unsupported boolean threshold comparison operator: ${thresholdComparison}`);
+    }
   }
 
   return false;
@@ -151,11 +169,11 @@ const thresholdBisector = bisector((threshold: Threshold) => threshold.value).le
  * This a map of comparison operator to order. The higher the order means higher the precedence.
  */
 const operatorOrder = {
-  [COMPARISON_OPERATOR.LESS_THAN_EQUAL]: 1,
-  [COMPARISON_OPERATOR.LESS_THAN]: 2,
-  [COMPARISON_OPERATOR.GREATER_THAN_EQUAL]: 3,
-  [COMPARISON_OPERATOR.GREATER_THAN]: 4,
-  [COMPARISON_OPERATOR.EQUAL]: 5,
+  [COMPARISON_OPERATOR.LTE]: 1,
+  [COMPARISON_OPERATOR.LT]: 2,
+  [COMPARISON_OPERATOR.GTE]: 3,
+  [COMPARISON_OPERATOR.GT]: 4,
+  [COMPARISON_OPERATOR.EQ]: 5,
   [COMPARISON_OPERATOR.CONTAINS]: 6,
 };
 


### PR DESCRIPTION
## Overview
thresholds were breaking on widgets that supported any data type
fixed this by checking for every possible comparison_operator type in `isThresholdBreached` function 
instead of erroring, the function will return `false` if operators aren't meant to work with the given data type 
![thresh](https://user-images.githubusercontent.com/28601414/228380977-9318a317-2084-41a1-b983-3808b62bcfd9.gif)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
