### PR TITLE
fix(react-components): useTimeSeriesData hook works when number of queries changes

### DIFF
--- a/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.spec.ts
+++ b/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.spec.ts
@@ -34,6 +34,70 @@ it('provides time series data returned from query', () => {
   expect(current.dataStreams).toEqual(QUERY_RESPONSE[0].dataStreams);
 });
 
+it('returns time series data when the number of time series queries changes', () => {
+  const THRESHOLD_1: Threshold = { comparisonOperator: 'GT', value: 10, color: 'black' };
+  const THRESHOLD_2: Threshold = { comparisonOperator: 'GT', value: 100, color: 'black' };
+
+  const DATA_STREAM_1: DataStream = { refId: 'red', id: 'abc-1', data: [], resolution: 0, name: 'my-name' };
+  const DATA_STREAM_2: DataStream = { refId: 'red', id: 'abc-2', data: [], resolution: 0, name: 'my-name' };
+
+  const QUERY_1 = { dataStreams: [DATA_STREAM_1], viewport: { duration: '5m' }, thresholds: [THRESHOLD_1] };
+  const QUERY_2 = { dataStreams: [DATA_STREAM_2], viewport: { duration: '5m' }, thresholds: [THRESHOLD_2] };
+
+  const INITIAL_QUERIES = [mockTimeSeriesDataQuery([QUERY_1])];
+  const UPDATED_QUERIES = [mockTimeSeriesDataQuery([QUERY_1]), mockTimeSeriesDataQuery([QUERY_2])];
+
+  const VIEWPORT = { duration: '5m' };
+
+  const { result, rerender } = renderHook((queries) => useTimeSeriesData({ queries, viewport: VIEWPORT }), {
+    initialProps: INITIAL_QUERIES,
+  });
+
+  expect(result.current).toEqual({
+    dataStreams: [DATA_STREAM_1],
+    thresholds: [THRESHOLD_1],
+  });
+
+  rerender(UPDATED_QUERIES);
+
+  expect(result.current).toEqual({
+    dataStreams: [DATA_STREAM_1, DATA_STREAM_2],
+    thresholds: [THRESHOLD_1, THRESHOLD_2],
+  });
+});
+
+it('returns time series data when the number of queries within one time series query changes', () => {
+  const THRESHOLD_1: Threshold = { comparisonOperator: 'GT', value: 10, color: 'black' };
+  const THRESHOLD_2: Threshold = { comparisonOperator: 'GT', value: 100, color: 'black' };
+
+  const DATA_STREAM_1: DataStream = { refId: 'red', id: 'abc-1', data: [], resolution: 0, name: 'my-name' };
+  const DATA_STREAM_2: DataStream = { refId: 'red', id: 'abc-2', data: [], resolution: 0, name: 'my-name' };
+
+  const QUERY_1 = { dataStreams: [DATA_STREAM_1], viewport: { duration: '5m' }, thresholds: [THRESHOLD_1] };
+  const QUERY_2 = { dataStreams: [DATA_STREAM_2], viewport: { duration: '5m' }, thresholds: [THRESHOLD_2] };
+
+  const INITIAL_QUERIES = [mockTimeSeriesDataQuery([QUERY_1])];
+  const UPDATED_QUERIES = [mockTimeSeriesDataQuery([QUERY_1, QUERY_2])];
+
+  const VIEWPORT = { duration: '5m' };
+
+  const { result, rerender } = renderHook((queries) => useTimeSeriesData({ queries, viewport: VIEWPORT }), {
+    initialProps: INITIAL_QUERIES,
+  });
+
+  expect(result.current).toEqual({
+    dataStreams: [DATA_STREAM_1],
+    thresholds: [THRESHOLD_1],
+  });
+
+  rerender(UPDATED_QUERIES);
+
+  expect(result.current).toEqual({
+    dataStreams: [DATA_STREAM_1, DATA_STREAM_2],
+    thresholds: [THRESHOLD_1, THRESHOLD_2],
+  });
+});
+
 it('binds style settings color to the data stream color', () => {
   const DATA_STREAM: DataStream = { refId: 'red', id: 'abc', data: [], resolution: 0, name: 'my-name' };
   const TIME_SERIES_DATA: TimeSeriesData = {

--- a/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.ts
+++ b/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.ts
@@ -43,43 +43,42 @@ export const useTimeSeriesData = ({
   const prevViewport = useRef<undefined | Viewport>(undefined);
   const provider = useRef<undefined | ProviderWithViewport<TimeSeriesData[]>>(undefined);
 
-  useEffect(
-    () => {
-      const id = uuid();
-      provider.current = combineProviders(
-        queries.map((query) =>
-          query.build(id, {
-            viewport,
-            settings,
-          })
-        )
-      );
+  const queriesString = queries.map((query) => query.toQueryString()).join();
 
-      provider.current.subscribe({
-        next: (timeSeriesDataCollection: TimeSeriesData[]) => {
-          const timeSeriesData = combineTimeSeriesData(timeSeriesDataCollection, viewport);
+  useEffect(() => {
+    const id = uuid();
+    provider.current = combineProviders(
+      queries.map((query) =>
+        query.build(id, {
+          viewport,
+          settings,
+        })
+      )
+    );
 
-          setTimeSeriesData({
-            ...timeSeriesData,
-            viewport,
-          });
-        },
-      });
+    provider.current.subscribe({
+      next: (timeSeriesDataCollection: TimeSeriesData[]) => {
+        const timeSeriesData = combineTimeSeriesData(timeSeriesDataCollection, viewport);
 
-      return () => {
-        // provider subscribe is asynchronous and will not be complete until the next frame stack, so we
-        // defer the unsubscription to ensure that the subscription is always complete before unsubscribed.
-        setTimeout(() => {
-          if (provider.current) {
-            provider.current.unsubscribe();
-          }
-          provider.current = undefined;
-          prevViewport.current = undefined;
+        setTimeSeriesData({
+          ...timeSeriesData,
+          viewport,
         });
-      };
-    },
-    queries.map((query) => query.toQueryString())
-  );
+      },
+    });
+
+    return () => {
+      // provider subscribe is asynchronous and will not be complete until the next frame stack, so we
+      // defer the unsubscription to ensure that the subscription is always complete before unsubscribed.
+      setTimeout(() => {
+        if (provider.current) {
+          provider.current.unsubscribe();
+        }
+        provider.current = undefined;
+        prevViewport.current = undefined;
+      });
+    };
+  }, [queriesString]);
 
   useEffect(() => {
     if (prevViewport.current != null) {


### PR DESCRIPTION
## Overview
React error was happening when the number of queries passed into useEffect changed
`The final argument passed to useEffect changed size between renders. The order and size of this array must remain constant.`

Now useEffect will check against a concatenated string of all the queries so it will always have a length of 1

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
