### PR TITLE
fix(composer): Set environment preset (lighting) to neutral on scene …

### DIFF
--- a/packages/scene-composer/src/components/panels/SettingsPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SettingsPanel.tsx
@@ -6,7 +6,13 @@ import useLifecycleLogging from '../../logger/react-logger/hooks/useLifecycleLog
 import { presets } from '../three-fiber/Environment';
 import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
 import { useStore } from '../../store';
-import { COMPOSER_FEATURES, IValueDataBindingProvider, KnownComponentType, KnownSceneProperty } from '../../interfaces';
+import {
+  COMPOSER_FEATURES,
+  EnvironmentPreset,
+  IValueDataBindingProvider,
+  KnownComponentType,
+  KnownSceneProperty,
+} from '../../interfaces';
 import { pascalCase } from '../../utils/stringUtils';
 import { getGlobalSettings } from '../../common/GlobalSettings';
 import { Component } from '../../models/SceneModels';
@@ -19,8 +25,6 @@ import { OverlayPanelVisibilityToggle } from './scene-settings/OverlayPanelVisib
 export interface SettingsPanelProps {
   valueDataBindingProvider?: IValueDataBindingProvider;
 }
-
-const NO_PRESET_VALUE = 'n/a';
 
 export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingProvider }) => {
   const log = useLifecycleLogging('SettingsPanel');
@@ -40,7 +44,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
   log?.verbose('Selected environment preset', selectedEnvPreset);
 
   const i18nPresetsStrings = defineMessages({
-    'No Preset': {
+    noPreset: {
       defaultMessage: 'No Preset',
       description: 'Environment presets drop down menu options',
     },
@@ -78,18 +82,23 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
   });
 
   const presetOptions = [
-    { label: intl.formatMessage(i18nPresetsStrings['No Preset']), value: NO_PRESET_VALUE },
     ...Object.keys(presets).map((preset) => ({
       label: intl.formatMessage(i18nPresetsStrings[preset]) || pascalCase(preset),
-      value: preset,
+      value: preset !== EnvironmentPreset.noPreset ? preset : '',
     })),
   ];
-  const selectedOption = selectedEnvPreset
+
+  const isNoPreset = selectedEnvPreset === '' || selectedEnvPreset === undefined;
+
+  const selectedOption = !isNoPreset
     ? {
         label: intl.formatMessage(i18nPresetsStrings[selectedEnvPreset]) || pascalCase(selectedEnvPreset),
         value: selectedEnvPreset,
       }
-    : null;
+    : {
+        label: intl.formatMessage(i18nPresetsStrings.noPreset),
+        value: '',
+      };
 
   return (
     <Fragment>
@@ -134,8 +143,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
               <Select
                 selectedOption={selectedOption}
                 onChange={(e) => {
-                  if (e.detail.selectedOption.value === NO_PRESET_VALUE) {
-                    setSceneProperty(KnownSceneProperty.EnvironmentPreset, undefined);
+                  if (e.detail.selectedOption.value === EnvironmentPreset.noPreset) {
+                    setSceneProperty(KnownSceneProperty.EnvironmentPreset, '');
                   } else {
                     setSceneProperty(KnownSceneProperty.EnvironmentPreset, e.detail.selectedOption.value);
                   }

--- a/packages/scene-composer/src/components/panels/__tests__/__snapshots__/SettingsPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__tests__/__snapshots__/SettingsPanel.spec.tsx.snap
@@ -48,7 +48,7 @@ exports[`SettingsPanel contains expected elements. should contains default eleme
       >
         <div
           data-mocked="Select"
-          options="[{\\"label\\":\\"No Preset\\",\\"value\\":\\"n/a\\"},{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"},{\\"label\\":\\"Directional\\",\\"value\\":\\"directional\\"},{\\"label\\":\\"Chromatic\\",\\"value\\":\\"chromatic\\"}]"
+          options="[{\\"label\\":\\"No Preset\\",\\"value\\":\\"\\"},{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"},{\\"label\\":\\"Directional\\",\\"value\\":\\"directional\\"},{\\"label\\":\\"Chromatic\\",\\"value\\":\\"chromatic\\"}]"
           placeholder="Choose an environment"
           selectedarialabel="Selected"
           selectedoption="{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"}"
@@ -181,7 +181,7 @@ exports[`SettingsPanel contains expected elements. should contains settings elem
       >
         <div
           data-mocked="Select"
-          options="[{\\"label\\":\\"No Preset\\",\\"value\\":\\"n/a\\"},{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"},{\\"label\\":\\"Directional\\",\\"value\\":\\"directional\\"},{\\"label\\":\\"Chromatic\\",\\"value\\":\\"chromatic\\"}]"
+          options="[{\\"label\\":\\"No Preset\\",\\"value\\":\\"\\"},{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"},{\\"label\\":\\"Directional\\",\\"value\\":\\"directional\\"},{\\"label\\":\\"Chromatic\\",\\"value\\":\\"chromatic\\"}]"
           placeholder="Choose an environment"
           selectedarialabel="Selected"
           selectedoption="{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"}"

--- a/packages/scene-composer/src/components/three-fiber/Environment.tsx
+++ b/packages/scene-composer/src/components/three-fiber/Environment.tsx
@@ -6,10 +6,18 @@ import NuetralHDR from '../../assets/hdri/Neutral_sm.hdr';
 import DirectionalHDR from '../../assets/hdri/Directional_sm.hdr';
 import ChromaticHDR from '../../assets/hdri/Chromatic_sm.hdr';
 
-export const presets = {
-  neutral: NuetralHDR as string,
-  directional: DirectionalHDR as string,
-  chromatic: ChromaticHDR as string,
+type Presets = {
+  noPreset: string;
+  neutral: string;
+  directional: string;
+  chromatic: string;
+};
+
+export const presets: Presets = {
+  noPreset: '',
+  neutral: NuetralHDR,
+  directional: DirectionalHDR,
+  chromatic: ChromaticHDR,
 };
 
 interface EnvironmentProps {

--- a/packages/scene-composer/src/components/three-fiber/__snapshots__/Environment.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/__snapshots__/Environment.spec.tsx.snap
@@ -26,3 +26,12 @@ exports[`<Environment /> should render neutral preset correctly with DREI Enviro
   />
 </div>
 `;
+
+exports[`<Environment /> should render noPreset preset correctly with DREI Environment 1`] = `
+<div>
+  <div
+    data-mocked="Environment"
+    files=""
+  />
+</div>
+`;

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -72,6 +72,13 @@ export enum KnownSceneProperty {
   MatterportModelId = 'matterportModelId',
 }
 
+export enum EnvironmentPreset {
+  noPreset = 'noPreset',
+  neutral = 'neutral',
+  directional = 'directional',
+  chromatic = 'chromatic',
+}
+
 /************************************************
  * Scene Composer Control APIs
  ************************************************/

--- a/packages/scene-composer/src/store/slices/SceneDocumentSlice.spec.ts
+++ b/packages/scene-composer/src/store/slices/SceneDocumentSlice.spec.ts
@@ -28,7 +28,9 @@ describe('createSceneDocumentSlice', () => {
     unit: 'meter',
     version: '1',
     specVersion: undefined,
-    properties: {},
+    properties: {
+      environmentPreset: 'neutral',
+    },
   };
 
   beforeEach(() => {

--- a/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
+++ b/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
@@ -71,7 +71,9 @@ function createEmptyDocumentState(): ISceneDocumentInternal {
     unit: 'meter',
     version: '1',
     specVersion: undefined,
-    properties: {},
+    properties: {
+      environmentPreset: 'neutral',
+    },
   };
 }
 


### PR DESCRIPTION
## Overview

- Sets the `Environment Preset` to `neutral` when initializing a scene for the first time. 
- Implements accessibility fix for Environment Preset settings. 
- Removes assignment of `undefined`.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
