### PR TITLE
fix(composer): initial loading of Matterport scene

### DIFF
--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
@@ -4,6 +4,7 @@ import styled, { ThemeContext } from 'styled-components';
 import { Canvas, ThreeEvent } from '@react-three/fiber';
 import { useContextBridge } from '@react-three/drei/core/useContextBridge';
 import { MatterportViewer, MpSdk } from '@matterport/r3f/dist';
+import { isEmpty } from 'lodash';
 
 import { getGlobalSettings, setMatterportSdk } from '../../common/GlobalSettings';
 import LoggingContext from '../../logger/react-logger/contexts/logging';
@@ -47,7 +48,7 @@ const R3FWrapper = (props: { matterportConfig?: MatterportConfig; children?: unk
   const sceneComposerId = useContext(sceneComposerIdContext);
   const ContextBridge = useContextBridge(LoggingContext, sceneComposerIdContext, ThemeContext);
   const { enableMatterportViewer } = useMatterportViewer();
-  const loadMatterport = enableMatterportViewer && matterportConfig;
+  const loadMatterport = enableMatterportViewer && matterportConfig && !isEmpty(matterportConfig.modelId);
 
   useEffect(() => {
     if (!loadMatterport) {


### PR DESCRIPTION
## Overview
- Added check for Matterport model Id to fix the issue with initial loading of a scene with Matterport space

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
