### PR TITLE
fix(composer): fix ViewCursorWidget for 3D Tiles

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/viewpoint/ViewCursorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/viewpoint/ViewCursorWidget.tsx
@@ -1,12 +1,17 @@
 import React, { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
-import { useFrame, useThree } from '@react-three/fiber';
-import { Mesh as THREEMesh, Object3D as THREEObject3D, Vector3 as THREEVector3 } from 'three';
+import { useFrame, useLoader, useThree } from '@react-three/fiber';
+import { Mesh as THREEMesh, Object3D as THREEObject3D, Vector3 as THREEVector3, Vector3 } from 'three';
+import { SVGLoader } from 'three-stdlib';
+import { TilesGroup } from '3d-tiles-renderer';
 
-import { convertSvgToMesh } from '../../../../utils/svgUtils';
+import { convertSvgToMesh, getDataUri } from '../../../../utils/svgUtils';
 import { getIntersectionTransform } from '../../../../utils/raycastUtils';
 import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
 import { useEditorState } from '../../../../store';
 import { ViewCursorEditSvgString, ViewCursorMoveSvgString } from '../../../../assets/svgs';
+
+export const INIT_SVG_SCALE = 0.003;
+export const INIT_SVG_VECTOR = new Vector3(INIT_SVG_SCALE, INIT_SVG_SCALE, INIT_SVG_SCALE);
 
 export const ViewCursorWidget = () => {
   const ref = useRef<THREEObject3D>(null);
@@ -15,9 +20,7 @@ export const ViewCursorWidget = () => {
   const { addingWidget, cursorVisible, cursorStyle, setAddingWidget, setCursorVisible, setCursorStyle } =
     useEditorState(sceneComposerId);
   const svg = cursorStyle === 'edit' ? ViewCursorEditSvgString : ViewCursorMoveSvgString;
-  // TODO: fix loading view cursor SVG
-  // const data = useLoader(SVGLoader, getDataUri(svg));
-  const data = undefined;
+  const data = useLoader(SVGLoader, getDataUri(svg));
 
   const esc = useCallback(() => {
     window.addEventListener('keyup', (e: KeyboardEvent) => {
@@ -29,22 +32,40 @@ export const ViewCursorWidget = () => {
   }, [addingWidget]);
 
   const shape = useMemo(() => {
-    return convertSvgToMesh(data);
+    return convertSvgToMesh(data, INIT_SVG_SCALE);
   }, [data]);
 
   /* istanbul ignore next */
   useFrame(({ raycaster, scene }) => {
-    const sceneMeshes: THREEObject3D[] = [];
+    const sceneObjects: THREEObject3D[] = [];
     scene.traverse((child) => {
-      return shape.id !== child.id && (child as THREEMesh).isMesh && child.type !== 'TransformControlsPlane'
-        ? sceneMeshes.push(child as THREEMesh)
-        : null;
+      // Raycast is handled at the TilesGroup level
+      if ((child as TilesGroup).tilesRenderer) {
+        return sceneObjects.push(child as THREEObject3D);
+      }
+      const mesh = child as THREEMesh;
+      if (
+        shape.id !== mesh.id &&
+        mesh.isMesh &&
+        mesh.type !== 'TransformControlsPlane' &&
+        mesh.parent?.parent?.type !== 'TransformControlsGizmo' && // Don't include the gizmo objects
+        !(mesh.parent?.parent?.parent as TilesGroup)?.tilesRenderer // Don't include meshes in the 3D Tiles
+      ) {
+        return sceneObjects.push(mesh);
+      }
+      return null;
     });
-    const intersects = raycaster.intersectObjects(sceneMeshes, false);
+    // Calculate closest intersection
+    const intersects = raycaster.intersectObjects(sceneObjects, false);
     if (intersects.length) {
-      const n = getIntersectionTransform(intersects[0]);
+      // Intersections are sorted
+      const closestIntersection = intersects[0];
+      const n = getIntersectionTransform(closestIntersection);
       shape.lookAt(n.normal as THREEVector3);
       shape.position.copy(n.position);
+      // Set scale based on intersection distance
+      shape.scale.copy(INIT_SVG_VECTOR);
+      shape.scale.multiplyScalar(closestIntersection.distance);
     }
   });
 

--- a/packages/scene-composer/src/utils/svgUtils.spec.ts
+++ b/packages/scene-composer/src/utils/svgUtils.spec.ts
@@ -1,6 +1,6 @@
 import { useLoader } from '@react-three/fiber';
 import { SVGLoader } from 'three-stdlib';
-import { Group as THREEGroup, MeshBasicMaterial as THREEMeshBasicMaterial } from 'three';
+import { Group as THREEGroup, MeshBasicMaterial as THREEMeshBasicMaterial, Vector3 } from 'three';
 
 import { ViewCursorEditSvgString } from '../assets/svgs';
 
@@ -19,15 +19,17 @@ describe('svgUtils', () => {
   describe('createSvg', () => {
     it('creates a mesh to be a type of THREEGroup', () => {
       const data = useLoader(SVGLoader, getDataUri(ViewCursorEditSvgString));
-      const svgMesh = convertSvgToMesh(data);
+      const scaleMult = 2;
+      const svgMesh = convertSvgToMesh(data, scaleMult);
       expect(svgMesh).toBeInstanceOf(THREEGroup);
+      expect(svgMesh.scale).toStrictEqual(new Vector3(scaleMult, scaleMult, scaleMult));
     });
     it('should silently fail if passed an undefined', () => {
-      const svgMesh = convertSvgToMesh(undefined);
+      const svgMesh = convertSvgToMesh(undefined, 1);
       expect(svgMesh).toBeInstanceOf(THREEGroup);
     });
     it('should silently fail if passed a null', () => {
-      const svgMesh = convertSvgToMesh(null);
+      const svgMesh = convertSvgToMesh(null, 1);
       expect(svgMesh).toBeInstanceOf(THREEGroup);
     });
   });

--- a/packages/scene-composer/src/utils/svgUtils.ts
+++ b/packages/scene-composer/src/utils/svgUtils.ts
@@ -21,7 +21,7 @@ export const createMesh = (color, opacity) => {
   });
 };
 
-export const convertSvgToMesh = (data) => {
+export const convertSvgToMesh = (data, scaleMult) => {
   const svgGroup = new THREEGroup();
   /* istanbul ignore next */
   data?.paths?.forEach((path) => {
@@ -51,7 +51,7 @@ export const convertSvgToMesh = (data) => {
       });
     }
   });
-  svgGroup.scale.multiplyScalar(0.005);
+  svgGroup.scale.multiplyScalar(scaleMult);
   return svgGroup;
 };
 

--- a/packages/scene-composer/stories/components/hooks/useLoader.ts
+++ b/packages/scene-composer/stories/components/hooks/useLoader.ts
@@ -4,8 +4,8 @@ import { useCallback, useMemo } from 'react';
 import scenes from '../../scenes';
 
 const region = 'us-east-1';
-// const rociEndpoint = 'https://iottwinmaker.us-east-1.amazonaws.com';
-const rociEndpoint = 'https://gamma.us-east-1.twinmaker.iot.aws.dev';
+const rociEndpoint = 'https://iottwinmaker.us-east-1.amazonaws.com';
+// const rociEndpoint = 'https://gamma.us-east-1.twinmaker.iot.aws.dev';
 
 const useLoader = (source, scene, awsCredentials, workspaceId, sceneId) => {
   const getSceneObject = useCallback((uri: string) => {

--- a/packages/scene-composer/stories/components/hooks/useSceneMetadataModule.ts
+++ b/packages/scene-composer/stories/components/hooks/useSceneMetadataModule.ts
@@ -3,8 +3,8 @@ import { TwinMakerSceneMetadataModule, initialize } from '@iot-app-kit/source-io
 import { useMemo } from 'react';
 
 const region = 'us-east-1';
-// const rociEndpoint = 'https://iottwinmaker.us-east-1.amazonaws.com';
-const rociEndpoint = 'https://gamma.us-east-1.twinmaker.iot.aws.dev';
+const rociEndpoint = 'https://iottwinmaker.us-east-1.amazonaws.com';
+// const rociEndpoint = 'https://gamma.us-east-1.twinmaker.iot.aws.dev';
 
 interface SceneMetadataModuleProps {
   source: string;


### PR DESCRIPTION
fix ViewCursorWidget for 3D Tiles and made cursor size dynamic based on camera distance

## Overview
When a user wants to add a tag, motion indicator, or model to the scene with enhanced editing, the mouse becomes a cursor with a projected SVG to show where the widget/object will be placed in relation to the surface of another object. A raycast from the camera to the mouse is used to calculate the intersection distance, position, and orientation for an object in the scene.

For regular 3D models this works fine, but the raycast for 3D Tiles did not work. After investigating I found that the `raycast` method for the 3D Tiles meshes in the scene is not called from the mesh object but from the TilesGroup which is a parent of all meshes in the tileset.

Updated the logic for traversing the scene and calculating the intersection of rays to objects. The list of objects that will call `raycast` are just any TilesGroup node and any non-tileset and non-gizmo meshes.

The size of the projected SVG is a static size which is difficult to see for large objects and a camera that is far away. It is too small and looks like the feature is broken. With this change I update the SVG scale based on the distance of the closest intersection.

## Verifying Changes
Verified in storybook with 3D Tilesets I have in my personal AWS account.

1. Scene with small 3D Tiles object and regular gltf object
2. Scene with large (in scale to the scene) 3D Tiles object and regular gltf object
3. Scene with small gltf object:

https://user-images.githubusercontent.com/87385528/231552392-a69d3b85-36ae-4727-a64b-f2acc63dd235.mov

4. Scene with 3D Tiles:

https://user-images.githubusercontent.com/87385528/231552458-cb8c1ff7-1b1e-4a67-b10f-6ff079c1ea44.mov

Test:
1. Select to add a tag
2. Hover over 3D Tiles object and gltf object to see the cursor
6. Zoom in and out and pan with the camera to see the cursor remain a visible and somewhat consistent size
7. Click on the 3D Tiles to place the tag

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
