### PR TITLE
fix(dashboard): update type path in package json

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/awslabs/iot-app-kit/issues"
   },
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/src/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "scripts": {


### PR DESCRIPTION
## Overview
update type path in package json.

This will allow typescript packages to find the correct types file for dashboard.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
