### PR TITLE
feat(TwinMakerTools): add tools-iottwinmaker to npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -78,3 +78,10 @@ jobs:
           package: './packages/scene-composer/package.json'
           token: ${{ secrets.NPM_TOKEN }}
           tag: 'alpha'
+
+      - name: Publish @iot-app-kit/tools-iottwinmaker
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          package: './packages/tools-iottwinmaker/package.json'
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: 'alpha'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -33,6 +33,9 @@
     "packages/source-iottwinmaker": {
       "component": "source-iottwinmaker"
     },
+    "packages/tools-iottwinmaker": {
+      "component": "tools-iottwinmaker"
+    },
     "configuration/ts-config": {
       "component": "ts-config"
     },
@@ -63,6 +66,7 @@
         "scene-composer",
         "source-iotsitewise",
         "source-iottwinmaker",
+        "tools-iottwinmaker",
         "testing-util",
         "core-util",
         "jest-config",


### PR DESCRIPTION
## Overview
add tools-iottwinmaker to npm publish workflow

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
