### PR TITLE
fix(dashboard): ensure auto size grid recalculates any time cellSize changes from outside component

### DIFF
--- a/packages/dashboard/src/components/grid/autoCellSize.tsx
+++ b/packages/dashboard/src/components/grid/autoCellSize.tsx
@@ -6,18 +6,27 @@ import { onChangeDashboardCellSizeAction } from '~/store/actions';
 
 export type AutoCellSizeProps = {
   width: number;
+  cellSize: number;
   children: React.ReactNode;
 };
-export const AutoCellSize: React.FC<AutoCellSizeProps> = ({ width, children }) => {
+export const AutoCellSize: React.FC<AutoCellSizeProps> = ({ width, cellSize, children }) => {
   const [measureRef, { width: measuredWidth }] = useMeasure<HTMLDivElement>();
 
   const dispatch = useDispatch();
 
   useEffect(() => {
     // Add one to the width to account for the grid padding
-    const cellSize = measuredWidth / (width + 1);
-    dispatch(onChangeDashboardCellSizeAction({ cellSize }));
-  }, [measuredWidth]);
+    const fittedCellSize = measuredWidth / (width + 1);
+
+    /**
+     * Ensures consistency between cellSize and fittedCellSize by acting as a safeguard.
+     * Proactively maintains the relationship between fittedCellSize and the measured width
+     * to desired width ratio, averting potential discrepancies caused by external cellSize changes.
+     */
+    if (cellSize !== fittedCellSize) {
+      dispatch(onChangeDashboardCellSizeAction({ cellSize: fittedCellSize }));
+    }
+  }, [measuredWidth, width, cellSize]);
 
   return <div ref={measureRef}>{children}</div>;
 };

--- a/packages/dashboard/src/components/grid/sizedGrid.tsx
+++ b/packages/dashboard/src/components/grid/sizedGrid.tsx
@@ -35,5 +35,5 @@ export const SizedGrid: React.FC<SizedGridProps> = ({
       children={children}
     />
   );
-  return stretchToFit ? <AutoCellSize width={width} children={gridComponent} /> : gridComponent;
+  return stretchToFit ? <AutoCellSize cellSize={cellSize} width={width} children={gridComponent} /> : gridComponent;
 };


### PR DESCRIPTION
## Overview
Make auto cell size recalculate whenever the width or cell size changes so that it stays in sync with changes outside of this component.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
