### PR TITLE
feat(composer): update overlay UI and flow

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -46,7 +46,7 @@
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --index-template tools/index-template.js -- src/assets/icons/",
     "release": "run-s compile copy-assets",
     "copy-assets": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" dist/",
-    "lint": "eslint . --max-warnings=726",
+    "lint": "eslint . --max-warnings=709",
     "fix": "eslint --fix .",
     "test": "jest --config jest.config.ts --coverage --silent",
     "test:dev": "jest --config jest.config.ts --coverage",

--- a/packages/scene-composer/public/overlay.scene.json
+++ b/packages/scene-composer/public/overlay.scene.json
@@ -9,8 +9,8 @@
         "overlayPanelVisible": true
       },
       "Tag": {
-        "autoRescale": true,
-        "scale": 2
+        "autoRescale": false,
+        "scale": 1
       }
     },
     "dataBindingConfig": {
@@ -304,8 +304,8 @@
       "transform": {
         "position": [
           0,
-          0,
-          0.25
+          -1,
+          -7
         ],
         "rotation": [
           0,
@@ -362,11 +362,11 @@
       },
       "components": [
         {
+          "type": "Tag"
+        },
+        {
           "type": "DataOverlay",
           "subType": "OverlayPanel",
-          "config": {
-            "isPinned": true
-          },
           "valueDataBindings": [
             {
               "bindingName": "binding a",
@@ -425,11 +425,11 @@
       },
       "components": [
         {
+          "type": "Tag"
+        },
+        {
           "type": "DataOverlay",
           "subType": "OverlayPanel",
-          "config": {
-            "isPinned": false
-          },
           "valueDataBindings": [
             {
               "bindingName": "binding a",

--- a/packages/scene-composer/public/scene_1.scene.json
+++ b/packages/scene-composer/public/scene_1.scene.json
@@ -352,11 +352,11 @@
       },
       "components": [
         {
+          "type": "Tag"
+        },
+        {
           "type": "DataOverlay",
           "subType": "OverlayPanel",
-          "config": {
-            "isPinned": true
-          },
           "valueDataBindings": [
             {
               "bindingName": "binding a",

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
@@ -21,7 +21,7 @@ import {
   SceneResourceType,
   SelectedAnchor,
 } from '../../../../interfaces';
-import { IAnchorComponentInternal, ISceneNodeInternal, useStore } from '../../../../store';
+import { IAnchorComponentInternal, ISceneNodeInternal, useStore, useViewOptionState } from '../../../../store';
 import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
 import { dataBindingValuesProvider, ruleEvaluator } from '../../../../utils/dataBindingUtils';
 import { applyDataBindingTemplate } from '../../../../utils/dataBindingTemplateUtils';
@@ -66,6 +66,8 @@ export function AsyncLoadedAnchorWidget({
     return tagSettings.autoRescale;
   }, [tagSettings.autoRescale]);
 
+  const tagVisible = useViewOptionState(sceneComposerId).componentVisibilities[KnownComponentType.Tag];
+
   const onWidgetClick = useStore(sceneComposerId)((state) => state.getEditorConfig().onWidgetClick);
   const getObject3DFromSceneNodeRef = useStore(sceneComposerId)((state) => state.getObject3DBySceneNodeRef);
 
@@ -95,7 +97,7 @@ export function AsyncLoadedAnchorWidget({
 
   // Evaluate visual state based on data binding
   const visualState = useMemo(() => {
-    const values: Record<string, any> = dataBindingValuesProvider(dataInput, valueDataBinding, dataBindingTemplate);
+    const values: Record<string, unknown> = dataBindingValuesProvider(dataInput, valueDataBinding, dataBindingTemplate);
     const ruleTarget = ruleEvaluator(defaultIcon, values, rule);
     const ruleTargetInfo = getSceneResourceInfo(ruleTarget as string);
     // Anchor widget only accepts icon, otherwise, default to Info icon
@@ -224,7 +226,7 @@ export function AsyncLoadedAnchorWidget({
   }
 
   return (
-    <group ref={rootGroupRef}>
+    <group ref={rootGroupRef} visible={tagVisible}>
       <group scale={finalScale}>
         <lineSegments ref={linesRef}>
           <lineBasicMaterial color='#ffffff' />

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/__snapshots__/AnchorWidget.spec.tsx.snap
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/__snapshots__/AnchorWidget.spec.tsx.snap
@@ -1,7 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AnchorWidget should render correctly 1`] = `
-<group>
+<group
+  visible={true}
+>
+  <group
+    scale={
+      Vector3 {
+        "x": 1,
+        "y": 1,
+        "z": 1,
+      }
+    }
+  >
+    <lineSegments>
+      <lineBasicMaterial
+        color="#ffffff"
+      />
+      <bufferGeometry
+        attach="geometry"
+      />
+    </lineSegments>
+    <anchor
+      isSelected={true}
+      onClick={[Function]}
+      position={
+        Array [
+          0,
+          0,
+          0,
+        ]
+      }
+      scale={
+        Array [
+          0.5,
+          0.5,
+          1,
+        ]
+      }
+      visualState="Info"
+    >
+      <div
+        data-test-id="Selected"
+      />
+      <div
+        data-test-id="Info"
+      />
+      <div
+        data-test-id="Warning"
+      />
+      <div
+        data-test-id="Error"
+      />
+      <div
+        data-test-id="Video"
+      />
+    </anchor>
+  </group>
+</group>
+`;
+
+exports[`AnchorWidget should render correctly when not visible 1`] = `
+<group
+  visible={false}
+>
   <group
     scale={
       Vector3 {
@@ -59,7 +121,9 @@ exports[`AnchorWidget should render correctly 1`] = `
 `;
 
 exports[`AnchorWidget should render correctly with an offset 1`] = `
-<group>
+<group
+  visible={true}
+>
   <group
     scale={
       Vector3 {
@@ -117,7 +181,9 @@ exports[`AnchorWidget should render correctly with an offset 1`] = `
 `;
 
 exports[`AnchorWidget should render correctly with non default tag settings 1`] = `
-<group>
+<group
+  visible={true}
+>
   <group
     scale={
       Vector3 {
@@ -175,7 +241,9 @@ exports[`AnchorWidget should render correctly with non default tag settings 1`] 
 `;
 
 exports[`AnchorWidget should render with a countered size when parent is scaled 1`] = `
-<group>
+<group
+  visible={true}
+>
   <group
     scale={
       Vector3 {

--- a/packages/scene-composer/src/components/WebGLCanvasManager.spec.tsx
+++ b/packages/scene-composer/src/components/WebGLCanvasManager.spec.tsx
@@ -98,13 +98,13 @@ describe('WebGLCanvasManagerSnap', () => {
 
   const group = new Group();
   const geometry = new BoxGeometry();
-  (geometry as any).uuid = 'Geometry';
+  geometry.uuid = 'Geometry';
   const material = new MeshBasicMaterial();
-  (material as any).uuid = 'Material';
+  material.uuid = 'Material';
   const mesh = new Mesh(geometry, material);
   group.name = 'Test';
-  (group as any).uuid = 'Forced';
-  (mesh as any).uuid = 'Forced2';
+  group.uuid = 'Forced';
+  mesh.uuid = 'Forced2';
   group.add(mesh);
 
   const baseState: any = {

--- a/packages/scene-composer/src/components/panels/AddOrRemoveOverlayButton.tsx
+++ b/packages/scene-composer/src/components/panels/AddOrRemoveOverlayButton.tsx
@@ -1,0 +1,66 @@
+import * as THREE from 'three';
+import React, { useCallback, useContext } from 'react';
+import { useIntl } from 'react-intl';
+import { Box, Button } from '@awsui/components-react';
+
+import { COMPOSER_FEATURES, KnownComponentType } from '../../interfaces';
+import { IDataOverlayComponentInternal, useStore } from '../../store';
+import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
+import { findComponentByType } from '../../utils/nodeUtils';
+import { getGlobalSettings } from '../../common/GlobalSettings';
+import { Component } from '../../models/SceneModels';
+
+export const AddOrRemoveOverlayButton: React.FC = () => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const selectedSceneNodeRef = useStore(sceneComposerId)((state) => state.selectedSceneNodeRef);
+  const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
+  const addComponentInternal = useStore(sceneComposerId)((state) => state.addComponentInternal);
+  const removeComponent = useStore(sceneComposerId)((state) => state.removeComponent);
+  const overlayEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Overlay];
+  const selectedSceneNode = getSceneNodeByRef(selectedSceneNodeRef);
+  const intl = useIntl();
+
+  const isTagComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.Tag);
+  const isOverlayComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.DataOverlay);
+
+  const onClick = useCallback(() => {
+    if (!selectedSceneNodeRef) return;
+
+    if (isOverlayComponent) {
+      removeComponent(
+        selectedSceneNodeRef,
+        findComponentByType(selectedSceneNode, KnownComponentType.DataOverlay)!.ref,
+      );
+      return;
+    }
+
+    const component: IDataOverlayComponentInternal = {
+      ref: THREE.MathUtils.generateUUID(),
+      type: KnownComponentType.DataOverlay,
+      subType: Component.DataOverlaySubType.OverlayPanel,
+      valueDataBindings: [],
+      dataRows: [
+        {
+          rowType: Component.DataOverlayRowType.Markdown,
+          content: '',
+        },
+      ],
+    };
+
+    addComponentInternal(selectedSceneNodeRef, component);
+  }, [selectedSceneNodeRef, isOverlayComponent, selectedSceneNode]);
+
+  return (
+    (overlayEnabled && isTagComponent && (
+      <div style={{ overflow: 'auto' }}>
+        <Box margin={{ top: 'xs' }} float={isOverlayComponent ? 'right' : 'left'}>
+          <Button onClick={onClick}>
+            {isOverlayComponent
+              ? intl.formatMessage({ defaultMessage: 'Remove overlay', description: 'button label' })
+              : intl.formatMessage({ defaultMessage: 'Add overlay', description: 'button label' })}
+          </Button>
+        </Box>
+      </div>
+    )) || <></>
+  );
+};

--- a/packages/scene-composer/src/components/panels/SettingsPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SettingsPanel.tsx
@@ -63,6 +63,10 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
       defaultMessage: 'Motion indicator',
       description: 'Sub section label',
     },
+    [KnownComponentType.Tag]: {
+      defaultMessage: 'Tag',
+      description: 'Sub section label',
+    },
     [Component.DataOverlaySubType.TextAnnotation]: {
       defaultMessage: 'Annotation',
       description: 'Sub section label',
@@ -95,6 +99,10 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
         <ComponentVisibilityToggle
           componentType={KnownComponentType.MotionIndicator}
           label={intl.formatMessage(visibilityToggleLabels[KnownComponentType.MotionIndicator])}
+        />
+        <ComponentVisibilityToggle
+          componentType={KnownComponentType.Tag}
+          label={intl.formatMessage(visibilityToggleLabels[KnownComponentType.Tag])}
         />
         {overlayEnabled && (
           <ComponentVisibilityToggle

--- a/packages/scene-composer/src/components/panels/__tests__/AddOrRemoveOverlayButton.spec.tsx
+++ b/packages/scene-composer/src/components/panels/__tests__/AddOrRemoveOverlayButton.spec.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+
+import { AddOrRemoveOverlayButton } from '../AddOrRemoveOverlayButton';
+import { useStore } from '../../../store';
+import { setFeatureConfig } from '../../../common/GlobalSettings';
+import { COMPOSER_FEATURES, KnownComponentType } from '../../../interfaces';
+import { Component } from '../../../models/SceneModels';
+
+jest.mock('@awsui/components-react', () => ({
+  ...jest.requireActual('@awsui/components-react'),
+}));
+
+describe('AddOrRemoveOverlayButton', () => {
+  const getSceneNodeByRef = jest.fn();
+  const addComponentInternal = jest.fn();
+  const removeComponent = jest.fn();
+
+  beforeEach(() => {
+    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
+    useStore('default').setState({
+      selectedSceneNodeRef: 'selected',
+      getSceneNodeByRef,
+      addComponentInternal,
+      removeComponent,
+    });
+  });
+
+  it('should add overlay when clicking the button and the node has Tag component but no overlay component', async () => {
+    getSceneNodeByRef.mockReturnValue({ components: [{ type: KnownComponentType.Tag }] });
+
+    const { getByRole } = render(<AddOrRemoveOverlayButton />);
+    const addButton = getByRole('button');
+
+    act(() => {
+      addButton!.click();
+    });
+
+    expect(addComponentInternal).toBeCalledTimes(1);
+    expect(addComponentInternal).toBeCalledWith(
+      'selected',
+      expect.objectContaining({
+        type: KnownComponentType.DataOverlay,
+        subType: Component.DataOverlaySubType.OverlayPanel,
+      }),
+    );
+  });
+
+  it('should render remove button when the node has Tag component and overlay component', async () => {
+    getSceneNodeByRef.mockReturnValue({
+      components: [
+        { type: KnownComponentType.Tag, ref: 'tag-ref' },
+        { type: KnownComponentType.DataOverlay, ref: 'overlay-ref' },
+      ],
+    });
+
+    const { getByRole } = render(<AddOrRemoveOverlayButton />);
+    const removeButton = getByRole('button');
+
+    act(() => {
+      removeButton!.click();
+    });
+
+    expect(removeComponent).toBeCalledTimes(1);
+    expect(removeComponent).toBeCalledWith('selected', 'overlay-ref');
+  });
+});

--- a/packages/scene-composer/src/components/panels/__tests__/AddOrRemoveOverlayButtonSnap.spec.tsx
+++ b/packages/scene-composer/src/components/panels/__tests__/AddOrRemoveOverlayButtonSnap.spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { AddOrRemoveOverlayButton } from '../AddOrRemoveOverlayButton';
+import { useStore } from '../../../store';
+import { setFeatureConfig } from '../../../common/GlobalSettings';
+import { COMPOSER_FEATURES, KnownComponentType } from '../../../interfaces';
+
+describe('AddOrRemoveOverlayButtonSnap', () => {
+  const getSceneNodeByRef = jest.fn();
+  const addComponentInternal = jest.fn();
+  const removeComponent = jest.fn();
+
+  beforeEach(() => {
+    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
+    useStore('default').setState({
+      selectedSceneNodeRef: 'selected',
+      getSceneNodeByRef,
+      addComponentInternal,
+      removeComponent,
+    });
+  });
+
+  it('should not render button when the node has no Tag component', async () => {
+    getSceneNodeByRef.mockReturnValue({ components: [] });
+
+    const { container } = render(<AddOrRemoveOverlayButton />);
+
+    expect(container).toMatchInlineSnapshot(`<div />`);
+  });
+
+  it('should render add button when the node has Tag component but no overlay component', async () => {
+    getSceneNodeByRef.mockReturnValue({ components: [{ type: KnownComponentType.Tag }] });
+
+    const { container, queryByText } = render(<AddOrRemoveOverlayButton />);
+
+    expect(queryByText('Add overlay')).not.toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render remove button when the node has Tag component and overlay component', async () => {
+    getSceneNodeByRef.mockReturnValue({
+      components: [{ type: KnownComponentType.Tag }, { type: KnownComponentType.DataOverlay }],
+    });
+
+    const { container, queryByText } = render(<AddOrRemoveOverlayButton />);
+
+    expect(queryByText('Remove overlay')).not.toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/panels/__tests__/SceneNodeInspectorPanel.spec.tsx
+++ b/packages/scene-composer/src/components/panels/__tests__/SceneNodeInspectorPanel.spec.tsx
@@ -2,24 +2,17 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import { SceneNodeInspectorPanel } from '../SceneNodeInspectorPanel';
-import { KnownComponentType } from '../../../interfaces';
+import { COMPOSER_FEATURES, KnownComponentType } from '../../../interfaces';
 import { Component, ModelType } from '../../../models/SceneModels';
+import { ISceneNodeInternal, useStore } from '../../../store';
+import { setFeatureConfig } from '../../../common/GlobalSettings';
 
 const getSceneNodeByRef = jest.fn();
 const updateSceneNodeInternal = jest.fn();
 
-jest.mock('../../../store/Store', () => {
-  const originalModule = jest.requireActual('../../../store/Store');
-  return {
-    __esModule: true,
-    ...originalModule,
-    useEditorState: jest.fn().mockReturnValue({ selectedSceneNodeRef: 'testNodeRef' }),
-    useSceneDocument: jest.fn(() => ({
-      getSceneNodeByRef: getSceneNodeByRef,
-      updateSceneNodeInternal: updateSceneNodeInternal,
-    })),
-  };
-});
+jest.mock('../ComponentEditor', () => ({
+  ComponentEditor: (...props: unknown[]) => <div data-testid='ComponentEditor'>{JSON.stringify(props)}</div>,
+}));
 
 jest.mock('../../../three/transformUtils', () => {
   const originalModule = jest.requireActual('../../../three/transformUtils');
@@ -31,8 +24,33 @@ jest.mock('../../../three/transformUtils', () => {
 });
 
 describe('SceneNodeInspectorPanel returns expected elements.', () => {
+  const baseNode: ISceneNodeInternal = {
+    ref: 'node-ref',
+    properties: {},
+    childRefs: [],
+    name: 'node-name',
+    transform: {
+      position: [1, 1, 1],
+      rotation: [0, 0, 0],
+      scale: [2, 2, 2],
+    },
+    transformConstraint: {
+      snapToFloor: false,
+    },
+    components: [],
+  };
+
+  beforeEach(() => {
+    useStore('default').setState({
+      selectedSceneNodeRef: 'testNodeRef',
+      getSceneNodeByRef: getSceneNodeByRef,
+      updateSceneNodeInternal: updateSceneNodeInternal,
+    });
+    jest.clearAllMocks();
+    setFeatureConfig({});
+  });
+
   it('SceneNode panel contains expected elements when none selected scene node.', async () => {
-    getSceneNodeByRef.mockReset();
     getSceneNodeByRef.mockReturnValue(null);
     const { container } = render(<SceneNodeInspectorPanel />);
 
@@ -40,19 +58,13 @@ describe('SceneNodeInspectorPanel returns expected elements.', () => {
   });
 
   it('SceneNode panel contains expected elements when selected scene node.', async () => {
-    getSceneNodeByRef.mockReset();
-    updateSceneNodeInternal.mockReset();
     getSceneNodeByRef.mockReturnValue({
+      ...baseNode,
       components: [
         {
           type: KnownComponentType.ModelRef,
         },
       ],
-      transform: {
-        position: [1, 1, 1],
-        rotation: [0, 0, 0],
-        scale: [2, 2, 2],
-      },
       transformConstraint: {
         snapToFloor: true,
       },
@@ -64,23 +76,14 @@ describe('SceneNodeInspectorPanel returns expected elements.', () => {
   });
 
   it('disable y scale when selected scene node is LinearPlane motion indicator.', async () => {
-    getSceneNodeByRef.mockReset();
-    updateSceneNodeInternal.mockReset();
     getSceneNodeByRef.mockReturnValue({
+      ...baseNode,
       components: [
         {
           type: KnownComponentType.MotionIndicator,
           shape: Component.MotionIndicatorShape.LinearPlane,
         },
       ],
-      transform: {
-        position: [1, 1, 1],
-        rotation: [0, 0, 0],
-        scale: [2, 2, 2],
-      },
-      transformConstraint: {
-        snapToFloor: false,
-      },
     });
 
     const { container } = render(<SceneNodeInspectorPanel />);
@@ -89,20 +92,14 @@ describe('SceneNodeInspectorPanel returns expected elements.', () => {
   });
 
   it('SceneNode panel contains expected elements when selected Environment model.', async () => {
-    getSceneNodeByRef.mockReset();
-    updateSceneNodeInternal.mockReset();
     getSceneNodeByRef.mockReturnValue({
+      ...baseNode,
       components: [
         {
           type: KnownComponentType.ModelRef,
           modelType: ModelType.Environment,
         },
       ],
-      transform: {
-        position: [1, 1, 1],
-        rotation: [0, 0, 0],
-        scale: [2, 2, 2],
-      },
       transformConstraint: {
         snapToFloor: true,
       },
@@ -110,6 +107,89 @@ describe('SceneNodeInspectorPanel returns expected elements.', () => {
 
     const { container } = render(<SceneNodeInspectorPanel />);
 
+    expect(container).toMatchSnapshot();
+  });
+
+  it('disable rotation, hide scale and render correct overlay section when selected scene node is Tag.', async () => {
+    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
+    getSceneNodeByRef.mockReturnValue({
+      ...baseNode,
+      components: [
+        {
+          type: KnownComponentType.Tag,
+        },
+      ],
+    });
+
+    const { container } = render(<SceneNodeInspectorPanel />);
+
+    expect(container.querySelector('[controlid="Rotation_input_X"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_X"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Y"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Y"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Z"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Z"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_X"')).toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_Y"')).toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_Z"')).toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('disable scale and rotation when selected scene node is Annotation.', async () => {
+    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
+    getSceneNodeByRef.mockReturnValue({
+      ...baseNode,
+      components: [
+        {
+          type: KnownComponentType.DataOverlay,
+          subType: Component.DataOverlaySubType.TextAnnotation,
+        },
+      ],
+    });
+
+    const { container } = render(<SceneNodeInspectorPanel />);
+
+    expect(container.querySelector('[controlid="Rotation_input_X"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_X"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Y"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Y"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Z"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Z"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_X"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_X"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_Y"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_Y"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_Z"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_Z"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('disable rotation, hide scale and render correct overlay section when selected scene node is Tag with Overlay panel.', async () => {
+    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
+    getSceneNodeByRef.mockReturnValue({
+      ...baseNode,
+      components: [
+        {
+          type: KnownComponentType.Tag,
+        },
+        {
+          type: KnownComponentType.DataOverlay,
+          subType: Component.DataOverlaySubType.OverlayPanel,
+        },
+      ],
+    });
+
+    const { container } = render(<SceneNodeInspectorPanel />);
+
+    expect(container.querySelector('[controlid="Rotation_input_X"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_X"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Y"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Y"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Z"')).not.toBeNull();
+    expect(container.querySelector('[controlid="Rotation_input_Z"')?.getAttribute('disabled')).not.toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_X"')).toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_Y"')).toBeNull();
+    expect(container.querySelector('[controlid="Scale_input_Z"')).toBeNull();
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/src/components/panels/__tests__/__snapshots__/AddOrRemoveOverlayButtonSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__tests__/__snapshots__/AddOrRemoveOverlayButtonSnap.spec.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddOrRemoveOverlayButtonSnap should render add button when the node has Tag component but no overlay component 1`] = `
+<div>
+  <div
+    style="overflow: auto;"
+  >
+    <div
+      data-mocked="Box"
+      float="left"
+      margin="{\\"top\\":\\"xs\\"}"
+    >
+      <div
+        data-mocked="Button"
+      >
+        Add overlay
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AddOrRemoveOverlayButtonSnap should render remove button when the node has Tag component and overlay component 1`] = `
+<div>
+  <div
+    style="overflow: auto;"
+  >
+    <div
+      data-mocked="Box"
+      float="right"
+      margin="{\\"top\\":\\"xs\\"}"
+    >
+      <div
+        data-mocked="Button"
+      >
+        Remove overlay
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/panels/__tests__/__snapshots__/SceneNodeInspectorPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__tests__/__snapshots__/SceneNodeInspectorPanel.spec.tsx.snap
@@ -47,8 +47,1892 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
 </div>
 `;
 
-exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel contains expected elements when selected Environment model. 1`] = `<div />`;
+exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel contains expected elements when selected Environment model. 1`] = `
+.c0 {
+  border-bottom: 1px solid colorBorderDividerDefault;
+}
 
-exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel contains expected elements when selected scene node. 1`] = `<div />`;
+.c0 > div:first-child {
+  background-color: colorBackgroundContainerHeader;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
 
-exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when selected scene node is LinearPlane motion indicator. 1`] = `<div />`;
+<div>
+  <div
+    style="overflow: auto;"
+  >
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Properties
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Name"
+          >
+            <div
+              data-mocked="Input"
+              value="node-name"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Model Reference
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-testid="ComponentEditor"
+        >
+          [{"node":{"ref":"node-ref","properties":{},"childRefs":[],"name":"node-name","transform":{"position":[1,1,1],"rotation":[0,0,0],"scale":[2,2,2]},"transformConstraint":{"snapToFloor":true},"components":[{"type":"ModelRef","modelType":"Environment"}]},"component":{"type":"ModelRef","modelType":"Environment"}},{}]
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel contains expected elements when selected scene node. 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+}
+
+.c2 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  padding-right: 8px;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c0 {
+  border-bottom: 1px solid colorBorderDividerDefault;
+}
+
+.c0 > div:first-child {
+  background-color: colorBackgroundContainerHeader;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+<div>
+  <div
+    style="overflow: auto;"
+  >
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Properties
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Name"
+          >
+            <div
+              data-mocked="Input"
+              value="node-name"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Transform
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Position"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_X"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_Y"
+                    data-mocked="Input"
+                    disabled=""
+                    value="1.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_Z"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            data-mocked="FormField"
+            label="Rotation"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_X"
+                    data-mocked="Input"
+                    value="0.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_Y"
+                    data-mocked="Input"
+                    value="0.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_Z"
+                    data-mocked="Input"
+                    value="0.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            data-mocked="FormField"
+            label="Scale"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Scale_input_X"
+                    data-mocked="Input"
+                    value="2.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Scale_input_Y"
+                    data-mocked="Input"
+                    value="2.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Scale_input_Z"
+                    data-mocked="Input"
+                    value="2.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            data-mocked="FormField"
+            label="Constraints"
+          >
+            <div
+              data-mocked="Checkbox"
+            >
+              Snap to floor
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Model Reference
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-testid="ComponentEditor"
+        >
+          [{"node":{"ref":"node-ref","properties":{},"childRefs":[],"name":"node-name","transform":{"position":[1,1,1],"rotation":[0,0,0],"scale":[2,2,2]},"transformConstraint":{"snapToFloor":true},"components":[{"type":"ModelRef"}]},"component":{"type":"ModelRef"}},{}]
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hide scale and render correct overlay section when selected scene node is Tag with Overlay panel. 1`] = `
+.c4 {
+  height: 1px;
+  border-width: 0px;
+  background-color: colorBorderDividerDefault;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+}
+
+.c2 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  padding-right: 8px;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c0 {
+  border-bottom: 1px solid colorBorderDividerDefault;
+}
+
+.c0 > div:first-child {
+  background-color: colorBackgroundContainerHeader;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+<div>
+  <div
+    style="overflow: auto;"
+  >
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Properties
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Name"
+          >
+            <div
+              data-mocked="Input"
+              value="node-name"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Transform
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Position"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_X"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_Y"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_Z"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            data-mocked="FormField"
+            label="Rotation"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_X"
+                    data-mocked="Input"
+                    disabled=""
+                    value="0.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_Y"
+                    data-mocked="Input"
+                    disabled=""
+                    value="0.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_Z"
+                    data-mocked="Input"
+                    disabled=""
+                    value="0.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Tag
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-testid="ComponentEditor"
+        >
+          [{"node":{"ref":"node-ref","properties":{},"childRefs":[],"name":"node-name","transform":{"position":[1,1,1],"rotation":[0,0,0],"scale":[2,2,2]},"transformConstraint":{"snapToFloor":false},"components":[{"type":"Tag"},{"type":"DataOverlay","subType":"OverlayPanel"}]},"component":{"type":"Tag"}},{}]
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Overlay
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-testid="ComponentEditor"
+        >
+          [{"node":{"ref":"node-ref","properties":{},"childRefs":[],"name":"node-name","transform":{"position":[1,1,1],"rotation":[0,0,0],"scale":[2,2,2]},"transformConstraint":{"snapToFloor":false},"components":[{"type":"Tag"},{"type":"DataOverlay","subType":"OverlayPanel"}]},"component":{"type":"DataOverlay","subType":"OverlayPanel"}},{}]
+        </div>
+        <div
+          data-mocked="Box"
+          margin="{\\"top\\":\\"s\\"}"
+        >
+          <hr
+            class="c4"
+          />
+          <div
+            style="overflow: auto;"
+          >
+            <div
+              data-mocked="Box"
+              float="right"
+              margin="{\\"top\\":\\"xs\\"}"
+            >
+              <div
+                data-mocked="Button"
+              >
+                Remove overlay
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hide scale and render correct overlay section when selected scene node is Tag. 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+}
+
+.c2 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  padding-right: 8px;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c0 {
+  border-bottom: 1px solid colorBorderDividerDefault;
+}
+
+.c0 > div:first-child {
+  background-color: colorBackgroundContainerHeader;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+<div>
+  <div
+    style="overflow: auto;"
+  >
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Properties
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Name"
+          >
+            <div
+              data-mocked="Input"
+              value="node-name"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Transform
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Position"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_X"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_Y"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_Z"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            data-mocked="FormField"
+            label="Rotation"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_X"
+                    data-mocked="Input"
+                    disabled=""
+                    value="0.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_Y"
+                    data-mocked="Input"
+                    disabled=""
+                    value="0.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_Z"
+                    data-mocked="Input"
+                    disabled=""
+                    value="0.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Tag
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-testid="ComponentEditor"
+        >
+          [{"node":{"ref":"node-ref","properties":{},"childRefs":[],"name":"node-name","transform":{"position":[1,1,1],"rotation":[0,0,0],"scale":[2,2,2]},"transformConstraint":{"snapToFloor":false},"components":[{"type":"Tag"}]},"component":{"type":"Tag"}},{}]
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Overlay
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        Currently no overlay
+        <div
+          style="overflow: auto;"
+        >
+          <div
+            data-mocked="Box"
+            float="left"
+            margin="{\\"top\\":\\"xs\\"}"
+          >
+            <div
+              data-mocked="Button"
+            >
+              Add overlay
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SceneNodeInspectorPanel returns expected elements. disable scale and rotation when selected scene node is Annotation. 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+}
+
+.c2 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  padding-right: 8px;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c0 {
+  border-bottom: 1px solid colorBorderDividerDefault;
+}
+
+.c0 > div:first-child {
+  background-color: colorBackgroundContainerHeader;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+<div>
+  <div
+    style="overflow: auto;"
+  >
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Properties
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Name"
+          >
+            <div
+              data-mocked="Input"
+              value="node-name"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Transform
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Position"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_X"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_Y"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_Z"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            data-mocked="FormField"
+            label="Rotation"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_X"
+                    data-mocked="Input"
+                    disabled=""
+                    value="0.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_Y"
+                    data-mocked="Input"
+                    disabled=""
+                    value="0.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_Z"
+                    data-mocked="Input"
+                    disabled=""
+                    value="0.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            data-mocked="FormField"
+            label="Scale"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Scale_input_X"
+                    data-mocked="Input"
+                    disabled=""
+                    value="2.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Scale_input_Y"
+                    data-mocked="Input"
+                    disabled=""
+                    value="2.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Scale_input_Z"
+                    data-mocked="Input"
+                    disabled=""
+                    value="2.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Annotation
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-testid="ComponentEditor"
+        >
+          [{"node":{"ref":"node-ref","properties":{},"childRefs":[],"name":"node-name","transform":{"position":[1,1,1],"rotation":[0,0,0],"scale":[2,2,2]},"transformConstraint":{"snapToFloor":false},"components":[{"type":"DataOverlay","subType":"TextAnnotation"}]},"component":{"type":"DataOverlay","subType":"TextAnnotation"}},{}]
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when selected scene node is LinearPlane motion indicator. 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+}
+
+.c2 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  padding-right: 8px;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c0 {
+  border-bottom: 1px solid colorBorderDividerDefault;
+}
+
+.c0 > div:first-child {
+  background-color: colorBackgroundContainerHeader;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+<div>
+  <div
+    style="overflow: auto;"
+  >
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Properties
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Name"
+          >
+            <div
+              data-mocked="Input"
+              value="node-name"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Transform
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+        >
+          <div
+            data-mocked="FormField"
+            label="Position"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_X"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_Y"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Position_input_Z"
+                    data-mocked="Input"
+                    value="1.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            data-mocked="FormField"
+            label="Rotation"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_X"
+                    data-mocked="Input"
+                    value="0.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_Y"
+                    data-mocked="Input"
+                    value="0.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Rotation_input_Z"
+                    data-mocked="Input"
+                    value="0.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            data-mocked="FormField"
+            label="Scale"
+          >
+            <div
+              data-mocked="Grid"
+              griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
+            >
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      X
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Scale_input_X"
+                    data-mocked="Input"
+                    value="2.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Y
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Scale_input_Y"
+                    data-mocked="Input"
+                    disabled=""
+                    value="2.000"
+                  />
+                </div>
+              </div>
+              <div
+                class="c1"
+              >
+                <div
+                  class="c2"
+                >
+                  <div
+                    data-mocked="TextContent"
+                  >
+                    <p>
+                      Z
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c3"
+                >
+                  <div
+                    controlid="Scale_input_Z"
+                    data-mocked="Input"
+                    value="2.000"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-mocked="ExpandableSection"
+    >
+      <div>
+        <div
+          data-mocked="TextContent"
+        >
+          <strong>
+            Motion Indicator
+          </strong>
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"m\\",\\"right\\":\\"m\\",\\"top\\":\\"xxs\\",\\"bottom\\":\\"xxs\\"}"
+      >
+        <div
+          data-testid="ComponentEditor"
+        >
+          [{"node":{"ref":"node-ref","properties":{},"childRefs":[],"name":"node-name","transform":{"position":[1,1,1],"rotation":[0,0,0],"scale":[2,2,2]},"transformConstraint":{"snapToFloor":false},"components":[{"type":"MotionIndicator","shape":"LinearPlane"}]},"component":{"type":"MotionIndicator","shape":"LinearPlane"}},{}]
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/panels/__tests__/__snapshots__/SettingsPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__tests__/__snapshots__/SettingsPanel.spec.tsx.snap
@@ -20,6 +20,20 @@ exports[`SettingsPanel contains expected elements. should contains default eleme
     >
       Visibility
     </div>
+    <div
+      data-mocked="Box"
+      font-weight="bold"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+      variant="p"
+    >
+      Tag
+    </div>
+    <div
+      data-mocked="Toggle"
+      disabled=""
+    >
+      Visibility
+    </div>
   </div>
   <div
     data-mocked="ExpandableInfoSection"
@@ -73,6 +87,20 @@ exports[`SettingsPanel contains expected elements. should contains default eleme
     >
       Visibility
     </div>
+    <div
+      data-mocked="Box"
+      font-weight="bold"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+      variant="p"
+    >
+      Tag
+    </div>
+    <div
+      data-mocked="Toggle"
+      disabled=""
+    >
+      Visibility
+    </div>
   </div>
 </div>
 `;
@@ -90,6 +118,20 @@ exports[`SettingsPanel contains expected elements. should contains settings elem
       variant="p"
     >
       Motion indicator
+    </div>
+    <div
+      data-mocked="Toggle"
+      disabled=""
+    >
+      Visibility
+    </div>
+    <div
+      data-mocked="Box"
+      font-weight="bold"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+      variant="p"
+    >
+      Tag
     </div>
     <div
       data-mocked="Toggle"
@@ -147,6 +189,20 @@ exports[`SettingsPanel contains expected elements. should contains tag settings 
       variant="p"
     >
       Motion indicator
+    </div>
+    <div
+      data-mocked="Toggle"
+      disabled=""
+    >
+      Visibility
+    </div>
+    <div
+      data-mocked="Box"
+      font-weight="bold"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+      variant="p"
+    >
+      Tag
     </div>
     <div
       data-mocked="Toggle"

--- a/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.tsx
@@ -8,7 +8,6 @@ import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { Component } from '../../../models/SceneModels';
 
 import { DataBindingMapEditor } from './data-overlay/DataBindingMapEditor';
-import { DataOverlayPanelConfigEditor } from './data-overlay/DataOverlayPanelConfigEditor';
 
 export interface IDataOverlayComponentEditorProps extends IComponentEditorProps {
   component: IDataOverlayComponentInternal;
@@ -36,12 +35,6 @@ export const DataOverlayComponentEditor: React.FC<IDataOverlayComponentEditorPro
 
   return (
     <SpaceBetween size='s'>
-      <DataBindingMapEditor
-        valueDataBindingProvider={valueDataBindingProvider}
-        component={component}
-        onUpdateCallback={onUpdateCallback}
-      />
-
       {component.dataRows.length > 0 &&
         component.dataRows.map(
           (row, index) =>
@@ -61,9 +54,17 @@ export const DataOverlayComponentEditor: React.FC<IDataOverlayComponentEditorPro
               </FormField>
             ),
         )}
-      {subtype === Component.DataOverlaySubType.OverlayPanel && (
+
+      <DataBindingMapEditor
+        valueDataBindingProvider={valueDataBindingProvider}
+        component={component}
+        onUpdateCallback={onUpdateCallback}
+      />
+
+      {/* Not supported in Data Overlay milestone 1 */}
+      {/* {subtype === Component.DataOverlaySubType.OverlayPanel && (
         <DataOverlayPanelConfigEditor config={component.config} onUpdateCallback={onUpdateCallback} />
-      )}
+      )} */}
     </SpaceBetween>
   );
 };

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/DataOverlayComponentEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/DataOverlayComponentEditorSnap.spec.tsx.snap
@@ -6,11 +6,6 @@ exports[`DataOverlayComponentEditor should render data rows for text annotation 
     data-mocked="SpaceBetween"
   >
     <div
-      data-testid="DataBindingMapEditor"
-    >
-      [{"valueDataBindingProvider":{},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"TextAnnotation","dataRows":[{"rowType":"Markdown","content":"markdown-content"}],"valueDataBindings":[{"bindingName":"binding-1","valueDataBinding":{"dataBindingContext":"random-1"}}]}},{}]
-    </div>
-    <div
       data-mocked="FormField"
       label="Markdown Content"
     >
@@ -18,6 +13,11 @@ exports[`DataOverlayComponentEditor should render data rows for text annotation 
         data-mocked="Textarea"
         value="markdown-content"
       />
+    </div>
+    <div
+      data-testid="DataBindingMapEditor"
+    >
+      [{"valueDataBindingProvider":{},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"TextAnnotation","dataRows":[{"rowType":"Markdown","content":"markdown-content"}],"valueDataBindings":[{"bindingName":"binding-1","valueDataBinding":{"dataBindingContext":"random-1"}}]}},{}]
     </div>
   </div>
 </div>
@@ -29,11 +29,6 @@ exports[`DataOverlayComponentEditor should render editor for overlay panel 1`] =
     data-mocked="SpaceBetween"
   >
     <div
-      data-testid="DataBindingMapEditor"
-    >
-      [{"valueDataBindingProvider":{},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"markdown-content"}],"valueDataBindings":[{"bindingName":"binding-1","valueDataBinding":{"dataBindingContext":"random-1"}}]}},{}]
-    </div>
-    <div
       data-mocked="FormField"
       label="Markdown Content"
     >
@@ -43,9 +38,9 @@ exports[`DataOverlayComponentEditor should render editor for overlay panel 1`] =
       />
     </div>
     <div
-      data-testid="DataOverlayPanelConfigEditor"
+      data-testid="DataBindingMapEditor"
     >
-      [{},{}]
+      [{"valueDataBindingProvider":{},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"markdown-content"}],"valueDataBindings":[{"bindingName":"binding-1","valueDataBinding":{"dataBindingContext":"random-1"}}]}},{}]
     </div>
   </div>
 </div>

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapEditor.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback } from 'react';
-import { Box, Button, ExpandableSection, SpaceBetween } from '@awsui/components-react';
+import { Box, Button, SpaceBetween } from '@awsui/components-react';
 import { useIntl } from 'react-intl';
 import { isEmpty } from 'lodash';
+import styled from 'styled-components';
 
 import { IValueDataBinding, IValueDataBindingProvider } from '../../../../interfaces';
 import { IDataOverlayComponentInternal } from '../../../../store';
 import { ValueDataBindingBuilder } from '../ValueDataBindingBuilder';
 import { generateUUID } from '../../../../utils/mathUtils';
+import { Divider } from '../../../Divider';
 
 import { DataBindingMapNameEditor } from './DataBindingMapNameEditor';
 
@@ -15,6 +17,14 @@ interface IDataBindingMapEditorProps {
   component: IDataOverlayComponentInternal;
   onUpdateCallback: (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean | undefined) => void;
 }
+
+const RemoveButtonContainer = styled.div`
+  float: right;
+  height: 12px;
+`;
+const Spacing = styled.div`
+  height: 8px;
+`;
 
 export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
   valueDataBindingProvider,
@@ -59,7 +69,20 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
         <>
           {!isEmpty(component.valueDataBindings) &&
             component.valueDataBindings.map(({ bindingName, valueDataBinding }, index) => (
-              <ExpandableSection header={bindingName} key={index}>
+              <Box key={index}>
+                <Divider />
+
+                <RemoveButtonContainer>
+                  <Button
+                    data-test-id='remove-binding-button'
+                    iconName='close'
+                    variant='icon'
+                    iconAlign='right'
+                    onClick={() => onRemoveBinding(index)}
+                  />
+                </RemoveButtonContainer>
+                <Spacing />
+
                 <DataBindingMapNameEditor
                   bindingName={bindingName}
                   index={index}
@@ -75,10 +98,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
                     onChange={(v) => onBindingChange(v, index)}
                   />
                 </Box>
-                <Button data-test-id='remove-binding-button' onClick={() => onRemoveBinding(index)}>
-                  {intl.formatMessage({ defaultMessage: 'Remove data binding', description: 'Button text' })}
-                </Button>
-              </ExpandableSection>
+              </Box>
             ))}
           <Button data-test-id='add-binding-button' onClick={onAddBinding}>
             {intl.formatMessage({ defaultMessage: 'Add data binding', description: 'Button text' })}

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditor.tsx
@@ -13,6 +13,9 @@ interface IDataBindingMapNameEditorProps {
   onUpdateCallback: (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean | undefined) => void;
 }
 
+// eslint-disable-next-line no-useless-escape
+const INVALID_BINDING_NAME_CHARACTERS = /[\$\{\}\.\[\]]/g;
+
 export const DataBindingMapNameEditor: React.FC<IDataBindingMapNameEditorProps> = ({
   bindingName,
   index,
@@ -22,12 +25,15 @@ export const DataBindingMapNameEditor: React.FC<IDataBindingMapNameEditorProps> 
   const { formatMessage } = useIntl();
 
   const bindingNameError = useCallback(
-    (bindingName) => {
+    (bindingName: string) => {
       if (isEmpty(bindingName)) {
         return formatMessage({ defaultMessage: 'Invalid name', description: 'Input error message' });
       }
       if (valueDataBindings.filter((v) => v.bindingName === bindingName).length > 1) {
         return formatMessage({ defaultMessage: 'Duplicate name', description: 'Input error message' });
+      }
+      if (bindingName.search(INVALID_BINDING_NAME_CHARACTERS) >= 0) {
+        return formatMessage({ defaultMessage: 'Invalid character in the name', description: 'Input error message' });
       }
       return null;
     },

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditorSnap.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditorSnap.spec.tsx
@@ -61,4 +61,60 @@ describe('DataBindingMapNameEditor', () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  it('should render with invalid character in name error for $', async () => {
+    const { container } = render(
+      <DataBindingMapNameEditor
+        bindingName='aa $ bb'
+        index={0}
+        valueDataBindings={valueDataBindings}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+
+    expect(container.querySelector('[errortext="Invalid character in the name"]')).not.toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with invalid character in name error for {', async () => {
+    const { container } = render(
+      <DataBindingMapNameEditor
+        bindingName='aa { bb'
+        index={0}
+        valueDataBindings={valueDataBindings}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+
+    expect(container.querySelector('[errortext="Invalid character in the name"]')).not.toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with invalid character in name error for }', async () => {
+    const { container } = render(
+      <DataBindingMapNameEditor
+        bindingName='aa } bb'
+        index={0}
+        valueDataBindings={valueDataBindings}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+
+    expect(container.querySelector('[errortext="Invalid character in the name"]')).not.toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with invalid character in name error for .', async () => {
+    const { container } = render(
+      <DataBindingMapNameEditor
+        bindingName='aa . bb'
+        index={0}
+        valueDataBindings={valueDataBindings}
+        onUpdateCallback={onUpdateCallbackMock}
+      />,
+    );
+
+    expect(container.querySelector('[errortext="Invalid character in the name"]')).not.toBeNull();
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataOverlayPanelConfigEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataOverlayPanelConfigEditor.tsx
@@ -7,9 +7,15 @@ import { Component } from '../../../../models/SceneModels';
 
 interface IDataOverlayPanelConfigEditorProps {
   config: Component.OverlayPanelConfig | undefined;
-  onUpdateCallback: (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean | undefined) => void;
+  onUpdateCallback: (
+    componentPartial: Partial<IDataOverlayComponentInternal> | object,
+    replace?: boolean | undefined,
+  ) => void;
+  // TODO: change back to this type when supporting overlay panel config
+  // onUpdateCallback: (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean | undefined) => void;
 }
 
+// TODO: Not used in Data Overlay milestone 1.
 export const DataOverlayPanelConfigEditor: React.FC<IDataOverlayPanelConfigEditorProps> = ({
   config,
   onUpdateCallback,

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
@@ -1,14 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
+.c0 {
+  height: 1px;
+  border-width: 0px;
+  background-color: colorBorderDividerDefault;
+}
+
+.c1 {
+  float: right;
+  height: 12px;
+}
+
+.c2 {
+  height: 8px;
+}
+
 <div>
   <div
     data-mocked="SpaceBetween"
   >
     <div
-      data-mocked="ExpandableSection"
-      header="binding-1"
+      data-mocked="Box"
     >
+      <hr
+        class="c0"
+      />
+      <div
+        class="c1"
+      >
+        <div
+          data-mocked="Button"
+          data-test-id="remove-binding-button"
+          iconalign="right"
+          iconname="close"
+          variant="icon"
+        />
+      </div>
+      <div
+        class="c2"
+      />
       <div
         data-mocked="FormField"
         errortext="null"
@@ -51,17 +82,27 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
           </div>
         </div>
       </div>
-      <div
-        data-mocked="Button"
-        data-test-id="remove-binding-button"
-      >
-        Remove data binding
-      </div>
     </div>
     <div
-      data-mocked="ExpandableSection"
-      header="binding-2"
+      data-mocked="Box"
     >
+      <hr
+        class="c0"
+      />
+      <div
+        class="c1"
+      >
+        <div
+          data-mocked="Button"
+          data-test-id="remove-binding-button"
+          iconalign="right"
+          iconname="close"
+          variant="icon"
+        />
+      </div>
+      <div
+        class="c2"
+      />
       <div
         data-mocked="FormField"
         errortext="null"
@@ -103,12 +144,6 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
             />
           </div>
         </div>
-      </div>
-      <div
-        data-mocked="Button"
-        data-test-id="remove-binding-button"
-      >
-        Remove data binding
       </div>
     </div>
     <div

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/__snapshots__/DataBindingMapNameEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/__snapshots__/DataBindingMapNameEditorSnap.spec.tsx.snap
@@ -47,3 +47,67 @@ exports[`DataBindingMapNameEditor should render with invalid binding name error 
   </div>
 </div>
 `;
+
+exports[`DataBindingMapNameEditor should render with invalid character in name error for $ 1`] = `
+<div>
+  <div
+    data-mocked="FormField"
+    errortext="Invalid character in the name"
+    label="Binding Name"
+  >
+    <div
+      data-mocked="Input"
+      data-test-id="binding-name-input"
+      value="aa $ bb"
+    />
+  </div>
+</div>
+`;
+
+exports[`DataBindingMapNameEditor should render with invalid character in name error for . 1`] = `
+<div>
+  <div
+    data-mocked="FormField"
+    errortext="Invalid character in the name"
+    label="Binding Name"
+  >
+    <div
+      data-mocked="Input"
+      data-test-id="binding-name-input"
+      value="aa . bb"
+    />
+  </div>
+</div>
+`;
+
+exports[`DataBindingMapNameEditor should render with invalid character in name error for { 1`] = `
+<div>
+  <div
+    data-mocked="FormField"
+    errortext="Invalid character in the name"
+    label="Binding Name"
+  >
+    <div
+      data-mocked="Input"
+      data-test-id="binding-name-input"
+      value="aa { bb"
+    />
+  </div>
+</div>
+`;
+
+exports[`DataBindingMapNameEditor should render with invalid character in name error for } 1`] = `
+<div>
+  <div
+    data-mocked="FormField"
+    errortext="Invalid character in the name"
+    label="Binding Name"
+  >
+    <div
+      data-mocked="Input"
+      data-test-id="binding-name-input"
+      value="aa } bb"
+    />
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/panels/scene-settings/ComponentVisibilityToggle.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/ComponentVisibilityToggle.tsx
@@ -45,7 +45,7 @@ export const ComponentVisibilityToggle: React.FC<ComponentVisibilityToggleProps>
   }, [componentNodeMap, getComponentRefByType]);
 
   return (
-    <React.Fragment>
+    <>
       <Box variant='p' fontWeight='bold' margin={{ bottom: 'xxs' }}>
         {label}
       </Box>
@@ -59,6 +59,6 @@ export const ComponentVisibilityToggle: React.FC<ComponentVisibilityToggleProps>
       >
         {formatMessage({ description: 'Toggle label', defaultMessage: 'Visibility' })}
       </Toggle>
-    </React.Fragment>
+    </>
   );
 };

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
@@ -1,9 +1,11 @@
 import React, { ReactElement, useContext } from 'react';
 import { Html } from '@react-three/drei';
+import { Vector3 } from 'three';
 
-import { ISceneNodeInternal } from '../../../store';
+import { ISceneNodeInternal, useStore } from '../../../store';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { IDataOverlayComponentInternal } from '../../../store/internalInterfaces';
+import { getSafeBoundingBox } from '../../../utils/objectThreeUtils';
 
 import { DataOverlayContainer } from './DataOverlayContainer';
 
@@ -12,13 +14,26 @@ export interface DataOverlayComponentProps {
   component: IDataOverlayComponentInternal;
 }
 
+const OBJECT_SIZE_RATIO = 0.85;
 export const DataOverlayComponent = ({ node, component }: DataOverlayComponentProps): ReactElement => {
   const sceneComposerId = useContext(sceneComposerIdContext);
+  const getObject3DBySceneNodeRef = useStore(sceneComposerId)((state) => state.getObject3DBySceneNodeRef);
+  const object3D = getObject3DBySceneNodeRef(node.ref);
+  const objectWorldPos = object3D?.getWorldPosition(new Vector3());
+  const objectSize = object3D && getSafeBoundingBox(object3D).getSize(new Vector3());
+  // TODO: fix for when tag auto rescale is on
+  const y = objectSize ? (objectSize.y / 2) * OBJECT_SIZE_RATIO : 0;
+  const position = objectWorldPos && new Vector3(objectWorldPos.x, objectWorldPos.y + y, objectWorldPos.z);
+
+  if (position && object3D) {
+    object3D.worldToLocal(position);
+  }
 
   return (
     <group>
       <Html
         className='html-wrapper'
+        position={position}
         style={{
           transform: 'translate3d(-50%,-100%,0)', // make the center of 3D transform the middle of bottom edge
         }}

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
@@ -27,7 +27,9 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
   const componentVisible = useOverlayVisible(subType);
   const initialVisibilitySkipped = useRef(false);
 
-  const [visible, setVisible] = useState(component.config?.isPinned || componentVisible);
+  // TODO: config.isPinned is not supported in milestone 1
+  // const [visible, setVisible] = useState(component.config?.isPinned || componentVisible);
+  const [visible, setVisible] = useState(componentVisible);
 
   // Toggle panel visibility on selection change
   useEffect(() => {
@@ -61,20 +63,29 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
   }, [setVisible]);
 
   return visible ? (
-    <div
-      ref={containerRef}
-      onPointerUp={onPointerUp}
-      onPointerDown={onPointerDown}
-      className={`container ${
-        component.subType === Component.DataOverlaySubType.TextAnnotation ? 'annotation-container' : 'panel-container'
-      }`}
-    >
-      {component.subType === Component.DataOverlaySubType.OverlayPanel && (
-        <div className='close-button'>
-          <Button iconName='close' variant='icon' iconAlign='right' onClick={onClickCloseButton} />
+    <>
+      <div
+        ref={containerRef}
+        onPointerUp={onPointerUp}
+        onPointerDown={onPointerDown}
+        className={`container ${
+          component.subType === Component.DataOverlaySubType.TextAnnotation ? 'annotation-container' : 'panel-container'
+        }`}
+      >
+        {component.subType === Component.DataOverlaySubType.OverlayPanel && (
+          <div className='close-button'>
+            <Button iconName='close' variant='icon' iconAlign='right' onClick={onClickCloseButton} />
+          </div>
+        )}
+        <DataOverlayRows component={component} />
+      </div>
+
+      {subType == Component.DataOverlaySubType.OverlayPanel && (
+        <div className='arrow'>
+          <div className='container arrow-outer' />
+          <div className='container arrow-outer arrow-inner' />
         </div>
       )}
-      <DataOverlayRows component={component} />
-    </div>
+    </>
   ) : null;
 };

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayComponentSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayComponentSnap.spec.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { BoxGeometry, Group, Mesh } from 'three';
 
 import { DataOverlayComponent } from '../DataOverlayComponent';
 import { Component } from '../../../../models/SceneModels';
 import { KnownComponentType } from '../../../../interfaces';
-import { IDataOverlayComponentInternal, ISceneNodeInternal } from '../../../../store';
+import { IDataOverlayComponentInternal, ISceneNodeInternal, useStore } from '../../../../store';
 
 jest.mock('../DataOverlayContainer', () => ({
   DataOverlayContainer: (...props: unknown[]) => <div data-testid='container'>{JSON.stringify(props)}</div>,
@@ -34,14 +35,32 @@ describe('DataOverlayComponent', () => {
     components: [mockComponent],
   };
 
+  const group = new Group();
+  const geometry = new BoxGeometry(2, 4, 6);
+  const mesh = new Mesh(geometry);
+  group.add(mesh);
+
+  const getObject3DBySceneNodeRef = jest.fn();
+
   beforeEach(() => {
     jest.resetAllMocks();
+    useStore('default').setState({ getObject3DBySceneNodeRef });
   });
 
-  it('should render the component correctly', async () => {
+  it('should render the component correctly', () => {
     const { container } = render(
       <DataOverlayComponent node={mockNode as ISceneNodeInternal} component={mockComponent} />,
     );
+    expect(container.getElementsByClassName('html-wrapper').length).toBe(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render the component correctly with object 3D size', () => {
+    getObject3DBySceneNodeRef.mockReturnValue(group);
+    const { container } = render(
+      <DataOverlayComponent node={mockNode as ISceneNodeInternal} component={mockComponent} />,
+    );
+    expect(container.querySelector('[position="{\\"x\\":0,\\"y\\":1.7,\\"z\\":0}"]')).not.toBeNull();
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayContainerSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayContainerSnap.spec.tsx
@@ -7,7 +7,6 @@ import { Component } from '../../../../models/SceneModels';
 import { DataOverlayContainer } from '../DataOverlayContainer';
 import { DataOverlayRowsProps } from '../DataOverlayRows';
 import useOverlayVisible from '../../../../hooks/useOverlayVisible';
-import { DEFAULT_OVERLAY_GLOBAL_SETTINGS } from '../../../../common/constants';
 
 jest.mock('../../../../hooks/useCallbackWhenNotPanning', () => (cb) => [
   jest.fn(),
@@ -58,18 +57,6 @@ describe('DataOverlayContainer', () => {
 
     const { container } = render(
       <DataOverlayContainer node={mockNode as ISceneNodeInternal} component={mockComponent} />,
-    );
-    expect(container).toMatchSnapshot();
-  });
-
-  it('should render with panel visible correctly when the overlay node is pinned', () => {
-    useStore('default').setState(baseState);
-
-    const { container } = render(
-      <DataOverlayContainer
-        node={mockNode as ISceneNodeInternal}
-        component={{ ...mockComponent, config: { isPinned: true } }}
-      />,
     );
     expect(container).toMatchSnapshot();
   });

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayComponentSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayComponentSnap.spec.tsx.snap
@@ -17,3 +17,22 @@ exports[`DataOverlayComponent should render the component correctly 1`] = `
   </group>
 </div>
 `;
+
+exports[`DataOverlayComponent should render the component correctly with object 3D size 1`] = `
+<div>
+  <group>
+    <div
+      class="html-wrapper"
+      data-mocked="Html"
+      position="{\\"x\\":0,\\"y\\":1.7,\\"z\\":0}"
+      style="transform: translate3d(-50%,-100%,0);"
+    >
+      <div
+        data-testid="container"
+      >
+        [{"node":{"ref":"node-ref","transform":{"position":[1,2,3],"rotation":[0,0,0],"scale":[0,0,0]},"components":[{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[{"bindingName":"bindingA","valueDataBinding":{"dataBindingContext":"dataBindingContext"}}]}]},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[{"bindingName":"bindingA","valueDataBinding":{"dataBindingContext":"dataBindingContext"}}]}},{}]
+      </div>
+    </div>
+  </group>
+</div>
+`;

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
@@ -39,29 +39,15 @@ exports[`DataOverlayContainer should render with panel visible correctly 1`] = `
       [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[]}},{}]
     </div>
   </div>
-</div>
-`;
-
-exports[`DataOverlayContainer should render with panel visible correctly when the overlay node is pinned 1`] = `
-<div>
   <div
-    class="container panel-container"
+    class="arrow"
   >
     <div
-      class="close-button"
-    >
-      <div
-        data-mocked="Button"
-        iconalign="right"
-        iconname="close"
-        variant="icon"
-      />
-    </div>
+      class="container arrow-outer"
+    />
     <div
-      data-testid="rows"
-    >
-      [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[],"config":{"isPinned":true}}},{}]
-    </div>
+      class="container arrow-outer arrow-inner"
+    />
   </div>
 </div>
 `;
@@ -86,6 +72,16 @@ exports[`DataOverlayContainer should render with panel visible correctly when th
     >
       [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[]}},{}]
     </div>
+  </div>
+  <div
+    class="arrow"
+  >
+    <div
+      class="container arrow-outer"
+    />
+    <div
+      class="container arrow-outer arrow-inner"
+    />
   </div>
 </div>
 `;

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.scss
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.scss
@@ -13,14 +13,43 @@
 
 // Container
 .container {
-  overflow: auto
+  overflow: auto;
+  background-color: awsui.$color-background-container-header;
+  border: 1px solid awsui.$color-border-button-normal-disabled;
+  border-radius: 2px;
+  box-shadow: 0px 1px 4px -2px rgba(0, 28, 36, 0.5);
 }
 .panel-container {
-  width: 300px;
-  background-color: awsui.$color-background-container-content
+  width: 210px;
+}
+.annotation-container {
+  padding-left: 12px;
+  padding-right: 12px;
 }
 .close-button {
   float: right;
   margin-top: 8px;
   margin-right: 8px
+}
+.arrow {
+  height: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .arrow-outer {
+    width: 18px; 
+    height: 18px; 
+    position: absolute;
+    z-index: -1;
+    bottom: 5px;
+    transform: rotate(45deg);
+  }
+  .arrow-inner {
+    border: 0px;
+    bottom: 6.5px;
+    width: 20px; 
+    height: 20px; 
+    z-index: 1;
+  }
 }

--- a/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/MotionIndicatorComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/MotionIndicatorComponent.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Color } from 'three';
 
 import { ISceneNodeInternal, IMotionIndicatorComponentInternal, useStore, useViewOptionState } from '../../../store';
@@ -18,11 +18,14 @@ interface IMotionIndicatorComponentProps {
   component: IMotionIndicatorComponentInternal;
 }
 
-const MotionIndicatorComponentView: React.FC<IMotionIndicatorComponentProps> = ({
+const MotionIndicatorComponent: React.FC<IMotionIndicatorComponentProps> = ({
   node,
   component,
 }: IMotionIndicatorComponentProps) => {
   const sceneComposerId = useSceneComposerId();
+  const motionIndicatorVisible =
+    useViewOptionState(sceneComposerId).componentVisibilities[KnownComponentType.MotionIndicator];
+
   const dataInput = useStore(sceneComposerId)((state) => state.dataInput);
   const dataBindingTemplate = useStore(sceneComposerId)((state) => state.dataBindingTemplate);
   const speedRule = useStore(sceneComposerId)((state) =>
@@ -123,7 +126,7 @@ const MotionIndicatorComponentView: React.FC<IMotionIndicatorComponentProps> = (
   ]);
 
   return (
-    <group name={getComponentGroupName(node.ref, 'MOTION_INDICATOR')}>
+    <group name={getComponentGroupName(node.ref, 'MOTION_INDICATOR')} visible={motionIndicatorVisible}>
       {component.shape === 'LinearPlane' && (
         <LinearPlaneMotionIndicator
           speed={speed}
@@ -153,18 +156,6 @@ const MotionIndicatorComponentView: React.FC<IMotionIndicatorComponentProps> = (
       )}
     </group>
   );
-};
-
-const MotionIndicatorComponent = ({ component, node }: IMotionIndicatorComponentProps) => {
-  const sceneComposerId = useSceneComposerId();
-  const motionIndicatorVisible =
-    useViewOptionState(sceneComposerId).componentVisibilities[KnownComponentType.MotionIndicator];
-
-  if (motionIndicatorVisible) {
-    return <MotionIndicatorComponentView component={component} node={node} />;
-  }
-
-  return <Fragment key={component.ref}></Fragment>;
 };
 
 export default MotionIndicatorComponent;

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
@@ -9,8 +9,8 @@ jest.doMock('../../../../../src/utils/nodeUtils', () => ({
   isEnvironmentNode: mockIsEnvironmentNode,
 }));
 
-import { AddObjectMenu } from '../../../../../src/components/toolbars/floatingToolbar/items/AddObjectMenu';
-import { IColorOverlayComponentInternal, useStore } from '../../../../../src/store';
+import { AddObjectMenu } from './AddObjectMenu';
+import { IColorOverlayComponentInternal, useStore } from '../../../../store';
 import {
   COMPOSER_FEATURES,
   DEFAULT_CAMERA_OPTIONS,
@@ -24,9 +24,9 @@ import {
   KnownComponentType,
   setFeatureConfig,
   setMetricRecorder,
-} from '../../../../../src';
-import { Component, LightType } from '../../../../../src/models/SceneModels';
-import { createNodeWithTransform } from '../../../../../src/utils/nodeUtils';
+} from '../../../..';
+import { Component, LightType } from '../../../../models/SceneModels';
+import { createNodeWithTransform } from '../../../../utils/nodeUtils';
 /* eslint-enable */
 
 jest.mock('../../../../../src/utils/pathUtils', () => ({
@@ -228,35 +228,6 @@ describe('AddObjectMenu', () => {
     render(<AddObjectMenu />);
 
     expect(screen.queryByTestId('add-overlay-menu')).toBeNull();
-  });
-
-  it('should call setAddingWidget when adding a data overlay', () => {
-    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true, [COMPOSER_FEATURES.ENHANCED_EDITING]: true });
-    const component: IDataOverlayComponent = {
-      type: KnownComponentType.DataOverlay,
-      valueDataBindings: [],
-      subType: Component.DataOverlaySubType.OverlayPanel,
-      dataRows: [
-        {
-          rowType: Component.DataOverlayRowType.Markdown,
-          content: '',
-        },
-      ],
-    };
-
-    render(<AddObjectMenu />);
-    const sut = screen.getByTestId('add-object-data-overlay');
-    fireEvent.pointerUp(sut);
-    expect(setAddingWidget).toBeCalledWith({
-      type: KnownComponentType.DataOverlay,
-      node: {
-        name: 'DataOverlay',
-        components: [component],
-        parentRef: selectedSceneNodeRef,
-      },
-    });
-    expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
-    expect(mockMetricRecorder.recordClick).toBeCalledWith('add-object-data-overlay');
   });
 
   it('should call setAddingWidget when adding a annotation', () => {

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -35,8 +35,6 @@ enum ObjectTypes {
   MotionIndicator = 'add-object-motion-indicator',
   Light = 'add-object-light',
   ViewCamera = 'add-object-view-camera',
-  OverlayMenu = 'add-overlay-menu',
-  DataOverlay = 'add-object-data-overlay',
   Annotation = 'add-object-annotation',
 }
 
@@ -54,8 +52,6 @@ const labelStrings: { [key in ObjectTypes]: MessageDescriptor } = defineMessages
   [ObjectTypes.ModelShader]: { defaultMessage: 'Model shader', description: 'Menu Item label' },
   [ObjectTypes.MotionIndicator]: { defaultMessage: 'Motion indicator', description: 'Menu Item label' },
   [ObjectTypes.ViewCamera]: { defaultMessage: 'Camera', description: 'Menu Item label' },
-  [ObjectTypes.OverlayMenu]: { defaultMessage: 'Overlay', description: 'Menu Item label' },
-  [ObjectTypes.DataOverlay]: { defaultMessage: 'Data overlay', description: 'Menu Item label' },
   [ObjectTypes.Annotation]: { defaultMessage: 'Annotation', description: 'Menu Item label' },
 });
 
@@ -68,9 +64,7 @@ const textStrings = defineMessages({
   [ObjectTypes.ModelShader]: { defaultMessage: 'Add model shader', description: 'Menu Item' },
   [ObjectTypes.MotionIndicator]: { defaultMessage: 'Add motion indicator', description: 'Menu Item' },
   [ObjectTypes.ViewCamera]: { defaultMessage: 'Add camera from current view', description: 'Menu Item' },
-  [ObjectTypes.OverlayMenu]: { defaultMessage: 'Add overlay', description: 'Menu Item' },
-  [ObjectTypes.DataOverlay]: { defaultMessage: 'Data overlay', description: 'Menu Item' },
-  [ObjectTypes.Annotation]: { defaultMessage: 'Annotation', description: 'Menu Item' },
+  [ObjectTypes.Annotation]: { defaultMessage: 'Add annotation', description: 'Menu Item' },
 });
 
 type ToolbarItemOptionRaw = Omit<ToolbarItemOptions, 'label' | 'text' | 'subItems'> & {
@@ -149,16 +143,8 @@ export const AddObjectMenu = () => {
           uuid: ObjectTypes.Tag,
         },
         {
-          uuid: ObjectTypes.OverlayMenu,
+          uuid: ObjectTypes.Annotation,
           feature: { name: COMPOSER_FEATURES.Overlay },
-          subItems: [
-            {
-              uuid: ObjectTypes.DataOverlay,
-            },
-            {
-              uuid: ObjectTypes.Annotation,
-            },
-          ],
         },
         {
           uuid: ObjectTypes.ModelShader,
@@ -383,9 +369,6 @@ export const AddObjectMenu = () => {
             break;
           case ObjectTypes.ViewCamera:
             handleAddViewCamera();
-            break;
-          case ObjectTypes.DataOverlay:
-            handleAddOverlay(Component.DataOverlaySubType.OverlayPanel);
             break;
           case ObjectTypes.Annotation:
             handleAddOverlay(Component.DataOverlaySubType.TextAnnotation);

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.spec.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-import { ObjectItemGroup } from '../../../../../src/components/toolbars/floatingToolbar/items';
-import { useStore } from '../../../../../src/store';
+import { useStore } from '../../../../store';
+
+import { ObjectItemGroup } from '.';
 
 describe('ObjectItemGroup', () => {
   const removeSceneNode = jest.fn();
@@ -17,7 +18,7 @@ describe('ObjectItemGroup', () => {
       transformControlMode: 'translate',
       setTransformControlMode,
       getSceneNodeByRef,
-    } as any);
+    });
     jest.clearAllMocks();
   });
 
@@ -31,7 +32,7 @@ describe('ObjectItemGroup', () => {
   it('should not call removeSceneNode when clicking delete without a selected node', () => {
     useStore('default').setState({
       selectedSceneNodeRef: undefined,
-    } as any);
+    });
     render(<ObjectItemGroup />);
     const sut = screen.getByTestId('delete');
     fireEvent.pointerUp(sut);

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.tsx
@@ -8,6 +8,7 @@ import { useEditorState, useSceneDocument } from '../../../../store';
 import { ToolbarItem } from '../../common/ToolbarItem';
 import { ToolbarItemGroup } from '../../common/styledComponents';
 import { ToolbarItemOptions } from '../../common/types';
+import { findComponentByType } from '../../../../utils/nodeUtils';
 
 enum TransformTypes {
   Translate = 'transform-translate',
@@ -33,11 +34,10 @@ export function ObjectItemGroup() {
   const { selectedSceneNodeRef, transformControlMode, setTransformControlMode } = useEditorState(sceneComposerId);
   const { getSceneNodeByRef, removeSceneNode } = useSceneDocument(sceneComposerId);
   const { formatMessage } = useIntl();
+  const selectedSceneNode = getSceneNodeByRef(selectedSceneNodeRef);
 
-  const isTagComponent = useMemo(() => {
-    const selectedSceneNode = getSceneNodeByRef(selectedSceneNodeRef);
-    return selectedSceneNode?.components.some((component) => component.type === KnownComponentType.Tag) === true;
-  }, [selectedSceneNodeRef]);
+  const isTagComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.Tag);
+  const isOverlayComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.DataOverlay);
 
   const transformSelectorItems = [
     {
@@ -50,13 +50,14 @@ export function ObjectItemGroup() {
       icon: { scale: 1.06, svg: RotateIconSvg },
       uuid: TransformTypes.Rotate,
       mode: 'rotate',
+      isDisabled: isTagComponent || isOverlayComponent,
       isSelected: transformControlMode === 'rotate',
     },
     {
       icon: { scale: 1.06, svg: ScaleIconSvg },
       uuid: TransformTypes.Scale,
       mode: 'scale',
-      isDisabled: isTagComponent,
+      isDisabled: isTagComponent || isOverlayComponent,
       isSelected: transformControlMode === 'scale',
     },
   ].map(
@@ -70,13 +71,13 @@ export function ObjectItemGroup() {
 
   const initialSelectedItem = useMemo(() => {
     return transformSelectorItems.find((item) => item.mode === transformControlMode) ?? transformSelectorItems[0];
-  }, [transformSelectorItems, transformControlMode, isTagComponent]);
+  }, [transformSelectorItems, transformControlMode, isTagComponent, isOverlayComponent]);
 
   const isDeleteDisabled = selectedSceneNodeRef === undefined;
 
   const translatedItems = useMemo(() => {
     return transformSelectorItems;
-  }, [intl, isTagComponent, transformControlMode]);
+  }, [intl, isTagComponent, isOverlayComponent, transformControlMode]);
 
   return (
     <ToolbarItemGroup>

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroupSnap.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroupSnap.spec.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { useStore } from '../../../../store';
+import { KnownComponentType } from '../../../../interfaces';
+
+import { ObjectItemGroup } from '.';
+
+jest.mock('../../common/ToolbarItem', () => ({
+  ToolbarItem: (...props: unknown[]) => <div data-testid='ToolbarItem'>{JSON.stringify(props)}</div>,
+}));
+
+jest.mock('../../../../assets/svgs', () => ({
+  DeleteSvg: 'DeleteSvg',
+  RotateIconSvg: 'RotateIconSvg',
+  ScaleIconSvg: 'ScaleIconSvg',
+  TranslateIconSvg: 'TranslateIconSvg',
+}));
+
+describe('ObjectItemGroupSnap', () => {
+  const removeSceneNode = jest.fn();
+  const selectedSceneNodeRef = 'test-ref';
+  const setTransformControlMode = jest.fn();
+  const getSceneNodeByRef = jest.fn();
+
+  beforeEach(() => {
+    useStore('default').setState({
+      selectedSceneNodeRef,
+      removeSceneNode,
+      transformControlMode: 'translate',
+      setTransformControlMode,
+      getSceneNodeByRef,
+    });
+    jest.clearAllMocks();
+  });
+
+  it('should render with disabled rotate and scale when Tag is selected', () => {
+    getSceneNodeByRef.mockReturnValue({ components: [{ type: KnownComponentType.Tag }] });
+    const { container, queryAllByText } = render(<ObjectItemGroup />);
+
+    expect(queryAllByText('"isDisabled":true', { exact: false }).length).toBe(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with disabled rotate and scale when Overlay is selected', () => {
+    getSceneNodeByRef.mockReturnValue({ components: [{ type: KnownComponentType.DataOverlay }] });
+    const { container, queryAllByText } = render(<ObjectItemGroup />);
+
+    expect(queryAllByText('"isDisabled":true', { exact: false }).length).toBe(1);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/__snapshots__/ObjectItemGroupSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/__snapshots__/ObjectItemGroupSnap.spec.tsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ObjectItemGroupSnap should render with disabled rotate and scale when Overlay is selected 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-top: 3px solid colorBorderDividerDefault;
+}
+
+.c0:first-of-type {
+  border-top: 0;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      data-testid="ToolbarItem"
+    >
+      [{"items":[{"label":"Delete","icon":{"svg":"DeleteSvg"},"uuid":"delete","isDisabled":false}],"type":"button"},{}]
+    </div>
+    <div
+      data-testid="ToolbarItem"
+    >
+      [{"items":[{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"},{"icon":{"scale":1.06,"svg":"RotateIconSvg"},"uuid":"transform-rotate","mode":"rotate","isDisabled":true,"isSelected":false,"label":"Rotate","text":"Rotate object"},{"icon":{"scale":1.06,"svg":"ScaleIconSvg"},"uuid":"transform-scale","mode":"scale","isDisabled":true,"isSelected":false,"label":"Scale","text":"Scale object"}],"type":"mode-select","initialSelectedItem":{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"}},{}]
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ObjectItemGroupSnap should render with disabled rotate and scale when Tag is selected 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-top: 3px solid colorBorderDividerDefault;
+}
+
+.c0:first-of-type {
+  border-top: 0;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      data-testid="ToolbarItem"
+    >
+      [{"items":[{"label":"Delete","icon":{"svg":"DeleteSvg"},"uuid":"delete","isDisabled":false}],"type":"button"},{}]
+    </div>
+    <div
+      data-testid="ToolbarItem"
+    >
+      [{"items":[{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"},{"icon":{"scale":1.06,"svg":"RotateIconSvg"},"uuid":"transform-rotate","mode":"rotate","isDisabled":true,"isSelected":false,"label":"Rotate","text":"Rotate object"},{"icon":{"scale":1.06,"svg":"ScaleIconSvg"},"uuid":"transform-scale","mode":"scale","isDisabled":true,"isSelected":false,"label":"Scale","text":"Scale object"}],"type":"mode-select","initialSelectedItem":{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"}},{}]
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/wrappers/ReactMarkdownWrapper.scss
+++ b/packages/scene-composer/src/components/wrappers/ReactMarkdownWrapper.scss
@@ -4,4 +4,7 @@
   a {
     color: awsui.$color-text-link-default
   }
+  img {
+    max-width: 100%;
+  }
 }

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -210,6 +210,7 @@ export namespace Component {
     TextAnnotation = 'TextAnnotation',
     OverlayPanel = 'OverlayPanel',
   }
+  // TODO: Not supported in milestone 1
   export interface OverlayPanelConfig {
     isPinned: boolean;
   }
@@ -222,7 +223,9 @@ export namespace Component {
   export interface DataOverlay extends IComponent {
     subType: DataOverlaySubType;
     dataRows: Array<DataOverlayMarkdownRow>;
-    config?: OverlayPanelConfig;
+
+    // TODO: Not supported in milestone 1
+    // config?: OverlayPanelConfig;
 
     valueDataBindings: ValueDataBindingNamedMap[];
   }

--- a/packages/scene-composer/src/store/slices/ViewOptionStateSlice.spec.ts
+++ b/packages/scene-composer/src/store/slices/ViewOptionStateSlice.spec.ts
@@ -64,6 +64,26 @@ describe('createViewOptionStateSlice', () => {
     expect(draft.noHistoryStates.componentVisibilities[Component.DataOverlaySubType.TextAnnotation]).toBeFalsy();
   });
 
+  it('should be able to change tag visibility', () => {
+    const draft = {
+      lastOperation: undefined,
+      noHistoryStates: { componentVisibilities: { [KnownComponentType.Tag]: false } },
+    };
+
+    const set = jest.fn((callback) => callback(draft));
+
+    const { toggleComponentVisibility } = createViewOptionStateSlice(set);
+    toggleComponentVisibility(KnownComponentType.Tag);
+
+    expect(draft.lastOperation).toEqual('toggleComponentVisibility');
+    expect(draft.noHistoryStates.componentVisibilities[KnownComponentType.Tag]).toBeTruthy();
+
+    toggleComponentVisibility(KnownComponentType.Tag);
+
+    expect(draft.lastOperation).toEqual('toggleComponentVisibility');
+    expect(draft.noHistoryStates.componentVisibilities[KnownComponentType.Tag]).toBeFalsy();
+  });
+
   it('should be able to change tag settings', () => {
     const draft = { lastOperation: undefined, noHistoryStates: { tagSettings: {} } };
 

--- a/packages/scene-composer/src/store/slices/ViewOptionStateSlice.ts
+++ b/packages/scene-composer/src/store/slices/ViewOptionStateSlice.ts
@@ -19,6 +19,7 @@ export interface IViewOptionStateSlice {
 export const createViewOptionStateSlice = (set: SetState<RootState>): IViewOptionStateSlice => ({
   componentVisibilities: {
     [KnownComponentType.MotionIndicator]: true,
+    [KnownComponentType.Tag]: true,
     [Component.DataOverlaySubType.TextAnnotation]: true,
   },
   tagSettings: undefined,

--- a/packages/scene-composer/src/three/TransformControls.ts
+++ b/packages/scene-composer/src/three/TransformControls.ts
@@ -124,6 +124,9 @@ class TransformControls<TCamera extends Camera = Camera> extends Object3D {
   private showX = true;
   private showY = true;
   private showZ = true;
+  // + Amazon
+  private flipY = false;
+  // - Amazon
 
   // events
   private changeEvent = { type: 'change' };
@@ -200,6 +203,9 @@ class TransformControls<TCamera extends Camera = Camera> extends Object3D {
     defineProperty('rotationAxis', this.rotationAxis);
     defineProperty('rotationAngle', this.rotationAngle);
     defineProperty('eye', this.eye);
+    // + Amazon
+    defineProperty('flipY', this.flipY);
+    // - Amazon
 
     this.domElement.addEventListener('pointerdown', this.onPointerDown);
     this.domElement.addEventListener('pointermove', this.onPointerHover);
@@ -675,6 +681,9 @@ class TransformControlsGizmo extends Object3D {
   private showX = true;
   private showY = true;
   private showZ = true;
+  // + Amazon
+  private flipY = false;
+  // - Amazon
 
   constructor() {
     super();
@@ -1231,7 +1240,12 @@ class TransformControlsGizmo extends Object3D {
         }
 
         if (handle.name.search('Y') !== -1) {
-          if (this.alignVector.copy(this.unitY).applyQuaternion(quaternion).dot(this.eye) < AXIS_FLIP_TRESHOLD) {
+          if (
+            // + Amazon
+            this.flipY ||
+            // - Amazon
+            this.alignVector.copy(this.unitY).applyQuaternion(quaternion).dot(this.eye) < AXIS_FLIP_TRESHOLD
+          ) {
             if (handle.tag === 'fwd') {
               handle.visible = false;
             } else {

--- a/packages/scene-composer/tests/__mocks__/MockTransformControls.ts
+++ b/packages/scene-composer/tests/__mocks__/MockTransformControls.ts
@@ -3,6 +3,7 @@ export class MockTransformControls {
 
   object: any = {};
   showY = true;
+  flipY = false;
   camera;
   domElement;
 

--- a/packages/scene-composer/tests/scenes/scene_1.json
+++ b/packages/scene-composer/tests/scenes/scene_1.json
@@ -352,11 +352,11 @@
       },
       "components": [
         {
+          "type": "Tag"
+        },
+        {
           "type": "DataOverlay",
           "subType": "OverlayPanel",
-          "config": {
-            "isPinned": true
-          },
           "valueDataBindings": [
             {
               "bindingName": "binding a",

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -1,4 +1,8 @@
 {
+  "+06qIR": {
+    "note": "Sub section label",
+    "text": "Tag"
+  },
   "+FW9s9": {
     "note": "signify No rule option to be selected in a drop down menu",
     "text": "No Rule"
@@ -11,9 +15,9 @@
     "note": "FormField label",
     "text": "Rule Id"
   },
-  "+okT2d": {
+  "/N+x/y": {
     "note": "Expandable Section title",
-    "text": "Data Overlay"
+    "text": "Overlay"
   },
   "/OvfUw": {
     "note": "Distance Units in a dropdown menu",
@@ -91,6 +95,10 @@
     "note": "Add parameter Button Text",
     "text": "Add parameter"
   },
+  "4YbINk": {
+    "note": "Expandable Section title",
+    "text": "Annotation"
+  },
   "5pV1+0": {
     "note": "Form field label",
     "text": "Ref"
@@ -151,10 +159,6 @@
     "note": "Form Field label",
     "text": "Model Path"
   },
-  "8W3SiU": {
-    "note": "Menu Item label",
-    "text": "Overlay"
-  },
   "8YlbtM": {
     "note": "Form field label",
     "text": "Near"
@@ -182,6 +186,10 @@
   "A/Q8OL": {
     "note": "Status indicator label",
     "text": "Camera view saved"
+  },
+  "AEkvpm": {
+    "note": "Input error message",
+    "text": "Invalid character in the name"
   },
   "As6z+e": {
     "note": "ExpandableInfoSection Title",
@@ -214,10 +222,6 @@
   "D9sm7a": {
     "note": "Menu Item label",
     "text": "3D model"
-  },
-  "DlaPGB": {
-    "note": "Menu Item label",
-    "text": "Data overlay"
   },
   "DsNVlc": {
     "note": "Input error message",
@@ -375,10 +379,6 @@
     "note": "Menu Item",
     "text": "Pan"
   },
-  "OgOwr7": {
-    "note": "Menu Item",
-    "text": "Data overlay"
-  },
   "OpGIbY": {
     "note": "Scene Icon types in a dropdown menu",
     "text": "Error"
@@ -499,10 +499,6 @@
     "note": "Form Field label",
     "text": "Distance"
   },
-  "X7gllM": {
-    "note": "Menu Item",
-    "text": "Annotation"
-  },
   "XXnvtK": {
     "note": "Error message",
     "text": "Error: invalid props to Matrix3XInputGrid, labels and values must be of length 3"
@@ -514,6 +510,10 @@
   "YAKCuf": {
     "note": "checkbox option",
     "text": "Enable Shadow"
+  },
+  "YGtqhG": {
+    "note": "button label",
+    "text": "Add overlay"
   },
   "ZKJ6Ci": {
     "note": "Toolbar label",
@@ -530,6 +530,10 @@
   "a2V9FB": {
     "note": "FormField label",
     "text": "Define arrow speed"
+  },
+  "aUtGJh": {
+    "note": "button label",
+    "text": "Remove overlay"
   },
   "aX7AgI": {
     "note": "select box option text value",
@@ -763,10 +767,6 @@
     "note": "placeholder",
     "text": "Choose a rule"
   },
-  "pNCs6s": {
-    "note": "Button text",
-    "text": "Remove data binding"
-  },
   "pyg21P": {
     "note": "Number of Triangles in a scene",
     "text": "Triangles : {sceneInfoTriangles, number}"
@@ -794,10 +794,6 @@
   "rDIRVn": {
     "note": "Menu Item label",
     "text": "Motion indicator"
-  },
-  "rH0oex": {
-    "note": "Menu Item",
-    "text": "Add overlay"
   },
   "rKeM3X": {
     "note": "Form Field label",
@@ -854,6 +850,10 @@
   "uJjz0b": {
     "note": "Form section header",
     "text": "Lens"
+  },
+  "ua6Icd": {
+    "note": "Menu Item",
+    "text": "Add annotation"
   },
   "ubyV0D": {
     "note": "Remove parameter Button Text",
@@ -918,5 +918,9 @@
   "z4V95/": {
     "note": "Expandable Section title",
     "text": "Camera"
+  },
+  "zH7jyn": {
+    "note": "Expandable section content",
+    "text": "Currently no overlay"
   }
 }


### PR DESCRIPTION
## Overview
- Add Tag visibility toggle in settings
- Remove overlay isPinned config
- Update overlay panal UI
- Flip handler of translate controller in y when data overlay is selected
- Disable rotate and scale for Tag and Overlay
- Add character validation for binding name
- Move add (and remove) overlay to Tag node inspector and place overlay above Tag 

<img width="1167" alt="overlay-ui-polish" src="https://user-images.githubusercontent.com/9315598/229668009-bfec0008-a0a5-4921-b542-b62cb82ccb98.png">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
