### PR TITLE
fix(dashboard): add buffer to dependencies so consuming apps don't need to install it

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -103,6 +103,7 @@
     "@iot-app-kit/source-iotsitewise": "5.1.1",
     "@popperjs/core": "^2.11.6",
     "box-intersect": "^1.0.2",
+    "buffer": "^6.0.3",
     "is-hotkey": "^0.2.0",
     "parse-duration": "^1.0.3",
     "react-dnd": "^16.0.1",

--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -4,6 +4,11 @@
   height: 100vh;
   display: flex;
   flex-direction: column;
+
+  /**
+    * css resets to prevent parent styles affecting the dashboard
+    */
+  text-align: initial;
 }
 
 .dashboard .divider {


### PR DESCRIPTION
## Overview
A dependency of dashboard is using buffer which is not present when trying to install / use the dashboard package.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
