### PR TITLE
fix(dashboard): update property name for tables when displaying alarms

### DIFF
--- a/packages/dashboard/src/components/resourceExplorer/components/mapper.spec.ts
+++ b/packages/dashboard/src/components/resourceExplorer/components/mapper.spec.ts
@@ -66,7 +66,7 @@ it('can map an asset description to asset summary', () => {
         properties: [
           {
             propertyId: 'e70495ff-c016-4175-9012-62c37857e0d1',
-            name: 'AWS/ALARM_STATE',
+            name: 'windSpeedAlarm',
             unit: undefined,
             alias: undefined,
             dataType: 'STRUCT',

--- a/packages/dashboard/src/components/resourceExplorer/components/mapper.ts
+++ b/packages/dashboard/src/components/resourceExplorer/components/mapper.ts
@@ -36,7 +36,11 @@ const mapPropertySummary = ({ id, name, unit, dataType, alias }: AssetProperty):
 const mapCompositeModelToAlarmSummary = (model: AssetCompositeModel): AlarmSummary => ({
   name: model.name,
   id: model?.id,
-  properties: model.properties?.filter(isAlarmState).map(mapPropertySummary) ?? [],
+  properties:
+    model.properties
+      ?.filter(isAlarmState)
+      .map(({ id, unit, dataType, alias }) => mapPropertySummary({ id, unit, dataType, alias, name: model.name })) ??
+    [],
 });
 
 export const mapAssetDescriptionToAssetSummary = (description: DescribeAssetResponse): AssetSummary => ({


### PR DESCRIPTION
## Overview
Bugfix for table widget to display alarm name instead of alarm state property name.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
