### PR TITLE
fix(composer): Sync tags correctly & addded status

### DIFF
--- a/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/MatterportTagSync.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/MatterportTagSync.spec.tsx.snap
@@ -3,10 +3,24 @@
 exports[`MatterportIntegration should render correctly 1`] = `
 <div>
   <div
-    data-mocked="Button"
-    data-testid="matterport-tag-sync-button"
+    data-mocked="Popover"
+    position="top"
+    triggertype="custom"
   >
-    Sync Matterport Tags
+    <div>
+      <div
+        data-mocked="StatusIndicator"
+        type="success"
+      >
+        Tags sync successful
+      </div>
+    </div>
+    <div
+      data-mocked="Button"
+      data-testid="matterport-tag-sync-button"
+    >
+      Sync Matterport Tags
+    </div>
   </div>
 </div>
 `;

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -147,6 +147,10 @@
     "note": "Input field label",
     "text": "Expression"
   },
+  "80grlm": {
+    "note": "Status indicator label",
+    "text": "Tags sync successful"
+  },
   "89bwEi": {
     "note": "Environment presets drop down menu options",
     "text": "Chromatic"


### PR DESCRIPTION
## Overview
Corrected the sync tags logic to handle v1 and v2 of Matterport tags. Also, added a status indicator on sync success.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
