### PR TITLE
build(dashboard): port over stylesheets to react-components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ creds.json
 
 # NPM publish artifcats
 packages/components/styles.css
+packages/react-components/styles.css
 **/NOTICE
 **/LICENSE
 

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -8,4 +8,5 @@ examples/
 coverage/
 packages/dashboard/src/components/internalDashboard/index.css
 packages/components/styles.css
+packages/react-components/styles.css
 storybook-static

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -8,7 +8,8 @@
   "files": [
     "dist/",
     "CHANGELOG.md",
-    "*NOTICE"
+    "*NOTICE",
+    "*styles.css"
   ],
   "publishConfig": {
     "access": "public"
@@ -18,9 +19,10 @@
     "start": "npx start-storybook -p 6007",
     "dev": "npm-watch build",
     "clean": "rm -rf dist && rm -rf storybook-static && rm -rf test-results && rm -rf coverage",
-    "build": "npm run clean && npm run build:es && npm run build:cjs",
+    "build": "npm run clean && npm run build:es && npm run build:cjs && npm run copy:styles",
     "build:es": "tsc -p ./tsconfig.build.json --outDir ./dist/es",
     "build:cjs": "tsc -p ./tsconfig.build.json --outDir ./dist/cjs --module CommonJS",
+    "copy:styles": "cp ../components/styles.css styles.css",
     "test": "npm run test:jest && npm run test:types",
     "test:jest": "TZ=utc jest",
     "test:types": "tsc -p ./tsconfig.json --noEmit",


### PR DESCRIPTION
## Overview
Port over stylesheets to from `components` package to `react-components` package. Users can import it as 
```
import "@iot-app-kit/react-components/styles.css";
```
to have components styled.

Also update `files` filed `package.json` to update `styles.css` to npm.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
