### PR TITLE
fix(composer): rendering issue when switching from a Matterport to non Matterport scene

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -46,7 +46,7 @@
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --index-template tools/index-template.js -- src/assets/icons/",
     "release": "run-s compile copy-assets",
     "copy-assets": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" dist/",
-    "lint": "eslint . --max-warnings=682",
+    "lint": "eslint . --max-warnings=680",
     "fix": "eslint --fix .",
     "test": "jest --config jest.config.ts --coverage --silent",
     "test:dev": "jest --config jest.config.ts --coverage",
@@ -174,10 +174,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "lines": 76.32,
-        "statements": 75.63,
-        "functions": 75.34,
-        "branches": 61,
+        "lines": 76.97,
+        "statements": 76.38,
+        "functions": 75.51,
+        "branches": 61.63,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/components/WebGLCanvasManager.tsx
+++ b/packages/scene-composer/src/components/WebGLCanvasManager.tsx
@@ -6,7 +6,7 @@ import { ThreeEvent, useThree } from '@react-three/fiber';
 
 import { KnownSceneProperty } from '../interfaces';
 import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLogging';
-import { useEditorState, useSceneDocument, useStore } from '../store';
+import { useEditorState, useSceneDocument, useStore, useViewOptionState } from '../store';
 import { sceneComposerIdContext } from '../common/sceneComposerIdContext';
 import { hexColorFromDesignToken } from '../utils/styleUtils';
 import { Layers, ROOT_OBJECT_3D_NAME } from '../common/constants';
@@ -35,12 +35,12 @@ export const WebGLCanvasManager: React.FC = () => {
 
   const sceneComposerId = useContext(sceneComposerIdContext);
   const { isEditing, addingWidget, setAddingWidget } = useEditorState(sceneComposerId);
+  const { enableMatterportViewer } = useViewOptionState(sceneComposerId);
   const { document, getSceneNodeByRef, getSceneProperty } = useSceneDocument(sceneComposerId);
   const appendSceneNode = useStore(sceneComposerId)((state) => state.appendSceneNode);
   const { gl } = useThree();
   const domRef = useRef<HTMLElement>(gl.domElement.parentElement);
   const environmentPreset = getSceneProperty(KnownSceneProperty.EnvironmentPreset);
-  const matterportModelId = getSceneProperty(KnownSceneProperty.MatterportModelId);
   const rootNodeRefs = document.rootNodeRefs;
 
   const editingTargetPlaneRef = useRef(null);
@@ -115,7 +115,7 @@ export const WebGLCanvasManager: React.FC = () => {
               name='Ground'
               rotation={[THREE.MathUtils.degToRad(270), 0, 0]}
               onClick={onClick}
-              renderOrder={matterportModelId ? 1 : undefined}
+              renderOrder={enableMatterportViewer ? 1 : undefined}
             >
               <planeGeometry args={[1000, 1000]} />
               <meshBasicMaterial colorWrite={false} />

--- a/packages/scene-composer/src/components/__snapshots__/SceneComposerInternal.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/SceneComposerInternal.spec.tsx.snap
@@ -21,7 +21,6 @@ exports[`SceneComposerInternal should render a default error view when loading a
         />
         <Unknown>
           <R3FWrapper
-            enableMatterport={false}
             sceneLoaded={true}
           >
             <React.Suspense
@@ -96,7 +95,6 @@ exports[`SceneComposerInternal should render both valid and invalid scene correc
           />
           <Unknown>
             <R3FWrapper
-              enableMatterport={false}
               sceneLoaded={true}
             >
               <React.Suspense
@@ -144,7 +142,6 @@ exports[`SceneComposerInternal should render both valid and invalid scene correc
           />
           <Unknown>
             <R3FWrapper
-              enableMatterport={false}
               sceneLoaded={true}
             >
               <React.Suspense
@@ -196,7 +193,6 @@ exports[`SceneComposerInternal should render correctly with a valid scene in edi
         />
         <Unknown>
           <R3FWrapper
-            enableMatterport={false}
             sceneLoaded={true}
           >
             <React.Suspense
@@ -246,9 +242,7 @@ exports[`SceneComposerInternal should render correctly with an empty scene in ed
           isViewing={false}
         />
         <Unknown>
-          <R3FWrapper
-            enableMatterport={false}
-          >
+          <R3FWrapper>
             <React.Suspense
               fallback={
                 <Provider>
@@ -291,9 +285,7 @@ exports[`SceneComposerInternal should render correctly with an empty scene in vi
           isViewing={true}
         />
         <Unknown>
-          <R3FWrapper
-            enableMatterport={false}
-          >
+          <R3FWrapper>
             <React.Suspense
               fallback={
                 <Provider>
@@ -334,7 +326,6 @@ exports[`SceneComposerInternal should render error when major version is newer 1
         />
         <Unknown>
           <R3FWrapper
-            enableMatterport={false}
             sceneLoaded={true}
           >
             <React.Suspense
@@ -385,7 +376,6 @@ exports[`SceneComposerInternal should render error when specVersion is invalid 1
         />
         <Unknown>
           <R3FWrapper
-            enableMatterport={false}
             sceneLoaded={true}
           >
             <React.Suspense
@@ -436,7 +426,6 @@ exports[`SceneComposerInternal should render warning when minor version is newer
         />
         <Unknown>
           <R3FWrapper
-            enableMatterport={false}
             sceneLoaded={true}
           >
             <React.Suspense
@@ -488,7 +477,6 @@ exports[`SceneComposerInternal should support rendering multiple valid scenes 1`
           />
           <Unknown>
             <R3FWrapper
-              enableMatterport={false}
               sceneLoaded={true}
             >
               <React.Suspense
@@ -536,7 +524,6 @@ exports[`SceneComposerInternal should support rendering multiple valid scenes 1`
           />
           <Unknown>
             <R3FWrapper
-              enableMatterport={false}
               sceneLoaded={true}
             >
               <React.Suspense

--- a/packages/scene-composer/src/components/panels/TopBar.tsx
+++ b/packages/scene-composer/src/components/panels/TopBar.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 import { ButtonDropdown, SpaceBetween } from '@awsui/components-react';
 import { useIntl } from 'react-intl';
 
-import { KnownComponentType, KnownSceneProperty } from '../../interfaces';
+import { KnownComponentType } from '../../interfaces';
 import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
-import { ICameraComponentInternal, useStore } from '../../store';
+import { ICameraComponentInternal, useStore, useViewOptionState } from '../../store';
 import useActiveCamera from '../../hooks/useActiveCamera';
 import { findComponentByType } from '../../utils/nodeUtils';
 import { getCameraSettings } from '../../utils/cameraUtils';
@@ -23,9 +23,7 @@ export const TopBar: FC = () => {
   const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
   const getObject3DBySceneNodeRef = useStore(sceneComposerId)((state) => state.getObject3DBySceneNodeRef);
   const { setActiveCameraSettings } = useActiveCamera();
-  const matterportModelId = useStore(sceneComposerId)((state) =>
-    state.getSceneProperty(KnownSceneProperty.MatterportModelId),
-  );
+  const { enableMatterportViewer } = useViewOptionState(sceneComposerId);
   const intl = useIntl();
 
   const cameraItems = useMemo(() => {
@@ -41,7 +39,7 @@ export const TopBar: FC = () => {
       });
   }, [nodeMap]);
 
-  const hasCameraView = cameraItems.length > 0 && matterportModelId === undefined;
+  const hasCameraView = cameraItems.length > 0 && !enableMatterportViewer;
   const showTopBar = hasCameraView;
 
   const setActiveCameraOnItemClick = useCallback(

--- a/packages/scene-composer/src/components/panels/scene-settings/MatterportIntegration.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/MatterportIntegration.tsx
@@ -36,7 +36,7 @@ export const MatterportIntegration: React.FC = () => {
       value: OPTIONS_PLACEHOLDER_VALUE,
     },
   ]);
-  const [selectedConnectionName, setSelectedConnectionName] = useState(OPTIONS_PLACEHOLDER_VALUE);
+  const [selectedConnectionName, setSelectedConnectionName] = useState<string>();
   const { setMatterportViewerEnabled } = useViewOptionState(sceneComposerId);
   const twinMakerSceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
 
@@ -120,10 +120,12 @@ export const MatterportIntegration: React.FC = () => {
   );
 
   const enableMatterportViewer =
-    !isEmpty(matterportModelIdInternal) && selectedConnectionName !== OPTIONS_PLACEHOLDER_VALUE;
+    !isEmpty(matterportModelIdInternal) &&
+    !isEmpty(selectedConnectionName) &&
+    selectedConnectionName !== OPTIONS_PLACEHOLDER_VALUE;
 
   useEffect(() => {
-    if (!focusInput) {
+    if (!focusInput && selectedConnectionName) {
       setMatterportViewerEnabled(enableMatterportViewer);
     }
   }, [focusInput, matterportModelIdInternal, selectedConnectionName]);

--- a/packages/scene-composer/src/components/three-fiber/EditorCamera.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EditorCamera.tsx
@@ -3,7 +3,7 @@ import React, { Fragment, useCallback, useContext, useEffect, useMemo, useRef, u
 import mergeRefs from 'react-merge-refs';
 import { PerspectiveCamera } from '@react-three/drei/core/PerspectiveCamera';
 import { Camera, useFrame, useThree } from '@react-three/fiber';
-import { useMatterportSdk, MatterportFocusCamera } from '@matterport/r3f/dist';
+import { MatterportFocusCamera } from '@matterport/r3f/dist';
 
 import useLogger from '../../logger/react-logger/hooks/useLogger';
 import {
@@ -21,16 +21,17 @@ import { useEditorState } from '../../store';
 import { CameraControlImpl, TweenValueObject } from '../../store/internalInterfaces';
 import useActiveCamera from '../../hooks/useActiveCamera';
 import { getSafeBoundingBox } from '../../utils/objectThreeUtils';
+import { getMatterportSdk } from '../../common/GlobalSettings';
 
 import { MapControls, OrbitControls } from './controls';
 
 export const EditorMainCamera = React.forwardRef<Camera>((_, forwardedRef) => {
   const log = useLogger('EditorMainCamera');
 
-  const matterportSdk = useMatterportSdk();
   const sceneComposerId = useContext(sceneComposerIdContext);
   const { cameraCommand, cameraControlsType, transformControls, getObject3DBySceneNodeRef, setMainCameraObject } =
     useEditorState(sceneComposerId);
+  const matterportSdk = getMatterportSdk(sceneComposerId);
   const scene = useThree((state) => state.scene);
   const setThree = useThree((state) => state.set);
   const makeDefault = cameraControlsType === 'orbit' || cameraControlsType === 'pan';
@@ -193,9 +194,7 @@ export const EditorMainCamera = React.forwardRef<Camera>((_, forwardedRef) => {
         from={cameraTarget?.target?.position}
         target={cameraTarget?.object3d ? cameraTarget?.object3d : cameraTarget?.target?.target}
         transition={
-          cameraTarget?.shouldTween
-            ? matterportSdk?.Mode.TransitionType.FLY
-            : matterportSdk?.Mode.TransitionType.INSTANT
+          cameraTarget?.shouldTween ? matterportSdk.Mode.TransitionType.FLY : matterportSdk.Mode.TransitionType.INSTANT
         }
       />
     </Fragment>

--- a/packages/scene-composer/src/components/three-fiber/EntityGroup/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EntityGroup/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useRef } from 'react';
 import { Euler, Object3D } from 'three';
-import { useMatterportSdk } from '@matterport/r3f/dist';
+import { ThreeEvent } from '@react-three/fiber';
 
 import {
   ISceneNodeInternal,
@@ -15,7 +15,7 @@ import { getChildrenGroupName, getEntityGroupName } from '../../../utils/objectT
 import { COMPOSER_FEATURES, KnownComponentType } from '../../../interfaces';
 import LogProvider from '../../../logger/react-logger/log-provider';
 import { findComponentByType, isEnvironmentNode } from '../../../utils/nodeUtils';
-import { getGlobalSettings } from '../../../common/GlobalSettings';
+import { getGlobalSettings, getMatterportSdk } from '../../../common/GlobalSettings';
 
 import ComponentGroup from './ComponentGroup';
 
@@ -65,10 +65,10 @@ const ChildGroup = ({ node }: { node: ISceneNodeInternal }) => {
   );
 };
 
-const EntityGroup = ({ node }: IEntityGroupProps) => {
+const EntityGroup = ({ node }: IEntityGroupProps): JSX.Element => {
   const sceneComposerId = useContext(sceneComposerIdContext);
   const object3dRef = useRef<THREE.Object3D>();
-  const matterportSdk = useMatterportSdk();
+  const matterportSdk = getMatterportSdk(sceneComposerId);
 
   const { transform, ref: nodeRef, components } = node;
   const { rotation, position, scale } = transform;
@@ -95,7 +95,8 @@ const EntityGroup = ({ node }: IEntityGroupProps) => {
     [selectedSceneNodeRef, nodeRef],
   );
 
-  let onPointerEnter, onPointerLeave;
+  let onPointerEnter: ((event: ThreeEvent<PointerEvent>) => void) | undefined,
+    onPointerLeave: ((event: ThreeEvent<PointerEvent>) => void) | undefined;
   if (matterportSdk) {
     // hide Matterport's cursor reticle when hovering entities
     onPointerEnter = (e) => {

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -14,11 +14,16 @@ import {
   IMotionIndicatorComponent,
   ISceneNode,
   KnownComponentType,
-  KnownSceneProperty,
 } from '../../../../interfaces';
 import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
 import { Component, LightType, ModelType } from '../../../../models/SceneModels';
-import { IColorOverlayComponentInternal, ISceneNodeInternal, useEditorState, useStore } from '../../../../store';
+import {
+  IColorOverlayComponentInternal,
+  ISceneNodeInternal,
+  useEditorState,
+  useStore,
+  useViewOptionState,
+} from '../../../../store';
 import { extractFileNameExtFromUrl, parseS3BucketFromArn } from '../../../../utils/pathUtils';
 import { ToolbarItem } from '../../common/ToolbarItem';
 import { ToolbarItemOptionRaw, ToolbarItemOptions } from '../../common/types';
@@ -80,12 +85,10 @@ export const AddObjectMenu = (): JSX.Element => {
   const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
   const nodeMap = useStore(sceneComposerId)((state) => state.document.nodeMap);
   const { setAddingWidget, getObject3DBySceneNodeRef } = useEditorState(sceneComposerId);
+  const { enableMatterportViewer } = useViewOptionState(sceneComposerId);
   const enhancedEditingEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.ENHANCED_EDITING];
   const { formatMessage } = useIntl();
   const { activeCameraSettings, mainCameraObject } = useActiveCamera();
-  const matterportModelId = useStore(sceneComposerId)((state) =>
-    state.getSceneProperty(KnownSceneProperty.MatterportModelId),
-  );
   const selectedSceneNode = useMemo(() => {
     return getSceneNodeByRef(selectedSceneNodeRef);
   }, [getSceneNodeByRef, selectedSceneNodeRef]);
@@ -138,7 +141,7 @@ export const AddObjectMenu = (): JSX.Element => {
         {
           uuid: ObjectTypes.ViewCamera,
           feature: { name: COMPOSER_FEATURES.CameraView },
-          isDisabled: matterportModelId,
+          isDisabled: enableMatterportViewer,
         },
         {
           uuid: ObjectTypes.Tag,
@@ -160,7 +163,7 @@ export const AddObjectMenu = (): JSX.Element => {
       sceneContainsEnvironmentModel,
       selectedSceneNodeRef,
       isEnvironmentNode,
-      matterportModelId,
+      enableMatterportViewer,
     ],
   );
 

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/SceneItemGroup.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/SceneItemGroup.tsx
@@ -2,9 +2,9 @@ import React, { useContext, useMemo } from 'react';
 import { useIntl, IntlShape } from 'react-intl';
 
 import { OrbitCameraSvg, PanCameraSvg } from '../../../../assets/svgs';
-import { CameraControlsType, KnownSceneProperty } from '../../../../interfaces';
+import { CameraControlsType } from '../../../../interfaces';
 import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
-import { useStore } from '../../../../store';
+import { useStore, useViewOptionState } from '../../../../store';
 import { ToolbarItem } from '../../common/ToolbarItem';
 import { ToolbarItemGroup } from '../../common/styledComponents';
 import { ToolbarItemOptions } from '../../common/types';
@@ -52,15 +52,11 @@ export interface SceneItemGroupProps {
   isViewing?: boolean;
 }
 
-export function SceneItemGroup({ isViewing = false }: SceneItemGroupProps) {
+export function SceneItemGroup({ isViewing = false }: SceneItemGroupProps): JSX.Element {
   const sceneComposerId = useContext(sceneComposerIdContext);
   const cameraControlsType = useStore(sceneComposerId)((state) => state.cameraControlsType);
   const setCameraControlsType = useStore(sceneComposerId)((state) => state.setCameraControlsType);
-  const isMatterportEnabled = useStore(sceneComposerId)(
-    (state) =>
-      state.getSceneProperty(KnownSceneProperty.MatterportModelId) &&
-      state.getSceneProperty(KnownSceneProperty.MatterportModelId) !== '',
-  );
+  const { enableMatterportViewer } = useViewOptionState(sceneComposerId);
   const intl = useIntl();
 
   const initialSelectedItem = useMemo(() => {
@@ -76,7 +72,7 @@ export function SceneItemGroup({ isViewing = false }: SceneItemGroupProps) {
   return (
     <ToolbarItemGroup>
       {!isViewing && <AddObjectMenu />}
-      {!isMatterportEnabled && (
+      {!enableMatterportViewer && (
         <ToolbarItem
           items={items}
           initialSelectedItem={initialSelectedItem}

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment, ReactNode, Suspense, useContext, useMemo, useRef } from 'react';
+import React, { FC, Fragment, ReactNode, Suspense, useContext, useEffect, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import styled, { ThemeContext } from 'styled-components';
 import { Canvas, ThreeEvent } from '@react-three/fiber';
@@ -20,14 +20,13 @@ import {
   TopBar,
 } from '../../components/panels';
 import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
-import { useSceneDocument, useStore } from '../../store';
+import { useSceneDocument, useStore, useViewOptionState } from '../../store';
 import LogProvider from '../../logger/react-logger/log-provider';
 import DefaultErrorFallback from '../../components/DefaultErrorFallback';
 import { COMPOSER_FEATURES, ExternalLibraryConfig, KnownComponentType, MatterportConfig } from '../../interfaces';
 import { CameraPreview } from '../../components/three-fiber/CameraPreview';
 import useSelectedNode from '../../hooks/useSelectedNode';
 import { findComponentByType } from '../../utils/nodeUtils';
-import useFeature from '../../hooks/useFeature';
 import { DeprecatedSceneNodeInspectorPanel } from '../../components/panels/SceneNodeInspectorPanel.C';
 
 import LeftPanel from './components/LeftPanel';
@@ -42,18 +41,27 @@ const UnselectableCanvas = styled(Canvas)`
   z-index: 0;
 `;
 
-const R3FWrapper = (props: {
-  enableMatterport: boolean;
-  matterportConfig?: MatterportConfig;
-  children?: any;
-  sceneLoaded?: boolean;
-}) => {
-  const { children, sceneLoaded, enableMatterport, matterportConfig } = props;
+const R3FWrapper = (props: { matterportConfig?: MatterportConfig; children?: unknown; sceneLoaded?: boolean }) => {
+  const { children, sceneLoaded, matterportConfig } = props;
   const sceneComposerId = useContext(sceneComposerIdContext);
   const ContextBridge = useContextBridge(LoggingContext, sceneComposerIdContext, ThemeContext);
-  const loadMatterPort = sceneLoaded && enableMatterport && matterportConfig?.modelId;
+  const { enableMatterportViewer } = useViewOptionState(sceneComposerId);
+  const loadMatterport = enableMatterportViewer && matterportConfig;
 
-  return loadMatterPort ? (
+  useEffect(() => {
+    if (!loadMatterport) {
+      setMatterportSdk(sceneComposerId);
+      /* Clear the Cache for THREE to reset the R3F when switching from a Matterport to a non-Matterport scene.
+      This is required to revert/reset the changes done by the Matterport viewer. */
+      window.THREE.Cache.clear();
+    }
+  }, [loadMatterport]);
+
+  if (!sceneLoaded) {
+    return null;
+  }
+
+  return loadMatterport ? (
     <MatterportViewer
       assetBase={matterportConfig?.assetBase}
       m={matterportConfig?.modelId}
@@ -61,11 +69,6 @@ const R3FWrapper = (props: {
       connect-auth={matterportConfig?.accessToken}
       connect-provider='iot-twinmaker'
       onReady={(matterportSdk: MpSdk) => {
-        // propagate this out elsewhere if you wish to useMatterportSdk() interface
-        // to control this viewer from other non-3d ui
-        // <MpSdkContext.Provider value={matterportSdk}>
-        //  <Other2DComponents/>
-        // <MpSdkContext.Provider/>
         setMatterportSdk(sceneComposerId, matterportSdk);
       }}
       style={{ width: '100%', height: '100%' }}
@@ -116,8 +119,6 @@ const SceneLayout: FC<SceneLayoutProps> = ({
     return isViewing ? false : !!findComponentByType(selectedNode.selectedSceneNode, KnownComponentType.Camera);
   }, [selectedNode]);
 
-  const [{ variation: matterportFeature }] = useFeature(COMPOSER_FEATURES.Matterport);
-
   const dataBindingComponentEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.DataBinding];
 
   const leftPanelEditModeProps = {
@@ -150,20 +151,11 @@ const SceneLayout: FC<SceneLayoutProps> = ({
         <Fragment>
           <LogProvider namespace='SceneLayout' ErrorView={DefaultErrorFallback}>
             <FloatingToolbar isViewing={isViewing} />
-            {/* {matterportModelId && <PoweredByMatterport matterportModelId={matterportModelId} />} */}
-            {/*
-            // TODO(mp): three upgrade type mismatch much unreadable, triage further.
-            <UnselectableCanvas shadows dpr={window.devicePixelRatio} onPointerMissed={onPointerMissed}>
-            */}
             <ContextBridge>
               {shouldShowPreview && (
                 <CameraPreviewTrack ref={renderDisplayRef} title={selectedNode.selectedSceneNode?.name} />
               )}
-              <R3FWrapper
-                enableMatterport={matterportFeature === 'T1' && !!externalLibraryConfig?.matterport?.modelId}
-                sceneLoaded={sceneLoaded}
-                matterportConfig={externalLibraryConfig?.matterport}
-              >
+              <R3FWrapper sceneLoaded={sceneLoaded} matterportConfig={externalLibraryConfig?.matterport}>
                 <Suspense fallback={LoadingView}>
                   {!sceneLoaded ? null : (
                     <Fragment>

--- a/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
+++ b/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
@@ -1813,14 +1813,6 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
   background-color: colorBackgroundDropdownItemDefault;
 }
 
-.c19 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  z-index: 0;
-}
-
 <div
   className="c0"
   data-mocked="Box"
@@ -2090,25 +2082,6 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="c19"
-          style={
-            Object {
-              "height": "100%",
-              "overflow": "hidden",
-              "position": "relative",
-              "width": "100%",
-            }
-          }
-        >
-          <canvas
-            style={
-              Object {
-                "display": "block",
-              }
-            }
-          />
         </div>
       </div>
     </div>
@@ -2452,14 +2425,6 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
   background-color: colorBackgroundDropdownItemDefault;
 }
 
-.c21 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  z-index: 0;
-}
-
 <div
   className="c0"
   data-mocked="Box"
@@ -2769,25 +2734,6 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="c21"
-          style={
-            Object {
-              "height": "100%",
-              "overflow": "hidden",
-              "position": "relative",
-              "width": "100%",
-            }
-          }
-        >
-          <canvas
-            style={
-              Object {
-                "display": "block",
-              }
-            }
-          />
         </div>
       </div>
     </div>

--- a/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
@@ -21,6 +21,7 @@ export const defaultArgs = {
     COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.Overlay,
     COMPOSER_FEATURES.TagResize,
+    COMPOSER_FEATURES.Matterport,
   ]
 }
 

--- a/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
@@ -19,6 +19,7 @@ export const defaultArgs = {
     COMPOSER_FEATURES.ENHANCED_EDITING,
     COMPOSER_FEATURES.CameraView,
     COMPOSER_FEATURES.OpacityRule,
+    COMPOSER_FEATURES.Matterport,
   ]
 }
 

--- a/packages/scene-composer/stories/SceneViewer.stories.mdx
+++ b/packages/scene-composer/stories/SceneViewer.stories.mdx
@@ -19,6 +19,7 @@ export const defaultArgs = {
     COMPOSER_FEATURES.ENHANCED_EDITING,
     COMPOSER_FEATURES.CameraView,
     COMPOSER_FEATURES.OpacityRule,
+    COMPOSER_FEATURES.Matterport,
   ]
 }
 

--- a/packages/scene-composer/tests/StateManager.spec.tsx
+++ b/packages/scene-composer/tests/StateManager.spec.tsx
@@ -28,6 +28,7 @@ import { DataStream } from '@iot-app-kit/core';
 import useActiveCamera from '../src/hooks/useActiveCamera';
 import { KnownComponentType } from '../src';
 import * as THREE from 'three';
+import { SCENE_CAPABILITY_MATTERPORT } from '../src/common/constants';
 
 jest.mock('../src/hooks/useActiveCamera', () => {
   return jest.fn().mockReturnValue({
@@ -66,10 +67,14 @@ describe('StateManager', () => {
     getSceneUrl: () => Promise.resolve('https://test.url'),
     getSceneObject: mockGetSceneObjectFunction,
   };
+  const MOCK_ARN = 'mockARN';
+  const getSceneInfo = jest.fn();
+  const updateSceneInfo = jest.fn();
+  const get3pConnectionList = jest.fn();
   const mockSceneMetadataModule = {
-    getSceneInfo: jest.fn(),
-    updateSceneInfo: jest.fn(),
-    get3pConnectionList: jest.fn(),
+    getSceneInfo,
+    updateSceneInfo,
+    get3pConnectionList,
   };
   const mockDataStreams: DataStream[] = [numberStream, stringStream];
 
@@ -78,6 +83,10 @@ describe('StateManager', () => {
 
     const mockArrayBuffer = str2ab(mockSceneContent);
     mockGetSceneObjectFunction.mockImplementation(() => Promise.resolve(mockArrayBuffer));
+    getSceneInfo.mockResolvedValue({
+      capabilities: [SCENE_CAPABILITY_MATTERPORT],
+      sceneMetadata: { MATTERPORT_SECRET_ARN: MOCK_ARN },
+    });
   });
 
   it('should render correctly', async () => {


### PR DESCRIPTION
## Overview
- Fixed the problem related to scene rendering and texture issue when switching from a Matterport to non-Matterport scene.
- Fixed the setting and handling of conditional variable that determines whether scene is Matterport enabled or not

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
