### PR TITLE
fix(Composer): Position data overlay over tag & model id undo/redo

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
@@ -3,7 +3,8 @@ import { Html } from '@react-three/drei';
 
 import { ISceneNodeInternal } from '../../../store';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
-import { IDataOverlayComponentInternal } from '../../../store/internalInterfaces';
+import { IAnchorComponentInternal, IDataOverlayComponentInternal } from '../../../store/internalInterfaces';
+import { KnownComponentType } from '../../../interfaces';
 
 import { DataOverlayContainer } from './DataOverlayContainer';
 
@@ -15,12 +16,21 @@ export interface DataOverlayComponentProps {
 export const DataOverlayComponent = ({ node, component }: DataOverlayComponentProps): ReactElement => {
   const sceneComposerId = useContext(sceneComposerIdContext);
 
+  const getOffsetFromTag = () => {
+    const tagComponent: IAnchorComponentInternal | undefined = node.components.find(
+      (elem) => elem.type === KnownComponentType.Tag,
+    );
+    if (tagComponent) {
+      return tagComponent.offset;
+    }
+  };
+
   return (
     <group>
       <Html
         className='tm-html-wrapper'
         // TODO: add position after finding proper way to always display overlay right above tag
-        // position={position}
+        position={getOffsetFromTag()}
         style={{
           transform: 'translate3d(-50%,-100%,0)', // make the center of 3D transform the middle of bottom edge
         }}


### PR DESCRIPTION
## Overview
- Position data overlay over tag
- Handle undo/redo of Matterport Model Id

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
