### PR TITLE
fix(Composer): Handle click event

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
@@ -178,8 +178,6 @@ export function AsyncLoadedAnchorWidget({
               ],
             });
           }
-
-          event.stopPropagation();
         }
       }
     },

--- a/packages/scene-composer/src/components/three-fiber/EntityGroup/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EntityGroup/index.tsx
@@ -80,7 +80,7 @@ const EntityGroup = ({ node }: IEntityGroupProps) => {
     useEditorState(sceneComposerId);
   const { addNodeError } = useNodeErrorState(sceneComposerId);
 
-  const onPointerUp = useCallback(
+  const onClick = useCallback(
     (e) => {
       e.stopPropagation(); // the most nested object in the click scope should get selected, and not bubble up to the parent.
 
@@ -150,7 +150,7 @@ const EntityGroup = ({ node }: IEntityGroupProps) => {
         rotation={new Euler(...rotation, 'XYZ')}
         scale={scale}
         dispose={null}
-        onPointerUp={onPointerUp}
+        onClick={onClick}
         onPointerEnter={onPointerEnter}
         onPointerLeave={onPointerLeave}
         userData={{ nodeRef: !isEnvironmentNode(node) ? nodeRef : undefined, componentTypes }} // Do not add ref for environment nodes


### PR DESCRIPTION
## Overview
Handle the click event correctly to make sure both regular and matterport scene works fine

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
