### PR TITLE
refactor(KPI): rename Kpi -> KPI to be consistent with v3

### DIFF
--- a/packages/dashboard/src/customization/widgets/kpi/component.tsx
+++ b/packages/dashboard/src/customization/widgets/kpi/component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import pickBy from 'lodash/pickBy';
-import { Kpi } from '@iot-app-kit/react-components';
+import { KPI } from '@iot-app-kit/react-components';
 import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { KPIWidget } from '../types';
@@ -52,7 +52,7 @@ const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
   );
 
   return (
-    <Kpi
+    <KPI
       key={key}
       query={query}
       viewport={viewport}

--- a/packages/react-components/src/components/kpi/kpi.spec.tsx
+++ b/packages/react-components/src/components/kpi/kpi.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { mockTimeSeriesDataQuery } from '@iot-app-kit/testing-util';
-import { Kpi } from './kpi';
+import { KPI } from './kpi';
 
 const VIEWPORT = { duration: '5m' };
 
@@ -23,7 +23,7 @@ it('renders', async () => {
     },
   ]);
 
-  render(<Kpi query={query} viewport={VIEWPORT} />);
+  render(<KPI query={query} viewport={VIEWPORT} />);
 
   expect(screen.queryByText(DATA_STREAM.unit)).not.toBeNull();
   expect(screen.queryByText(LATEST_VALUE)).not.toBeNull();

--- a/packages/react-components/src/components/kpi/kpi.tsx
+++ b/packages/react-components/src/components/kpi/kpi.tsx
@@ -7,7 +7,7 @@ import { DEFAULT_VIEWPORT } from '../../common/constants';
 import type { Threshold, StyleSettingsMap, Viewport, TimeSeriesDataQuery } from '@iot-app-kit/core';
 import type { KPISettings } from './types';
 
-export const Kpi = ({
+export const KPI = ({
   query,
   viewport: passedInViewport,
   thresholds = [],

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -10,7 +10,7 @@ export { Table } from './components/table';
 export { LineChart } from './components/line-chart';
 export { BarChart } from './components/bar-chart';
 export { ScatterChart } from './components/scatter-chart';
-export { Kpi } from './components/kpi/kpi';
+export { KPI } from './components/kpi/kpi';
 export { StatusTimeline } from './components/status-timeline';
 export { Status } from './components/status/status';
 

--- a/packages/react-components/stories/kpi/kpi.stories.tsx
+++ b/packages/react-components/stories/kpi/kpi.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { Kpi } from '../../src/components/kpi/kpi';
+import { KPI } from '../../src/components/kpi/kpi';
 import { initialize } from '@iot-app-kit/source-iotsitewise';
 
 const ASSET_ID = '587295b6-e0d0-4862-b7db-b905afd7c514';
@@ -8,7 +8,7 @@ const PROPERTY_ID = '16d45cb7-bb8b-4a1e-8256-55276f261d93';
 
 export default {
   title: 'Widgets/KPI/KPI',
-  component: Kpi,
+  component: KPI,
   argTypes: {
     assetId: { control: { type: 'string' }, defaultValue: ASSET_ID },
     propertyId: { control: { type: 'string' }, defaultValue: PROPERTY_ID },
@@ -19,7 +19,7 @@ export default {
   parameters: {
     layout: 'fullscreen',
   },
-} as ComponentMeta<typeof Kpi>;
+} as ComponentMeta<typeof KPI>;
 
 const { query } = initialize({
   awsCredentials: {
@@ -29,8 +29,8 @@ const { query } = initialize({
   },
 });
 
-export const Main: ComponentStory<typeof Kpi> = () => (
-  <Kpi
+export const Main: ComponentStory<typeof KPI> = () => (
+  <KPI
     viewport={{ duration: '5m' }}
     query={query.timeSeriesData({
       assets: [


### PR DESCRIPTION
Rename so `KPI` widget remains the same before and after v4 release of IoT App Kit

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
