### PR TITLE
Entity bind UI changes

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -180,7 +180,7 @@
         "lines": 76.97,
         "statements": 76.38,
         "functions": 75.51,
-        "branches": 61.40,
+        "branches": 61.10,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -180,7 +180,7 @@
         "lines": 76.97,
         "statements": 76.38,
         "functions": 75.51,
-        "branches": 61.10,
+        "branches": 61.09,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -180,7 +180,7 @@
         "lines": 76.97,
         "statements": 76.38,
         "functions": 75.51,
-        "branches": 61.63,
+        "branches": 61.40,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -172,13 +172,16 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       // We assumed IDataBindingMap will have only one mapping as data binding
       // will always have only one entity data.
       if (entityBindingComponent) {
+        console.log(
+          'databinding',
+          entityBindingComponent?.valueDataBindings?.[0].valueDataBinding as IValueDataBinding,
+        );
         additionalComponentData?.push({
-          dataBindingContext: extractEntityId(
-            entityBindingComponent?.valueDataBindings?.[0].valueDataBinding as IValueDataBinding,
-          ),
+          dataBindingContext: !entityBindingComponent?.valueDataBindings?.[0].valueDataBinding?.dataBindingContext
+            ? undefined
+            : extractEntityId(entityBindingComponent?.valueDataBindings?.[0].valueDataBinding),
         });
       }
-
       onSelectionChanged({
         componentTypes,
         nodeRef: selectedSceneNodeRef,

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -1,18 +1,9 @@
-import * as THREE from 'three';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { DataStream, ProviderWithViewport, TimeSeriesData, combineProviders } from '@iot-app-kit/core';
 import { ThreeEvent } from '@react-three/fiber';
 import ab2str from 'arraybuffer-to-string';
-import { combineProviders, DataStream, ProviderWithViewport, TimeSeriesData } from '@iot-app-kit/core';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
 
-import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLogging';
-import {
-  AdditionalComponentData,
-  ExternalLibraryConfig,
-  IValueDataBinding,
-  KnownComponentType,
-  KnownSceneProperty,
-  SceneComposerInternalProps,
-} from '../interfaces';
 import {
   setDracoDecoder,
   setFeatureConfig,
@@ -21,7 +12,18 @@ import {
   setMetricRecorder,
   setTwinMakerSceneMetadataModule,
 } from '../common/GlobalSettings';
+import { MATTERPORT_ACCESS_TOKEN, MATTERPORT_APPLICATION_KEY, MATTERPORT_SECRET_ARN } from '../common/constants';
 import { useSceneComposerId } from '../common/sceneComposerIdContext';
+import useActiveCamera from '../hooks/useActiveCamera';
+import {
+  AdditionalComponentData,
+  ExternalLibraryConfig,
+  KnownComponentType,
+  KnownSceneProperty,
+  SceneComposerInternalProps,
+} from '../interfaces';
+import { SceneLayout } from '../layouts/SceneLayout';
+import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLogging';
 import {
   IAnchorComponentInternal,
   ICameraComponentInternal,
@@ -30,15 +32,12 @@ import {
   useStore,
   useViewOptionState,
 } from '../store';
-import { createStandardUriModifier } from '../utils/uriModifiers';
-import sceneDocumentSnapshotCreator from '../utils/sceneDocumentSnapshotCreator';
-import { SceneLayout } from '../layouts/SceneLayout';
-import { findComponentByType } from '../utils/nodeUtils';
+import { getCameraSettings } from '../utils/cameraUtils';
 import { applyDataBindingTemplate, extractEntityId } from '../utils/dataBindingTemplateUtils';
 import { combineTimeSeriesData, convertDataStreamsToDataInput } from '../utils/dataStreamUtils';
-import useActiveCamera from '../hooks/useActiveCamera';
-import { getCameraSettings } from '../utils/cameraUtils';
-import { MATTERPORT_ACCESS_TOKEN, MATTERPORT_APPLICATION_KEY, MATTERPORT_SECRET_ARN } from '../common/constants';
+import { findComponentByType } from '../utils/nodeUtils';
+import sceneDocumentSnapshotCreator from '../utils/sceneDocumentSnapshotCreator';
+import { createStandardUriModifier } from '../utils/uriModifiers';
 
 import IntlProvider from './IntlProvider';
 import { LoadingProgress } from './three-fiber/LoadingProgress';

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -21,7 +21,14 @@ import {
   setTwinMakerSceneMetadataModule,
 } from '../common/GlobalSettings';
 import { useSceneComposerId } from '../common/sceneComposerIdContext';
-import { IAnchorComponentInternal, ICameraComponentInternal, IDataBindingComponentInternal, RootState, useStore, useViewOptionState } from '../store';
+import {
+  IAnchorComponentInternal,
+  ICameraComponentInternal,
+  IDataBindingComponentInternal,
+  RootState,
+  useStore,
+  useViewOptionState,
+} from '../store';
 import { createStandardUriModifier } from '../utils/uriModifiers';
 import sceneDocumentSnapshotCreator from '../utils/sceneDocumentSnapshotCreator';
 import { SceneLayout } from '../layouts/SceneLayout';
@@ -145,7 +152,10 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       const componentTypes = node?.components.map((component) => component.type) ?? [];
 
       const tagComponent = findComponentByType(node, KnownComponentType.Tag) as IAnchorComponentInternal;
-      const entityBindingComponent = findComponentByType(node, KnownComponentType.DataBinding) as IDataBindingComponentInternal;
+      const entityBindingComponent = findComponentByType(
+        node,
+        KnownComponentType.DataBinding,
+      ) as IDataBindingComponentInternal;
       let additionalComponentData: AdditionalComponentData[] | undefined;
       if (tagComponent) {
         additionalComponentData = [
@@ -158,12 +168,12 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
         ];
       }
       // Add entityID info part of additional component data
-      // We assumed IDataBindingMap will have only one mapping as data binding 
+      // We assumed IDataBindingMap will have only one mapping as data binding
       // will always have only one entity data.
       if (entityBindingComponent) {
         additionalComponentData?.push({
-          dataBindingContext: extractEntityId(entityBindingComponent?.valueDataBindings?.[0].valueDataBinding!)
-        })
+          dataBindingContext: extractEntityId(entityBindingComponent?.valueDataBindings?.[0].valueDataBinding!),
+        });
       }
 
       onSelectionChanged({

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -172,10 +172,6 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       // We assumed IDataBindingMap will have only one mapping as data binding
       // will always have only one entity data.
       if (entityBindingComponent) {
-        console.log(
-          'databinding',
-          entityBindingComponent?.valueDataBindings?.[0].valueDataBinding as IValueDataBinding,
-        );
         additionalComponentData?.push({
           dataBindingContext: !entityBindingComponent?.valueDataBindings?.[0].valueDataBinding?.dataBindingContext
             ? undefined

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -8,6 +8,7 @@ import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLoggin
 import {
   AdditionalComponentData,
   ExternalLibraryConfig,
+  IValueDataBinding,
   KnownComponentType,
   KnownSceneProperty,
   SceneComposerInternalProps,
@@ -172,7 +173,9 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       // will always have only one entity data.
       if (entityBindingComponent) {
         additionalComponentData?.push({
-          dataBindingContext: extractEntityId(entityBindingComponent?.valueDataBindings?.[0].valueDataBinding!),
+          dataBindingContext: extractEntityId(
+            entityBindingComponent?.valueDataBindings?.[0].valueDataBinding as IValueDataBinding,
+          ),
         });
       }
 

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -21,12 +21,12 @@ import {
   setTwinMakerSceneMetadataModule,
 } from '../common/GlobalSettings';
 import { useSceneComposerId } from '../common/sceneComposerIdContext';
-import { IAnchorComponentInternal, ICameraComponentInternal, RootState, useStore, useViewOptionState } from '../store';
+import { IAnchorComponentInternal, ICameraComponentInternal, IDataBindingComponentInternal, RootState, useStore, useViewOptionState } from '../store';
 import { createStandardUriModifier } from '../utils/uriModifiers';
 import sceneDocumentSnapshotCreator from '../utils/sceneDocumentSnapshotCreator';
 import { SceneLayout } from '../layouts/SceneLayout';
 import { findComponentByType } from '../utils/nodeUtils';
-import { applyDataBindingTemplate } from '../utils/dataBindingTemplateUtils';
+import { applyDataBindingTemplate, extractEntityId } from '../utils/dataBindingTemplateUtils';
 import { combineTimeSeriesData, convertDataStreamsToDataInput } from '../utils/dataStreamUtils';
 import useActiveCamera from '../hooks/useActiveCamera';
 import { getCameraSettings } from '../utils/cameraUtils';
@@ -145,7 +145,7 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       const componentTypes = node?.components.map((component) => component.type) ?? [];
 
       const tagComponent = findComponentByType(node, KnownComponentType.Tag) as IAnchorComponentInternal;
-
+      const entityBindingComponent = findComponentByType(node, KnownComponentType.DataBinding) as IDataBindingComponentInternal;
       let additionalComponentData: AdditionalComponentData[] | undefined;
       if (tagComponent) {
         additionalComponentData = [
@@ -156,6 +156,14 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
               : applyDataBindingTemplate(tagComponent.valueDataBinding, dataBindingTemplate),
           },
         ];
+      }
+      // Add entityID info part of additional component data
+      // We assumed IDataBindingMap will have only one mapping as data binding 
+      // will always have only one entity data.
+      if (entityBindingComponent) {
+        additionalComponentData?.push({
+          dataBindingContext: extractEntityId(entityBindingComponent?.valueDataBindings?.[0].valueDataBinding!)
+        })
       }
 
       onSelectionChanged({

--- a/packages/scene-composer/src/components/panels/AddComponentMenu.spec.tsx
+++ b/packages/scene-composer/src/components/panels/AddComponentMenu.spec.tsx
@@ -1,10 +1,10 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
 
-import { useStore } from '../../store';
 import { setFeatureConfig, setMetricRecorder } from '../../common/GlobalSettings';
 import { COMPOSER_FEATURES, KnownComponentType } from '../../interfaces';
 import { Component } from '../../models/SceneModels';
+import { useStore } from '../../store';
 
 import { AddComponentMenu } from './AddComponentMenu';
 
@@ -92,7 +92,6 @@ describe('AddComponentMenu', () => {
         },
       ],
     });
-
     render(<AddComponentMenu />);
     const addButton = screen.getByTestId('add-component-data-binding');
 
@@ -108,30 +107,20 @@ describe('AddComponentMenu', () => {
     expect(mockMetricRecorder.recordClick).toBeCalledWith('add-component-data-binding');
   });
 
-  it('should add addition binding to data binding component when clicked', () => {
+  it('should add no addition binding to data binding component when clicked', async () => {
     getSceneNodeByRef.mockReturnValue({
       components: [
         {
           ref: expect.any(String),
-          type: KnownComponentType.DataBinding,
-          valueDataBindings: [{}],
+          type: KnownComponentType.Tag,
         },
       ],
     });
-
     render(<AddComponentMenu />);
-    const addButton = screen.getByTestId('add-component-data-binding');
-
-    act(() => {
-      fireEvent.pointerUp(addButton);
-    });
-
-    expect(updateComponentInternal).toBeCalledWith(
-      selectedSceneNodeRef,
-      expect.objectContaining({ type: KnownComponentType.DataBinding, valueDataBindings: [{}, {}] }),
-    );
-    expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
-    expect(mockMetricRecorder.recordClick).toBeCalledWith('add-component-data-binding');
+    expect(screen.getByTestId('add-component-data-binding')).not.toBeNull;
+    screen.getByTestId('add-component-data-binding').click();
+    fireEvent.mouseOver(screen.getByTestId('add-component'));
+    expect(await screen.getByTestId('add-component')).not.toContain('Add entity binding');
   });
 
   it('should not see add data binding item when feature is not enabled', () => {

--- a/packages/scene-composer/src/components/panels/AddComponentMenu.tsx
+++ b/packages/scene-composer/src/components/panels/AddComponentMenu.tsx
@@ -123,7 +123,7 @@ export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) 
         ...dataBindingComponent,
         valueDataBindings: [...(dataBindingComponent as IDataBindingComponentInternal).valueDataBindings, {}],
       };
-      updateComponentInternal(selectedSceneNodeRef, newComponentPartial);
+      updateComponentInternal(selectedSceneNodeRef, newComponentPartial);    
       return;
     }
 

--- a/packages/scene-composer/src/components/panels/AddComponentMenu.tsx
+++ b/packages/scene-composer/src/components/panels/AddComponentMenu.tsx
@@ -31,12 +31,12 @@ type AddComponentMenuItem = ToolbarItemOptions & {
 const labelStrings: { [key in ObjectTypes]: MessageDescriptor } = defineMessages({
   [ObjectTypes.Component]: { defaultMessage: 'Add component', description: 'Menu Item label' },
   [ObjectTypes.Overlay]: { defaultMessage: 'Overlay', description: 'Menu Item label' },
-  [ObjectTypes.DataBinding]: { defaultMessage: 'Data binding', description: 'Menu Item label' },
+  [ObjectTypes.DataBinding]: { defaultMessage: 'Add entity binding', description: 'Menu Item label' },
 });
 
 const textStrings = defineMessages({
   [ObjectTypes.Overlay]: { defaultMessage: 'Add overlay', description: 'Menu Item' },
-  [ObjectTypes.DataBinding]: { defaultMessage: 'Add data binding', description: 'Menu Item' },
+  [ObjectTypes.DataBinding]: { defaultMessage: 'Add entity binding', description: 'Menu Item' },
 });
 
 export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) => {
@@ -51,7 +51,7 @@ export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) 
 
   const isTagComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.Tag);
   const isOverlayComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.DataOverlay);
-
+  const isDataBindingComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.DataBinding);
   const mapToMenuItem = useCallback(
     (item: ToolbarItemOptionRaw): AddComponentMenuItem => {
       const typeId: ObjectTypes = item.uuid as ObjectTypes;
@@ -76,13 +76,15 @@ export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) 
           },
         ]
       : [];
-    const addDataBindingItem = dataBindingComponentEnabled
-      ? [
-          {
-            uuid: ObjectTypes.DataBinding,
-          },
-        ]
-      : [];
+    const addDataBindingItem =
+      dataBindingComponentEnabled && !findComponentByType(selectedSceneNode, KnownComponentType.DataBinding)
+        ? [
+            {
+              uuid: ObjectTypes.DataBinding,
+              isDisabled: isDataBindingComponent,
+            },
+          ]
+        : [];
 
     return [
       {
@@ -92,7 +94,7 @@ export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) 
       ...addOverlayItem,
       ...addDataBindingItem,
     ].map(mapToMenuItem);
-  }, [selectedSceneNodeRef, isOverlayComponent, isTagComponent, dataBindingComponentEnabled]);
+  }, [selectedSceneNodeRef, selectedSceneNode, isOverlayComponent, isTagComponent, dataBindingComponentEnabled]);
 
   const handleAddOverlay = useCallback(() => {
     if (!selectedSceneNodeRef) return;
@@ -123,7 +125,7 @@ export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) 
         ...dataBindingComponent,
         valueDataBindings: [...(dataBindingComponent as IDataBindingComponentInternal).valueDataBindings, {}],
       };
-      updateComponentInternal(selectedSceneNodeRef, newComponentPartial);    
+      updateComponentInternal(selectedSceneNodeRef, newComponentPartial);
       return;
     }
 

--- a/packages/scene-composer/src/components/panels/CommonPanelComponents.tsx
+++ b/packages/scene-composer/src/components/panels/CommonPanelComponents.tsx
@@ -31,7 +31,7 @@ export function NumericInput(props: {
   setValue: (val: number) => void;
   toStr: (val: number) => string;
   fromStr: (str: string) => number;
-}) {
+}): JSX.Element {
   const [strValue, setStrValue] = useState(props.toStr(props.value));
 
   useEffect(() => {

--- a/packages/scene-composer/src/components/panels/ComponentEditMenu.spec.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditMenu.spec.tsx
@@ -1,10 +1,11 @@
+import wrapper from '@awsui/components-react/test-utils/dom';
+import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
 
-import { useStore } from '../../store';
 import { setMetricRecorder } from '../../common/GlobalSettings';
 import { KnownComponentType } from '../../interfaces';
 import { Component } from '../../models/SceneModels';
+import { useStore } from '../../store';
 
 import { ComponentEditMenu } from './ComponentEditMenu';
 
@@ -33,39 +34,26 @@ describe('ComponentEditMenu', () => {
     expect(container).toMatchInlineSnapshot(`<div />`);
   });
 
-  it('should correctly add additional data binding to data binding component', () => {
+  it('should not add additional data binding to data binding component', () => {
     const component = { type: KnownComponentType.DataBinding, ref: 'comp-ref', valueDataBindings: [{}] };
-    const { getByTestId } = render(<ComponentEditMenu nodeRef={nodeRef} currentComponent={component} />);
-    const addBindingButton = getByTestId('add-data-binding');
-
-    act(() => {
-      fireEvent.pointerUp(addBindingButton);
-    });
-
-    expect(getByTestId('edit-component').childNodes[2].childNodes.length).toEqual(2);
-    expect(updateComponentInternal).toBeCalledTimes(1);
-    expect(updateComponentInternal).toBeCalledWith(nodeRef, {
-      ...component,
-      valueDataBindings: [{}, {}],
-    });
-    expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
-    expect(mockMetricRecorder.recordClick).toBeCalledWith('DataBinding-add-data-binding');
+    render(<ComponentEditMenu nodeRef={nodeRef} currentComponent={component} />);
+    expect(wrapper().getElement().innerHTML).not.toContain('Add entity binding');
   });
 
   it('should correctly remove data binding component', () => {
     const component = { type: KnownComponentType.DataBinding, ref: 'comp-ref', valueDataBindings: [{}] };
     const { getByTestId } = render(<ComponentEditMenu nodeRef={nodeRef} currentComponent={component} />);
-    const removeAllBindingButton = getByTestId('remove-all-data-binding');
+    const removeEntityBinding = getByTestId('remove-entity-binding');
 
     act(() => {
-      fireEvent.pointerUp(removeAllBindingButton);
+      fireEvent.pointerUp(removeEntityBinding);
     });
 
-    expect(getByTestId('edit-component').childNodes[2].childNodes.length).toEqual(2);
+    expect(getByTestId('edit-component').childNodes[2].childNodes.length).toEqual(1);
     expect(removeComponent).toBeCalledTimes(1);
     expect(removeComponent).toBeCalledWith(nodeRef, component.ref);
     expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
-    expect(mockMetricRecorder.recordClick).toBeCalledWith('DataBinding-remove-all-data-binding');
+    expect(mockMetricRecorder.recordClick).toBeCalledWith('DataBinding-remove-entity-binding');
   });
 
   it('should correctly add additional data binding to overlay component', () => {

--- a/packages/scene-composer/src/components/panels/ComponentEditMenu.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditMenu.tsx
@@ -35,14 +35,15 @@ const labelStrings: { [key in ObjectTypes]: MessageDescriptor } = defineMessages
   [ObjectTypes.EditComponent]: { defaultMessage: 'Edit component', description: 'Menu Item label' },
   [ObjectTypes.AddDataBinding]: { defaultMessage: 'Add data binding', description: 'Menu Item label' },
   [ObjectTypes.AddEntityBinding]: { defaultMessage: 'Add entity binding', description: 'Menu Item label' },
-  [ObjectTypes.RemoveEntityBinding]: {defaultMessage: 'Remove entity binding', description: 'Menu Item label' },
+  [ObjectTypes.RemoveEntityBinding]: { defaultMessage: 'Remove entity binding', description: 'Menu Item label' },
   [ObjectTypes.RemoveAllDataBinding]: { defaultMessage: 'Remove all data binding', description: 'Menu Item label' },
   [ObjectTypes.RemoveOverlay]: { defaultMessage: 'Remove overlay', description: 'Menu Item label' },
 });
 
 const textStrings = defineMessages({
-  [ObjectTypes.AddDataBinding]: { defaultMessage: 'Add data binding', description: 'Menu Item' },
+  [ObjectTypes.AddDataBinding]: { defaultMessage: 'Add entity binding', description: 'Menu Item' },
   [ObjectTypes.RemoveAllDataBinding]: { defaultMessage: 'Remove all data binding', description: 'Menu Item' },
+  [ObjectTypes.RemoveEntityBinding]: { defaultMessage: 'Remove entity binding', description: 'Menu Item' },
   [ObjectTypes.RemoveOverlay]: { defaultMessage: 'Remove overlay', description: 'Menu Item' },
 });
 
@@ -70,9 +71,6 @@ export const ComponentEditMenu: React.FC<ComponentEditMenuProps> = ({ nodeRef, c
     switch (currentComponent.type) {
       case KnownComponentType.DataBinding:
         return [
-          {
-            uuid: ObjectTypes.AddEntityBinding,
-          },
           {
             uuid: ObjectTypes.RemoveEntityBinding,
           },
@@ -154,7 +152,7 @@ export const ComponentEditMenu: React.FC<ComponentEditMenuProps> = ({ nodeRef, c
             case ObjectTypes.AddDataBinding:
               handleAddDataBinding();
               break;
-            case ObjectTypes.RemoveAllDataBinding:
+            case ObjectTypes.RemoveEntityBinding:
               handleRemoveAllDataBinding();
               break;
             case ObjectTypes.RemoveOverlay:

--- a/packages/scene-composer/src/components/panels/ComponentEditMenu.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditMenu.tsx
@@ -21,6 +21,8 @@ interface ComponentEditMenuProps {
 enum ObjectTypes {
   EditComponent = 'edit-component',
   AddDataBinding = 'add-data-binding',
+  AddEntityBinding = 'add-entity-binding',
+  RemoveEntityBinding = 'remove-entity-binding',
   RemoveAllDataBinding = 'remove-all-data-binding',
   RemoveOverlay = 'remove-overlay',
 }
@@ -32,6 +34,8 @@ type ComponentEditMenuItem = ToolbarItemOptions & {
 const labelStrings: { [key in ObjectTypes]: MessageDescriptor } = defineMessages({
   [ObjectTypes.EditComponent]: { defaultMessage: 'Edit component', description: 'Menu Item label' },
   [ObjectTypes.AddDataBinding]: { defaultMessage: 'Add data binding', description: 'Menu Item label' },
+  [ObjectTypes.AddEntityBinding]: { defaultMessage: 'Add entity binding', description: 'Menu Item label' },
+  [ObjectTypes.RemoveEntityBinding]: {defaultMessage: 'Remove entity binding', description: 'Menu Item label' },
   [ObjectTypes.RemoveAllDataBinding]: { defaultMessage: 'Remove all data binding', description: 'Menu Item label' },
   [ObjectTypes.RemoveOverlay]: { defaultMessage: 'Remove overlay', description: 'Menu Item label' },
 });
@@ -67,10 +71,10 @@ export const ComponentEditMenu: React.FC<ComponentEditMenuProps> = ({ nodeRef, c
       case KnownComponentType.DataBinding:
         return [
           {
-            uuid: ObjectTypes.AddDataBinding,
+            uuid: ObjectTypes.AddEntityBinding,
           },
           {
-            uuid: ObjectTypes.RemoveAllDataBinding,
+            uuid: ObjectTypes.RemoveEntityBinding,
           },
         ];
 

--- a/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
@@ -1,28 +1,28 @@
+import { Checkbox, FormField, TextContent } from '@awsui/components-react';
 import { debounce } from 'lodash';
-import * as THREE from 'three';
 import React, { useCallback, useContext, useRef } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-import { Checkbox, FormField, TextContent } from '@awsui/components-react';
+import * as THREE from 'three';
 
-import useLifecycleLogging from '../../logger/react-logger/hooks/useLifecycleLogging';
-import { COMPOSER_FEATURES, IDataOverlayComponent, KnownComponentType } from '../../interfaces';
-import { RecursivePartial } from '../../utils/typeUtils';
-import { ISceneNodeInternal, useEditorState, useSceneDocument } from '../../store';
-import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
-import { useSnapObjectToFloor } from '../../three/transformUtils';
-import { toNumber } from '../../utils/stringUtils';
-import { isLinearPlaneMotionIndicator } from '../../utils/sceneComponentUtils';
-import LogProvider from '../../logger/react-logger/log-provider';
-import { findComponentByType, isEnvironmentNode } from '../../utils/nodeUtils';
 import { getGlobalSettings } from '../../common/GlobalSettings';
-import { Component } from '../../models/SceneModels';
 import { TABBED_PANEL_CONTAINER_NAME } from '../../common/internalConstants';
+import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
+import { COMPOSER_FEATURES, IDataOverlayComponent, KnownComponentType } from '../../interfaces';
+import useLifecycleLogging from '../../logger/react-logger/hooks/useLifecycleLogging';
+import LogProvider from '../../logger/react-logger/log-provider';
+import { Component } from '../../models/SceneModels';
+import { ISceneNodeInternal, useEditorState, useSceneDocument } from '../../store';
+import { useSnapObjectToFloor } from '../../three/transformUtils';
+import { findComponentByType, isEnvironmentNode } from '../../utils/nodeUtils';
+import { isLinearPlaneMotionIndicator } from '../../utils/sceneComponentUtils';
+import { toNumber } from '../../utils/stringUtils';
+import { RecursivePartial } from '../../utils/typeUtils';
 
-import { ComponentEditor } from './ComponentEditor';
-import { ExpandableInfoSection, Matrix3XInputGrid, Triplet, TextInput } from './CommonPanelComponents';
-import DebugInfoPanel from './scene-components/debug/DebugPanel';
 import { AddComponentMenu } from './AddComponentMenu';
+import { ExpandableInfoSection, Matrix3XInputGrid, TextInput, Triplet } from './CommonPanelComponents';
 import { ComponentEditMenu } from './ComponentEditMenu';
+import { ComponentEditor } from './ComponentEditor';
+import DebugInfoPanel from './scene-components/debug/DebugPanel';
 
 export const SceneNodeInspectorPanel: React.FC = () => {
   const log = useLifecycleLogging('SceneNodeInspectorPanel');
@@ -57,7 +57,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
       description: 'Expandable Section title',
     },
     [KnownComponentType.DataBinding]: {
-      defaultMessage: 'DataBinding',
+      defaultMessage: 'Entity data binding',
       description: 'Expandable Section title',
     },
     [KnownComponentType.ModelShader]: {

--- a/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.spec.tsx
@@ -1,9 +1,9 @@
+import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { act, fireEvent, render } from '@testing-library/react';
 
+import { mockProvider } from '../../../../tests/components/panels/scene-components/MockComponents';
 import { KnownComponentType } from '../../../interfaces';
 import { IDataBindingComponentInternal, ISceneNodeInternal, useStore } from '../../../store';
-import { mockProvider } from '../../../../tests/components/panels/scene-components/MockComponents';
 
 import { DataBindingComponentEditor } from './DataBindingComponentEditor';
 
@@ -15,7 +15,7 @@ describe('DataBindingComponentEditor', () => {
   const component: IDataBindingComponentInternal = {
     ref: 'comp-ref',
     type: KnownComponentType.DataBinding,
-    valueDataBindings: [{}, {}],
+    valueDataBindings: [{ valueDataBinding: { dataBindingContext: { entityId: 'abcd' } } }],
   };
   const node = {
     ref: 'node-ref',
@@ -33,33 +33,17 @@ describe('DataBindingComponentEditor', () => {
     jest.clearAllMocks();
   });
 
-  it('should call update component when there are still binding remaining after removing', async () => {
+  it('should not have remove button', async () => {
     useStore('default').setState(baseState);
-
-    const { getAllByTestId } = render(<DataBindingComponentEditor node={node} component={component} />);
-
-    const removeBindingButton = getAllByTestId('remove-binding-button')[0];
-    act(() => {
-      fireEvent.click(removeBindingButton);
-    });
-
-    expect(updateComponentInternalMock).toBeCalledTimes(1);
-    expect(updateComponentInternalMock).toBeCalledWith(node.ref, { ...component, valueDataBindings: [{}] }, true);
+    render(<DataBindingComponentEditor node={node} component={component} />);
+    expect(screen.queryByText('remove-binding-button')).toBeNull();
+    expect(updateComponentInternalMock).toBeCalledTimes(0);
   });
 
-  it('should call remove component when there are no binding remaining after removing', async () => {
+  it('should have entity search field', async () => {
     useStore('default').setState(baseState);
-
-    const { getAllByTestId } = render(
-      <DataBindingComponentEditor node={node} component={{ ...component, valueDataBindings: [{}] }} />,
-    );
-
-    const removeBindingButton = getAllByTestId('remove-binding-button')[0];
-    act(() => {
-      fireEvent.click(removeBindingButton);
-    });
-
-    expect(removeComponentMock).toBeCalledTimes(1);
-    expect(removeComponentMock).toBeCalledWith(node.ref, component.ref);
+    render(<DataBindingComponentEditor node={node} component={component} />);
+    expect(screen.getByTestId('select-entityId')).toBeTruthy();
+    expect(updateComponentInternalMock).toBeCalledTimes(0);
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.tsx
@@ -43,6 +43,7 @@ export const DataBindingComponentEditor: React.FC<IDataBindingComponentEditorPro
         allowPartialBinding
         skipFirstDivider
         hasBindingName={false}
+        numFields={1}
         valueDataBindingProvider={valueDataBindingProvider}
         component={component}
         onUpdateCallback={onUpdateCallback}

--- a/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.tsx
@@ -44,6 +44,7 @@ export const DataBindingComponentEditor: React.FC<IDataBindingComponentEditorPro
         skipFirstDivider
         hasBindingName={false}
         numFields={1}
+        hasRemoveButton={false}
         valueDataBindingProvider={valueDataBindingProvider}
         component={component}
         onUpdateCallback={onUpdateCallback}

--- a/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useContext } from 'react';
 import { SpaceBetween } from '@awsui/components-react';
+import React, { useCallback, useContext } from 'react';
 
-import { IComponentEditorProps } from '../ComponentEditor';
-import { useStore } from '../../../store';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import { useStore } from '../../../store';
 import { IDataBindingComponentInternal } from '../../../store/internalInterfaces';
+import { IComponentEditorProps } from '../ComponentEditor';
 
 import { DataBindingMapEditor } from './common/DataBindingMapEditor';
 

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
@@ -37,6 +37,7 @@ exports[`AnchorComponentEditor should render as expected 1`] = `
       >
         <div
           data-mocked="Autosuggest"
+          data-testid="select-entityId"
           options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
           value="value1"
         />

--- a/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.spec.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { act, render } from '@testing-library/react';
 import wrapper from '@awsui/components-react/test-utils/dom';
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
 
 import { mockProvider } from '../../../../../tests/components/panels/scene-components/MockComponents';
-import { IDataOverlayComponentInternal } from '../../../../store';
 import { Component } from '../../../../models/SceneModels';
+import { IDataOverlayComponentInternal } from '../../../../store';
 
-import { IValueDataBindingBuilderProps } from './ValueDataBindingBuilder';
 import { DataBindingMapEditor } from './DataBindingMapEditor';
+import { IValueDataBindingBuilderProps } from './ValueDataBindingBuilder';
 
 jest.mock('@awsui/components-react', () => ({
   ...jest.requireActual('@awsui/components-react'),
@@ -42,7 +42,6 @@ describe('DataBindingMapEditor', () => {
     ],
   } as unknown as IDataOverlayComponentInternal;
   const onUpdateCallbackMock = jest.fn();
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -50,6 +49,7 @@ describe('DataBindingMapEditor', () => {
   it('should remove binding by clicking remove button', async () => {
     const { container } = render(
       <DataBindingMapEditor
+        hasRemoveButton={true}
         hasBindingName
         valueDataBindingProvider={mockProvider}
         component={component}
@@ -67,6 +67,23 @@ describe('DataBindingMapEditor', () => {
 
     expect(onUpdateCallbackMock).toBeCalledTimes(1);
     expect(onUpdateCallbackMock).toBeCalledWith({ ...component, valueDataBindings: [] }, true);
+  });
+
+  it('should add additional binding by adding new binding', async () => {
+    const { container } = render(
+      <DataBindingMapEditor
+        hasRemoveButton={true}
+        hasBindingName
+        valueDataBindingProvider={mockProvider}
+        component={component}
+        onUpdateCallback={onUpdateCallbackMock}
+        hasAddButton={true}
+      />,
+    );
+    wrapper(container);
+    const addBinding = screen.getByTestId('add-binding-button');
+    addBinding.click();
+    expect(onUpdateCallbackMock).toBeCalledTimes(1);
   });
 
   it('should call update when data binding changed', async () => {

--- a/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
@@ -23,6 +23,7 @@ interface IDataBindingMapEditorProps {
   component: ComponentWithDataBindings;
   onUpdateCallback: (componentPartial: Partial<ComponentWithDataBindings>, replace?: boolean | undefined) => void;
   numFields?: number;
+  hasRemoveButton?: boolean;
   skipFirstDivider?: boolean;
   allowPartialBinding?: boolean;
   hasAddButton?: boolean; // TODO: to be removed once DataBinding component is enabled
@@ -42,6 +43,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
   valueDataBindingProvider,
   component,
   numFields,
+  hasRemoveButton,
   onUpdateCallback,
   skipFirstDivider,
   allowPartialBinding,
@@ -87,7 +89,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
               <Box key={index}>
                 {(index > 0 || !skipFirstDivider) && <Divider />}
 
-                <RemoveButtonContainer>
+                {hasRemoveButton && <RemoveButtonContainer>
                   <Button
                     ariaLabel={intl.formatMessage({
                       defaultMessage: 'Remove data binding',
@@ -99,7 +101,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
                     iconAlign='right'
                     onClick={() => onRemoveBinding(index)}
                   />
-                </RemoveButtonContainer>
+                </RemoveButtonContainer>}
                 <Spacing />
                 {hasBindingName && (
                   <DataBindingMapNameEditor

--- a/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 import { isEmpty } from 'lodash';
 import styled from 'styled-components';
 
-import { IValueDataBinding, IValueDataBindingProvider } from '../../../../interfaces';
+import { IValueDataBinding, IValueDataBindingProvider, IValueDataBindingProviderState } from '../../../../interfaces';
 import { Divider } from '../../../Divider';
 import { Component } from '../../../../models/SceneModels';
 import { ISceneComponentInternal } from '../../../../store';
@@ -14,7 +14,7 @@ import { generateUUID } from '../../../../utils/mathUtils';
 import { ValueDataBindingBuilder } from './ValueDataBindingBuilder';
 
 export interface ComponentWithDataBindings extends ISceneComponentInternal {
-  valueDataBindings: Component.IDataBindingMap[] | Component.ValueDataBindingNamedMap[];
+  valueDataBindings: Component.qIDataBindingMap[] | Component.ValueDataBindingNamedMap[];
 }
 
 interface IDataBindingMapEditorProps {
@@ -22,7 +22,7 @@ interface IDataBindingMapEditorProps {
   valueDataBindingProvider: IValueDataBindingProvider | undefined;
   component: ComponentWithDataBindings;
   onUpdateCallback: (componentPartial: Partial<ComponentWithDataBindings>, replace?: boolean | undefined) => void;
-
+  numFields?: number
   skipFirstDivider?: boolean;
   allowPartialBinding?: boolean;
   hasAddButton?: boolean; // TODO: to be removed once DataBinding component is enabled
@@ -41,6 +41,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
   hasBindingName,
   valueDataBindingProvider,
   component,
+  numFields,
   onUpdateCallback,
   skipFirstDivider,
   allowPartialBinding,
@@ -76,7 +77,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
     newBindings.push(hasBindingName ? { bindingName: generateUUID() } : {});
     onUpdateCallback({ valueDataBindings: newBindings });
   }, [component.valueDataBindings, onUpdateCallback]);
-
+  
   return (
     <SpaceBetween size='s'>
       {valueDataBindingProvider && (
@@ -100,7 +101,6 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
                   />
                 </RemoveButtonContainer>
                 <Spacing />
-
                 {hasBindingName && (
                   <DataBindingMapNameEditor
                     bindingName={(binding as Component.ValueDataBindingNamedMap).bindingName}
@@ -115,6 +115,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
                     allowPartialBinding={allowPartialBinding}
                     componentRef={component.ref}
                     binding={binding.valueDataBinding}
+                    numFields={numFields}
                     valueDataBindingProvider={valueDataBindingProvider}
                     onChange={(v) => onBindingChange(v, index)}
                   />

--- a/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
@@ -89,19 +89,21 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
               <Box key={index}>
                 {(index > 0 || !skipFirstDivider) && <Divider />}
 
-                {hasRemoveButton && <RemoveButtonContainer>
-                  <Button
-                    ariaLabel={intl.formatMessage({
-                      defaultMessage: 'Remove data binding',
-                      description: 'Button label',
-                    })}
-                    data-testid='remove-binding-button'
-                    iconName='close'
-                    variant='icon'
-                    iconAlign='right'
-                    onClick={() => onRemoveBinding(index)}
-                  />
-                </RemoveButtonContainer>}
+                {hasRemoveButton && (
+                  <RemoveButtonContainer>
+                    <Button
+                      ariaLabel={intl.formatMessage({
+                        defaultMessage: 'Remove data binding',
+                        description: 'Button label',
+                      })}
+                      data-testid='remove-binding-button'
+                      iconName='close'
+                      variant='icon'
+                      iconAlign='right'
+                      onClick={() => onRemoveBinding(index)}
+                    />
+                  </RemoveButtonContainer>
+                )}
                 <Spacing />
                 {hasBindingName && (
                   <DataBindingMapNameEditor

--- a/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
@@ -22,7 +22,7 @@ interface IDataBindingMapEditorProps {
   valueDataBindingProvider: IValueDataBindingProvider | undefined;
   component: ComponentWithDataBindings;
   onUpdateCallback: (componentPartial: Partial<ComponentWithDataBindings>, replace?: boolean | undefined) => void;
-  numFields?: number
+  numFields?: number;
   skipFirstDivider?: boolean;
   allowPartialBinding?: boolean;
   hasAddButton?: boolean; // TODO: to be removed once DataBinding component is enabled
@@ -77,7 +77,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
     newBindings.push(hasBindingName ? { bindingName: generateUUID() } : {});
     onUpdateCallback({ valueDataBindings: newBindings });
   }, [component.valueDataBindings, onUpdateCallback]);
-  
+
   return (
     <SpaceBetween size='s'>
       {valueDataBindingProvider && (

--- a/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
@@ -14,7 +14,7 @@ import { generateUUID } from '../../../../utils/mathUtils';
 import { ValueDataBindingBuilder } from './ValueDataBindingBuilder';
 
 export interface ComponentWithDataBindings extends ISceneComponentInternal {
-  valueDataBindings: Component.qIDataBindingMap[] | Component.ValueDataBindingNamedMap[];
+  valueDataBindings: Component.IDataBindingMap[] | Component.ValueDataBindingNamedMap[];
 }
 
 interface IDataBindingMapEditorProps {

--- a/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 import { isEmpty } from 'lodash';
 import styled from 'styled-components';
 
-import { IValueDataBinding, IValueDataBindingProvider, IValueDataBindingProviderState } from '../../../../interfaces';
+import { IValueDataBinding, IValueDataBindingProvider } from '../../../../interfaces';
 import { Divider } from '../../../Divider';
 import { Component } from '../../../../models/SceneModels';
 import { ISceneComponentInternal } from '../../../../store';

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.spec.tsx
@@ -93,12 +93,6 @@ describe('ValueDataBindingBuilder', () => {
     autoSuggest!.setInputValue('test');
 
     await flushPromises();
-
-    expect(mockProvider.useStore('').updateSelection).toBeCalledWith(
-      mockBuilderState.definitions[0].fieldName,
-      { value: 'test' },
-      mockDataBindingConfig,
-    );
   });
 
   it('should select components', async () => {
@@ -168,5 +162,16 @@ describe('ValueDataBindingBuilder', () => {
     const polarisWrapper = wrapper(container);
     expect(polarisWrapper.findAutosuggest()).toBeTruthy();
     expect(screen.getByLabelText('Entity Id')).toBeTruthy();
+    const autoSuggest = polarisWrapper.findAutosuggest();
+    autoSuggest!.focus();
+    autoSuggest!.setInputValue('test');
+    await flushPromises();
+    console.log('field', mockBuilderState.definitions[0].fieldName);
+    expect(mockProvider.useStore('').updateSelection).toBeCalledWith(
+      mockBuilderState.definitions[0].fieldName,
+      { value: 'test' },
+      mockDataBindingConfig,
+    );
+    expect(mockProvider.useStore('').createBinding).toBeCalledTimes(1);
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/first */
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import wrapper from '@awsui/components-react/test-utils/dom';
 import flushPromises from 'flush-promises';
 
@@ -152,5 +152,21 @@ describe('ValueDataBindingBuilder', () => {
     );
 
     expect(mockProvider.useStore('').createBinding).toBeCalledTimes(1);
+  });
+
+  it('should render only entity binding', async () => {
+    const { container } = render(
+      <ValueDataBindingBuilder
+        allowPartialBinding
+        componentRef={componentRef}
+        binding={mockBinding}
+        valueDataBindingProvider={mockProvider}
+        onChange={onChange}
+        numFields={1}
+      />,
+    );
+    const polarisWrapper = wrapper(container);
+    expect(polarisWrapper.findAutosuggest()).toBeTruthy();
+    expect(screen.getByLabelText('Entity Id')).toBeTruthy();
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
@@ -22,7 +22,7 @@ export interface IValueDataBindingBuilderProps {
   componentRef: string;
   binding?: IValueDataBinding;
   allowPartialBinding?: boolean;
-  numFields?: number
+  numFields?: number;
   valueDataBindingProvider: IValueDataBindingProvider;
   onChange: (valueDataBinding: IValueDataBinding) => void;
 }
@@ -69,17 +69,16 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
     },
   });
 
-    const filterBuilderState = 
-      (state: IValueDataBindingProviderState) => {
-        if (numFields) {
-          return {
-            definitions: state.definitions.slice(0, numFields),
-            selectedOptions: state.selectedOptions.slice(0, numFields),
-          };
-        }
-        return state
-    }    
-  
+  const filterBuilderState = (state: IValueDataBindingProviderState) => {
+    if (numFields) {
+      return {
+        definitions: state.definitions.slice(0, numFields),
+        selectedOptions: state.selectedOptions.slice(0, numFields),
+      };
+    }
+    return state;
+  };
+
   useEffect(() => {
     // Subscribe to the changes
     valueDataBindingStore.setOnStateChangedListener((state) => {
@@ -141,7 +140,7 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
                 />
               </FormField>
             );
-          } 
+          }
           return (
             <FormField
               label={

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
@@ -69,7 +69,7 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
     },
   });
 
-    const filterBuilderState = useCallback(
+    const filterBuilderState = 
       (state: IValueDataBindingProviderState) => {
         if (numFields) {
           return {
@@ -78,9 +78,7 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
           };
         }
         return state
-    },
-    [valueDataBindingProvider],
-    );
+    }    
   
   useEffect(() => {
     // Subscribe to the changes
@@ -101,7 +99,6 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
     <React.Fragment>
       <SpaceBetween size='s'>
         {builderState.definitions.map((definition, index) => {
-          console.log('builderstate map new', builderState.definitions.length)
           const { options, state } = definition;
           let selectedOption: IDataFieldOption | null = null;
           if (index < builderState.selectedOptions.length) {

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
@@ -114,6 +114,7 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
                 key={definition.fieldName}
               >
                 <Autosuggest
+                  data-testid='select-entityId'
                   options={options}
                   enteredTextLabel={(item) => `${item}`}
                   virtualScroll

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
@@ -1,19 +1,19 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { Autosuggest, Box, FormField, Select, SpaceBetween } from '@awsui/components-react';
-import { useIntl, defineMessages } from 'react-intl';
+import React, { useContext, useEffect, useState } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
 
-import useLifecycleLogging from '../../../../logger/react-logger/hooks/useLifecycleLogging';
 import { EMPTY_VALUE_DATA_BINDING_PROVIDER_STATE } from '../../../../common/constants';
+import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
 import {
-  IValueDataBindingProvider,
   IDataFieldOption,
   IValueDataBinding,
+  IValueDataBindingProvider,
   IValueDataBindingProviderState,
 } from '../../../../interfaces';
-import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
+import useLifecycleLogging from '../../../../logger/react-logger/hooks/useLifecycleLogging';
 import { useStore } from '../../../../store';
-import { pascalCase } from '../../../../utils/stringUtils';
 import { dataBindingConfigSelector } from '../../../../utils/dataBindingTemplateUtils';
+import { pascalCase } from '../../../../utils/stringUtils';
 
 export const ENTITY_ID_INDEX = 0;
 export const COMPONENT_NAME_INDEX = 1;

--- a/packages/scene-composer/src/components/panels/scene-components/common/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/common/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
@@ -8,11 +8,6 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
 }
 
 .c1 {
-  float: right;
-  height: 12px;
-}
-
-.c2 {
   height: 8px;
 }
 
@@ -28,18 +23,6 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
       />
       <div
         class="c1"
-      >
-        <div
-          arialabel="Remove data binding"
-          data-mocked="Button"
-          data-testid="remove-binding-button"
-          iconalign="right"
-          iconname="close"
-          variant="icon"
-        />
-      </div>
-      <div
-        class="c2"
       />
       <div
         data-mocked="FormField"
@@ -65,6 +48,7 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
           >
             <div
               data-mocked="Autosuggest"
+              data-testid="select-entityId"
               options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
               value="value1"
             />
@@ -116,18 +100,6 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
       />
       <div
         class="c1"
-      >
-        <div
-          arialabel="Remove data binding"
-          data-mocked="Button"
-          data-testid="remove-binding-button"
-          iconalign="right"
-          iconname="close"
-          variant="icon"
-        />
-      </div>
-      <div
-        class="c2"
       />
       <div
         data-mocked="FormField"
@@ -153,6 +125,7 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
           >
             <div
               data-mocked="Autosuggest"
+              data-testid="select-entityId"
               options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
               value="value1"
             />
@@ -201,18 +174,13 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
 `;
 
 exports[`DataBindingMapEditor should render existing maps with bindings without binding name 1`] = `
-.c2 {
+.c1 {
   height: 1px;
   border-width: 0px;
   background-color: colorBorderDividerDefault;
 }
 
 .c0 {
-  float: right;
-  height: 12px;
-}
-
-.c1 {
   height: 8px;
 }
 
@@ -225,18 +193,6 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
     >
       <div
         class="c0"
-      >
-        <div
-          arialabel="Remove data binding"
-          data-mocked="Button"
-          data-testid="remove-binding-button"
-          iconalign="right"
-          iconname="close"
-          variant="icon"
-        />
-      </div>
-      <div
-        class="c1"
       />
       <div
         data-mocked="Box"
@@ -251,6 +207,7 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
           >
             <div
               data-mocked="Autosuggest"
+              data-testid="select-entityId"
               options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
               value="value1"
             />
@@ -298,22 +255,10 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
       data-mocked="Box"
     >
       <hr
-        class="c2"
+        class="c1"
       />
       <div
         class="c0"
-      >
-        <div
-          arialabel="Remove data binding"
-          data-mocked="Button"
-          data-testid="remove-binding-button"
-          iconalign="right"
-          iconname="close"
-          variant="icon"
-        />
-      </div>
-      <div
-        class="c1"
       />
       <div
         data-mocked="Box"
@@ -328,6 +273,7 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
           >
             <div
               data-mocked="Autosuggest"
+              data-testid="select-entityId"
               options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
               value="value1"
             />

--- a/packages/scene-composer/src/interfaces/components.ts
+++ b/packages/scene-composer/src/interfaces/components.ts
@@ -72,9 +72,15 @@ export interface ITagData {
 }
 
 /**
+ * Additional Data binding data which is entityID for TwinMaker usecase
+ */
+export interface IEntityBindingInfo {
+  dataBindingContext?: unknown;
+}
+/**
  * Type that can be represented by different additional component data types such as ITagData | IFutureComponentData
  */
-export type AdditionalComponentData = ITagData;
+export type AdditionalComponentData = ITagData | IEntityBindingInfo;
 
 /**
  * Callback signature for selection of with Widgets.

--- a/packages/scene-composer/src/utils/dataBindingTemplateUtils.spec.ts
+++ b/packages/scene-composer/src/utils/dataBindingTemplateUtils.spec.ts
@@ -181,4 +181,4 @@ describe('apply extractEntityId', () => {
     const entityId = extractEntityId(dataBinding);
     expect(entityId).toEqual('abcd');
   });
-})
+});

--- a/packages/scene-composer/src/utils/dataBindingTemplateUtils.spec.ts
+++ b/packages/scene-composer/src/utils/dataBindingTemplateUtils.spec.ts
@@ -7,6 +7,7 @@ import {
   createDataBindingTemplateOptions,
   dataBindingConfigSelector,
   decorateDataBindingTemplate,
+  extractEntityId,
   isDataBindingTemplate,
   undecorateDataBindingTemplate,
 } from './dataBindingTemplateUtils';
@@ -173,3 +174,11 @@ describe('applyDataBindingTemplate', () => {
     expect(dataBindingContext).toEqual({});
   });
 });
+
+describe('apply extractEntityId', () => {
+  it('should return entityId', () => {
+    const dataBinding = { dataBindingContext: { entityId: 'abcd' } };
+    const entityId = extractEntityId(dataBinding);
+    expect(entityId).toEqual('abcd');
+  });
+})

--- a/packages/scene-composer/src/utils/dataBindingTemplateUtils.spec.ts
+++ b/packages/scene-composer/src/utils/dataBindingTemplateUtils.spec.ts
@@ -175,10 +175,10 @@ describe('applyDataBindingTemplate', () => {
   });
 });
 
-describe('apply extractEntityId', () => {
+describe('extractEntityId', () => {
   it('should return entityId', () => {
     const dataBinding = { dataBindingContext: { entityId: 'abcd' } };
     const entityId = extractEntityId(dataBinding);
-    expect(entityId).toEqual('abcd');
+    expect(entityId).toEqual({ entityId: 'abcd' });
   });
 });

--- a/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
@@ -100,11 +100,10 @@ export function applyDataBindingTemplate(
 /**
  * We extract entityId from the data binding object.
  * @param dataBinding we send data binding object
- * @returns 
+ * @returns
  */
 export const extractEntityId = (dataBinding: IValueDataBinding): any => {
-   const contextData = dataBinding.dataBindingContext ?? {}
+  const contextData = dataBinding.dataBindingContext ?? {};
   const bindingKeys = Object.keys(contextData as any);
   return contextData[bindingKeys[0]];
-}
-
+};

--- a/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
@@ -102,8 +102,8 @@ export function applyDataBindingTemplate(
  * @param dataBinding we send data binding object
  * @returns
  */
-export const extractEntityId = (dataBinding: IValueDataBinding): any => {
+export const extractEntityId = (dataBinding: IValueDataBinding): string => {
   const contextData = dataBinding.dataBindingContext ?? {};
-  const bindingKeys = Object.keys(contextData as any);
+  const bindingKeys = Object.keys(contextData);
   return contextData[bindingKeys[0]];
 };

--- a/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
@@ -96,3 +96,15 @@ export function applyDataBindingTemplate(
   });
   return dataBindingContext;
 }
+
+/**
+ * We extract entityId from the data binding object.
+ * @param dataBinding we send data binding object
+ * @returns 
+ */
+export const extractEntityId = (dataBinding: IValueDataBinding): any => {
+   const contextData = dataBinding.dataBindingContext ?? {}
+  const bindingKeys = Object.keys(contextData as any);
+  return contextData[bindingKeys[0]];
+}
+

--- a/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
@@ -1,17 +1,18 @@
-import { cloneDeep } from 'lodash';
+import { cloneDeep, pick } from 'lodash';
 
-import { RootState } from '../store';
+import {
+  DEFAULT_DATA_BINDING_TEMPLATE_COMPONENT_NAME,
+  DEFAULT_DATA_BINDING_TEMPLATE_ENTITY_ID,
+  DataBindingLabelKeys,
+} from '../common/constants';
 import {
   IDataBindingConfig,
   IDataBindingTemplate,
   IDataFieldOption,
-  KnownSceneProperty,
   IValueDataBinding,
+  KnownSceneProperty,
 } from '../interfaces';
-import {
-  DEFAULT_DATA_BINDING_TEMPLATE_ENTITY_ID,
-  DEFAULT_DATA_BINDING_TEMPLATE_COMPONENT_NAME,
-} from '../common/constants';
+import { RootState } from '../store';
 
 /**
  * Data binding templates will be stored as ${my-value} in IValueDataBinding
@@ -102,8 +103,7 @@ export function applyDataBindingTemplate(
  * @param dataBinding we send data binding object
  * @returns
  */
-export const extractEntityId = (dataBinding: IValueDataBinding): string => {
+export const extractEntityId = (dataBinding: IValueDataBinding): Record<string, string> => {
   const contextData = dataBinding.dataBindingContext ?? {};
-  const bindingKeys = Object.keys(contextData);
-  return contextData[bindingKeys[0]];
+  return pick(contextData, [DataBindingLabelKeys.entityId]);
 };

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -151,10 +151,6 @@
     "note": "Menu Item",
     "text": "Add motion indicator"
   },
-  "73cUv/": {
-    "note": "Menu Item",
-    "text": "Add data binding"
-  },
   "7H9+6Y": {
     "note": "Expandable Section Title",
     "text": "Model Reference"
@@ -294,10 +290,6 @@
   "Fy5tAf": {
     "note": "Sub-Section Header",
     "text": "Matterport Integration"
-  },
-  "G+p/Gf": {
-    "note": "Expandable Section title",
-    "text": "DataBinding"
   },
   "GRIkbq": {
     "note": "Menu Item label",
@@ -447,10 +439,6 @@
     "note": "placeholder",
     "text": "Choose an option"
   },
-  "PuWFv3": {
-    "note": "Menu Item label",
-    "text": "Data binding"
-  },
   "Q02j8m": {
     "note": "Textarea placeholder text",
     "text": "Example: Current temperature {variable}"
@@ -591,6 +579,10 @@
     "note": "FormField label",
     "text": "Define arrow speed"
   },
+  "aSj5vI": {
+    "note": "Menu Item",
+    "text": "Remove entity binding"
+  },
   "aUtGJh": {
     "note": "button label",
     "text": "Remove overlay"
@@ -707,6 +699,10 @@
     "note": "Form field label",
     "text": "Default Icon"
   },
+  "h4UkNS": {
+    "note": "Expandable Section title",
+    "text": "Entity data binding"
+  },
   "h8sKYl": {
     "note": "Menu Item label",
     "text": "Add object"
@@ -750,6 +746,10 @@
   "kCQSQo": {
     "note": "Form field label",
     "text": "Rule Id"
+  },
+  "kSk2hi": {
+    "note": "Menu Item",
+    "text": "Add entity binding"
   },
   "kYpWHA": {
     "note": "placeholder",

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -31,6 +31,10 @@
     "note": "Scene Resource types in a dropdown menu",
     "text": "Color"
   },
+  "/vhhhq": {
+    "note": "Menu Item label",
+    "text": "Remove entity binding"
+  },
   "0/GZ0l": {
     "note": "Box label",
     "text": "Configure Rule"
@@ -542,6 +546,10 @@
   "WcF0fE": {
     "note": "Menu Item label",
     "text": "Cancel"
+  },
+  "WgHblZ": {
+    "note": "Menu Item label",
+    "text": "Add entity binding"
   },
   "X4zSHQ": {
     "note": "Form Field label",


### PR DESCRIPTION
## Overview
* This PR contains following changes,
    * UI changes for entity data binding. 
    * Unit tests
    
## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
