### PR TITLE
fix(source-iotsitewise): use alarm model name in data stream instead of alarm state name

### DIFF
--- a/packages/source-iotsitewise/src/__mocks__/alarm.ts
+++ b/packages/source-iotsitewise/src/__mocks__/alarm.ts
@@ -279,7 +279,7 @@ export const TIME_SERIES_DATA_WITH_ALARMS = {
   dataStreams: [{
     id: 'alarm-asset-id---alarm-state-property-id',
     streamType: 'ALARM',
-    name: 'AWS/ALARM_STATE',
+    name: 'test',
     resolution: 0,
     refId: undefined,
     isRefreshing: false,

--- a/packages/source-iotsitewise/src/alarms/iotevents/util/completeAlarmStream.spec.ts
+++ b/packages/source-iotsitewise/src/alarms/iotevents/util/completeAlarmStream.spec.ts
@@ -24,7 +24,7 @@ it('returns alarm stream if property found in asset model composite model', () =
   ).toEqual(
     expect.objectContaining({
       id: 'alarm-asset-id---alarm-state-property-id',
-      name: 'AWS/ALARM_STATE',
+      name: 'test',
       streamType: 'ALARM',
       dataType: 'NUMBER',
       data: [
@@ -54,7 +54,7 @@ it('returns alarm stream if no asset model but inferred to be iot events alarm s
   ).toEqual(
     expect.objectContaining({
       id: 'alarm-asset-id---alarm-state-property-id',
-      name: 'AWS/ALARM_STATE',
+      name: 'test',
       streamType: 'ALARM',
       dataType: 'NUMBER',
       data: [

--- a/packages/source-iotsitewise/src/alarms/iotevents/util/getAlarmStateProperty.spec.ts
+++ b/packages/source-iotsitewise/src/alarms/iotevents/util/getAlarmStateProperty.spec.ts
@@ -2,5 +2,8 @@ import { getAlarmStateProperty } from './getAlarmStateProperty';
 import { ASSET_MODEL_WITH_ALARM, ALARM_STATE_PROPERTY_ID, ALARM_STATE_PROPERTY } from '../../../__mocks__';
 
 it('get alarm source from asset model', () => {
-  expect(getAlarmStateProperty(ASSET_MODEL_WITH_ALARM, ALARM_STATE_PROPERTY_ID)).toEqual(ALARM_STATE_PROPERTY);
+  expect(getAlarmStateProperty(ASSET_MODEL_WITH_ALARM, ALARM_STATE_PROPERTY_ID)).toEqual({
+    ...ALARM_STATE_PROPERTY,
+    name: 'test',
+  });
 });

--- a/packages/source-iotsitewise/src/alarms/iotevents/util/getAlarmStateProperty.ts
+++ b/packages/source-iotsitewise/src/alarms/iotevents/util/getAlarmStateProperty.ts
@@ -1,11 +1,36 @@
-import type { DescribeAssetModelResponse, AssetModelProperty } from '@aws-sdk/client-iotsitewise';
+import type {
+  DescribeAssetModelResponse,
+  AssetModelProperty,
+  AssetModelCompositeModel,
+} from '@aws-sdk/client-iotsitewise';
+import first from 'lodash/first';
+import { isDefined } from '../../../common/predicates';
+
+const isAlarm = (model: AssetModelCompositeModel) => model.type === 'AWS/ALARM';
+const isAlarmState = (property: AssetModelProperty) => property.name === 'AWS/ALARM_STATE';
+
+const getAlarmStatePropertyFromAssetModel =
+  (alarmStatePropertyId: string) =>
+  ({ properties, name }: AssetModelCompositeModel): AssetModelProperty | undefined => {
+    const alarmStateProperty = properties?.find(
+      (property) => property?.id === alarmStatePropertyId && isAlarmState(property)
+    );
+
+    return (
+      alarmStateProperty && {
+        ...alarmStateProperty,
+        name,
+      }
+    );
+  };
 
 export const getAlarmStateProperty = (
   assetModel: DescribeAssetModelResponse,
   alarmStatePropertyId: string
 ): AssetModelProperty | undefined =>
-  assetModel.assetModelCompositeModels
-    ?.filter(({ type }) => type === 'AWS/ALARM')
-    .map(({ properties }) => properties)
-    .flat()
-    .find((property) => property?.id === alarmStatePropertyId && property?.name === 'AWS/ALARM_STATE');
+  first(
+    assetModel.assetModelCompositeModels
+      ?.filter(isAlarm)
+      .map(getAlarmStatePropertyFromAssetModel(alarmStatePropertyId))
+      .filter(isDefined)
+  );

--- a/packages/source-iotsitewise/src/completeDataStreams.spec.ts
+++ b/packages/source-iotsitewise/src/completeDataStreams.spec.ts
@@ -78,7 +78,7 @@ it('returns data stream when provided alarm stream but no alarms', () => {
   expect(completeDataStreams({ dataStreams: [alarmStream], assetModels, alarms })).toEqual([
     {
       ...alarmStream,
-      name: 'AWS/ALARM_STATE',
+      name: 'test',
       streamType: 'ALARM',
     },
   ]);


### PR DESCRIPTION
## Overview
Bugfix to use asset composite model name for AWS/ALARM type models as the name in the data stream.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
