### PR TITLE
docs: point documentation to doc site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,10 @@
 [![Bundle Size](https://img.shields.io/bundlephobia/minzip/@iot-app-kit/core)](https://bundlephobia.com/package/@iot-app-kit/core)
 [![Downloads](https://img.shields.io/npm/dw/@iot-app-kit/core)](https://npmjs.org/package/@iot-app-kit/core)
 
----
-**NEW in 4.0**: IoT Application Kit has been fully migrated to React 18! There are a number of key breaking changes in React 18 that you should be aware of before upgrading to this version, which you can find details about here:
 
-- https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html
+## [Official IoT App Kit documentation site](https://awslabs.github.io/iot-app-kit/)
 
-At this point, AppKit version ^3 versions move into maintenance mode, and will only receive critical upgrades. Please submit a Github issue if you need a new feature and are currently unable to upgrade, and we
-will work with you on coming up with a solution.
-
-There should be no breaking changes in the AppKit components themselves, but their behaviors might be altered as a result of this upgrade, so if you find any issues please report them via the github issues at the top, and we will do our best to prioritize these.
-
-Thanks!
-- AWS IoT AppKit Team
----
+## Overview
 
 IoT Application Kit is a development library for building Industrial IoT web based applications.
 
@@ -26,48 +17,6 @@ IoT App Kit is an open-source library consisting of front-end components and uti
 For an example of a real world use case using the IoT App Kit, [visit this tutorial on how to use IoT App Kit](https://aws.amazon.com/blogs/iot/build-iot-applications-using-aws-iot-application-kit/)
 
 <img width="1170" alt="IoT App Kit Demo" src="https://user-images.githubusercontent.com/6397726/159107236-ea95e7ba-a89c-43e6-a34c-c5ea1dd37e8b.png">
-
-# Table of contents
-* [Getting started with IoT Application Kit](https://github.com/awslabs/iot-app-kit/tree/main/docs/GettingStarted.md)
-
-## Components
-
-* [Line chart](https://github.com/awslabs/iot-app-kit/tree/main/docs/LineChart.md)
-* [Scatter chart](https://github.com/awslabs/iot-app-kit/tree/main/docs/ScatterChart.md)
-* [Bar chart](https://github.com/awslabs/iot-app-kit/tree/main/docs/BarChart.md)
-* [Status grid](https://github.com/awslabs/iot-app-kit/tree/main/docs/StatusGrid.md)
-* [KPI](https://github.com/awslabs/iot-app-kit/tree/main/docs/KPI.md)
-* [Status timeline](https://github.com/awslabs/iot-app-kit/tree/main/docs/StatusTimeline.md)
-* [Resource explorer](https://github.com/awslabs/iot-app-kit/tree/main/docs/ResourceExplorer.md)
-* [Table](https://github.com/awslabs/iot-app-kit/tree/main/docs/Table.md)
-* [Scene Viewer](https://github.com/awslabs/iot-app-kit/blob/main/docs/SceneViewer.md)
-* [Video Player](https://github.com/awslabs/iot-app-kit/blob/main/docs/VideoPlayer.md)
-* [Time Sync](https://github.com/awslabs/iot-app-kit/blob/main/docs/TimeSync.md)
-
-## React hooks (For building custom IoT App Kit components)
-
-* [useViewport](https://github.com/awslabs/iot-app-kit/blob/main/docs/useViewport.md)
-
-## Utilities
-
-* [Viewport manager](https://github.com/awslabs/iot-app-kit/tree/main/docs/ViewportManager.md) - Learn how to make your custom IoT App Kit components synchronize with viewport groups
-
-## Data sources
-
-* [AWS IoT SiteWise source](https://github.com/awslabs/iot-app-kit/tree/main/docs/AWSIoTSiteWiseSource.md) - Learn how to connect the IoT App Kit components with AWS IoT SiteWise
-
-* [AWS IoT TwinMaker source](https://github.com/awslabs/iot-app-kit/blob/main/docs/AWSIoTTwinMakerSource.md) - Learn how to connect the IoT App Kit components with AWS IoT TwinMaker
-
-## Data source features built into AWS IoT SiteWise and AWS IoT TwinMaker
-
-* [Time series data features](https://github.com/awslabs/iot-app-kit/tree/main/docs/TimeSeriesDataFeatures.md) - Learn about what IoT App Kit does for you when managing time series data around caching, TTLs, buffering, etc.
-
-
-## For IoT App Kit contributors
-
-* [Core](https://github.com/awslabs/iot-app-kit/tree/main/docs/Core.md) - Learn more about the core of IoT App Kit.
-
-* [Creating a custom source](https://github.com/awslabs/iot-app-kit/tree/main/docs/CustomSources.md) - Learn how to create a custom source for your needs.
 
 ## Contributors guide to IoT App Kit
 Learn how to contribute at [the development guide](https://github.com/awslabs/iot-app-kit/tree/main/docs/development.md).

--- a/docs/AWSIoTSiteWiseSource.md
+++ b/docs/AWSIoTSiteWiseSource.md
@@ -1,3 +1,6 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
+
 # AWS IoT SiteWise source
 
 The AWS IoT SiteWise source enables you to visualize and interact with your [AWS IoT SiteWise](https://docs.aws.amazon.com/iot-sitewise/latest/userguide/what-is-sitewise.html) data and assets.

--- a/docs/AWSIoTTwinMakerSource.md
+++ b/docs/AWSIoTTwinMakerSource.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # AWS IoT TwinMaker source
 
 The AWS IoT TwinMaker source enables you to visualize your [AWS IoT TwinMaker](https://docs.aws.amazon.com/iot-twinmaker/latest/guide/what-is-twinmaker.html) data and digital twins.

--- a/docs/BarChart.md
+++ b/docs/BarChart.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Bar chart
 
 A bar chart is another way to visualize time series data. You might use a bar chart when your data values change infrequently, such as daily readings. With a bar chart, you can interact with IoT data from one or more data sources. The bar chart only supports displayed time series data that are aggregated by applying the same aggregation period.

--- a/docs/Components.md
+++ b/docs/Components.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Components
 
 IoT App Kit provides the following components that you can use to interact with time series data and AWS IoT SiteWise assets. A component can be a web component or a React component. 

--- a/docs/Core.md
+++ b/docs/Core.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Core
 
 The core package contains functionality and data types that are shared across all IoT App Kit sources. The core defines a common time series data structure and functionality, as well as utilities to help create a [custom time series data source](https://github.com/awslabs/iot-app-kit/tree/main/docs/CustomSources.md). 

--- a/docs/CustomSources.md
+++ b/docs/CustomSources.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Custom sources
 
 IoT App Kit is extensible, this means that most IoT App Kit components can work with any data source which provides the correct type of data. These data-sources can be found within IoT App Kit itself, or custom data sources you implement.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Getting started with IoT Application Kit 
 
 Use the step-by-step tutorial in this section to learn how to set up IoT Application Kit. 

--- a/docs/KPI.md
+++ b/docs/KPI.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # KPI
 
 The Key Performance Indicator (KPI) component provides a compact representation when you need an overview of your asset properties. This overview gives you the most critical insights into the overall performance of your devices, equipment, or processes. With the KPI, you can interact with IoT data from one or more data sources.

--- a/docs/LineChart.md
+++ b/docs/LineChart.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Line chart
 
 The line chart component provides a way to visualize time series data that fluctuates over time. With a line chart, you can interact with IoT data from one or more data sources. 

--- a/docs/ResourceExplorer.md
+++ b/docs/ResourceExplorer.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 ## Resource explorer
 
 The resource explorer allows you to navigate and select AWS IoT SiteWise assets in an expandable tree structure.

--- a/docs/ScatterChart.md
+++ b/docs/ScatterChart.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Scatter chart
 
 You can use a scatter chart to visualize time series data with distinct data points. A scatter chart looks like a line graph without lines between data points. With a scatter chart, you can interact with IoT data from one or more data sources.

--- a/docs/SceneViewer.md
+++ b/docs/SceneViewer.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Scene Viewer
 
 The SceneViewer component allows you to render a specified [AWS IoT TwinMaker scene](https://docs.aws.amazon.com/iot-twinmaker/latest/guide/scenes.html) for viewing experience.

--- a/docs/StatusGrid.md
+++ b/docs/StatusGrid.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Status grid
 
 A status grid is a good way to visualize data that has a small number of well-defined states, such as an alarm. For example, if you have a pressure indicator that can be high, medium, or low, you could display each state in a different color with a status grid. With the status grid, you can interact with IoT data from one or more data sources.

--- a/docs/StatusTimeline.md
+++ b/docs/StatusTimeline.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Status timeline
 
 A status timeline is a good way to visualize data that has a small number of well-defined states, such as an alarm. For example, if you have a pressure indicator that can be high, medium, or low, you could display each state over time in a different color with a status timeline. With the status timeline, you can interact with IoT data from one or more data sources. 

--- a/docs/Table.md
+++ b/docs/Table.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Table
 The table component provides a compact form for viewing one or more data streams from one or more time series data sources.
 

--- a/docs/TimeSeriesDataFeatures.md
+++ b/docs/TimeSeriesDataFeatures.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Time series data
 
 Time series data is an important part of IoT data, as such, IoT App Kit comes with a set of features and tools to help efficiently manage time series data.

--- a/docs/TimeSync.md
+++ b/docs/TimeSync.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Time Sync component
 The `<TimeSync />` is a component of IoT App Kit which enables the management of viewports between all of your IoT App Kit components, enabling use cases such as synchronizing viewports across components in one or more groups, and providing the ability
 for components to easily send updates to their viewport group.

--- a/docs/VideoPlayer.md
+++ b/docs/VideoPlayer.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Video Player
 
 The VideoPlayer component allows you to stream a video from the Kinesis Video Streams. It supports the following configuration:

--- a/docs/ViewportManager.md
+++ b/docs/ViewportManager.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # Viewport manager
 
 The viewport manager is an exposed utility of `@iot-app-kit/core` which allows IoT App Kit components to synchronize their viewport within their

--- a/docs/useTimeSeriesData.md
+++ b/docs/useTimeSeriesData.md
@@ -1,5 +1,6 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # useTimeSeriesData react hook (feature in development)
-**NOTE:** This feature is under active development and may change its interface
 
 The `useTimeSeriesData` react hook is a function which allows you to easily utilize time series data within your react components from IoT App Kit datasources.
 

--- a/docs/useViewport.md
+++ b/docs/useViewport.md
@@ -1,3 +1,5 @@
+## [This documentation is deprecated: instead visit the IoT App Kit Docs](https://awslabs.github.io/iot-app-kit/)
+
 # useViewport react hook
 The `useViewport` react hook is a function which can be used within react components to utilize and update a shared time frame within a group of
 IoT App Kit widgets.


### PR DESCRIPTION
## Overview
Update docs to point to https://awslabs.github.io/iot-app-kit/

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
