### PR TITLE
feat(scene composer): fixed search entityId using free text

### DIFF
--- a/packages/scene-composer/.eslintrc.js
+++ b/packages/scene-composer/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': 'warn',
     '@typescript-eslint/explicit-module-boundary-types': 'warn',
     '@typescript-eslint/ban-ts-comment': 'warn',
-    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     'formatjs/no-offset': 'error',
     'formatjs/blocklist-elements': [2, ['plural', 'selectordinal', 'select']],

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -180,7 +180,7 @@
         "lines": 76.97,
         "statements": 76.38,
         "functions": 75.51,
-        "branches": 61.63,
+        "branches": 61.09,
         "branchesTrue": 100
       }
     }

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -1,17 +1,9 @@
-import * as THREE from 'three';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { DataStream, ProviderWithViewport, TimeSeriesData, combineProviders } from '@iot-app-kit/core';
 import { ThreeEvent } from '@react-three/fiber';
 import ab2str from 'arraybuffer-to-string';
-import { combineProviders, DataStream, ProviderWithViewport, TimeSeriesData } from '@iot-app-kit/core';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
 
-import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLogging';
-import {
-  AdditionalComponentData,
-  ExternalLibraryConfig,
-  KnownComponentType,
-  KnownSceneProperty,
-  SceneComposerInternalProps,
-} from '../interfaces';
 import {
   setDracoDecoder,
   setFeatureConfig,
@@ -20,17 +12,32 @@ import {
   setMetricRecorder,
   setTwinMakerSceneMetadataModule,
 } from '../common/GlobalSettings';
+import { MATTERPORT_ACCESS_TOKEN, MATTERPORT_APPLICATION_KEY, MATTERPORT_SECRET_ARN } from '../common/constants';
 import { useSceneComposerId } from '../common/sceneComposerIdContext';
-import { IAnchorComponentInternal, ICameraComponentInternal, RootState, useStore, useViewOptionState } from '../store';
-import { createStandardUriModifier } from '../utils/uriModifiers';
-import sceneDocumentSnapshotCreator from '../utils/sceneDocumentSnapshotCreator';
+import useActiveCamera from '../hooks/useActiveCamera';
+import {
+  AdditionalComponentData,
+  ExternalLibraryConfig,
+  KnownComponentType,
+  KnownSceneProperty,
+  SceneComposerInternalProps,
+} from '../interfaces';
 import { SceneLayout } from '../layouts/SceneLayout';
-import { findComponentByType } from '../utils/nodeUtils';
+import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLogging';
+import {
+  IAnchorComponentInternal,
+  ICameraComponentInternal,
+  IDataBindingComponentInternal,
+  RootState,
+  useStore,
+  useViewOptionState,
+} from '../store';
+import { getCameraSettings } from '../utils/cameraUtils';
 import { applyDataBindingTemplate } from '../utils/dataBindingTemplateUtils';
 import { combineTimeSeriesData, convertDataStreamsToDataInput } from '../utils/dataStreamUtils';
-import useActiveCamera from '../hooks/useActiveCamera';
-import { getCameraSettings } from '../utils/cameraUtils';
-import { MATTERPORT_ACCESS_TOKEN, MATTERPORT_APPLICATION_KEY, MATTERPORT_SECRET_ARN } from '../common/constants';
+import { findComponentByType } from '../utils/nodeUtils';
+import sceneDocumentSnapshotCreator from '../utils/sceneDocumentSnapshotCreator';
+import { createStandardUriModifier } from '../utils/uriModifiers';
 
 import IntlProvider from './IntlProvider';
 import { LoadingProgress } from './three-fiber/LoadingProgress';
@@ -145,7 +152,10 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       const componentTypes = node?.components.map((component) => component.type) ?? [];
 
       const tagComponent = findComponentByType(node, KnownComponentType.Tag) as IAnchorComponentInternal;
-
+      const entityBindingComponent = findComponentByType(
+        node,
+        KnownComponentType.DataBinding,
+      ) as IDataBindingComponentInternal;
       let additionalComponentData: AdditionalComponentData[] | undefined;
       if (tagComponent) {
         additionalComponentData = [
@@ -157,7 +167,16 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
           },
         ];
       }
-
+      // Add entityID info part of additional component data
+      // We assumed IDataBindingMap will have only one mapping as data binding
+      // will always have only one entity data.
+      if (entityBindingComponent) {
+        additionalComponentData?.push({
+          dataBindingContext: !entityBindingComponent?.valueDataBinding?.dataBindingContext
+            ? undefined
+            : entityBindingComponent?.valueDataBinding?.dataBindingContext,
+        });
+      }
       onSelectionChanged({
         componentTypes,
         nodeRef: selectedSceneNodeRef,

--- a/packages/scene-composer/src/components/panels/AddComponentMenu.spec.tsx
+++ b/packages/scene-composer/src/components/panels/AddComponentMenu.spec.tsx
@@ -100,38 +100,29 @@ describe('AddComponentMenu', () => {
       fireEvent.pointerUp(addButton);
     });
 
-    expect(addComponentInternal).toBeCalledWith(
-      selectedSceneNodeRef,
-      expect.objectContaining({ type: KnownComponentType.DataBinding, valueDataBindings: [{}] }),
-    );
+    expect(addComponentInternal).toBeCalledWith(selectedSceneNodeRef, {
+      ref: expect.any(String),
+      type: KnownComponentType.DataBinding,
+      valueDataBinding: { dataBindingContext: {} },
+    });
     expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
     expect(mockMetricRecorder.recordClick).toBeCalledWith('add-component-data-binding');
   });
 
-  it('should add addition binding to data binding component when clicked', () => {
+  it('should add no addition binding to data binding component when clicked', async () => {
     getSceneNodeByRef.mockReturnValue({
       components: [
         {
           ref: expect.any(String),
-          type: KnownComponentType.DataBinding,
-          valueDataBindings: [{}],
+          type: KnownComponentType.Tag,
         },
       ],
     });
-
     render(<AddComponentMenu />);
-    const addButton = screen.getByTestId('add-component-data-binding');
-
-    act(() => {
-      fireEvent.pointerUp(addButton);
-    });
-
-    expect(updateComponentInternal).toBeCalledWith(
-      selectedSceneNodeRef,
-      expect.objectContaining({ type: KnownComponentType.DataBinding, valueDataBindings: [{}, {}] }),
-    );
-    expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
-    expect(mockMetricRecorder.recordClick).toBeCalledWith('add-component-data-binding');
+    expect(screen.getByTestId('add-component-data-binding')).not.toBeNull();
+    screen.getByTestId('add-component-data-binding').click();
+    fireEvent.mouseOver(screen.getByTestId('add-component'));
+    expect(await screen.getByTestId('add-component')).not.toContain('Add entity binding');
   });
 
   it('should not see add data binding item when feature is not enabled', () => {

--- a/packages/scene-composer/src/components/panels/CommonPanelComponents.tsx
+++ b/packages/scene-composer/src/components/panels/CommonPanelComponents.tsx
@@ -31,7 +31,7 @@ export function NumericInput(props: {
   setValue: (val: number) => void;
   toStr: (val: number) => string;
   fromStr: (str: string) => number;
-}) {
+}): JSX.Element {
   const [strValue, setStrValue] = useState(props.toStr(props.value));
 
   useEffect(() => {

--- a/packages/scene-composer/src/components/panels/ComponentEditMenu.spec.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditMenu.spec.tsx
@@ -1,10 +1,11 @@
+import wrapper from '@awsui/components-react/test-utils/dom';
+import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
 
-import { useStore } from '../../store';
 import { setMetricRecorder } from '../../common/GlobalSettings';
 import { KnownComponentType } from '../../interfaces';
 import { Component } from '../../models/SceneModels';
+import { useStore } from '../../store';
 
 import { ComponentEditMenu } from './ComponentEditMenu';
 
@@ -33,39 +34,26 @@ describe('ComponentEditMenu', () => {
     expect(container).toMatchInlineSnapshot(`<div />`);
   });
 
-  it('should correctly add additional data binding to data binding component', () => {
+  it('should not add additional data binding to data binding component', () => {
     const component = { type: KnownComponentType.DataBinding, ref: 'comp-ref', valueDataBindings: [{}] };
-    const { getByTestId } = render(<ComponentEditMenu nodeRef={nodeRef} currentComponent={component} />);
-    const addBindingButton = getByTestId('add-data-binding');
-
-    act(() => {
-      fireEvent.pointerUp(addBindingButton);
-    });
-
-    expect(getByTestId('edit-component').childNodes[2].childNodes.length).toEqual(2);
-    expect(updateComponentInternal).toBeCalledTimes(1);
-    expect(updateComponentInternal).toBeCalledWith(nodeRef, {
-      ...component,
-      valueDataBindings: [{}, {}],
-    });
-    expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
-    expect(mockMetricRecorder.recordClick).toBeCalledWith('DataBinding-add-data-binding');
+    render(<ComponentEditMenu nodeRef={nodeRef} currentComponent={component} />);
+    expect(wrapper().getElement().innerHTML).not.toContain('Add entity binding');
   });
 
   it('should correctly remove data binding component', () => {
     const component = { type: KnownComponentType.DataBinding, ref: 'comp-ref', valueDataBindings: [{}] };
     const { getByTestId } = render(<ComponentEditMenu nodeRef={nodeRef} currentComponent={component} />);
-    const removeAllBindingButton = getByTestId('remove-all-data-binding');
+    const removeEntityBinding = getByTestId('remove-entity-binding');
 
     act(() => {
-      fireEvent.pointerUp(removeAllBindingButton);
+      fireEvent.pointerUp(removeEntityBinding);
     });
 
-    expect(getByTestId('edit-component').childNodes[2].childNodes.length).toEqual(2);
+    expect(getByTestId('edit-component').childNodes[2].childNodes.length).toEqual(1);
     expect(removeComponent).toBeCalledTimes(1);
     expect(removeComponent).toBeCalledWith(nodeRef, component.ref);
     expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
-    expect(mockMetricRecorder.recordClick).toBeCalledWith('DataBinding-remove-all-data-binding');
+    expect(mockMetricRecorder.recordClick).toBeCalledWith('DataBinding-remove-entity-binding');
   });
 
   it('should correctly add additional data binding to overlay component', () => {

--- a/packages/scene-composer/src/components/panels/ComponentEditMenu.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditMenu.tsx
@@ -21,6 +21,8 @@ interface ComponentEditMenuProps {
 enum ObjectTypes {
   EditComponent = 'edit-component',
   AddDataBinding = 'add-data-binding',
+  AddEntityBinding = 'add-entity-binding',
+  RemoveEntityBinding = 'remove-entity-binding',
   RemoveAllDataBinding = 'remove-all-data-binding',
   RemoveOverlay = 'remove-overlay',
 }
@@ -32,13 +34,16 @@ type ComponentEditMenuItem = ToolbarItemOptions & {
 const labelStrings: { [key in ObjectTypes]: MessageDescriptor } = defineMessages({
   [ObjectTypes.EditComponent]: { defaultMessage: 'Edit component', description: 'Menu Item label' },
   [ObjectTypes.AddDataBinding]: { defaultMessage: 'Add data binding', description: 'Menu Item label' },
+  [ObjectTypes.AddEntityBinding]: { defaultMessage: 'Add entity binding', description: 'Menu Item label' },
+  [ObjectTypes.RemoveEntityBinding]: { defaultMessage: 'Remove entity binding', description: 'Menu Item label' },
   [ObjectTypes.RemoveAllDataBinding]: { defaultMessage: 'Remove all data binding', description: 'Menu Item label' },
   [ObjectTypes.RemoveOverlay]: { defaultMessage: 'Remove overlay', description: 'Menu Item label' },
 });
 
 const textStrings = defineMessages({
-  [ObjectTypes.AddDataBinding]: { defaultMessage: 'Add data binding', description: 'Menu Item' },
+  [ObjectTypes.AddDataBinding]: { defaultMessage: 'Add entity binding', description: 'Menu Item' },
   [ObjectTypes.RemoveAllDataBinding]: { defaultMessage: 'Remove all data binding', description: 'Menu Item' },
+  [ObjectTypes.RemoveEntityBinding]: { defaultMessage: 'Remove entity binding', description: 'Menu Item' },
   [ObjectTypes.RemoveOverlay]: { defaultMessage: 'Remove overlay', description: 'Menu Item' },
 });
 
@@ -67,10 +72,7 @@ export const ComponentEditMenu: React.FC<ComponentEditMenuProps> = ({ nodeRef, c
       case KnownComponentType.DataBinding:
         return [
           {
-            uuid: ObjectTypes.AddDataBinding,
-          },
-          {
-            uuid: ObjectTypes.RemoveAllDataBinding,
+            uuid: ObjectTypes.RemoveEntityBinding,
           },
         ];
 
@@ -109,7 +111,7 @@ export const ComponentEditMenu: React.FC<ComponentEditMenuProps> = ({ nodeRef, c
       case KnownComponentType.DataBinding: {
         const newComponentPartial = {
           ...currentComponent,
-          valueDataBindings: [...((currentComponent as IDataBindingComponentInternal).valueDataBindings || []), {}],
+          valueDataBindings: [(currentComponent as IDataBindingComponentInternal).valueDataBinding || [], {}],
         };
         updateComponentInternal(nodeRef, newComponentPartial);
         return;
@@ -150,7 +152,7 @@ export const ComponentEditMenu: React.FC<ComponentEditMenuProps> = ({ nodeRef, c
             case ObjectTypes.AddDataBinding:
               handleAddDataBinding();
               break;
-            case ObjectTypes.RemoveAllDataBinding:
+            case ObjectTypes.RemoveEntityBinding:
               handleRemoveAllDataBinding();
               break;
             case ObjectTypes.RemoveOverlay:

--- a/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
@@ -1,28 +1,28 @@
+import { Checkbox, FormField, TextContent } from '@awsui/components-react';
 import { debounce } from 'lodash';
-import * as THREE from 'three';
 import React, { useCallback, useContext, useRef } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-import { Checkbox, FormField, TextContent } from '@awsui/components-react';
+import * as THREE from 'three';
 
-import useLifecycleLogging from '../../logger/react-logger/hooks/useLifecycleLogging';
-import { COMPOSER_FEATURES, IDataOverlayComponent, KnownComponentType } from '../../interfaces';
-import { RecursivePartial } from '../../utils/typeUtils';
-import { ISceneNodeInternal, useEditorState, useSceneDocument } from '../../store';
-import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
-import { useSnapObjectToFloor } from '../../three/transformUtils';
-import { toNumber } from '../../utils/stringUtils';
-import { isLinearPlaneMotionIndicator } from '../../utils/sceneComponentUtils';
-import LogProvider from '../../logger/react-logger/log-provider';
-import { findComponentByType, isEnvironmentNode } from '../../utils/nodeUtils';
 import { getGlobalSettings } from '../../common/GlobalSettings';
-import { Component } from '../../models/SceneModels';
 import { TABBED_PANEL_CONTAINER_NAME } from '../../common/internalConstants';
+import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
+import { COMPOSER_FEATURES, IDataOverlayComponent, KnownComponentType } from '../../interfaces';
+import useLifecycleLogging from '../../logger/react-logger/hooks/useLifecycleLogging';
+import LogProvider from '../../logger/react-logger/log-provider';
+import { Component } from '../../models/SceneModels';
+import { ISceneNodeInternal, useEditorState, useSceneDocument } from '../../store';
+import { useSnapObjectToFloor } from '../../three/transformUtils';
+import { findComponentByType, isEnvironmentNode } from '../../utils/nodeUtils';
+import { isLinearPlaneMotionIndicator } from '../../utils/sceneComponentUtils';
+import { toNumber } from '../../utils/stringUtils';
+import { RecursivePartial } from '../../utils/typeUtils';
 
-import { ComponentEditor } from './ComponentEditor';
-import { ExpandableInfoSection, Matrix3XInputGrid, Triplet, TextInput } from './CommonPanelComponents';
-import DebugInfoPanel from './scene-components/debug/DebugPanel';
 import { AddComponentMenu } from './AddComponentMenu';
+import { ExpandableInfoSection, Matrix3XInputGrid, TextInput, Triplet } from './CommonPanelComponents';
 import { ComponentEditMenu } from './ComponentEditMenu';
+import { ComponentEditor } from './ComponentEditor';
+import DebugInfoPanel from './scene-components/debug/DebugPanel';
 
 export const SceneNodeInspectorPanel: React.FC = () => {
   const log = useLifecycleLogging('SceneNodeInspectorPanel');
@@ -57,7 +57,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
       description: 'Expandable Section title',
     },
     [KnownComponentType.DataBinding]: {
-      defaultMessage: 'DataBinding',
+      defaultMessage: 'Entity data binding',
       description: 'Expandable Section title',
     },
     [KnownComponentType.ModelShader]: {

--- a/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.spec.tsx
@@ -1,9 +1,9 @@
+import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { act, fireEvent, render } from '@testing-library/react';
 
+import { mockProvider } from '../../../../tests/components/panels/scene-components/MockComponents';
 import { KnownComponentType } from '../../../interfaces';
 import { IDataBindingComponentInternal, ISceneNodeInternal, useStore } from '../../../store';
-import { mockProvider } from '../../../../tests/components/panels/scene-components/MockComponents';
 
 import { DataBindingComponentEditor } from './DataBindingComponentEditor';
 
@@ -15,8 +15,11 @@ describe('DataBindingComponentEditor', () => {
   const component: IDataBindingComponentInternal = {
     ref: 'comp-ref',
     type: KnownComponentType.DataBinding,
-    valueDataBindings: [{}, {}],
+    valueDataBinding: {
+      dataBindingContext: { entityId: 'abcd' },
+    },
   };
+
   const node = {
     ref: 'node-ref',
   } as ISceneNodeInternal;
@@ -33,33 +36,17 @@ describe('DataBindingComponentEditor', () => {
     jest.clearAllMocks();
   });
 
-  it('should call update component when there are still binding remaining after removing', async () => {
+  it('should not have remove button', async () => {
     useStore('default').setState(baseState);
-
-    const { getAllByTestId } = render(<DataBindingComponentEditor node={node} component={component} />);
-
-    const removeBindingButton = getAllByTestId('remove-binding-button')[0];
-    act(() => {
-      fireEvent.click(removeBindingButton);
-    });
-
-    expect(updateComponentInternalMock).toBeCalledTimes(1);
-    expect(updateComponentInternalMock).toBeCalledWith(node.ref, { ...component, valueDataBindings: [{}] }, true);
+    render(<DataBindingComponentEditor node={node} component={component} />);
+    expect(screen.queryByText('remove-binding-button')).toBeNull();
+    expect(updateComponentInternalMock).toBeCalledTimes(0);
   });
 
-  it('should call remove component when there are no binding remaining after removing', async () => {
+  it('should have entity search field', async () => {
     useStore('default').setState(baseState);
-
-    const { getAllByTestId } = render(
-      <DataBindingComponentEditor node={node} component={{ ...component, valueDataBindings: [{}] }} />,
-    );
-
-    const removeBindingButton = getAllByTestId('remove-binding-button')[0];
-    act(() => {
-      fireEvent.click(removeBindingButton);
-    });
-
-    expect(removeComponentMock).toBeCalledTimes(1);
-    expect(removeComponentMock).toBeCalledWith(node.ref, component.ref);
+    render(<DataBindingComponentEditor node={node} component={component} />);
+    expect(screen.getByTestId('select-entityId')).toBeTruthy();
+    expect(updateComponentInternalMock).toBeCalledTimes(0);
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataBindingComponentEditor.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useContext } from 'react';
 import { SpaceBetween } from '@awsui/components-react';
+import React, { useCallback, useContext } from 'react';
 
-import { IComponentEditorProps } from '../ComponentEditor';
-import { useStore } from '../../../store';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import { useStore } from '../../../store';
 import { IDataBindingComponentInternal } from '../../../store/internalInterfaces';
+import { IComponentEditorProps } from '../ComponentEditor';
+import { Component } from '../../../models/SceneModels';
 
 import { DataBindingMapEditor } from './common/DataBindingMapEditor';
 
@@ -28,7 +29,7 @@ export const DataBindingComponentEditor: React.FC<IDataBindingComponentEditorPro
       const componentPartialWithRef = { ref: component.ref, type: component.type, ...componentPartial };
       // When the data binding component has valueDataBindings left, update the component, otherwise remove
       // the whole component instead
-      if (componentPartialWithRef.valueDataBindings && componentPartialWithRef.valueDataBindings.length > 0) {
+      if (componentPartialWithRef.valueDataBinding) {
         updateComponentInternal(node.ref, componentPartialWithRef, replace);
       } else {
         removeComponent(node.ref, component.ref);
@@ -43,8 +44,10 @@ export const DataBindingComponentEditor: React.FC<IDataBindingComponentEditorPro
         allowPartialBinding
         skipFirstDivider
         hasBindingName={false}
+        numFields={1}
+        hasRemoveButton={false}
         valueDataBindingProvider={valueDataBindingProvider}
-        component={component}
+        component={{ ...component, valueDataBindings: [component.valueDataBinding as Component.IDataBindingMap] }}
         onUpdateCallback={onUpdateCallback}
       />
     </SpaceBetween>

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
@@ -37,6 +37,7 @@ exports[`AnchorComponentEditor should render as expected 1`] = `
       >
         <div
           data-mocked="Autosuggest"
+          data-testid="select-entityId"
           options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
           value="value1"
         />

--- a/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.spec.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { act, render } from '@testing-library/react';
 import wrapper from '@awsui/components-react/test-utils/dom';
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
 
 import { mockProvider } from '../../../../../tests/components/panels/scene-components/MockComponents';
-import { IDataOverlayComponentInternal } from '../../../../store';
 import { Component } from '../../../../models/SceneModels';
+import { IDataOverlayComponentInternal } from '../../../../store';
 
-import { IValueDataBindingBuilderProps } from './ValueDataBindingBuilder';
 import { DataBindingMapEditor } from './DataBindingMapEditor';
+import { IValueDataBindingBuilderProps } from './ValueDataBindingBuilder';
 
 jest.mock('@awsui/components-react', () => ({
   ...jest.requireActual('@awsui/components-react'),
@@ -42,7 +42,6 @@ describe('DataBindingMapEditor', () => {
     ],
   } as unknown as IDataOverlayComponentInternal;
   const onUpdateCallbackMock = jest.fn();
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -50,6 +49,7 @@ describe('DataBindingMapEditor', () => {
   it('should remove binding by clicking remove button', async () => {
     const { container } = render(
       <DataBindingMapEditor
+        hasRemoveButton={true}
         hasBindingName
         valueDataBindingProvider={mockProvider}
         component={component}
@@ -67,6 +67,23 @@ describe('DataBindingMapEditor', () => {
 
     expect(onUpdateCallbackMock).toBeCalledTimes(1);
     expect(onUpdateCallbackMock).toBeCalledWith({ ...component, valueDataBindings: [] }, true);
+  });
+
+  it('should add additional binding by adding new binding', async () => {
+    const { container } = render(
+      <DataBindingMapEditor
+        hasRemoveButton={true}
+        hasBindingName
+        valueDataBindingProvider={mockProvider}
+        component={component}
+        onUpdateCallback={onUpdateCallbackMock}
+        hasAddButton={true}
+      />,
+    );
+    wrapper(container);
+    const addBinding = screen.getByTestId('add-binding-button');
+    addBinding.click();
+    expect(onUpdateCallbackMock).toBeCalledTimes(1);
   });
 
   it('should call update when data binding changed', async () => {

--- a/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
@@ -1,15 +1,15 @@
-import React, { useCallback } from 'react';
 import { Box, Button, SpaceBetween } from '@awsui/components-react';
-import { useIntl } from 'react-intl';
 import { isEmpty } from 'lodash';
+import React, { useCallback } from 'react';
+import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { IValueDataBinding, IValueDataBindingProvider } from '../../../../interfaces';
-import { Divider } from '../../../Divider';
 import { Component } from '../../../../models/SceneModels';
 import { ISceneComponentInternal } from '../../../../store';
-import { DataBindingMapNameEditor } from '../data-overlay/DataBindingMapNameEditor';
 import { generateUUID } from '../../../../utils/mathUtils';
+import { Divider } from '../../../Divider';
+import { DataBindingMapNameEditor } from '../data-overlay/DataBindingMapNameEditor';
 
 import { ValueDataBindingBuilder } from './ValueDataBindingBuilder';
 
@@ -22,7 +22,8 @@ interface IDataBindingMapEditorProps {
   valueDataBindingProvider: IValueDataBindingProvider | undefined;
   component: ComponentWithDataBindings;
   onUpdateCallback: (componentPartial: Partial<ComponentWithDataBindings>, replace?: boolean | undefined) => void;
-
+  numFields?: number;
+  hasRemoveButton?: boolean;
   skipFirstDivider?: boolean;
   allowPartialBinding?: boolean;
   hasAddButton?: boolean; // TODO: to be removed once DataBinding component is enabled
@@ -41,6 +42,8 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
   hasBindingName,
   valueDataBindingProvider,
   component,
+  numFields,
+  hasRemoveButton,
   onUpdateCallback,
   skipFirstDivider,
   allowPartialBinding,
@@ -77,6 +80,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
     onUpdateCallback({ valueDataBindings: newBindings });
   }, [component.valueDataBindings, onUpdateCallback]);
 
+  console.log('test', component.valueDataBindings);
   return (
     <SpaceBetween size='s'>
       {valueDataBindingProvider && (
@@ -86,21 +90,22 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
               <Box key={index}>
                 {(index > 0 || !skipFirstDivider) && <Divider />}
 
-                <RemoveButtonContainer>
-                  <Button
-                    ariaLabel={intl.formatMessage({
-                      defaultMessage: 'Remove data binding',
-                      description: 'Button label',
-                    })}
-                    data-testid='remove-binding-button'
-                    iconName='close'
-                    variant='icon'
-                    iconAlign='right'
-                    onClick={() => onRemoveBinding(index)}
-                  />
-                </RemoveButtonContainer>
+                {hasRemoveButton && (
+                  <RemoveButtonContainer>
+                    <Button
+                      ariaLabel={intl.formatMessage({
+                        defaultMessage: 'Remove data binding',
+                        description: 'Button label',
+                      })}
+                      data-testid='remove-binding-button'
+                      iconName='close'
+                      variant='icon'
+                      iconAlign='right'
+                      onClick={() => onRemoveBinding(index)}
+                    />
+                  </RemoveButtonContainer>
+                )}
                 <Spacing />
-
                 {hasBindingName && (
                   <DataBindingMapNameEditor
                     bindingName={(binding as Component.ValueDataBindingNamedMap).bindingName}
@@ -115,6 +120,7 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
                     allowPartialBinding={allowPartialBinding}
                     componentRef={component.ref}
                     binding={binding.valueDataBinding}
+                    numFields={numFields}
                     valueDataBindingProvider={valueDataBindingProvider}
                     onChange={(v) => onBindingChange(v, index)}
                   />

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/first */
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import wrapper from '@awsui/components-react/test-utils/dom';
 import flushPromises from 'flush-promises';
 
@@ -93,12 +93,6 @@ describe('ValueDataBindingBuilder', () => {
     autoSuggest!.setInputValue('test');
 
     await flushPromises();
-
-    expect(mockProvider.useStore('').updateSelection).toBeCalledWith(
-      mockBuilderState.definitions[0].fieldName,
-      { value: 'test' },
-      mockDataBindingConfig,
-    );
   });
 
   it('should select components', async () => {
@@ -151,6 +145,32 @@ describe('ValueDataBindingBuilder', () => {
       mockDataBindingConfig,
     );
 
+    expect(mockProvider.useStore('').createBinding).toBeCalledTimes(1);
+  });
+
+  it('should render only entity binding', async () => {
+    const { container } = render(
+      <ValueDataBindingBuilder
+        allowPartialBinding
+        componentRef={componentRef}
+        binding={mockBinding}
+        valueDataBindingProvider={mockProvider}
+        onChange={onChange}
+        numFields={1}
+      />,
+    );
+    const polarisWrapper = wrapper(container);
+    expect(polarisWrapper.findAutosuggest()).toBeTruthy();
+    expect(screen.getByLabelText('Entity Id')).toBeTruthy();
+    const autoSuggest = polarisWrapper.findAutosuggest();
+    autoSuggest!.focus();
+    autoSuggest!.setInputValue('test');
+    await flushPromises();
+    expect(mockProvider.useStore('').updateSelection).toBeCalledWith(
+      mockBuilderState.definitions[0].fieldName,
+      { value: 'test' },
+      mockDataBindingConfig,
+    );
     expect(mockProvider.useStore('').createBinding).toBeCalledTimes(1);
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
@@ -1,19 +1,19 @@
-import React, { useContext, useEffect, useState } from 'react';
 import { Autosuggest, Box, FormField, Select, SpaceBetween } from '@awsui/components-react';
-import { useIntl, defineMessages } from 'react-intl';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
 
-import useLifecycleLogging from '../../../../logger/react-logger/hooks/useLifecycleLogging';
 import { EMPTY_VALUE_DATA_BINDING_PROVIDER_STATE } from '../../../../common/constants';
+import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
 import {
-  IValueDataBindingProvider,
   IDataFieldOption,
   IValueDataBinding,
+  IValueDataBindingProvider,
   IValueDataBindingProviderState,
 } from '../../../../interfaces';
-import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
+import useLifecycleLogging from '../../../../logger/react-logger/hooks/useLifecycleLogging';
 import { useStore } from '../../../../store';
-import { pascalCase } from '../../../../utils/stringUtils';
 import { dataBindingConfigSelector } from '../../../../utils/dataBindingTemplateUtils';
+import { pascalCase } from '../../../../utils/stringUtils';
 
 export const ENTITY_ID_INDEX = 0;
 export const COMPONENT_NAME_INDEX = 1;
@@ -22,6 +22,7 @@ export interface IValueDataBindingBuilderProps {
   componentRef: string;
   binding?: IValueDataBinding;
   allowPartialBinding?: boolean;
+  numFields?: number;
   valueDataBindingProvider: IValueDataBindingProvider;
   onChange: (valueDataBinding: IValueDataBinding) => void;
 }
@@ -30,6 +31,7 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
   componentRef,
   binding,
   allowPartialBinding,
+  numFields,
   valueDataBindingProvider,
   onChange,
 }: IValueDataBindingBuilderProps) => {
@@ -67,10 +69,20 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
     },
   });
 
+  const filterBuilderState = (state: IValueDataBindingProviderState) => {
+    if (numFields) {
+      return {
+        definitions: state.definitions.slice(0, numFields),
+        selectedOptions: state.selectedOptions.slice(0, numFields),
+      };
+    }
+    return state;
+  };
+
   useEffect(() => {
     // Subscribe to the changes
     valueDataBindingStore.setOnStateChangedListener((state) => {
-      setBuilderState(state);
+      setBuilderState(filterBuilderState(state));
     });
     return () => valueDataBindingStore.setOnStateChangedListener(undefined);
   }, [valueDataBindingProvider]);
@@ -78,8 +90,8 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
   useEffect(() => {
     // Initiate the provider
     const state = valueDataBindingStore.setBinding(componentRef, binding, dataBindingConfig);
-    setBuilderState(state);
-    setAutoSuggestValue(state.selectedOptions[ENTITY_ID_INDEX]?.value || '');
+    setBuilderState(filterBuilderState(state));
+    setAutoSuggestValue(state.selectedOptions[ENTITY_ID_INDEX]?.value || autoSuggestValue);
   }, [componentRef, binding, valueDataBindingProvider, dataBindingConfig]);
 
   return (
@@ -102,6 +114,7 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
                 key={definition.fieldName}
               >
                 <Autosuggest
+                  data-testid='select-entityId'
                   options={options}
                   enteredTextLabel={(item) => `${item}`}
                   virtualScroll
@@ -129,7 +142,6 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
               </FormField>
             );
           }
-
           return (
             <FormField
               label={

--- a/packages/scene-composer/src/components/panels/scene-components/common/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/common/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
@@ -8,11 +8,6 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
 }
 
 .c1 {
-  float: right;
-  height: 12px;
-}
-
-.c2 {
   height: 8px;
 }
 
@@ -28,18 +23,6 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
       />
       <div
         class="c1"
-      >
-        <div
-          arialabel="Remove data binding"
-          data-mocked="Button"
-          data-testid="remove-binding-button"
-          iconalign="right"
-          iconname="close"
-          variant="icon"
-        />
-      </div>
-      <div
-        class="c2"
       />
       <div
         data-mocked="FormField"
@@ -65,6 +48,7 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
           >
             <div
               data-mocked="Autosuggest"
+              data-testid="select-entityId"
               options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
               value="value1"
             />
@@ -116,18 +100,6 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
       />
       <div
         class="c1"
-      >
-        <div
-          arialabel="Remove data binding"
-          data-mocked="Button"
-          data-testid="remove-binding-button"
-          iconalign="right"
-          iconname="close"
-          variant="icon"
-        />
-      </div>
-      <div
-        class="c2"
       />
       <div
         data-mocked="FormField"
@@ -153,6 +125,7 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
           >
             <div
               data-mocked="Autosuggest"
+              data-testid="select-entityId"
               options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
               value="value1"
             />
@@ -201,18 +174,13 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
 `;
 
 exports[`DataBindingMapEditor should render existing maps with bindings without binding name 1`] = `
-.c2 {
+.c1 {
   height: 1px;
   border-width: 0px;
   background-color: colorBorderDividerDefault;
 }
 
 .c0 {
-  float: right;
-  height: 12px;
-}
-
-.c1 {
   height: 8px;
 }
 
@@ -225,18 +193,6 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
     >
       <div
         class="c0"
-      >
-        <div
-          arialabel="Remove data binding"
-          data-mocked="Button"
-          data-testid="remove-binding-button"
-          iconalign="right"
-          iconname="close"
-          variant="icon"
-        />
-      </div>
-      <div
-        class="c1"
       />
       <div
         data-mocked="Box"
@@ -251,6 +207,7 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
           >
             <div
               data-mocked="Autosuggest"
+              data-testid="select-entityId"
               options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
               value="value1"
             />
@@ -298,22 +255,10 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
       data-mocked="Box"
     >
       <hr
-        class="c2"
+        class="c1"
       />
       <div
         class="c0"
-      >
-        <div
-          arialabel="Remove data binding"
-          data-mocked="Button"
-          data-testid="remove-binding-button"
-          iconalign="right"
-          iconname="close"
-          variant="icon"
-        />
-      </div>
-      <div
-        class="c1"
       />
       <div
         data-mocked="Box"
@@ -328,6 +273,7 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
           >
             <div
               data-mocked="Autosuggest"
+              data-testid="select-entityId"
               options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
               value="value1"
             />

--- a/packages/scene-composer/src/interfaces/components.ts
+++ b/packages/scene-composer/src/interfaces/components.ts
@@ -72,9 +72,15 @@ export interface ITagData {
 }
 
 /**
+ * Additional Data binding data which is entityID for TwinMaker usecase
+ */
+export interface IEntityBindingInfo {
+  dataBindingContext?: unknown;
+}
+/**
  * Type that can be represented by different additional component data types such as ITagData | IFutureComponentData
  */
-export type AdditionalComponentData = ITagData;
+export type AdditionalComponentData = ITagData | IEntityBindingInfo;
 
 /**
  * Callback signature for selection of with Widgets.

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -3,6 +3,8 @@
  * Changes to this file should be backward compatible.
  */
 
+import { IValueDataBinding } from '../interfaces';
+
 export type KeyValuePair = { [key: string]: unknown };
 export type UUID = string;
 export type Vector3 = [number, number, number];
@@ -166,9 +168,7 @@ export namespace Component {
   export interface OpacityFilter extends IComponent, IDataBindingRuleMap {}
 
   export interface DataBindingComponent extends IComponent {
-    // May change type to ValueDataBindingNamedMap[] so that it can be used by sibling components referenced
-    // by bindingName
-    valueDataBindings: IDataBindingMap[];
+    valueDataBinding: IValueDataBinding;
   }
 
   // Motion Indicator

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -264,7 +264,7 @@ function deserializeComponent(
       return createDataOverlayComponent(component as Component.DataOverlay, resolver, errorCollector);
     }
     case Component.Type.DataBinding: {
-      return createDataBindingComponent(component as Component.DataOverlay);
+      return createDataBindingComponent(component as Component.DataBindingComponent);
     }
     default: {
       LOG.warn(`component not supported type[${component.type}]. It will be ignored.`);

--- a/packages/scene-composer/src/store/internalInterfaces.ts
+++ b/packages/scene-composer/src/store/internalInterfaces.ts
@@ -119,7 +119,7 @@ export type IMotionIndicatorComponentInternal = ISceneComponentInternal & IMotio
 
 export type IDataOverlayComponentInternal = ISceneComponentInternal & IDataOverlayComponent;
 
-export type IDataBindingComponentInternal = ISceneComponentInternal & IDataBindingComponent;
+export type IDataBindingComponentInternal = IDataBoundSceneComponentInternal & IDataBindingComponent;
 
 /******************************************************************************
  * Type magic...

--- a/packages/scene-composer/src/utils/dataBindingTemplateUtils.spec.ts
+++ b/packages/scene-composer/src/utils/dataBindingTemplateUtils.spec.ts
@@ -7,6 +7,7 @@ import {
   createDataBindingTemplateOptions,
   dataBindingConfigSelector,
   decorateDataBindingTemplate,
+  extractEntityId,
   isDataBindingTemplate,
   undecorateDataBindingTemplate,
 } from './dataBindingTemplateUtils';
@@ -171,5 +172,13 @@ describe('applyDataBindingTemplate', () => {
   it('should return empty data binding if data binding is missing', () => {
     const dataBindingContext = applyDataBindingTemplate(undefined, mockDataBindingTemplate);
     expect(dataBindingContext).toEqual({});
+  });
+});
+
+describe('extractEntityId', () => {
+  it('should return entityId', () => {
+    const dataBinding = { dataBindingContext: { entityId: 'abcd' } };
+    const entityId = extractEntityId(dataBinding);
+    expect(entityId).toEqual({ entityId: 'abcd' });
   });
 });

--- a/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingTemplateUtils.ts
@@ -1,17 +1,18 @@
-import { cloneDeep } from 'lodash';
+import { cloneDeep, pick } from 'lodash';
 
-import { RootState } from '../store';
+import {
+  DEFAULT_DATA_BINDING_TEMPLATE_COMPONENT_NAME,
+  DEFAULT_DATA_BINDING_TEMPLATE_ENTITY_ID,
+  DataBindingLabelKeys,
+} from '../common/constants';
 import {
   IDataBindingConfig,
   IDataBindingTemplate,
   IDataFieldOption,
-  KnownSceneProperty,
   IValueDataBinding,
+  KnownSceneProperty,
 } from '../interfaces';
-import {
-  DEFAULT_DATA_BINDING_TEMPLATE_ENTITY_ID,
-  DEFAULT_DATA_BINDING_TEMPLATE_COMPONENT_NAME,
-} from '../common/constants';
+import { RootState } from '../store';
 
 /**
  * Data binding templates will be stored as ${my-value} in IValueDataBinding
@@ -96,3 +97,13 @@ export function applyDataBindingTemplate(
   });
   return dataBindingContext;
 }
+
+/**
+ * We extract entityId from the data binding object.
+ * @param dataBinding we send data binding object
+ * @returns
+ */
+export const extractEntityId = (dataBinding: IValueDataBinding): Record<string, string> => {
+  const contextData = dataBinding.dataBindingContext ?? {};
+  return pick(contextData, [DataBindingLabelKeys.entityId]);
+};

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -31,6 +31,10 @@
     "note": "Scene Resource types in a dropdown menu",
     "text": "Color"
   },
+  "/vhhhq": {
+    "note": "Menu Item label",
+    "text": "Remove entity binding"
+  },
   "0/GZ0l": {
     "note": "Box label",
     "text": "Configure Rule"
@@ -146,10 +150,6 @@
   "6y5r/N": {
     "note": "Menu Item",
     "text": "Add motion indicator"
-  },
-  "73cUv/": {
-    "note": "Menu Item",
-    "text": "Add data binding"
   },
   "7H9+6Y": {
     "note": "Expandable Section Title",
@@ -290,10 +290,6 @@
   "Fy5tAf": {
     "note": "Sub-Section Header",
     "text": "Matterport Integration"
-  },
-  "G+p/Gf": {
-    "note": "Expandable Section title",
-    "text": "DataBinding"
   },
   "GRIkbq": {
     "note": "Menu Item label",
@@ -443,10 +439,6 @@
     "note": "placeholder",
     "text": "Choose an option"
   },
-  "PuWFv3": {
-    "note": "Menu Item label",
-    "text": "Data binding"
-  },
   "Q02j8m": {
     "note": "Textarea placeholder text",
     "text": "Example: Current temperature {variable}"
@@ -543,6 +535,10 @@
     "note": "Menu Item label",
     "text": "Cancel"
   },
+  "WgHblZ": {
+    "note": "Menu Item label",
+    "text": "Add entity binding"
+  },
   "X4zSHQ": {
     "note": "Form Field label",
     "text": "Distance"
@@ -582,6 +578,10 @@
   "a2V9FB": {
     "note": "FormField label",
     "text": "Define arrow speed"
+  },
+  "aSj5vI": {
+    "note": "Menu Item",
+    "text": "Remove entity binding"
   },
   "aUtGJh": {
     "note": "button label",
@@ -699,6 +699,10 @@
     "note": "Form field label",
     "text": "Default Icon"
   },
+  "h4UkNS": {
+    "note": "Expandable Section title",
+    "text": "Entity data binding"
+  },
   "h8sKYl": {
     "note": "Menu Item label",
     "text": "Add object"
@@ -742,6 +746,10 @@
   "kCQSQo": {
     "note": "Form field label",
     "text": "Rule Id"
+  },
+  "kSk2hi": {
+    "note": "Menu Item",
+    "text": "Add entity binding"
   },
   "kYpWHA": {
     "note": "placeholder",


### PR DESCRIPTION
## Overview
* Fixing search functionality of entity data binding. 

## Verifying Changes
* npm run test
* npm run build
### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
