### PR TITLE
fix(composer): gate empty overlay section in inspector

### DIFF
--- a/packages/scene-composer/src/components/panels/AddOrRemoveOverlayButton.tsx
+++ b/packages/scene-composer/src/components/panels/AddOrRemoveOverlayButton.tsx
@@ -3,11 +3,10 @@ import React, { useCallback, useContext } from 'react';
 import { useIntl } from 'react-intl';
 import { Box, Button } from '@awsui/components-react';
 
-import { COMPOSER_FEATURES, KnownComponentType } from '../../interfaces';
+import { KnownComponentType } from '../../interfaces';
 import { IDataOverlayComponentInternal, useStore } from '../../store';
 import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
 import { findComponentByType } from '../../utils/nodeUtils';
-import { getGlobalSettings } from '../../common/GlobalSettings';
 import { Component } from '../../models/SceneModels';
 
 export const AddOrRemoveOverlayButton: React.FC = () => {
@@ -16,7 +15,6 @@ export const AddOrRemoveOverlayButton: React.FC = () => {
   const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
   const addComponentInternal = useStore(sceneComposerId)((state) => state.addComponentInternal);
   const removeComponent = useStore(sceneComposerId)((state) => state.removeComponent);
-  const overlayEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Overlay];
   const selectedSceneNode = getSceneNodeByRef(selectedSceneNodeRef);
   const intl = useIntl();
 
@@ -51,7 +49,7 @@ export const AddOrRemoveOverlayButton: React.FC = () => {
   }, [selectedSceneNodeRef, isOverlayComponent, selectedSceneNode]);
 
   return (
-    (overlayEnabled && isTagComponent && (
+    (isTagComponent && (
       <div style={{ overflow: 'auto' }}>
         <Box margin={{ top: 'xs' }} float={isOverlayComponent ? 'right' : 'left'}>
           <Button onClick={onClick}>

--- a/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
@@ -32,6 +32,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
   const intl = useIntl();
 
   const subModelMovementEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.SubModelMovement];
+  const overlayEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Overlay];
 
   const i18nKnownComponentTypesStrings = defineMessages({
     [KnownComponentType.ModelRef]: {
@@ -141,7 +142,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
 
         {/* If the component is a Tag and there is no overlay component in the selected node, then an empty
           overlay sections is added. */}
-        {component.type === KnownComponentType.Tag && !isOverlayComponent && (
+        {overlayEnabled && component.type === KnownComponentType.Tag && !isOverlayComponent && (
           <ExpandableInfoSection
             withoutSpaceBetween
             key={KnownComponentType.DataOverlay + '_' + index}

--- a/packages/scene-composer/src/components/panels/__tests__/AddOrRemoveOverlayButton.spec.tsx
+++ b/packages/scene-composer/src/components/panels/__tests__/AddOrRemoveOverlayButton.spec.tsx
@@ -3,8 +3,7 @@ import { act, render } from '@testing-library/react';
 
 import { AddOrRemoveOverlayButton } from '../AddOrRemoveOverlayButton';
 import { useStore } from '../../../store';
-import { setFeatureConfig } from '../../../common/GlobalSettings';
-import { COMPOSER_FEATURES, KnownComponentType } from '../../../interfaces';
+import { KnownComponentType } from '../../../interfaces';
 import { Component } from '../../../models/SceneModels';
 
 jest.mock('@awsui/components-react', () => ({
@@ -17,7 +16,6 @@ describe('AddOrRemoveOverlayButton', () => {
   const removeComponent = jest.fn();
 
   beforeEach(() => {
-    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
     useStore('default').setState({
       selectedSceneNodeRef: 'selected',
       getSceneNodeByRef,


### PR DESCRIPTION
## Overview
Merge https://github.com/awslabs/iot-app-kit/pull/914 into main for gating empty overlay section in inspector panel instead of add/remove overlay button to not showing the empty section when overlay is not on.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
