### PR TITLE
feat(dashboard): disable asset drop for widgets that are not compatible with that data type

### DIFF
--- a/packages/dashboard/src/components/dragLayer/index.tsx
+++ b/packages/dashboard/src/components/dragLayer/index.tsx
@@ -46,6 +46,7 @@ const CustomDragLayer: React.FC<CustomDragLayerProps> = ({ messageOverrides }) =
       case ItemTypes.Component:
         return <DashboardWidget componentTag={item.componentTag} messageOverrides={messageOverrides} />;
       case ItemTypes.ResourceExplorerAssetProperty:
+      case ItemTypes.ResourceExplorerAlarm:
         return <ResourceExplorerPanelAssetPropertyDragGhost item={item} />;
       default:
         return null;

--- a/packages/dashboard/src/components/resourceExplorer/components/panel.tsx
+++ b/packages/dashboard/src/components/resourceExplorer/components/panel.tsx
@@ -22,7 +22,7 @@ type PanelSummary = {
 };
 
 type PanelDrag = {
-  type: 'asset';
+  type: 'property' | 'alarm';
   name: string;
   assetSummary: Pick<AssetSummary, 'assetId' | 'assetName' | 'properties'>;
 };
@@ -53,7 +53,7 @@ const PanelEmpty = ({ messageOverrides }: { messageOverrides: DashboardMessages 
 const Asset: React.FC<PanelDrag> = (item) => {
   const [, dragSource] = useDrag(() => {
     return {
-      type: ItemTypes.ResourceExplorerAssetProperty,
+      type: item.type === 'property' ? ItemTypes.ResourceExplorerAssetProperty : ItemTypes.ResourceExplorerAlarm,
       item: {
         name: item.name,
         assetSummary: item.assetSummary,
@@ -84,7 +84,8 @@ const tableColumnDefinitions = [
     header: null,
     cell: (cell: PanelItem) => {
       switch (cell.type) {
-        case 'asset':
+        case 'property':
+        case 'alarm':
           return <Asset {...cell} />;
         case 'header':
           return <Header name={cell.name} />;
@@ -97,8 +98,9 @@ const tableColumnDefinitions = [
 
 const mapPanelAssetSummary =
   (assetId: string, assetName: string) =>
+  (type: 'property' | 'alarm') =>
   (summary: PropertySummary | AlarmSummary): PanelDrag => ({
-    type: 'asset',
+    type,
     name: summary.name || '',
     assetSummary: {
       assetId,
@@ -126,7 +128,7 @@ export const ResourceExplorerPanel: React.FC<ResourceExplorerPanelProps> = ({
       type: 'header',
       name: 'Asset properties',
     });
-    items.push(...properties.map(mapper));
+    items.push(...properties.map(mapper('property')));
   }
 
   if (alarms.length > 0) {
@@ -134,7 +136,7 @@ export const ResourceExplorerPanel: React.FC<ResourceExplorerPanelProps> = ({
       type: 'header',
       name: 'Alarms',
     });
-    items.push(...alarms.map(mapper));
+    items.push(...alarms.map(mapper('alarm')));
   }
 
   return (

--- a/packages/dashboard/src/customization/widgets/barChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/plugin.tsx
@@ -4,12 +4,13 @@ import BarChartWidgetComponent from './component';
 import BarIcon from './icon';
 import type { DashboardPlugin } from '~/customization/api';
 import type { BarChartWidget } from '../types';
+import { PropertyDataType } from '@aws-sdk/client-iotsitewise';
 
 export const barChartPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
     registerWidget<BarChartWidget>('bar-chart', {
       render: (widget) => (
-        <MultiQueryWidget {...widget}>
+        <MultiQueryWidget {...widget} allowedDataTypes={[PropertyDataType.DOUBLE, PropertyDataType.INTEGER]}>
           <BarChartWidgetComponent {...widget} />
         </MultiQueryWidget>
       ),

--- a/packages/dashboard/src/customization/widgets/lineChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/lineChart/plugin.tsx
@@ -4,12 +4,13 @@ import LineChartWidgetComponent from './component';
 import LineIcon from './icon';
 import type { DashboardPlugin } from '~/customization/api';
 import type { LineChartWidget } from '../types';
+import { PropertyDataType } from '@aws-sdk/client-iotsitewise';
 
 export const lineChartPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
     registerWidget<LineChartWidget>('line-chart', {
       render: (widget) => (
-        <MultiQueryWidget {...widget}>
+        <MultiQueryWidget {...widget} allowedDataTypes={[PropertyDataType.DOUBLE, PropertyDataType.INTEGER]}>
           <LineChartWidgetComponent {...widget} />
         </MultiQueryWidget>
       ),

--- a/packages/dashboard/src/customization/widgets/queryWidget/multiQueryWidget.tsx
+++ b/packages/dashboard/src/customization/widgets/queryWidget/multiQueryWidget.tsx
@@ -1,14 +1,18 @@
 import type { ReactNode } from 'react';
 import React from 'react';
 import { useDrop } from 'react-dnd';
+import { PropertyDataType } from '@aws-sdk/client-iotsitewise';
+import { Box } from '@cloudscape-design/components';
 
 import { useWidgetActions } from '../../hooks/useWidgetActions';
 import { ItemTypes } from '~/components/dragLayer/itemTypes';
 import { assignDefaultStyles } from '../utils/assignDefaultStyleSettings';
 import { mergeAssetQueries } from '~/util/mergeAssetQueries';
-import './queryWidget.css';
 import type { QueryWidget } from '../types';
 import type { ResourcePanelItem } from '~/components/resourceExplorer/components/panel';
+import { isDefined } from '~/util/isDefined';
+
+import './queryWidget.css';
 
 export type onDropHandler<W extends QueryWidget = QueryWidget> = (item: ResourcePanelItem, widget: W) => W;
 export const defaultOnDropHandler: onDropHandler = (item, widget) => {
@@ -40,27 +44,56 @@ export const defaultOnDropHandler: onDropHandler = (item, widget) => {
  * HOC widget component for handling drag and drop of a widget that can have multiple assets per query
  *
  */
-const MultiQueryWidgetComponent: React.FC<QueryWidget & { children: ReactNode; onDropHandler?: onDropHandler }> = ({
+const MultiQueryWidgetComponent: React.FC<
+  QueryWidget & { children: ReactNode; onDropHandler?: onDropHandler; allowedDataTypes?: PropertyDataType[] }
+> = ({
   children,
   onDropHandler = defaultOnDropHandler,
+  allowedDataTypes = [
+    PropertyDataType.BOOLEAN,
+    PropertyDataType.DOUBLE,
+    PropertyDataType.INTEGER,
+    PropertyDataType.STRING,
+    PropertyDataType.STRUCT,
+  ],
   ...widget
 }) => {
   const { update } = useWidgetActions<QueryWidget>();
 
-  const [, drop] = useDrop(
+  const [collected, drop] = useDrop(
     () => ({
       accept: [ItemTypes.ResourceExplorerAssetProperty, ItemTypes.ResourceExplorerAlarm],
       drop: (item: ResourcePanelItem) => {
         const updatedWidget = onDropHandler(item, widget);
         update(assignDefaultStyles(updatedWidget));
       },
+      canDrop: (item, monitor) =>
+        monitor.getItemType() === ItemTypes.ResourceExplorerAlarm ||
+        item.assetSummary.properties
+          .map(({ dataType }) => dataType)
+          .filter(isDefined)
+          .every((type) => allowedDataTypes.includes(type as PropertyDataType)),
+      collect: (monitor) => ({
+        isOver: !!monitor.isOver(),
+        canDrop: !!monitor.canDrop(),
+      }),
     }),
     [widget]
   );
 
+  const { canDrop, isOver } = collected;
+
   return (
     <div ref={drop} className='query-widget'>
-      {children}
+      {isOver && !canDrop ? (
+        <div className='query-widget-drop-disabled'>
+          <Box color='text-status-error' variant='p' textAlign='center'>
+            Data type not compatible.
+          </Box>
+        </div>
+      ) : (
+        children
+      )}
     </div>
   );
 };

--- a/packages/dashboard/src/customization/widgets/queryWidget/queryWidget.css
+++ b/packages/dashboard/src/customization/widgets/queryWidget/queryWidget.css
@@ -2,3 +2,11 @@
   height: 100%;
   width: 100%;
 }
+
+.query-widget-drop-disabled {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}

--- a/packages/dashboard/src/customization/widgets/scatterChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/scatterChart/plugin.tsx
@@ -4,12 +4,13 @@ import ScatterChartWidgetComponent from './component';
 import ScatterIcon from './icon';
 import type { DashboardPlugin } from '~/customization/api';
 import type { ScatterChartWidget } from '../types';
+import { PropertyDataType } from '@aws-sdk/client-iotsitewise';
 
 export const scatterChartPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
     registerWidget<ScatterChartWidget>('scatter-chart', {
       render: (widget) => (
-        <MultiQueryWidget {...widget}>
+        <MultiQueryWidget {...widget} allowedDataTypes={[PropertyDataType.DOUBLE, PropertyDataType.INTEGER]}>
           <ScatterChartWidgetComponent {...widget} />
         </MultiQueryWidget>
       ),


### PR DESCRIPTION
## Overview
Allow multi query widgets to define a subset of asset property data types they will allow to be dropped.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
