### PR TITLE
feat(dashboard): add initial view mode configuration to dashboard

### DIFF
--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -27,3 +27,28 @@ it('renders', function () {
   expect(queryByText(/actions/i)).toBeInTheDocument();
   expect(queryByText(/time machine/i)).toBeInTheDocument();
 });
+
+it('renders in readonly initially', function () {
+  const { queryByText } = render(
+    <Dashboard
+      onSave={() => Promise.resolve()}
+      dashboardConfiguration={{
+        displaySettings: {
+          numColumns: 100,
+          numRows: 100,
+        },
+        widgets: [],
+        viewport: { duration: '5m' },
+      }}
+      clientConfiguration={{
+        iotEventsClient: createMockIoTEventsSDK(),
+        iotSiteWiseClient: createMockSiteWiseSDK(),
+      }}
+      initialViewMode='preview'
+    />
+  );
+
+  expect(queryByText(/component library/i)).not.toBeInTheDocument();
+  expect(queryByText(/actions/i)).toBeInTheDocument();
+  expect(queryByText(/time machine/i)).toBeInTheDocument();
+});

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -24,13 +24,20 @@ export type DashboardProperties = {
   onSave: DashboardSave;
   clientConfiguration: DashboardClientConfiguration;
   dashboardConfiguration: DashboardConfiguration;
+  initialViewMode?: 'preview' | 'edit';
 };
 
-const Dashboard: React.FC<DashboardProperties> = ({ onSave, clientConfiguration, dashboardConfiguration }) => {
+const Dashboard: React.FC<DashboardProperties> = ({
+  onSave,
+  clientConfiguration,
+  dashboardConfiguration,
+  initialViewMode,
+}) => {
+  const readOnly = initialViewMode && initialViewMode === 'preview';
   return (
     <ClientContext.Provider value={getClients(clientConfiguration)}>
       <QueryContext.Provider value={getQueries(clientConfiguration)}>
-        <Provider store={configureDashboardStore({ ...toDashboardState(dashboardConfiguration), readOnly: false })}>
+        <Provider store={configureDashboardStore({ ...toDashboardState(dashboardConfiguration), readOnly })}>
           <DndProvider
             backend={TouchBackend}
             options={{


### PR DESCRIPTION
## Overview
Adds a configuration property to Dashboard to pick which view mode is shown initially (edit / preview).

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
