### PR TITLE
fix(Composer): Close button inline style in overlay

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement, useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { Button } from '@awsui/components-react';
 
 import { IDataOverlayComponentInternal, ISceneNodeInternal } from '../../../store/internalInterfaces';
 import { Component } from '../../../models/SceneModels';
@@ -14,6 +13,7 @@ import {
   tmArrowInner,
   tmArrowOuter,
   tmCloseButton,
+  tmCloseButtonDiv,
   tmContainer,
   tmPanelContainer,
 } from './styles';
@@ -79,8 +79,10 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
         style={{ ...tmContainer, ...(isAnnotation ? tmAnnotationContainer : tmPanelContainer) }}
       >
         {!isAnnotation && !componentVisible && (
-          <div style={tmCloseButton}>
-            <Button iconName='close' variant='icon' iconAlign='right' onClick={onClickCloseButton} />
+          <div style={tmCloseButtonDiv}>
+            <button style={tmCloseButton} onClick={onClickCloseButton}>
+              X
+            </button>
           </div>
         )}
         <DataOverlayRows component={component} />

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
@@ -50,12 +50,11 @@ exports[`DataOverlayContainer should render with panel visible correctly when th
     <div
       style="float: right; margin-top: 8px; margin-right: 8px;"
     >
-      <div
-        data-mocked="Button"
-        iconalign="right"
-        iconname="close"
-        variant="icon"
-      />
+      <button
+        style="background-color: transparent; border-color: transparent; color: white;"
+      >
+        X
+      </button>
     </div>
     <div
       data-testid="rows"

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.ts
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.ts
@@ -30,10 +30,15 @@ export const tmAnnotationContainer: CSSProperties = {
   paddingLeft: '12px',
   paddingRight: '12px',
 };
-export const tmCloseButton: CSSProperties = {
+export const tmCloseButtonDiv: CSSProperties = {
   float: 'right',
   marginTop: '8px',
   marginRight: '8px',
+};
+export const tmCloseButton: CSSProperties = {
+  backgroundColor: 'transparent',
+  borderColor: 'transparent',
+  color: 'white',
 };
 
 // Overlay panel arrow


### PR DESCRIPTION
## Overview
Close button inline style for data overlay

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
