### PR TITLE
fix(build): drive release of IoT App Kit + minor doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ The IoT Application Kit containing the following public packages:
 
 [Learn more here](https://github.com/awslabs/iot-app-kit/tree/main/docs/Core.md).
 
+### @iot-app-kit/tools-iottwinmaker
+`@iot-app-kit/tools-iottwinmaker` contains functionality for the AWS IoT TwinMaker Development Tools (TMDT), a set of tools to aid in [AWS IoT TwinMaker](https://docs.aws.amazon.com/iot-twinmaker/latest/guide/what-is-twinmaker.html) project management.
+
+[Learn more here](https://github.com/awslabs/iot-app-kit/tree/main/packages/tools-iottwinmaker).
+
 ## Security
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 


### PR DESCRIPTION
## Overview
drive release of IoT App Kit + minor doc update

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
