### PR TITLE
fix(TwinMakerTools): added a additional condition to prevent saving an s3 folder as a model

### DIFF
--- a/packages/tools-iottwinmaker/README.md
+++ b/packages/tools-iottwinmaker/README.md
@@ -14,13 +14,12 @@ You can follow [AWS IoT TwinMaker Getting Started](https://github.com/aws-sample
 First clone the latest tip of this tool:
 
 ```
-git clone https://github.com/johnnyw-aws/aws-iot-twinmaker-samples --depth 1 --branch main-tmdt && cd aws-iot-twinmaker-samples/src/libs/tmdt
+git clone https://github.com/awslabs/iot-app-kit.git  && cd iot-app-kit/packages/tools-iottwinmaker
 ```
 
-Navigate to the `tmdt` directory and install any node dependencies:
+Navigate to the `tools-iottwinmaker` directory and install any node dependencies:
 
 ```
-cd src/libs/tmdt
 npm install
 ```
 Build the package:

--- a/packages/tools-iottwinmaker/src/commands/init.ts
+++ b/packages/tools-iottwinmaker/src/commands/init.ts
@@ -154,7 +154,7 @@ async function import_scenes_and_models(workspaceIdStr: string, tmdt_config: tmd
                   if (objlist['Contents'] != undefined) {
                     const contents = objlist['Contents'];
                     for (const [, value] of Object.entries(contents)) {
-                      if ('Key' in value) {
+                      if ('Key' in value && value['Size'] && value['Size'] > 0) {
                         // TODO consider path.join in all s3 URI for better cross platform support?
                         modelFiles.add(`s3://${s3bucket}/${value['Key']}`);
                       }


### PR DESCRIPTION
## Overview
Quick customer fix

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
