### PR TITLE
fix(scene composer): cleanup for polaris css imports & moving interfa…

### DIFF
--- a/packages/scene-composer/src/interfaces/sceneViewer.ts
+++ b/packages/scene-composer/src/interfaces/sceneViewer.ts
@@ -1,19 +1,12 @@
 import { SceneLoader, TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 import { DataStream, TimeQuery, TimeSeriesData, TimeSeriesDataRequest, Viewport } from '@iot-app-kit/core';
 
-import { Direction } from '../layouts/SceneLayout/components/utils';
-
 import { IDataBindingTemplate } from './dataBinding';
 import { SelectionChangedEventCallback, WidgetClickEventCallback } from './components';
 
 export interface DracoDecoderConfig {
   enable: boolean;
   path?: string;
-}
-
-export interface PanelType {
-  direction: typeof Direction.Left | typeof Direction.Right;
-  panels: Record<string, JSX.Element>;
 }
 
 export interface SceneViewerConfig {

--- a/packages/scene-composer/src/layouts/SceneLayout/components/FoldableContainer.scss
+++ b/packages/scene-composer/src/layouts/SceneLayout/components/FoldableContainer.scss
@@ -1,4 +1,4 @@
-// @use '~/@awsui-design-tokens/polaris.scss';
+@use '@awsui/design-tokens/index.scss' as awsui;
 
 .tm-wrapper-left,
 .tm-wrapper-right {
@@ -17,10 +17,10 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  border-left: 1px solid #414750; // TODO: fix awsui import to use $colorBorderDividerDefault;
-  border-right: 1px solid #414750; // TODO: fix awsui import to use $colorBorderDividerDefault;
+  border-left: 1px solid awsui.$color-border-divider-default; 
+  border-right: 1px solid awsui.$color-border-divider-default; 
 
   &:hover {
-    background-color: #414750; // TODO: fix awsui import to use $colorBackgroundDropdownItemHover;
+    background-color: awsui.$color-background-dropdown-item-hover; 
   }
 }

--- a/packages/scene-composer/src/layouts/SceneLayout/components/ScenePanel.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/components/ScenePanel.tsx
@@ -1,10 +1,14 @@
 import React, { useRef, useState } from 'react';
 
-import { PanelType } from '../../../interfaces';
-
+import { Direction } from './utils';
 import FoldableContainer from './FoldableContainer';
 import TabbedPanelContainer from './TabbedPanelContainer';
 import './ScenePanel.scss';
+
+interface PanelType {
+  direction: typeof Direction.Left | typeof Direction.Right;
+  panels: Record<string, JSX.Element>;
+}
 
 const ScenePanel = (props: PanelType) => {
   const { direction, panels } = props;


### PR DESCRIPTION
## Overview
Follow-up PR to address TODOs from scene collapse implementation
- Fixes Polaris imports for .scss file
- Moves `PanelType` interface to internal component file 

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
