### PR TITLE
fix(composer): click events for tag and overlay

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
@@ -178,8 +178,6 @@ export function AsyncLoadedAnchorWidget({
               ],
             });
           }
-
-          event.stopPropagation();
         }
       }
     },

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
@@ -55,7 +55,7 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
   }, [componentVisible]);
 
   // Same behavior as other components to select node when clicked on the panel
-  const onPointerUp = useCallback(
+  const onClickContainer = useCallback(
     (e) => {
       e.stopPropagation();
       if (selectedSceneNodeRef !== node.ref) {
@@ -77,13 +77,12 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
     <>
       <div
         ref={containerRef}
-        onPointerUp={onPointerUp}
-        onPointerDown={(e) => e.stopPropagation()}
+        onClick={onClickContainer}
         style={{ ...tmContainer, ...(isAnnotation ? tmAnnotationContainer : tmPanelContainer) }}
       >
         {!isAnnotation && !componentVisible && (
           <div style={tmCloseButtonDiv}>
-            <button style={tmCloseButton} onPointerUp={onClickCloseButton}>
+            <button style={tmCloseButton} onClick={onClickCloseButton}>
               X
             </button>
           </div>


### PR DESCRIPTION
## Overview
Fix the issues:
- click on Tag in 3D scene doesn't select the Tag
- mouse down somewhere, move the camera, release mouse over the overlay or annotation, the camera continues tracking with the mouse until clicking again

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
