### PR TITLE
fix(composer): close overlay auto select attached tag

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
@@ -66,9 +66,13 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
     [selectedSceneNodeRef, node.ref],
   );
 
-  const onClickCloseButton = useCallback(() => {
-    setVisible(false);
-  }, [setVisible]);
+  const onClickCloseButton = useCallback(
+    (e) => {
+      setVisible(false);
+      e.stopPropagation();
+    },
+    [setVisible],
+  );
 
   return visible ? (
     <>
@@ -80,7 +84,7 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
       >
         {!isAnnotation && !componentVisible && (
           <div style={tmCloseButtonDiv}>
-            <button style={tmCloseButton} onClick={onClickCloseButton}>
+            <button style={tmCloseButton} onPointerUp={onClickCloseButton}>
               X
             </button>
           </div>


### PR DESCRIPTION
## Overview
Merge https://github.com/awslabs/iot-app-kit/pull/1189 into main
- Close overlay should not auto select the attached Tag, but should keep the current selection

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
