### PR TITLE
feat(3dkg): added 3dkg changes for entity data binding

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -180,7 +180,7 @@
         "lines": 76.97,
         "statements": 76.38,
         "functions": 75.51,
-        "branches": 61.63,
+        "branches": 61.10,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -1,17 +1,9 @@
-import * as THREE from 'three';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { DataStream, ProviderWithViewport, TimeSeriesData, combineProviders } from '@iot-app-kit/core';
 import { ThreeEvent } from '@react-three/fiber';
 import ab2str from 'arraybuffer-to-string';
-import { combineProviders, DataStream, ProviderWithViewport, TimeSeriesData } from '@iot-app-kit/core';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
 
-import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLogging';
-import {
-  AdditionalComponentData,
-  ExternalLibraryConfig,
-  KnownComponentType,
-  KnownSceneProperty,
-  SceneComposerInternalProps,
-} from '../interfaces';
 import {
   setDracoDecoder,
   setFeatureConfig,
@@ -20,17 +12,32 @@ import {
   setMetricRecorder,
   setTwinMakerSceneMetadataModule,
 } from '../common/GlobalSettings';
-import { useSceneComposerId } from '../common/sceneComposerIdContext';
-import { IAnchorComponentInternal, ICameraComponentInternal, RootState, useStore, useViewOptionState } from '../store';
-import { createStandardUriModifier } from '../utils/uriModifiers';
-import sceneDocumentSnapshotCreator from '../utils/sceneDocumentSnapshotCreator';
-import { SceneLayout } from '../layouts/SceneLayout';
-import { findComponentByType } from '../utils/nodeUtils';
-import { applyDataBindingTemplate } from '../utils/dataBindingTemplateUtils';
-import { combineTimeSeriesData, convertDataStreamsToDataInput } from '../utils/dataStreamUtils';
-import useActiveCamera from '../hooks/useActiveCamera';
-import { getCameraSettings } from '../utils/cameraUtils';
 import { MATTERPORT_ACCESS_TOKEN, MATTERPORT_APPLICATION_KEY, MATTERPORT_SECRET_ARN } from '../common/constants';
+import { useSceneComposerId } from '../common/sceneComposerIdContext';
+import useActiveCamera from '../hooks/useActiveCamera';
+import {
+  AdditionalComponentData,
+  ExternalLibraryConfig,
+  KnownComponentType,
+  KnownSceneProperty,
+  SceneComposerInternalProps,
+} from '../interfaces';
+import { SceneLayout } from '../layouts/SceneLayout';
+import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLogging';
+import {
+  IAnchorComponentInternal,
+  ICameraComponentInternal,
+  IDataBindingComponentInternal,
+  RootState,
+  useStore,
+  useViewOptionState,
+} from '../store';
+import { getCameraSettings } from '../utils/cameraUtils';
+import { applyDataBindingTemplate, extractEntityId } from '../utils/dataBindingTemplateUtils';
+import { combineTimeSeriesData, convertDataStreamsToDataInput } from '../utils/dataStreamUtils';
+import { findComponentByType } from '../utils/nodeUtils';
+import sceneDocumentSnapshotCreator from '../utils/sceneDocumentSnapshotCreator';
+import { createStandardUriModifier } from '../utils/uriModifiers';
 
 import IntlProvider from './IntlProvider';
 import { LoadingProgress } from './three-fiber/LoadingProgress';
@@ -145,7 +152,10 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       const componentTypes = node?.components.map((component) => component.type) ?? [];
 
       const tagComponent = findComponentByType(node, KnownComponentType.Tag) as IAnchorComponentInternal;
-
+      const entityBindingComponent = findComponentByType(
+        node,
+        KnownComponentType.DataBinding,
+      ) as IDataBindingComponentInternal;
       let additionalComponentData: AdditionalComponentData[] | undefined;
       if (tagComponent) {
         additionalComponentData = [
@@ -157,7 +167,16 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
           },
         ];
       }
-
+      // Add entityID info part of additional component data
+      // We assumed IDataBindingMap will have only one mapping as data binding
+      // will always have only one entity data.
+      if (entityBindingComponent) {
+        additionalComponentData?.push({
+          dataBindingContext: !entityBindingComponent?.valueDataBindings?.[0].valueDataBinding?.dataBindingContext
+            ? undefined
+            : extractEntityId(entityBindingComponent?.valueDataBindings?.[0].valueDataBinding),
+        });
+      }
       onSelectionChanged({
         componentTypes,
         nodeRef: selectedSceneNodeRef,

--- a/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useContext } from 'react';
 import { SpaceBetween } from '@awsui/components-react';
+import React, { useCallback, useContext } from 'react';
 
-import { IComponentEditorProps } from '../ComponentEditor';
-import { useStore } from '../../../store';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import { useStore } from '../../../store';
 import { IDataBindingComponentInternal } from '../../../store/internalInterfaces';
+import { IComponentEditorProps } from '../ComponentEditor';
 
 import { DataBindingMapEditor } from './common/DataBindingMapEditor';
 
@@ -43,6 +43,7 @@ export const DataBindingComponentEditor: React.FC<IDataBindingComponentEditorPro
         allowPartialBinding
         skipFirstDivider
         hasBindingName={false}
+        numFields={1}
         valueDataBindingProvider={valueDataBindingProvider}
         component={component}
         onUpdateCallback={onUpdateCallback}

--- a/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
@@ -22,7 +22,7 @@ interface IDataBindingMapEditorProps {
   valueDataBindingProvider: IValueDataBindingProvider | undefined;
   component: ComponentWithDataBindings;
   onUpdateCallback: (componentPartial: Partial<ComponentWithDataBindings>, replace?: boolean | undefined) => void;
-
+  numFields?: number;
   skipFirstDivider?: boolean;
   allowPartialBinding?: boolean;
   hasAddButton?: boolean; // TODO: to be removed once DataBinding component is enabled
@@ -41,6 +41,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
   hasBindingName,
   valueDataBindingProvider,
   component,
+  numFields,
   onUpdateCallback,
   skipFirstDivider,
   allowPartialBinding,
@@ -100,7 +101,6 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
                   />
                 </RemoveButtonContainer>
                 <Spacing />
-
                 {hasBindingName && (
                   <DataBindingMapNameEditor
                     bindingName={(binding as Component.ValueDataBindingNamedMap).bindingName}
@@ -115,6 +115,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
                     allowPartialBinding={allowPartialBinding}
                     componentRef={component.ref}
                     binding={binding.valueDataBinding}
+                    numFields={numFields}
                     valueDataBindingProvider={valueDataBindingProvider}
                     onChange={(v) => onBindingChange(v, index)}
                   />

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/first */
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import wrapper from '@awsui/components-react/test-utils/dom';
 import flushPromises from 'flush-promises';
 
@@ -152,5 +152,21 @@ describe('ValueDataBindingBuilder', () => {
     );
 
     expect(mockProvider.useStore('').createBinding).toBeCalledTimes(1);
+  });
+
+  it('should render only entity binding', async () => {
+    const { container } = render(
+      <ValueDataBindingBuilder
+        allowPartialBinding
+        componentRef={componentRef}
+        binding={mockBinding}
+        valueDataBindingProvider={mockProvider}
+        onChange={onChange}
+        numFields={1}
+      />,
+    );
+    const polarisWrapper = wrapper(container);
+    expect(polarisWrapper.findAutosuggest()).toBeTruthy();
+    expect(screen.getByLabelText('Entity Id')).toBeTruthy();
   });
 });

--- a/packages/scene-composer/src/interfaces/components.ts
+++ b/packages/scene-composer/src/interfaces/components.ts
@@ -72,9 +72,15 @@ export interface ITagData {
 }
 
 /**
+ * Additional Data binding data which is entityID for TwinMaker usecase
+ */
+export interface IEntityBindingInfo {
+  dataBindingContext?: unknown;
+}
+/**
  * Type that can be represented by different additional component data types such as ITagData | IFutureComponentData
  */
-export type AdditionalComponentData = ITagData;
+export type AdditionalComponentData = ITagData | IEntityBindingInfo;
 
 /**
  * Callback signature for selection of with Widgets.

--- a/packages/scene-composer/src/utils/dataBindingTemplateUtils.spec.ts
+++ b/packages/scene-composer/src/utils/dataBindingTemplateUtils.spec.ts
@@ -7,6 +7,7 @@ import {
   createDataBindingTemplateOptions,
   dataBindingConfigSelector,
   decorateDataBindingTemplate,
+  extractEntityId,
   isDataBindingTemplate,
   undecorateDataBindingTemplate,
 } from './dataBindingTemplateUtils';
@@ -171,5 +172,13 @@ describe('applyDataBindingTemplate', () => {
   it('should return empty data binding if data binding is missing', () => {
     const dataBindingContext = applyDataBindingTemplate(undefined, mockDataBindingTemplate);
     expect(dataBindingContext).toEqual({});
+  });
+});
+
+describe('extractEntityId', () => {
+  it('should return entityId', () => {
+    const dataBinding = { dataBindingContext: { entityId: 'abcd' } };
+    const entityId = extractEntityId(dataBinding);
+    expect(entityId).toEqual({ entityId: 'abcd' });
   });
 });

--- a/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
@@ -1,17 +1,18 @@
-import { cloneDeep } from 'lodash';
+import { cloneDeep, pick } from 'lodash';
 
-import { RootState } from '../store';
+import {
+  DEFAULT_DATA_BINDING_TEMPLATE_COMPONENT_NAME,
+  DEFAULT_DATA_BINDING_TEMPLATE_ENTITY_ID,
+  DataBindingLabelKeys,
+} from '../common/constants';
 import {
   IDataBindingConfig,
   IDataBindingTemplate,
   IDataFieldOption,
-  KnownSceneProperty,
   IValueDataBinding,
+  KnownSceneProperty,
 } from '../interfaces';
-import {
-  DEFAULT_DATA_BINDING_TEMPLATE_ENTITY_ID,
-  DEFAULT_DATA_BINDING_TEMPLATE_COMPONENT_NAME,
-} from '../common/constants';
+import { RootState } from '../store';
 
 /**
  * Data binding templates will be stored as ${my-value} in IValueDataBinding
@@ -96,3 +97,13 @@ export function applyDataBindingTemplate(
   });
   return dataBindingContext;
 }
+
+/**
+ * We extract entityId from the data binding object.
+ * @param dataBinding we send data binding object
+ * @returns
+ */
+export const extractEntityId = (dataBinding: IValueDataBinding): Record<string, string> => {
+  const contextData = dataBinding.dataBindingContext ?? {};
+  return pick(contextData, [DataBindingLabelKeys.entityId]);
+};


### PR DESCRIPTION
## Overview
This PR contains following changes,
* Logic to removed components and properties from data binding.
* Logic On the onSelelctionChangeEvent, take entityId from the data binding and provide it to the additionalDatacomponent variable.
* Unit tests.

## Verifying Changes
* Tested on console.
![Screen Shot 2023-05-16 at 11 12 16 AM](https://github.com/awslabs/iot-app-kit/assets/54058998/59317772-7ec6-414f-8616-c1149605c42b)
* npm run test


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
