### PR TITLE
fix(dashboard): remove testing-util as a dependency

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -102,7 +102,6 @@
     "@iot-app-kit/core-util": "*",
     "@iot-app-kit/react-components": "4.0.1",
     "@iot-app-kit/source-iotsitewise": "4.0.1",
-    "@iot-app-kit/testing-util": "*",
     "@popperjs/core": "^2.11.6",
     "box-intersect": "^1.0.2",
     "is-hotkey": "^0.2.0",


### PR DESCRIPTION
## Overview
remove testing-util as a dependency

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
