### PR TITLE
ci: turbo charge dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,14 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    versioning-strategy: "increase"
+  - package-ecosystem: npm
+    directory: /
+    versioning-strategy: increase
     schedule:
-      interval: "daily"
+      interval: daily
+    open-pull-requests-limit: 25
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/dependabot-hook.yml
+++ b/.github/workflows/dependabot-hook.yml
@@ -1,0 +1,30 @@
+name: Dependabot Hook
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Enable Auto-Merge for PR
+        run: gh pr merge --auto --rebase --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Overview

This change turbo charges Dependabot with the following changes:
- Enable up to 25 version bumps a day.
- Enable GitHub Actions version bumps.
- Auto-approve version bump PRs.
- Enable auto-merge with rebase on version bump PRs.

The work automates dependency updates. Dependency updates will only need to be manually touched if a required check fails. If required checks fail, it's often easiest to just close the PR, unless we really want the update.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
