### PR TITLE
fix(charts): fix live mode viewport scrollingbug

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -95,7 +95,7 @@
     "@cloudscape-design/components": "^3.0.228",
     "@cloudscape-design/design-tokens": "^3.0.9",
     "@cloudscape-design/global-styles": "^1.0.7",
-    "@iot-app-kit/charts-core": "^1.6.0",
+    "@iot-app-kit/charts-core": "^1.7.0",
     "@iot-app-kit/components": "^4.0.0",
     "@iot-app-kit/core": "^4.0.0",
     "@iot-app-kit/core-util": "*",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -83,8 +83,8 @@
   "dependencies": {
     "@cloudscape-design/collection-hooks": "^1.0.19",
     "@cloudscape-design/components": "^3.0.228",
-    "@iot-app-kit/charts-core": "^1.6.0",
-    "@iot-app-kit/charts": "^1.6.0",
+    "@iot-app-kit/charts-core": "^1.7.0",
+    "@iot-app-kit/charts": "^1.7.0",
     "@iot-app-kit/components": "4.0.0",
     "@iot-app-kit/core": "4.0.0",
     "@iot-app-kit/source-iottwinmaker": "4.0.0",


### PR DESCRIPTION
## Overview
an initial live mode viewport was making any scroll jump back to live mode instead of keeping viewport where user had scrolled

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
