### PR TITLE
feat(dashboard): enable edit mode for text widget on widget creation

### DIFF
--- a/packages/dashboard/src/customization/widgets/text/component.tsx
+++ b/packages/dashboard/src/customization/widgets/text/component.tsx
@@ -17,7 +17,7 @@ import type { DashboardState } from '~/store/state';
 const TextWidgetComponent: React.FC<TextWidget> = (widget) => {
   const readOnly = useSelector((state: DashboardState) => state.readOnly);
   const isSelected = useIsSelected(widget);
-  const { isUrl } = widget.properties;
+  const { isUrl, value } = widget.properties;
 
   const dispatch = useDispatch();
   const [isEditing, setIsEditing] = useState(false);
@@ -26,6 +26,11 @@ const TextWidgetComponent: React.FC<TextWidget> = (widget) => {
     dispatch(onChangeDashboardGridEnabledAction({ enabled: !editing }));
     setIsEditing(editing);
   };
+
+  useEffect(() => {
+    // allow immediate edit if no value on widget creation
+    if (!value) handleSetEdit(true);
+  }, []);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Overview
- enable edit mode for text widget immediately after droping a text widget to grid
- copy & paste widgets contains text will not enable editing mode. so behaviours are identical to previous.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
