### PR TITLE
fix(scene composer): modifying auto collapse to only apply to viewer

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.spec.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.spec.tsx
@@ -20,11 +20,14 @@ describe('svgIconToWidgetSprite', () => {
     ['Error', { key: DefaultAnchorStatus.Error, icon: ErrorIconSvgString }],
     ['Video', { key: DefaultAnchorStatus.Video, icon: VideoIconSvgString }],
   ];
-
+  interface Icons {
+    key: string;
+    icon: string;
+  }
   icons.forEach((value) => {
     it(`it should render the ${value[0]} correctly`, () => {
       jest.spyOn(window.Math, 'random').mockReturnValue(0.1);
-      const { key, icon } = value[1] as any;
+      const { key, icon } = value[1] as Icons;
       const container = renderer.create(svgIconToWidgetSprite(icon, key, false, true));
 
       expect(container).toMatchSnapshot();
@@ -34,7 +37,7 @@ describe('svgIconToWidgetSprite', () => {
   icons.forEach((value) => {
     it(`it should render the always visible ${value[0]} correctly`, () => {
       jest.spyOn(window.Math, 'random').mockReturnValue(0.1);
-      const { key, icon } = value[1] as any;
+      const { key, icon } = value[1] as Icons;
       const container = renderer.create(svgIconToWidgetSprite(icon, key, true, true));
 
       expect(container).toMatchSnapshot();
@@ -44,7 +47,7 @@ describe('svgIconToWidgetSprite', () => {
   icons.forEach((value) => {
     it(`it should render the constant sized ${value[0]} correctly`, () => {
       jest.spyOn(window.Math, 'random').mockReturnValue(0.1);
-      const { key, icon } = value[1] as any;
+      const { key, icon } = value[1] as Icons;
       const container = renderer.create(svgIconToWidgetSprite(icon, key, false, false));
 
       expect(container).toMatchSnapshot();

--- a/packages/scene-composer/src/components/__snapshots__/SceneComposerInternal.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/SceneComposerInternal.spec.tsx.snap
@@ -321,6 +321,7 @@ exports[`SceneComposerInternal should render correctly with an empty scene in vi
   header={false}
   leftPanel={
     <ScenePanel
+      collapse={true}
       direction="Left"
       panels={
         Object {

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
@@ -135,6 +135,7 @@ const SceneLayout: FC<SceneLayoutProps> = ({
   };
   const leftPanelViewModeProps = {
     direction: Direction.Left,
+    collapse: isViewing,
     panels: {
       [intl.formatMessage({ defaultMessage: 'Hierarchy', description: 'Panel Tab title' })]: <SceneHierarchyPanel />,
       [intl.formatMessage({ defaultMessage: 'Settings', description: 'Panel Tab title' })]: (

--- a/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
+++ b/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
@@ -140,13 +140,44 @@ exports[`SceneLayout should not render camera preview if editing and non-camera 
         className="tm-wrapper-left"
       >
         <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneHierarchyPanel />,
+                    "id": "Hierarchy",
+                    "label": "Hierarchy",
+                  },
+                  Object {
+                    "content": <SceneRulesPanel />,
+                    "id": "Rules",
+                    "label": "Rules",
+                  },
+                  Object {
+                    "content": <SettingsPanel />,
+                    "id": "Settings",
+                    "label": "Settings",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
           className="tm-handle"
           data-testid="handle"
           onClick={[Function]}
         >
           <div
             data-mocked="Icon"
-            name="angle-right"
+            name="angle-left"
             size="small"
             variant="normal"
           />
@@ -221,13 +252,34 @@ exports[`SceneLayout should not render camera preview if editing and non-camera 
         className="tm-wrapper-right"
       >
         <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneNodeInspectorPanel />,
+                    "id": "Inspector",
+                    "label": "Inspector",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
           className="tm-handle"
           data-testid="handle"
           onClick={[Function]}
         >
           <div
             data-mocked="Icon"
-            name="angle-left"
+            name="angle-right"
             size="small"
             variant="normal"
           />
@@ -378,13 +430,44 @@ exports[`SceneLayout should render camera preview if editing and camera componen
         className="tm-wrapper-left"
       >
         <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneHierarchyPanel />,
+                    "id": "Hierarchy",
+                    "label": "Hierarchy",
+                  },
+                  Object {
+                    "content": <SceneRulesPanel />,
+                    "id": "Rules",
+                    "label": "Rules",
+                  },
+                  Object {
+                    "content": <SettingsPanel />,
+                    "id": "Settings",
+                    "label": "Settings",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
           className="tm-handle"
           data-testid="handle"
           onClick={[Function]}
         >
           <div
             data-mocked="Icon"
-            name="angle-right"
+            name="angle-left"
             size="small"
             variant="normal"
           />
@@ -459,13 +542,34 @@ exports[`SceneLayout should render camera preview if editing and camera componen
         className="tm-wrapper-right"
       >
         <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneNodeInspectorPanel />,
+                    "id": "Inspector",
+                    "label": "Inspector",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
           className="tm-handle"
           data-testid="handle"
           onClick={[Function]}
         >
           <div
             data-mocked="Icon"
-            name="angle-left"
+            name="angle-right"
             size="small"
             variant="normal"
           />
@@ -616,13 +720,44 @@ exports[`SceneLayout should render correctly in Edit mode 1`] = `
         className="tm-wrapper-left"
       >
         <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneHierarchyPanel />,
+                    "id": "Hierarchy",
+                    "label": "Hierarchy",
+                  },
+                  Object {
+                    "content": <SceneRulesPanel />,
+                    "id": "Rules",
+                    "label": "Rules",
+                  },
+                  Object {
+                    "content": <SettingsPanel />,
+                    "id": "Settings",
+                    "label": "Settings",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
           className="tm-handle"
           data-testid="handle"
           onClick={[Function]}
         >
           <div
             data-mocked="Icon"
-            name="angle-right"
+            name="angle-left"
             size="small"
             variant="normal"
           />
@@ -697,13 +832,34 @@ exports[`SceneLayout should render correctly in Edit mode 1`] = `
         className="tm-wrapper-right"
       >
         <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneNodeInspectorPanel />,
+                    "id": "Inspector",
+                    "label": "Inspector",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
           className="tm-handle"
           data-testid="handle"
           onClick={[Function]}
         >
           <div
             data-mocked="Icon"
-            name="angle-left"
+            name="angle-right"
             size="small"
             variant="normal"
           />
@@ -894,13 +1050,44 @@ exports[`SceneLayout should render correctly in Edit mode with Modal 1`] = `
         className="tm-wrapper-left"
       >
         <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneHierarchyPanel />,
+                    "id": "Hierarchy",
+                    "label": "Hierarchy",
+                  },
+                  Object {
+                    "content": <SceneRulesPanel />,
+                    "id": "Rules",
+                    "label": "Rules",
+                  },
+                  Object {
+                    "content": <SettingsPanel />,
+                    "id": "Settings",
+                    "label": "Settings",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
           className="tm-handle"
           data-testid="handle"
           onClick={[Function]}
         >
           <div
             data-mocked="Icon"
-            name="angle-right"
+            name="angle-left"
             size="small"
             variant="normal"
           />
@@ -975,13 +1162,34 @@ exports[`SceneLayout should render correctly in Edit mode with Modal 1`] = `
         className="tm-wrapper-right"
       >
         <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneNodeInspectorPanel />,
+                    "id": "Inspector",
+                    "label": "Inspector",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
           className="tm-handle"
           data-testid="handle"
           onClick={[Function]}
         >
           <div
             data-mocked="Icon"
-            name="angle-left"
+            name="angle-right"
             size="small"
             variant="normal"
           />

--- a/packages/scene-composer/src/layouts/SceneLayout/components/FoldableContainer.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/components/FoldableContainer.tsx
@@ -8,7 +8,6 @@ type FoldableContainerProps = React.PropsWithChildren<{
   direction: Direction;
   open: boolean;
   setIsOpen: (boolean) => void;
-  ref: React.ReactFragment | undefined;
 }>;
 
 const FoldableContainer: React.FC<FoldableContainerProps> = ({

--- a/packages/scene-composer/src/layouts/SceneLayout/components/ScenePanel.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/components/ScenePanel.tsx
@@ -8,15 +8,15 @@ import './ScenePanel.scss';
 interface PanelType {
   direction: typeof Direction.Left | typeof Direction.Right;
   panels: Record<string, JSX.Element>;
+  collapse?: boolean;
 }
 
 const ScenePanel = (props: PanelType) => {
-  const { direction, panels } = props;
-  const [isOpen, setIsOpen] = useState<boolean>(false);
-  const ref = useRef<React.ReactFragment>(null);
+  const { direction, collapse = false, panels } = props;
+  const [isOpen, setIsOpen] = useState<boolean>(!collapse);
 
   return (
-    <FoldableContainer ref={ref} direction={direction} open={isOpen} setIsOpen={setIsOpen}>
+    <FoldableContainer direction={direction} open={isOpen} setIsOpen={setIsOpen}>
       <div className={'tm-collapse-panel ' + `${isOpen ? 'open' : ''}`}>
         <TabbedPanelContainer panels={panels} />
       </div>

--- a/packages/scene-composer/src/layouts/SceneLayout/components/__snapshots__/ScenePanel.spec.tsx.snap
+++ b/packages/scene-composer/src/layouts/SceneLayout/components/__snapshots__/ScenePanel.spec.tsx.snap
@@ -8,9 +8,10 @@ Object {
       <div
         data-testid="FoldableContainer"
         direction="Left"
+        open=""
       >
         <div
-          class="tm-collapse-panel "
+          class="tm-collapse-panel open"
         >
           <div
             data-testid="TabbedPanelContainer"
@@ -24,9 +25,10 @@ Object {
     <div
       data-testid="FoldableContainer"
       direction="Left"
+      open=""
     >
       <div
-        class="tm-collapse-panel "
+        class="tm-collapse-panel open"
       >
         <div
           data-testid="TabbedPanelContainer"
@@ -188,9 +190,10 @@ Object {
       <div
         data-testid="FoldableContainer"
         direction="Right"
+        open=""
       >
         <div
-          class="tm-collapse-panel "
+          class="tm-collapse-panel open"
         >
           <div
             data-testid="TabbedPanelContainer"
@@ -204,9 +207,10 @@ Object {
     <div
       data-testid="FoldableContainer"
       direction="Right"
+      open=""
     >
       <div
-        class="tm-collapse-panel "
+        class="tm-collapse-panel open"
       >
         <div
           data-testid="TabbedPanelContainer"


### PR DESCRIPTION
## Overview
Updating default collapse behavior to only apply to `SceneViewer` left panel.

https://github.com/awslabs/iot-app-kit/assets/6610619/6b5014ed-a786-43eb-a55c-c59bda65fbcf

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
