### PR TITLE
fix(composer): Restores loading indicator for scene-composer

### DIFF
--- a/packages/scene-composer/src/components/Tree/tree.scss
+++ b/packages/scene-composer/src/components/Tree/tree.scss
@@ -15,7 +15,6 @@ $active-color: #ec7211;
   background: $active-bg;
 }
 @mixin selected-action {
-  @include selected;
   background: $active-bg-gradient;
   margin-top: -1px;
   margin-bottom: -1px;

--- a/packages/scene-composer/src/components/__snapshots__/SceneComposerInternal.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/SceneComposerInternal.spec.tsx.snap
@@ -20,22 +20,22 @@ exports[`SceneComposerInternal should render a default error view when loading a
           isViewing={false}
         />
         <Unknown>
-          <React.Suspense
-            fallback={
-              <Provider>
-                <LoadingProgress />
-              </Provider>
-            }
+          <R3FWrapper
+            enableMatterport={false}
+            sceneLoaded={true}
           >
-            <R3FWrapper
-              enableMatterport={false}
-              sceneLoaded={true}
+            <React.Suspense
+              fallback={
+                <Provider>
+                  <LoadingProgress />
+                </Provider>
+              }
             >
               <React.Fragment>
                 <WebGLCanvasManager />
               </React.Fragment>
-            </R3FWrapper>
-          </React.Suspense>
+            </React.Suspense>
+          </R3FWrapper>
         </Unknown>
       </LogProvider>
     </React.Fragment>
@@ -95,22 +95,22 @@ exports[`SceneComposerInternal should render both valid and invalid scene correc
             isViewing={false}
           />
           <Unknown>
-            <React.Suspense
-              fallback={
-                <Provider>
-                  <LoadingProgress />
-                </Provider>
-              }
+            <R3FWrapper
+              enableMatterport={false}
+              sceneLoaded={true}
             >
-              <R3FWrapper
-                enableMatterport={false}
-                sceneLoaded={true}
+              <React.Suspense
+                fallback={
+                  <Provider>
+                    <LoadingProgress />
+                  </Provider>
+                }
               >
                 <React.Fragment>
                   <WebGLCanvasManager />
                 </React.Fragment>
-              </R3FWrapper>
-            </React.Suspense>
+              </React.Suspense>
+            </R3FWrapper>
           </Unknown>
         </LogProvider>
       </React.Fragment>
@@ -143,22 +143,22 @@ exports[`SceneComposerInternal should render both valid and invalid scene correc
             isViewing={false}
           />
           <Unknown>
-            <React.Suspense
-              fallback={
-                <Provider>
-                  <LoadingProgress />
-                </Provider>
-              }
+            <R3FWrapper
+              enableMatterport={false}
+              sceneLoaded={true}
             >
-              <R3FWrapper
-                enableMatterport={false}
-                sceneLoaded={true}
+              <React.Suspense
+                fallback={
+                  <Provider>
+                    <LoadingProgress />
+                  </Provider>
+                }
               >
                 <React.Fragment>
                   <WebGLCanvasManager />
                 </React.Fragment>
-              </R3FWrapper>
-            </React.Suspense>
+              </React.Suspense>
+            </R3FWrapper>
           </Unknown>
         </LogProvider>
       </React.Fragment>
@@ -195,22 +195,22 @@ exports[`SceneComposerInternal should render correctly with a valid scene in edi
           isViewing={false}
         />
         <Unknown>
-          <React.Suspense
-            fallback={
-              <Provider>
-                <LoadingProgress />
-              </Provider>
-            }
+          <R3FWrapper
+            enableMatterport={false}
+            sceneLoaded={true}
           >
-            <R3FWrapper
-              enableMatterport={false}
-              sceneLoaded={true}
+            <React.Suspense
+              fallback={
+                <Provider>
+                  <LoadingProgress />
+                </Provider>
+              }
             >
               <React.Fragment>
                 <WebGLCanvasManager />
               </React.Fragment>
-            </R3FWrapper>
-          </React.Suspense>
+            </React.Suspense>
+          </R3FWrapper>
         </Unknown>
       </LogProvider>
     </React.Fragment>
@@ -246,17 +246,17 @@ exports[`SceneComposerInternal should render correctly with an empty scene in ed
           isViewing={false}
         />
         <Unknown>
-          <React.Suspense
-            fallback={
-              <Provider>
-                <LoadingProgress />
-              </Provider>
-            }
+          <R3FWrapper
+            enableMatterport={false}
           >
-            <R3FWrapper
-              enableMatterport={false}
+            <React.Suspense
+              fallback={
+                <Provider>
+                  <LoadingProgress />
+                </Provider>
+              }
             />
-          </React.Suspense>
+          </R3FWrapper>
         </Unknown>
       </LogProvider>
     </React.Fragment>
@@ -291,17 +291,17 @@ exports[`SceneComposerInternal should render correctly with an empty scene in vi
           isViewing={true}
         />
         <Unknown>
-          <React.Suspense
-            fallback={
-              <Provider>
-                <LoadingProgress />
-              </Provider>
-            }
+          <R3FWrapper
+            enableMatterport={false}
           >
-            <R3FWrapper
-              enableMatterport={false}
+            <React.Suspense
+              fallback={
+                <Provider>
+                  <LoadingProgress />
+                </Provider>
+              }
             />
-          </React.Suspense>
+          </R3FWrapper>
         </Unknown>
       </LogProvider>
     </React.Fragment>
@@ -333,22 +333,22 @@ exports[`SceneComposerInternal should render error when major version is newer 1
           isViewing={false}
         />
         <Unknown>
-          <React.Suspense
-            fallback={
-              <Provider>
-                <LoadingProgress />
-              </Provider>
-            }
+          <R3FWrapper
+            enableMatterport={false}
+            sceneLoaded={true}
           >
-            <R3FWrapper
-              enableMatterport={false}
-              sceneLoaded={true}
+            <React.Suspense
+              fallback={
+                <Provider>
+                  <LoadingProgress />
+                </Provider>
+              }
             >
               <React.Fragment>
                 <WebGLCanvasManager />
               </React.Fragment>
-            </R3FWrapper>
-          </React.Suspense>
+            </React.Suspense>
+          </R3FWrapper>
         </Unknown>
       </LogProvider>
     </React.Fragment>
@@ -384,22 +384,22 @@ exports[`SceneComposerInternal should render error when specVersion is invalid 1
           isViewing={false}
         />
         <Unknown>
-          <React.Suspense
-            fallback={
-              <Provider>
-                <LoadingProgress />
-              </Provider>
-            }
+          <R3FWrapper
+            enableMatterport={false}
+            sceneLoaded={true}
           >
-            <R3FWrapper
-              enableMatterport={false}
-              sceneLoaded={true}
+            <React.Suspense
+              fallback={
+                <Provider>
+                  <LoadingProgress />
+                </Provider>
+              }
             >
               <React.Fragment>
                 <WebGLCanvasManager />
               </React.Fragment>
-            </R3FWrapper>
-          </React.Suspense>
+            </React.Suspense>
+          </R3FWrapper>
         </Unknown>
       </LogProvider>
     </React.Fragment>
@@ -435,22 +435,22 @@ exports[`SceneComposerInternal should render warning when minor version is newer
           isViewing={false}
         />
         <Unknown>
-          <React.Suspense
-            fallback={
-              <Provider>
-                <LoadingProgress />
-              </Provider>
-            }
+          <R3FWrapper
+            enableMatterport={false}
+            sceneLoaded={true}
           >
-            <R3FWrapper
-              enableMatterport={false}
-              sceneLoaded={true}
+            <React.Suspense
+              fallback={
+                <Provider>
+                  <LoadingProgress />
+                </Provider>
+              }
             >
               <React.Fragment>
                 <WebGLCanvasManager />
               </React.Fragment>
-            </R3FWrapper>
-          </React.Suspense>
+            </React.Suspense>
+          </R3FWrapper>
         </Unknown>
       </LogProvider>
     </React.Fragment>
@@ -487,22 +487,22 @@ exports[`SceneComposerInternal should support rendering multiple valid scenes 1`
             isViewing={false}
           />
           <Unknown>
-            <React.Suspense
-              fallback={
-                <Provider>
-                  <LoadingProgress />
-                </Provider>
-              }
+            <R3FWrapper
+              enableMatterport={false}
+              sceneLoaded={true}
             >
-              <R3FWrapper
-                enableMatterport={false}
-                sceneLoaded={true}
+              <React.Suspense
+                fallback={
+                  <Provider>
+                    <LoadingProgress />
+                  </Provider>
+                }
               >
                 <React.Fragment>
                   <WebGLCanvasManager />
                 </React.Fragment>
-              </R3FWrapper>
-            </React.Suspense>
+              </React.Suspense>
+            </R3FWrapper>
           </Unknown>
         </LogProvider>
       </React.Fragment>
@@ -535,22 +535,22 @@ exports[`SceneComposerInternal should support rendering multiple valid scenes 1`
             isViewing={false}
           />
           <Unknown>
-            <React.Suspense
-              fallback={
-                <Provider>
-                  <LoadingProgress />
-                </Provider>
-              }
+            <R3FWrapper
+              enableMatterport={false}
+              sceneLoaded={true}
             >
-              <R3FWrapper
-                enableMatterport={false}
-                sceneLoaded={true}
+              <React.Suspense
+                fallback={
+                  <Provider>
+                    <LoadingProgress />
+                  </Provider>
+                }
               >
                 <React.Fragment>
                   <WebGLCanvasManager />
                 </React.Fragment>
-              </R3FWrapper>
-            </React.Suspense>
+              </React.Suspense>
+            </R3FWrapper>
           </Unknown>
         </LogProvider>
       </React.Fragment>

--- a/packages/scene-composer/src/components/panels/TopBar.tsx
+++ b/packages/scene-composer/src/components/panels/TopBar.tsx
@@ -3,13 +3,12 @@ import styled from 'styled-components';
 import { ButtonDropdown, SpaceBetween } from '@awsui/components-react';
 import { useIntl } from 'react-intl';
 
-import { KnownComponentType } from '../../interfaces';
+import { KnownComponentType, KnownSceneProperty } from '../../interfaces';
 import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
-import { ICameraComponentInternal, useStore } from '../../store';
+import { ICameraComponentInternal, useStore, useViewOptionState } from '../../store';
 import useActiveCamera from '../../hooks/useActiveCamera';
 import { findComponentByType } from '../../utils/nodeUtils';
 import { getCameraSettings } from '../../utils/cameraUtils';
-import { getMatterportSdk } from '../../common/GlobalSettings';
 
 // TODO: SpaceBetween is not intended to have custom styles, we should refactor this to use our own spacing component
 // if these styles are really needed.
@@ -24,7 +23,9 @@ export const TopBar: FC = () => {
   const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
   const getObject3DBySceneNodeRef = useStore(sceneComposerId)((state) => state.getObject3DBySceneNodeRef);
   const { setActiveCameraSettings } = useActiveCamera();
-  const matterportSdk = getMatterportSdk(sceneComposerId);
+  const matterportModelId = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty(KnownSceneProperty.MatterportModelId),
+  );
   const intl = useIntl();
 
   const cameraItems = useMemo(() => {
@@ -40,7 +41,7 @@ export const TopBar: FC = () => {
       });
   }, [nodeMap]);
 
-  const hasCameraView = cameraItems.length > 0 && !matterportSdk;
+  const hasCameraView = cameraItems.length > 0 && matterportModelId === undefined;
   const showTopBar = hasCameraView;
 
   const setActiveCameraOnItemClick = useCallback(

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -13,14 +13,21 @@ import {
   IModelRefComponent,
   IMotionIndicatorComponent,
   KnownComponentType,
+  KnownSceneProperty,
 } from '../../../../interfaces';
 import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
 import { Component, LightType, ModelType } from '../../../../models/SceneModels';
-import { IColorOverlayComponentInternal, ISceneNodeInternal, useEditorState, useStore } from '../../../../store';
+import {
+  IColorOverlayComponentInternal,
+  ISceneNodeInternal,
+  useEditorState,
+  useStore,
+  useViewOptionState,
+} from '../../../../store';
 import { extractFileNameExtFromUrl, parseS3BucketFromArn } from '../../../../utils/pathUtils';
 import { ToolbarItem } from '../../common/ToolbarItem';
 import { ToolbarItemOptions } from '../../common/types';
-import { getGlobalSettings, getMatterportSdk } from '../../../../common/GlobalSettings';
+import { getGlobalSettings } from '../../../../common/GlobalSettings';
 import useActiveCamera from '../../../../hooks/useActiveCamera';
 import { createNodeWithTransform, findComponentByType, isEnvironmentNode } from '../../../../utils/nodeUtils';
 
@@ -85,8 +92,9 @@ export const AddObjectMenu = (): JSX.Element => {
   const enhancedEditingEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.ENHANCED_EDITING];
   const { formatMessage } = useIntl();
   const { activeCameraSettings, mainCameraObject } = useActiveCamera();
-  const matterportSdk = getMatterportSdk(sceneComposerId);
-
+  const matterportModelId = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty(KnownSceneProperty.MatterportModelId),
+  );
   const selectedSceneNode = useMemo(() => {
     return getSceneNodeByRef(selectedSceneNodeRef);
   }, [getSceneNodeByRef, selectedSceneNodeRef]);
@@ -139,7 +147,7 @@ export const AddObjectMenu = (): JSX.Element => {
         {
           uuid: ObjectTypes.ViewCamera,
           feature: { name: COMPOSER_FEATURES.CameraView },
-          isDisabled: matterportSdk !== undefined,
+          isDisabled: matterportModelId,
         },
         {
           uuid: ObjectTypes.Tag,
@@ -156,7 +164,13 @@ export const AddObjectMenu = (): JSX.Element => {
           uuid: ObjectTypes.MotionIndicator,
         },
       ].map(mapToMenuItem),
-    [showAssetBrowserCallback, sceneContainsEnvironmentModel, selectedSceneNodeRef, isEnvironmentNode, matterportSdk],
+    [
+      showAssetBrowserCallback,
+      sceneContainsEnvironmentModel,
+      selectedSceneNodeRef,
+      isEnvironmentNode,
+      matterportModelId,
+    ],
   );
 
   const getRefForParenting = useCallback(() => {

--- a/packages/scene-composer/src/hooks/useMatterportObserver.ts
+++ b/packages/scene-composer/src/hooks/useMatterportObserver.ts
@@ -10,7 +10,7 @@ const useMatterportObserver = (): {
   tagObserver: TagObserver;
 } => {
   const sceneComposerId = useSceneComposerId();
-  const matterportSdk = getMatterportSdk(sceneComposerId); //
+  const matterportSdk = getMatterportSdk(sceneComposerId);
 
   const [mattertagObserver] = useState<MattertagObserver>(new MattertagObserver());
   const [tagObserver] = useState<TagObserver>(new TagObserver());

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
@@ -47,52 +47,44 @@ const R3FWrapper = (props: {
   children?: any;
   sceneLoaded?: boolean;
 }) => {
+  const { children, sceneLoaded, enableMatterport, matterportConfig } = props;
   const sceneComposerId = useContext(sceneComposerIdContext);
   const ContextBridge = useContextBridge(LoggingContext, sceneComposerIdContext, ThemeContext);
+  const loadMatterPort = sceneLoaded && enableMatterport && matterportConfig?.modelId;
 
-  if (!props.sceneLoaded) {
-    return null;
-  }
-
-  if (props.enableMatterport && props.matterportConfig?.modelId) {
-    return (
-      <MatterportViewer
-        assetBase={props.matterportConfig?.assetBase}
-        m={props.matterportConfig?.modelId}
-        applicationKey={props.matterportConfig?.applicationKey}
-        connect-auth={props.matterportConfig?.accessToken}
-        connect-provider='iot-twinmaker'
-        onReady={(matterportSdk: MpSdk) => {
-          // propagate this out elsewhere if you wish to useMatterportSdk() interface
-          // to control this viewer from other non-3d ui
-          // <MpSdkContext.Provider value={matterportSdk}>
-          //  <Other2DComponents/>
-          // <MpSdkContext.Provider/>
-          console.log('MatterportViewer SDK ready!', matterportSdk);
-          setMatterportSdk(sceneComposerId, matterportSdk);
-        }}
-        style={{ width: '100%', height: '100%' }}
-        search={0}
-        title={0}
-        mt={0}
-        play={1}
-        mls={1}
-      >
-        <ContextBridge>
-          <Suspense fallback={null}>{props.children}</Suspense>
-        </ContextBridge>
-      </MatterportViewer>
-    );
-  } else {
-    setMatterportSdk(sceneComposerId, undefined);
-    return (
-      <UnselectableCanvas shadows dpr={window.devicePixelRatio}>
-        <ContextBridge>
-          <Suspense fallback={null}>{props.children}</Suspense>
-        </ContextBridge>
-      </UnselectableCanvas>
-    );
-  }
+  return loadMatterPort ? (
+    <MatterportViewer
+      assetBase={matterportConfig?.assetBase}
+      m={matterportConfig?.modelId}
+      applicationKey={matterportConfig?.applicationKey}
+      connect-auth={matterportConfig?.accessToken}
+      connect-provider='iot-twinmaker'
+      onReady={(matterportSdk: MpSdk) => {
+        // propagate this out elsewhere if you wish to useMatterportSdk() interface
+        // to control this viewer from other non-3d ui
+        // <MpSdkContext.Provider value={matterportSdk}>
+        //  <Other2DComponents/>
+        // <MpSdkContext.Provider/>
+        setMatterportSdk(sceneComposerId, matterportSdk);
+      }}
+      style={{ width: '100%', height: '100%' }}
+      search={0}
+      title={0}
+      mt={0}
+      play={1}
+      mls={1}
+    >
+      <ContextBridge>
+        <Suspense fallback={null}>{children}</Suspense>
+      </ContextBridge>
+    </MatterportViewer>
+  ) : (
+    <UnselectableCanvas shadows dpr={window.devicePixelRatio}>
+      <ContextBridge>
+        <Suspense fallback={null}>{children}</Suspense>
+      </ContextBridge>
+    </UnselectableCanvas>
+  );
 };
 
 interface SceneLayoutProps {
@@ -102,7 +94,6 @@ interface SceneLayoutProps {
   showMessageModal: boolean;
   externalLibraryConfig?: ExternalLibraryConfig;
 }
-
 const SceneLayout: FC<SceneLayoutProps> = ({
   isViewing,
   LoadingView = null,
@@ -110,7 +101,6 @@ const SceneLayout: FC<SceneLayoutProps> = ({
   externalLibraryConfig,
 }) => {
   const sceneComposerId = useContext(sceneComposerIdContext);
-
   const valueDataBindingProvider = useStore(sceneComposerId)((state) => state.getEditorConfig)()
     .valueDataBindingProvider;
   const ContextBridge = useContextBridge(LoggingContext, sceneComposerIdContext, ThemeContext);
@@ -162,24 +152,23 @@ const SceneLayout: FC<SceneLayoutProps> = ({
             <UnselectableCanvas shadows dpr={window.devicePixelRatio} onPointerMissed={onPointerMissed}>
             */}
             <ContextBridge>
-              <Suspense fallback={LoadingView}>
-                {shouldShowPreview && (
-                  <CameraPreviewTrack ref={renderDisplayRef} title={selectedNode.selectedSceneNode?.name} />
-                )}
-                <R3FWrapper
-                  enableMatterport={matterportFeature === 'T1' && !!externalLibraryConfig?.matterport?.modelId}
-                  sceneLoaded={sceneLoaded}
-                  matterportConfig={externalLibraryConfig?.matterport}
-                >
-                  {/* TODO: Add loading view */}
+              {shouldShowPreview && (
+                <CameraPreviewTrack ref={renderDisplayRef} title={selectedNode.selectedSceneNode?.name} />
+              )}
+              <R3FWrapper
+                enableMatterport={matterportFeature === 'T1' && !!externalLibraryConfig?.matterport?.modelId}
+                sceneLoaded={sceneLoaded}
+                matterportConfig={externalLibraryConfig?.matterport}
+              >
+                <Suspense fallback={LoadingView}>
                   {!sceneLoaded ? null : (
                     <Fragment>
                       <WebGLCanvasManager />
                       {shouldShowPreview && <CameraPreview track={renderDisplayRef} />}
                     </Fragment>
                   )}
-                </R3FWrapper>
-              </Suspense>
+                </Suspense>
+              </R3FWrapper>
             </ContextBridge>
           </LogProvider>
         </Fragment>

--- a/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
+++ b/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
@@ -1814,6 +1814,14 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
   background-color: colorBackgroundDropdownItemDefault;
 }
 
+.c19 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 0;
+}
+
 <div
   className="c0"
   data-mocked="Box"
@@ -2080,6 +2088,25 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
               </div>
             </div>
           </div>
+        </div>
+        <div
+          className="c19"
+          style={
+            Object {
+              "height": "100%",
+              "overflow": "hidden",
+              "position": "relative",
+              "width": "100%",
+            }
+          }
+        >
+          <canvas
+            style={
+              Object {
+                "display": "block",
+              }
+            }
+          />
         </div>
       </div>
     </div>
@@ -2424,6 +2451,14 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
   background-color: colorBackgroundDropdownItemDefault;
 }
 
+.c21 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 0;
+}
+
 <div
   className="c0"
   data-mocked="Box"
@@ -2730,6 +2765,25 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
               </div>
             </div>
           </div>
+        </div>
+        <div
+          className="c21"
+          style={
+            Object {
+              "height": "100%",
+              "overflow": "hidden",
+              "position": "relative",
+              "width": "100%",
+            }
+          }
+        >
+          <canvas
+            style={
+              Object {
+                "display": "block",
+              }
+            }
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Overview
Bug fix to restore loading indicator in scene composer. 

Additionally included minor fix to remove double-border appearing on action icons in the Scene Hierarchy panel. 

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
