### PR TITLE
fix(dashboard): add css resets

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -4,6 +4,11 @@
   height: 100vh;
   display: flex;
   flex-direction: column;
+
+  /**
+    * css resets to prevent parent styles affecting the dashboard
+    */
+  text-align: initial;
 }
 
 .dashboard .divider {


### PR DESCRIPTION
## Overview
Bugfix to prevent external styling breaking the UX for dashboard.

If a user set the text align on a parent element of the dashboard, it would cause the charts and most of the text to shift position.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
