### PR TITLE
fix(composer): adding widget fix for 3d tiles

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/ModelRefComponent/TilesModelComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ModelRefComponent/TilesModelComponent.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
-import { useFrame } from '@react-three/fiber';
+import { ThreeEvent, useFrame } from '@react-three/fiber';
 
 import useLifecycleLogging from '../../../logger/react-logger/hooks/useLifecycleLogging';
-import { IModelRefComponentInternal, ISceneNodeInternal, useStore } from '../../../store';
+import { IModelRefComponentInternal, ISceneNodeInternal, useEditorState, useStore } from '../../../store';
 import { getComponentGroupName } from '../../../utils/objectThreeUtils';
+import { findComponentByType } from '../../../utils/nodeUtils';
 import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
+import { createNodeWithPositionAndNormal, findNearestViableParentAncestorNodeRef } from '../../../utils/nodeUtils';
+import { KnownComponentType } from '../../../interfaces';
+import { getIntersectionTransform } from '../../../utils/raycastUtils';
 
 import { useTiles } from './TilesLoader';
 
@@ -16,7 +20,10 @@ interface TilesModelProps {
 export const TilesModelComponent: React.FC<TilesModelProps> = ({ node, component }: TilesModelProps) => {
   const sceneComposerId = useSceneComposerId();
   useLifecycleLogging('TilesModelComponent');
+  const { getSceneNodeByRef } = useStore(sceneComposerId)((state) => state);
+  const appendSceneNode = useStore(sceneComposerId)((state) => state.appendSceneNode);
   const uriModifier = useStore(sceneComposerId)((state) => state.getEditorConfig().uriModifier);
+  const { isEditing, addingWidget, setAddingWidget, cursorLookAt } = useEditorState(sceneComposerId);
 
   // TODO: tilesRenderer holds "group" and it'll load tiles and B3DM/I3DM files dynanimcally, so we don't need
   //       to clone the model like what we did in GLTFModelComponent. However, if we found this assumption is
@@ -26,9 +33,45 @@ export const TilesModelComponent: React.FC<TilesModelProps> = ({ node, component
     tilesRenderer.update();
   });
 
+  const handleAddWidget = (e: ThreeEvent<MouseEvent>) => {
+    if (addingWidget) {
+      const hierarchicalParent = findNearestViableParentAncestorNodeRef(e.eventObject);
+      const hierarchicalParentNode = getSceneNodeByRef(hierarchicalParent?.userData.nodeRef);
+      let physicalParent = hierarchicalParent;
+      if (findComponentByType(hierarchicalParentNode, KnownComponentType.SubModelRef)) {
+        while (physicalParent) {
+          if (physicalParent.userData.componentTypes?.includes(KnownComponentType.ModelRef)) break;
+          physicalParent = physicalParent.parent as THREE.Object3D<Event>;
+        }
+      }
+      const { position } = getIntersectionTransform(e.intersections[0]);
+      const newWidgetNode = createNodeWithPositionAndNormal(
+        addingWidget,
+        position,
+        cursorLookAt,
+        physicalParent,
+        hierarchicalParent?.userData.nodeRef,
+      );
+
+      setAddingWidget(undefined);
+      appendSceneNode(newWidgetNode);
+      e.stopPropagation();
+    }
+  };
+
+  const MAX_CLICK_DISTANCE = 2;
+
+  const onClick = (e: ThreeEvent<MouseEvent>) => {
+    if (e.delta <= MAX_CLICK_DISTANCE) {
+      if (isEditing() && addingWidget) {
+        handleAddWidget(e);
+      }
+    }
+  };
+
   return (
     <group name={getComponentGroupName(node.ref, 'TILES_MODEL')} dispose={null}>
-      <primitive object={tilesRenderer.group} />
+      <primitive object={tilesRenderer.group} onClick={onClick} />
     </group>
   );
 };


### PR DESCRIPTION
## Overview
Same change as in the release-3.x branch: https://github.com/awslabs/iot-app-kit/pull/985

Adding a widget to a 3D Tiles model was recently broken.

Added logic from GLTFModelComponent handleAddWidget to TilesModelComponent to find the closest parent node in the scene and attach the widget as a child. Added this onClick action to the component if addingWidget is active.

## Verifying Changes

Same tests as in PR #985 

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
