### PR TITLE
Knowledge Graph DataSource

### DIFF
--- a/packages/source-iottwinmaker/src/__mocks__/iottwinmakerSDK.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/iottwinmakerSDK.ts
@@ -1,4 +1,18 @@
-import { GetEntityCommandInput, GetEntityCommandOutput, GetPropertyValueHistoryCommandInput, GetPropertyValueHistoryCommandOutput, GetSceneCommandInput, GetSceneCommandOutput, IoTTwinMakerClient, ListEntitiesCommandInput, ListEntitiesCommandOutput, UpdateSceneCommandInput, UpdateSceneCommandOutput } from '@aws-sdk/client-iottwinmaker';
+import {
+  ExecuteQueryCommandInput,
+  ExecuteQueryCommandOutput,
+  GetEntityCommandInput,
+  GetEntityCommandOutput,
+  GetPropertyValueHistoryCommandInput,
+  GetPropertyValueHistoryCommandOutput,
+  GetSceneCommandInput,
+  GetSceneCommandOutput,
+  IoTTwinMakerClient,
+  ListEntitiesCommandInput,
+  ListEntitiesCommandOutput,
+  UpdateSceneCommandInput,
+  UpdateSceneCommandOutput,
+} from '@aws-sdk/client-iottwinmaker';
 
 const nonOverriddenMock = () => Promise.reject(new Error('Mock method not override.'));
 
@@ -8,12 +22,16 @@ export const createMockTwinMakerSDK = ({
   getScene = nonOverriddenMock,
   listEntities = nonOverriddenMock,
   updateScene = nonOverriddenMock,
+  executeQuery = nonOverriddenMock,
 }: {
   getEntity?: (input: GetEntityCommandInput) => Promise<GetEntityCommandOutput>;
-  getPropertyValueHistory?: (input: GetPropertyValueHistoryCommandInput) => Promise<GetPropertyValueHistoryCommandOutput>;
+  getPropertyValueHistory?: (
+    input: GetPropertyValueHistoryCommandInput
+  ) => Promise<GetPropertyValueHistoryCommandOutput>;
   getScene?: (input: GetSceneCommandInput) => Promise<GetSceneCommandOutput>;
   listEntities?: (input: ListEntitiesCommandInput) => Promise<ListEntitiesCommandOutput>;
   updateScene?: (input: UpdateSceneCommandInput) => Promise<UpdateSceneCommandOutput>;
+  executeQuery?: (input: ExecuteQueryCommandInput) => Promise<ExecuteQueryCommandOutput>;
 } = {}) =>
   ({
     send: (command: { input: any }) => {
@@ -32,6 +50,8 @@ export const createMockTwinMakerSDK = ({
           return listEntities(command.input);
         case 'UpdateSceneCommand':
           return updateScene(command.input);
+        case 'ExecuteQueryCommand':
+          return executeQuery(command.input);
         default:
           throw new Error(
             `missing mock implementation for command name ${commandName}. Add a new command within the mock IotTwinMaker SDK.`

--- a/packages/source-iottwinmaker/src/initialize.ts
+++ b/packages/source-iottwinmaker/src/initialize.ts
@@ -16,6 +16,7 @@ import {
 } from './aws-sdks';
 import { S3SceneLoader } from './scene-module/S3SceneLoader';
 import { SceneMetadataModule } from './scene-module/SceneMetadataModule';
+import { KGDataModule } from './knowledgeGraph-module/KGDataModule';
 import { VideoDataImpl } from './video-data/VideoData';
 import { VideoDataProps } from './types';
 import { TwinMakerDataStreamQuery, TwinMakerQuery } from './time-series-data/types';
@@ -153,6 +154,7 @@ export const initialize = (
     s3SceneLoader: (sceneId: string) => new S3SceneLoader({ workspaceId, sceneId, twinMakerClient, s3Client }),
     sceneMetadataModule: (sceneId: string) =>
       new SceneMetadataModule({ workspaceId, sceneId, twinMakerClient, secretsManagerClient }),
+    kGDatamodule: (queryStatement: string) => new KGDataModule({ workspaceId, twinMakerClient, queryStatement }),
     videoData: (videoDataProps: VideoDataProps) =>
       new VideoDataImpl({
         workspaceId: workspaceId,

--- a/packages/source-iottwinmaker/src/knowledgeGraph-module/KGDataModule.spec.ts
+++ b/packages/source-iottwinmaker/src/knowledgeGraph-module/KGDataModule.spec.ts
@@ -1,0 +1,72 @@
+import { KGDataModule } from './KGDataModule';
+import { createMockTwinMakerSDK } from '../__mocks__/iottwinmakerSDK';
+
+const executeQuery = jest.fn();
+const twinMakerClientMock = createMockTwinMakerSDK({
+  executeQuery,
+});
+
+const kgMetadataModule = new KGDataModule({
+  workspaceId: 'wsId',
+  twinMakerClient: twinMakerClientMock,
+  queryStatement: "SELECT e.entityName FROM EntityGraph MATCH (e) WHERE e.entityName LIKE 'room_%'",
+});
+
+describe('executeQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should get a valid response', async () => {
+    executeQuery.mockResolvedValue({
+      columnDescriptions: [
+        {
+          name: 'EntityName',
+          type: 'VALUE',
+        },
+      ],
+      rows: [
+        {
+          rowData: ['room_0'],
+        },
+        {
+          rowData: ['room_1'],
+        },
+      ],
+      $metadata: {},
+    });
+
+    const expected = {
+      columnDescriptions: [
+        {
+          name: 'EntityName',
+          type: 'VALUE',
+        },
+      ],
+      rows: [
+        {
+          rowData: ['room_0'],
+        },
+        {
+          rowData: ['room_1'],
+        },
+      ],
+      $metadata: {},
+    };
+    const result = await kgMetadataModule.executeQuery();
+
+    expect(executeQuery).toBeCalledTimes(1);
+    expect(result).toEqual(expected);
+  });
+
+  it('should get error when API failed', async () => {
+    executeQuery.mockRejectedValue('TwinMaker API failed');
+
+    try {
+      await kgMetadataModule.executeQuery();
+    } catch (err) {
+      expect(err).toEqual('TwinMaker API failed');
+      expect(executeQuery).toBeCalledTimes(1);
+    }
+  });
+});

--- a/packages/source-iottwinmaker/src/knowledgeGraph-module/KGDataModule.ts
+++ b/packages/source-iottwinmaker/src/knowledgeGraph-module/KGDataModule.ts
@@ -1,0 +1,48 @@
+import {
+  ExecuteQueryCommand,
+  ExecuteQueryCommandOutput,
+  ExecuteQueryCommandInput,
+  IoTTwinMakerClient,
+  ColumnDescription,
+  Row,
+} from '@aws-sdk/client-iottwinmaker';
+import { KGDataModuleInput } from './types';
+import { TwinMakerKGQueryDataModule } from '../types';
+
+export class KGDataModule implements TwinMakerKGQueryDataModule {
+  private twinMakerClient: IoTTwinMakerClient;
+  private workspaceId: string;
+  private queryStatement: string;
+  private maxResultsCount: number;
+
+  constructor(input: KGDataModuleInput) {
+    this.twinMakerClient = input.twinMakerClient;
+    this.workspaceId = input.workspaceId;
+    this.queryStatement = input.queryStatement;
+    if (input.maxResultsCount) this.maxResultsCount = input.maxResultsCount;
+  }
+
+  executeQuery = async (): Promise<ExecuteQueryCommandOutput> => {
+    const rows: Row[] = [];
+    let columnDescriptions: ColumnDescription[] = [];
+    let $metadata = {};
+    const commandInput: ExecuteQueryCommandInput = {
+      workspaceId: this.workspaceId,
+      queryStatement: this.queryStatement,
+    };
+    do {
+      const response: ExecuteQueryCommandOutput = await this.twinMakerClient.send(
+        new ExecuteQueryCommand(commandInput)
+      );
+      if (response.rows) {
+        rows.push(...response.rows);
+      }
+      if (response.columnDescriptions && columnDescriptions.length === 0) {
+        columnDescriptions = response.columnDescriptions;
+      }
+      if (response.$metadata && Object.keys($metadata).length === 0) $metadata = response.$metadata;
+      commandInput.nextToken = response.nextToken;
+    } while (this.maxResultsCount ? commandInput.nextToken && this.maxResultsCount : commandInput.nextToken);
+    return { rows, columnDescriptions, $metadata };
+  };
+}

--- a/packages/source-iottwinmaker/src/knowledgeGraph-module/types.ts
+++ b/packages/source-iottwinmaker/src/knowledgeGraph-module/types.ts
@@ -1,0 +1,7 @@
+import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
+export type KGDataModuleInput = {
+  workspaceId: string;
+  twinMakerClient: IoTTwinMakerClient;
+  queryStatement: string;
+  maxResultsCount?: number;
+};

--- a/packages/source-iottwinmaker/src/types.ts
+++ b/packages/source-iottwinmaker/src/types.ts
@@ -1,4 +1,4 @@
-import { GetSceneCommandOutput } from '@aws-sdk/client-iottwinmaker';
+import { GetSceneCommandOutput, ExecuteQueryCommandOutput } from '@aws-sdk/client-iottwinmaker';
 import { SecretListEntry } from '@aws-sdk/client-secrets-manager';
 import { VideoPlaybackMode } from './video-data/types';
 
@@ -40,3 +40,6 @@ export type VideoDataProps =
       sitewiseAssetId?: string;
       videoUploadRequestPropertyId?: string;
     };
+export interface TwinMakerKGQueryDataModule {
+  executeQuery: () => Promise<ExecuteQueryCommandOutput>;
+}


### PR DESCRIPTION
## Overview
This PR adds TwinMaker Knowledge Graph DataSource for the source-iottwinmaker package. The datasource rely on the ExecuteQueryCommand API.



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
