### PR TITLE
fix(composer): fix viewCursorWidget for 3D tiles and made cursor size dynamic

### DIFF
--- a/packages/scene-composer/src/utils/svgUtils.spec.ts
+++ b/packages/scene-composer/src/utils/svgUtils.spec.ts
@@ -1,6 +1,6 @@
 import { useLoader } from '@react-three/fiber';
 import { SVGLoader } from 'three-stdlib';
-import { Group as THREEGroup, MeshBasicMaterial as THREEMeshBasicMaterial } from 'three';
+import { Group as THREEGroup, MeshBasicMaterial as THREEMeshBasicMaterial, Vector3 } from 'three';
 
 import { ViewCursorEditSvgString } from '../assets/svgs';
 
@@ -19,15 +19,17 @@ describe('svgUtils', () => {
   describe('createSvg', () => {
     it('creates a mesh to be a type of THREEGroup', () => {
       const data = useLoader(SVGLoader, getDataUri(ViewCursorEditSvgString));
-      const svgMesh = convertSvgToMesh(data);
+      const scaleMult = 2;
+      const svgMesh = convertSvgToMesh(data, scaleMult);
       expect(svgMesh).toBeInstanceOf(THREEGroup);
+      expect(svgMesh.scale).toStrictEqual(new Vector3(scaleMult, scaleMult, scaleMult));
     });
     it('should silently fail if passed an undefined', () => {
-      const svgMesh = convertSvgToMesh(undefined);
+      const svgMesh = convertSvgToMesh(undefined, 1);
       expect(svgMesh).toBeInstanceOf(THREEGroup);
     });
     it('should silently fail if passed a null', () => {
-      const svgMesh = convertSvgToMesh(null);
+      const svgMesh = convertSvgToMesh(null, 1);
       expect(svgMesh).toBeInstanceOf(THREEGroup);
     });
   });

--- a/packages/scene-composer/src/utils/svgUtils.ts
+++ b/packages/scene-composer/src/utils/svgUtils.ts
@@ -21,7 +21,7 @@ export const createMesh = (color, opacity) => {
   });
 };
 
-export const convertSvgToMesh = (data) => {
+export const convertSvgToMesh = (data, scaleMult) => {
   const svgGroup = new THREEGroup();
   /* istanbul ignore next */
   data?.paths?.forEach((path) => {
@@ -51,7 +51,7 @@ export const convertSvgToMesh = (data) => {
       });
     }
   });
-  svgGroup.scale.multiplyScalar(0.005);
+  svgGroup.scale.multiplyScalar(scaleMult);
   return svgGroup;
 };
 

--- a/packages/scene-composer/stories/components/hooks/useSceneMetadataModule.ts
+++ b/packages/scene-composer/stories/components/hooks/useSceneMetadataModule.ts
@@ -3,8 +3,8 @@ import { TwinMakerSceneMetadataModule, initialize } from '@iot-app-kit/source-io
 import { useMemo } from 'react';
 
 const region = 'us-east-1';
-// const rociEndpoint = 'https://iottwinmaker.us-east-1.amazonaws.com';
-const rociEndpoint = 'https://gamma.us-east-1.twinmaker.iot.aws.dev';
+const rociEndpoint = 'https://iottwinmaker.us-east-1.amazonaws.com';
+// const rociEndpoint = 'https://gamma.us-east-1.twinmaker.iot.aws.dev';
 
 interface SceneMetadataModuleProps {
   source: string;


### PR DESCRIPTION
Merge commit from release-3.x to main:
* [Commit](https://github.com/awslabs/iot-app-kit/commit/a023cf714c187a4d09b765a4fb5a78e526424fc5)
* [PR](https://github.com/awslabs/iot-app-kit/pull/948) 

## Overview
Updated the logic for traversing the scene and calculating the intersection of rays to objects for the ViewCursorWidget. The list of objects that will call raycast are any TilesGroup node and any non-tileset and non-gizmo meshes.

The size of the projected SVG is a static size which is difficult to see for large objects and a camera that is far away. It is too small and looks like the feature is broken. With this change I update the SVG scale based on the distance of the closest intersection.

## Verifying Changes
Verified in storybook with 3D Tilesets I have in my personal AWS account.

Ran the same tests as in PR #948 

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
