### PR TITLE
feat: <QueryEditor />

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -7,11 +7,7 @@
   "description": "A dashboard widget for IoT App Kit components",
   "homepage": "https://github.com/awslabs/iot-app-kit#readme",
   "license": "Apache-2.0",
-  "files": [
-    "dist/",
-    "CHANGELOG.md",
-    "*NOTICE"
-  ],
+  "files": ["dist/", "CHANGELOG.md", "*NOTICE"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/awslabs/iot-app-kit.git"
@@ -49,12 +45,12 @@
     "@storybook/manager-webpack5": "^6.5.16",
     "@storybook/react": "^6.5.16",
     "@storybook/testing-library": "^0.1.0",
+    "@tanstack/eslint-plugin-query": "^4.29.9",
+    "@tanstack/react-query-devtools": "^4.29.13",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "@tanstack/eslint-plugin-query": "^4.29.9",
-    "@tanstack/react-query-devtools": "^4.29.14",
     "@types/is-hotkey": "^0.1.7",
     "@types/lodash": "^4.14.195",
     "@types/node": "^18.16.18",
@@ -92,6 +88,7 @@
   "dependencies": {
     "@aws-sdk/client-iot-events": "3.353.0",
     "@aws-sdk/client-iotsitewise": "3.353.0",
+    "@cloudscape-design/collection-hooks": "^1.0.21",
     "@cloudscape-design/components": "^3.0.286",
     "@cloudscape-design/design-tokens": "^3.0.15",
     "@cloudscape-design/global-styles": "^1.0.10",
@@ -109,8 +106,10 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dnd-touch-backend": "^16.0.1",
+    "react-error-boundary": "^4.0.10",
     "react-popper": "^2.3.0",
     "react-use": "17.4.0",
+    "tiny-invariant": "^1.3.1",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { DndProvider } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
 import { QueryClientProvider } from '@tanstack/react-query';
-
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import InternalDashboard from '../internalDashboard';
 
 import { configureDashboardStore, toDashboardState } from '~/store';
@@ -52,6 +52,7 @@ const Dashboard: React.FC<DashboardProperties> = ({
               <InternalDashboard onSave={onSave} editable={true} propertiesSections={propertiesSections} />
             </DndProvider>
           </Provider>
+          <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>
       </QueryContext.Provider>
     </ClientContext.Provider>

--- a/packages/dashboard/src/components/queryEditor/README.md
+++ b/packages/dashboard/src/components/queryEditor/README.md
@@ -1,0 +1,3 @@
+# <QueryEditor />
+
+`<QueryEditor />` provides the IoT App Kit dashboard with user interface for configuring the data visualized by a dashboard widget.

--- a/packages/dashboard/src/components/queryEditor/__tests__/README.md
+++ b/packages/dashboard/src/components/queryEditor/__tests__/README.md
@@ -1,0 +1,7 @@
+# Testing
+
+`<QueryEditor />` is tested using unit tests with a mock implementation of the AWS SDK v3 IoT SiteWise client. The client's `send` method is mocked and resolved with SDK command output stubs.
+
+## Tips
+
+To know what requests the component is making, use `expect(subject).toHaveBeenNthCalledWith(1)` in the test and read the test runner output. 

--- a/packages/dashboard/src/components/queryEditor/__tests__/latestValues.spec.tsx
+++ b/packages/dashboard/src/components/queryEditor/__tests__/latestValues.spec.tsx
@@ -1,0 +1,109 @@
+import {
+  type BatchGetAssetPropertyValueCommandOutput,
+  type ListAssetsCommandOutput,
+  type IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+import { QueryEditor } from '../queryEditor';
+import { createAssetSummaryStub } from '../helpers/test/createAssetSummaryStub';
+import { createAssetPropertyStub } from '../helpers/test/createAssetPropertyStub';
+import { fromSummaryToDescription } from '../helpers/test/fromSummaryToDescription';
+
+const queryClient = new QueryClient();
+
+const Wrapper = ({ children }: React.PropsWithChildren) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('Latest values', () => {
+  afterEach(() => {
+    // don't cache queries between tests
+    queryClient.clear();
+  });
+
+  it('should request the latest values for the asset properties of the selected asset(s)', async () => {
+    const rootAsset = createAssetSummaryStub();
+    const listRootAssetsStub: ListAssetsCommandOutput = { assetSummaries: [rootAsset], $metadata: {} };
+
+    const rootAssetDescription = fromSummaryToDescription({
+      ...rootAsset,
+      assetProperties: [createAssetPropertyStub(), createAssetPropertyStub(), createAssetPropertyStub()],
+    });
+
+    const batchGetAssetPropertyValueStub: BatchGetAssetPropertyValueCommandOutput = {
+      successEntries: [
+        {
+          entryId: `${rootAssetDescription.assetId.slice(0, 8)}--${rootAssetDescription.assetProperties[0].id}`,
+          assetPropertyValue: {
+            quality: 'GOOD',
+            timestamp: {
+              timeInSeconds: 0,
+              offsetInNanos: 0,
+            },
+            value: {
+              stringValue: 'FIRST!',
+            },
+          },
+        },
+        {
+          entryId: `${rootAssetDescription.assetId.slice(0, 8)}--${rootAssetDescription.assetProperties[1].id}`,
+          assetPropertyValue: {
+            quality: 'GOOD',
+            timestamp: {
+              timeInSeconds: 0,
+              offsetInNanos: 0,
+            },
+            value: {
+              integerValue: 123456789012,
+            },
+          },
+        },
+        {
+          entryId: `${rootAssetDescription.assetId.slice(0, 8)}--${rootAssetDescription.assetProperties[2].id}`,
+          assetPropertyValue: {
+            quality: 'GOOD',
+            timestamp: {
+              timeInSeconds: 0,
+              offsetInNanos: 0,
+            },
+            value: {
+              doubleValue: 3.141592653589793,
+            },
+          },
+        },
+      ],
+      skippedEntries: [],
+      errorEntries: [],
+      $metadata: {},
+    };
+
+    const mockClient = {
+      send: jest
+        .fn()
+        .mockResolvedValueOnce(listRootAssetsStub)
+        .mockResolvedValueOnce(rootAssetDescription)
+        .mockResolvedValueOnce(batchGetAssetPropertyValueStub),
+    } as unknown as IoTSiteWiseClient;
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <QueryEditor client={mockClient} />
+      </Wrapper>
+    );
+
+    await waitFor(() => expect(screen.queryByText('Loading assets...')).not.toBeInTheDocument());
+
+    // select the asset
+    await user.click(screen.getByRole('checkbox', { name: `Select asset ${rootAsset.name}` }));
+
+    // see the values
+    await waitFor(() => expect(screen.getByText('FIRST!')).toBeVisible());
+    expect(screen.getByText('123456789012')).toBeVisible();
+    expect(screen.getByText('3.141592653589793')).toBeVisible();
+  });
+});

--- a/packages/dashboard/src/components/queryEditor/__tests__/selection.spec.tsx
+++ b/packages/dashboard/src/components/queryEditor/__tests__/selection.spec.tsx
@@ -1,0 +1,190 @@
+import { QueryEditor } from '../queryEditor';
+import { type ListAssetsCommandOutput, type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { createAssetPropertyStub } from '../helpers/test/createAssetPropertyStub';
+import { createAssetSummaryStub } from '../helpers/test/createAssetSummaryStub';
+import { fromSummaryToDescription } from '../helpers/test/fromSummaryToDescription';
+
+const queryClient = new QueryClient();
+
+const Wrapper = ({ children }: React.PropsWithChildren) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('Selection', () => {
+  afterEach(() => {
+    // don't cache between tests
+    queryClient.clear();
+  });
+
+  it('should list the asset properties of the selected asset(s)', async () => {
+    const rootAssetA = createAssetSummaryStub();
+    const rootAssetB = createAssetSummaryStub();
+    const listRootAssetsStub: ListAssetsCommandOutput = { assetSummaries: [rootAssetA, rootAssetB], $metadata: {} };
+
+    const assetProperties = [
+      createAssetPropertyStub({
+        alias: '/test/propertyA1',
+        dataType: 'BOOLEAN',
+        name: 'Test Property A1',
+        unit: 'isActive',
+      }),
+      createAssetPropertyStub({
+        alias: '/test/propertyB',
+        dataType: 'INTEGER',
+        name: 'Test Property B1',
+        unit: 'm/s',
+      }),
+      createAssetPropertyStub({
+        alias: '/test/propertyC',
+        dataType: 'DOUBLE',
+        name: 'Test Property C1',
+        unit: 'm/s',
+      }),
+      createAssetPropertyStub({
+        dataType: 'STRING',
+        name: 'Test Property D1',
+        unit: 'direction',
+      }),
+      createAssetPropertyStub({
+        dataType: 'STRUCT',
+        dataTypeSpec: 'ALARM',
+        name: 'Test Property E1',
+      }),
+      createAssetPropertyStub({
+        alias: '/test/propertyA1',
+        dataType: 'BOOLEAN',
+        name: 'Test Property A2',
+        unit: 'isActive',
+      }),
+      createAssetPropertyStub({
+        alias: '/test/propertyB',
+        dataType: 'INTEGER',
+        name: 'Test Property B2',
+        unit: 'm/s',
+      }),
+      createAssetPropertyStub({
+        alias: '/test/propertyC',
+        dataType: 'DOUBLE',
+        name: 'Test Property C2',
+        unit: 'm/s',
+      }),
+      createAssetPropertyStub({
+        dataType: 'STRING',
+        name: 'Test Property D2',
+        unit: 'direction',
+      }),
+      createAssetPropertyStub({
+        dataType: 'STRUCT',
+        dataTypeSpec: 'ALARM',
+        name: 'Test Property E2',
+      }),
+    ];
+    const rootAssetADescription = fromSummaryToDescription({
+      ...rootAssetA,
+      assetProperties: [...assetProperties.slice(0, 3)],
+      assetCompositeModels: [
+        {
+          name: 'Test Composite Model A1',
+          type: 'COMPOSITE',
+          properties: [...assetProperties.slice(3, 4)],
+        },
+        {
+          name: 'Test Composite Model B1',
+          type: 'COMPOSITE',
+          properties: [...assetProperties.slice(4, 5)],
+        },
+      ],
+    });
+    const rootAssetBDescription = fromSummaryToDescription({
+      ...rootAssetB,
+      assetProperties: [...assetProperties.slice(5, 8)],
+      assetCompositeModels: [
+        {
+          name: 'Test Composite Model A1',
+          type: 'COMPOSITE',
+          properties: [...assetProperties.slice(8, 9)],
+        },
+        {
+          name: 'Test Composite Model B1',
+          type: 'COMPOSITE',
+          properties: [...assetProperties.slice(9)],
+        },
+      ],
+    });
+
+    const mockClient = {
+      send: jest
+        .fn()
+        .mockResolvedValueOnce(listRootAssetsStub)
+        .mockResolvedValueOnce(rootAssetADescription)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(rootAssetBDescription),
+    } as unknown as IoTSiteWiseClient;
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <QueryEditor client={mockClient} />
+      </Wrapper>
+    );
+
+    await waitFor(() => expect(screen.queryByText('Loading assets...')).not.toBeInTheDocument());
+
+    expect(screen.getByText('No asset properties.')).toBeVisible();
+
+    await user.click(screen.getByRole('checkbox', { name: `Select asset ${rootAssetA.name}` }));
+
+    await waitFor(() => expect(screen.getByText(assetProperties[0].name)).toBeVisible());
+    expect(screen.getByText(assetProperties[1].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[2].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[3].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[4].name)).toBeVisible();
+
+    await user.click(screen.getByRole('checkbox', { name: `Select asset ${rootAssetB.name}` }));
+
+    await waitFor(() => expect(screen.getByText(assetProperties[5].name)).toBeVisible());
+    expect(screen.getByText(assetProperties[6].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[7].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[8].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[9].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[1].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[2].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[3].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[4].name)).toBeVisible();
+
+    // FIXME: The label should say "Deselect asset ..."
+    await user.click(screen.getByRole('checkbox', { name: `Select asset ${rootAssetA.name}` }));
+
+    await waitFor(() => expect(screen.queryByText(assetProperties[0].name)).not.toBeInTheDocument());
+    expect(screen.queryByText(assetProperties[1].name)).not.toBeInTheDocument();
+    expect(screen.queryByText(assetProperties[2].name)).not.toBeInTheDocument();
+    expect(screen.queryByText(assetProperties[3].name)).not.toBeInTheDocument();
+    expect(screen.queryByText(assetProperties[4].name)).not.toBeInTheDocument();
+    expect(screen.getByText(assetProperties[5].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[6].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[7].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[8].name)).toBeVisible();
+    expect(screen.getByText(assetProperties[9].name)).toBeVisible();
+
+    // FIXME: The label should say "Deselect asset ..."
+    await user.click(screen.getByRole('checkbox', { name: `Select asset ${rootAssetB.name}` }));
+
+    await waitFor(() => expect(screen.queryByText(assetProperties[5].name)).not.toBeInTheDocument());
+    expect(screen.queryByText(assetProperties[1].name)).not.toBeInTheDocument();
+    expect(screen.queryByText(assetProperties[2].name)).not.toBeInTheDocument();
+    expect(screen.queryByText(assetProperties[3].name)).not.toBeInTheDocument();
+    expect(screen.queryByText(assetProperties[4].name)).not.toBeInTheDocument();
+    expect(screen.queryByText(assetProperties[5].name)).not.toBeInTheDocument();
+    expect(screen.queryByText(assetProperties[6].name)).not.toBeInTheDocument();
+    expect(screen.queryByText(assetProperties[7].name)).not.toBeInTheDocument();
+    expect(screen.queryByText(assetProperties[8].name)).not.toBeInTheDocument();
+    expect(screen.queryByText(assetProperties[9].name)).not.toBeInTheDocument();
+
+    expect(screen.getByText('No asset properties.')).toBeVisible();
+  });
+});

--- a/packages/dashboard/src/components/queryEditor/__tests__/traversal.spec.tsx
+++ b/packages/dashboard/src/components/queryEditor/__tests__/traversal.spec.tsx
@@ -1,0 +1,168 @@
+import {
+  type DescribeAssetCommandOutput,
+  type ListAssetsCommandOutput,
+  type ListAssociatedAssetsCommandOutput,
+  type IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { v4 as uuid } from 'uuid';
+
+import { QueryEditor } from '../queryEditor';
+import { createAssetSummaryStub } from '../helpers/test/createAssetSummaryStub';
+import { fromSummaryToDescription } from '../helpers/test/fromSummaryToDescription';
+
+const queryClient = new QueryClient();
+
+const Wrapper = ({ children }: React.PropsWithChildren) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('Traversal', () => {
+  afterEach(() => {
+    // don't cache between tests
+    queryClient.clear();
+  });
+
+  it('should render empty state when there are no root assets', async () => {
+    const listAssetsOutputStub: ListAssetsCommandOutput = { assetSummaries: [], $metadata: {} };
+
+    const mockClient = {
+      send: jest.fn().mockResolvedValueOnce(listAssetsOutputStub),
+    } as unknown as IoTSiteWiseClient;
+
+    render(
+      <Wrapper>
+        <QueryEditor client={mockClient} />
+      </Wrapper>
+    );
+
+    // wait for root assets to finish loading
+    await waitFor(() => expect(screen.queryByText('Loading assets...')).not.toBeInTheDocument());
+
+    // see empty state
+    expect(screen.getByText('No assets.')).toBeVisible();
+  });
+
+  it('should enable traversal down and back up the asset hierarchy', async () => {
+    const rootAssetA = createAssetSummaryStub({ hierarchies: [{ id: uuid(), name: 'Test hierarchy' }] });
+    const rootAssetB = createAssetSummaryStub();
+    const listRootAssetsStub: ListAssetsCommandOutput = { assetSummaries: [rootAssetA, rootAssetB], $metadata: {} };
+
+    const rootAssetADescription = fromSummaryToDescription(rootAssetA);
+    const describeAssetStub1: DescribeAssetCommandOutput = { ...rootAssetADescription, $metadata: {} };
+
+    const getParentAssetStub1: ListAssociatedAssetsCommandOutput = {
+      // no parents at the root
+      assetSummaries: [],
+      $metadata: {},
+    };
+
+    const childAssetA = createAssetSummaryStub({ hierarchies: [{ id: uuid(), name: 'Test hierarchy' }] });
+    const childAssetB = createAssetSummaryStub();
+    const listChildAssetsStub: ListAssociatedAssetsCommandOutput = {
+      assetSummaries: [childAssetA, childAssetB],
+      $metadata: {},
+    };
+
+    const childAssetADescription = fromSummaryToDescription(childAssetA);
+    const describeAssetStub2: DescribeAssetCommandOutput = { ...childAssetADescription, $metadata: {} };
+
+    const getParentAssetStub2: ListAssociatedAssetsCommandOutput = {
+      assetSummaries: [rootAssetA],
+      $metadata: {},
+    };
+
+    const grandChildAssetA = createAssetSummaryStub();
+    const grandChildAssetB = createAssetSummaryStub();
+    const listGrandChildAssetsStub: ListAssociatedAssetsCommandOutput = {
+      assetSummaries: [grandChildAssetA, grandChildAssetB],
+      $metadata: {},
+    };
+
+    /**
+     * It's not pretty and it's couple to the implementation, yet it works. It also gives us an understanding of the
+     * sequence of API calls made.
+     */
+    const mockClient = {
+      send: jest
+        .fn()
+        .mockResolvedValueOnce(listRootAssetsStub)
+        .mockResolvedValueOnce(describeAssetStub1)
+        .mockResolvedValueOnce(getParentAssetStub1)
+        .mockResolvedValueOnce(listChildAssetsStub)
+        .mockResolvedValueOnce(describeAssetStub2)
+        .mockResolvedValueOnce(getParentAssetStub2)
+        .mockResolvedValueOnce(getParentAssetStub1)
+        .mockResolvedValueOnce(listGrandChildAssetsStub)
+        .mockResolvedValueOnce(describeAssetStub1)
+        .mockResolvedValueOnce(getParentAssetStub1)
+        .mockResolvedValueOnce(listChildAssetsStub),
+    } as unknown as IoTSiteWiseClient;
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <QueryEditor client={mockClient} />
+      </Wrapper>
+    );
+
+    expect(screen.getByText('Loading assets...')).toBeVisible();
+
+    await waitFor(() => expect(screen.queryByText('Loading assets...')).not.toBeInTheDocument());
+    // both root assets are visible in the table
+    expect(screen.getByText(rootAssetA.name)).toBeVisible();
+    expect(screen.getByText(rootAssetB.name)).toBeVisible();
+    // no child assets are visible
+    expect(screen.queryByText(childAssetA.name)).not.toBeInTheDocument();
+    expect(screen.queryByText(childAssetB.name)).not.toBeInTheDocument();
+    expect(screen.queryByText(grandChildAssetA.name)).not.toBeInTheDocument();
+    expect(screen.queryByText(grandChildAssetB.name)).not.toBeInTheDocument();
+
+    // click on an assets name
+    await user.click(screen.getByText(rootAssetA.name));
+
+    // we see the child assets
+    await waitFor(() => expect(screen.getByText(childAssetA.name)).toBeVisible());
+    expect(screen.getByText(childAssetB.name)).toBeVisible();
+
+    // the root asset's name is visible in the breadcrumbs
+    expect(screen.getByText(rootAssetA.name)).toBeVisible();
+    // though we are no longer at the root
+    expect(screen.queryByText(rootAssetB.name)).not.toBeInTheDocument();
+    // but we aren't at the grandchild level yet
+    expect(screen.queryByText(grandChildAssetA.name)).not.toBeInTheDocument();
+    expect(screen.queryByText(grandChildAssetB.name)).not.toBeInTheDocument();
+
+    // click on a child asset's name
+    await user.click(screen.getByText(childAssetA.name));
+
+    // we see the grandchild assets
+    await waitFor(() => expect(screen.getByText(grandChildAssetA.name)).toBeVisible());
+    expect(screen.getByText(grandChildAssetB.name)).toBeVisible();
+
+    // the parent asset name is visible in the breadcrumbs
+    expect(screen.getByText(childAssetA.name)).toBeVisible();
+    // the root asset name is also visible in the breadcrumbs
+    expect(screen.getByText(rootAssetA.name)).toBeVisible();
+
+    expect(screen.queryByText(rootAssetB.name)).not.toBeInTheDocument();
+    expect(screen.queryByText(childAssetB.name)).not.toBeInTheDocument();
+
+    // we click on the parent asset name in the breadcrumbs
+    await user.click(screen.getByText(rootAssetA.name));
+
+    await waitFor(() => expect(screen.getByText(childAssetB.name)).toBeVisible());
+    expect(screen.queryByText(grandChildAssetA.name)).not.toBeInTheDocument();
+    expect(screen.queryByText(grandChildAssetB.name)).not.toBeInTheDocument();
+
+    // we click the root breadcrumb to go back to the root
+    await user.click(screen.getByText('Root'));
+    // we are back at the root and we see both root assets
+    await waitFor(() => expect(screen.getByText(rootAssetA.name)).toBeVisible());
+    expect(screen.getByText(rootAssetB.name)).toBeVisible();
+    expect(screen.queryByText(childAssetA.name)).not.toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/components/queryEditor/data/assetPropertyValues.ts
+++ b/packages/dashboard/src/components/queryEditor/data/assetPropertyValues.ts
@@ -1,0 +1,16 @@
+import { type BatchGetAssetPropertyValueCommandInput } from '@aws-sdk/client-iotsitewise';
+
+import { iotSiteWiseKey } from './sitewise';
+
+/** Cache key factory for IoT SiteWise asset property values. */
+export const assetPropertyValueKeys = {
+  /** Cache key for all asset property value resources. */
+  all: [{ ...iotSiteWiseKey[0], scope: 'asset property values' }] as const,
+
+  /** Cache key for all batches of asset property values. */
+  batchLatestValuesBatches: () => [{ ...assetPropertyValueKeys.all[0], resource: 'batch latest values' }] as const,
+
+  /** Cache key for a single batch of asset property values. */
+  batchLatestValues: (input: BatchGetAssetPropertyValueCommandInput) =>
+    [{ ...assetPropertyValueKeys.batchLatestValuesBatches()[0], entries: input.entries }] as const,
+};

--- a/packages/dashboard/src/components/queryEditor/data/assets.ts
+++ b/packages/dashboard/src/components/queryEditor/data/assets.ts
@@ -1,0 +1,34 @@
+import {
+  type DescribeAssetCommandInput,
+  type ListAssetsCommandInput,
+  type ListAssociatedAssetsCommandInput,
+} from '@aws-sdk/client-iotsitewise';
+
+import { iotSiteWiseKey } from './sitewise';
+
+/** Cache key factory for IoT SiteWise assets.  */
+export const assetKeys = {
+  /** Cache key for all asset resources. */
+  all: [{ ...iotSiteWiseKey[0], scope: 'assets' }] as const,
+
+  /** Cache key for all asset summaries returned by ListAssets. */
+  lists: () => [{ ...assetKeys.all[0], resource: 'asset summary' }] as const,
+
+  /** Cache key for an asset summary list returned by ListAssets. */
+  list: (input: ListAssetsCommandInput) =>
+    [{ ...assetKeys.lists()[0], filter: input.filter, assetModelId: input.assetModelId }] as const,
+
+  /** Cache key for all asset summaries returned by ListAssociatedAssets. */
+  associatedLists: () => [{ ...assetKeys.all[0], resource: 'associated asset summary' }] as const,
+
+  /** Cache key for an asset summary list returned by ListAssociatedAssets. */
+  associatedList: ({ assetId, hierarchyId, traversalDirection }: ListAssociatedAssetsCommandInput) =>
+    [{ ...assetKeys.associatedLists()[0], assetId, hierarchyId, traversalDirection }] as const,
+
+  /** Cache key for all asset descriptions. */
+  descriptions: () => [{ ...assetKeys.all[0], resource: 'asset description' }] as const,
+
+  /** Cache key for an asset description. */
+  description: (input: DescribeAssetCommandInput) =>
+    [{ ...assetKeys.descriptions()[0], assetId: input.assetId }] as const,
+};

--- a/packages/dashboard/src/components/queryEditor/data/sitewise.ts
+++ b/packages/dashboard/src/components/queryEditor/data/sitewise.ts
@@ -1,0 +1,2 @@
+/** Cache key for all IoT SiteWise resources. */
+export const iotSiteWiseKey = [{ service: 'iot sitewise' }] as const;

--- a/packages/dashboard/src/components/queryEditor/helpers/test/createAssetDescriptionStub.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/test/createAssetDescriptionStub.ts
@@ -1,0 +1,33 @@
+import { type DescribeAssetCommandOutput } from '@aws-sdk/client-iotsitewise';
+import { v4 as uuid } from 'uuid';
+
+export type AssetDescription = Omit<DescribeAssetCommandOutput, '$metadata'>;
+
+/** Create an IoT asset description stub to use for testing. Configure it for your test, or don't! */
+export function createAssetDescriptionStub({
+  assetModelId = uuid(),
+  assetId = uuid(),
+  assetArn = `arn:aws:iotsitewise:us-east-1:123456789012:asset/${assetId}`,
+  assetName = `Test Asset Description (${assetId})`,
+  assetDescription = undefined,
+  assetHierarchies = [],
+  assetProperties = [],
+  assetCompositeModels = [],
+  assetStatus = undefined,
+  assetCreationDate = new Date(0),
+  assetLastUpdateDate = new Date(0),
+}: Partial<AssetDescription> = {}) {
+  return {
+    assetModelId,
+    assetId,
+    assetArn,
+    assetName,
+    assetDescription,
+    assetHierarchies,
+    assetProperties,
+    assetCompositeModels,
+    assetStatus,
+    assetCreationDate,
+    assetLastUpdateDate,
+  } as const satisfies AssetDescription;
+}

--- a/packages/dashboard/src/components/queryEditor/helpers/test/createAssetPropertyStub.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/test/createAssetPropertyStub.ts
@@ -1,0 +1,21 @@
+import { type AssetProperty } from '@aws-sdk/client-iotsitewise';
+import { v4 as uuid } from 'uuid';
+
+/** Create an IoT asset property stub to use for testing. Configure it for your test, or don't! */
+export function createAssetPropertyStub({
+  id = uuid(),
+  name = `Test Asset Property (${id})`,
+  alias = undefined,
+  unit = undefined,
+  dataType = 'INTEGER',
+  dataTypeSpec = undefined,
+}: Partial<AssetProperty> = {}) {
+  return {
+    id,
+    alias,
+    name,
+    unit,
+    dataType,
+    dataTypeSpec,
+  } as const satisfies AssetProperty;
+}

--- a/packages/dashboard/src/components/queryEditor/helpers/test/createAssetSummaryStub.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/test/createAssetSummaryStub.ts
@@ -1,0 +1,25 @@
+import { type AssetSummary } from '@aws-sdk/client-iotsitewise';
+import { v4 as uuid } from 'uuid';
+
+/** Create an IoT asset summary stub to use for testing. Configure it for your test, or don't! */
+export function createAssetSummaryStub({
+  assetModelId = uuid(),
+  id = uuid(),
+  arn = `arn:aws:iotsitewise:us-east-1:123456789012:asset/${id}`,
+  name = `Test Asset Summary (${id})`,
+  hierarchies = [],
+  status = undefined,
+  creationDate = new Date(0),
+  lastUpdateDate = new Date(0),
+}: Partial<AssetSummary> = {}) {
+  return {
+    assetModelId,
+    id,
+    arn,
+    name,
+    hierarchies,
+    status,
+    creationDate,
+    lastUpdateDate,
+  } as const satisfies AssetSummary;
+}

--- a/packages/dashboard/src/components/queryEditor/helpers/test/errorBoundaryTester.tsx
+++ b/packages/dashboard/src/components/queryEditor/helpers/test/errorBoundaryTester.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+
+/**
+ * Render this component inside of an `<ErrorBoundary />` and click the button
+ * to trigger the error boundary. For use in testing and development of error
+ * handling.
+ */
+export function ErrorBoundaryTester() {
+  // the error needs to be held in state through re-renders
+  const [throwError, setThrowError] = useState(false);
+
+  if (throwError) {
+    // we need to throw the error every render
+    throw new Error();
+  }
+
+  return (
+    <>
+      <div>error fallback is not being rendered</div>
+      <button onClick={() => setThrowError(true)}>EXPLODE</button>
+    </>
+  );
+}

--- a/packages/dashboard/src/components/queryEditor/helpers/test/fromSummaryToDescription.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/test/fromSummaryToDescription.ts
@@ -1,0 +1,34 @@
+import { createAssetDescriptionStub, type AssetDescription } from './createAssetDescriptionStub';
+import { type createAssetSummaryStub } from './createAssetSummaryStub';
+
+/** Transform an asset summary stub to a description. It happens! */
+export function fromSummaryToDescription({
+  id,
+  assetModelId,
+  arn,
+  name,
+  hierarchies,
+  status,
+  creationDate,
+  lastUpdateDate,
+  assetDescription = undefined,
+  assetProperties = [],
+  assetCompositeModels = [],
+}: Partial<
+  ReturnType<typeof createAssetSummaryStub> &
+    Pick<AssetDescription, 'assetDescription' | 'assetProperties' | 'assetCompositeModels'>
+> = {}) {
+  return createAssetDescriptionStub({
+    assetModelId,
+    assetId: id,
+    assetArn: arn,
+    assetName: name,
+    assetHierarchies: hierarchies,
+    assetStatus: status,
+    assetCreationDate: creationDate,
+    assetLastUpdateDate: lastUpdateDate,
+    assetDescription,
+    assetProperties,
+    assetCompositeModels,
+  } as const satisfies AssetDescription);
+}

--- a/packages/dashboard/src/components/queryEditor/index.ts
+++ b/packages/dashboard/src/components/queryEditor/index.ts
@@ -1,0 +1,1 @@
+export { QueryEditor, type QueryEditorProps } from './queryEditor';

--- a/packages/dashboard/src/components/queryEditor/queryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/queryEditor.tsx
@@ -1,0 +1,44 @@
+import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import React, { useState } from 'react';
+
+import { QueryEditorErrorBoundary } from './queryEditorErrorBoundary';
+import { ResourceExplorer, ResourceExplorerProps } from './resourceExplorer';
+import { StreamExplorer } from './streamExplorer';
+
+export interface QueryEditorProps {
+  client: IoTSiteWiseClient;
+}
+
+/**
+ * User interface element enabling users to manage their data source queries.
+ *
+ * @remarks
+ *
+ * At this highest level, the QueryEditor's responsibility is to manage the state synchronizing the
+ * ResourceExplorer and StreamExplorer components.
+ */
+export function QueryEditor({ client }: QueryEditorProps) {
+  const [selectedAssets, setSelectedAssets] = useState<ResourceExplorerProps['selectedAssets']>([]);
+  const [assetId, setAssetId] = useState<string | undefined>(undefined);
+
+  // these assets will be described and their asset properties listed by the stream explorer
+  const selectedAssetIds = selectedAssets
+    .filter((asset): asset is typeof asset & { id: string } => asset.id != null)
+    .map(({ id }) => id);
+
+  return (
+    <QueryEditorErrorBoundary>
+      <SpaceBetween size='l'>
+        <ResourceExplorer
+          client={client}
+          selectedAssets={selectedAssets}
+          onSelect={setSelectedAssets}
+          assetId={assetId}
+          onChangeAssetId={setAssetId}
+        />
+        <StreamExplorer client={client} assetIds={selectedAssetIds} />
+      </SpaceBetween>
+    </QueryEditorErrorBoundary>
+  );
+}

--- a/packages/dashboard/src/components/queryEditor/queryEditorErrorBoundary/index.ts
+++ b/packages/dashboard/src/components/queryEditor/queryEditorErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { QueryEditorErrorBoundary, type QueryEditorErrorBoundaryProps } from './queryEditorErrorBoundary';

--- a/packages/dashboard/src/components/queryEditor/queryEditorErrorBoundary/queryEditorErrorBoundary.tsx
+++ b/packages/dashboard/src/components/queryEditor/queryEditorErrorBoundary/queryEditorErrorBoundary.tsx
@@ -1,0 +1,39 @@
+import React, { type PropsWithChildren } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import Box from '@cloudscape-design/components/box';
+import Link from '@cloudscape-design/components/link';
+
+export type QueryEditorErrorBoundaryProps = PropsWithChildren;
+
+export function QueryEditorErrorBoundary({ children }: QueryEditorErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      fallbackRender={({ error }) => (
+        <Box padding={{ top: 'l' }} textAlign='center'>
+          <b>An error occured.</b>
+
+          <Box variant='p' color='inherit'>
+            An error occurred when displaying the query editor.
+          </Box>
+
+          <Box>
+            <Link
+              external
+              href={`https://github.com/awslabs/iot-app-kit/issues/new?labels=bug&title=+Query+editor+failed+to+display&body=${error.message}&labels=bug`}
+            >
+              Report the error
+            </Link>
+          </Box>
+        </Box>
+      )}
+      onError={handleError}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+function handleError(error: Error) {
+  const errorMessage = `An error has triggered <QueryEditor>'s error boundary and the component has failed to render. Error: ${error}`;
+  console.error(errorMessage);
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/index.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/index.ts
@@ -1,0 +1,1 @@
+export { ResourceExplorer, type ResourceExplorerProps } from './resourceExplorer';

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceExplorer.tsx
@@ -1,0 +1,286 @@
+import { type AssetSummary } from '@aws-sdk/client-iotsitewise';
+import { useCollection } from '@cloudscape-design/collection-hooks';
+import Box from '@cloudscape-design/components/box';
+import CollectionPreferences from '@cloudscape-design/components/collection-preferences';
+import Link from '@cloudscape-design/components/link';
+import Pagination from '@cloudscape-design/components/pagination';
+import PropertyFilter from '@cloudscape-design/components/property-filter';
+import Table from '@cloudscape-design/components/table';
+import React from 'react';
+
+import { ResourceHierarchyPath } from './resourceHierarchyPath';
+import { useAssets } from './useAssets';
+import { useExplorerPreferences } from '../shared/useExplorerPreferences';
+import type { WithIoTSiteWiseClient } from '../types';
+
+export interface ResourceExplorerProps extends WithIoTSiteWiseClient {
+  /** List of selected assets. State stored in parent component. */
+  selectedAssets: AssetSummary[];
+  /** Callback invoked when the user selects assets. */
+  onSelect: (assets: AssetSummary[]) => void;
+  /**
+   * Optional asset ID. Renders root assets when asset ID is not defined. Renders
+   * child assets when the asset ID is not defined. */
+  assetId?: string;
+  /** Callback invoked when the user clicks an asset name of an asset with hierarchies. */
+  onChangeAssetId: (assetId?: string) => void;
+}
+
+/** User interface element enabling the exploration and selection of assets. */
+export function ResourceExplorer({
+  assetId,
+  onChangeAssetId,
+  onSelect,
+  selectedAssets,
+  client,
+}: ResourceExplorerProps) {
+  const [preferences, setPreferences] = useExplorerPreferences({
+    defaultVisibleContent: ['name'],
+    resourceName: 'asset',
+  });
+  const { assets, isFetching, fetchNextPage } = useAssets({ assetId, client });
+  const { items, collectionProps, paginationProps, propertyFilterProps } = useCollection(assets, {
+    propertyFiltering: {
+      filteringProperties: [
+        {
+          key: 'id',
+          propertyLabel: 'ID',
+          groupValuesLabel: 'Property IDs',
+          operators: ['=', '!=', ':', '!:'],
+        },
+        {
+          key: 'name',
+          propertyLabel: 'Name',
+          groupValuesLabel: 'Property names',
+          operators: ['=', '!=', ':', '!:'],
+        },
+        {
+          key: 'description',
+          propertyLabel: 'Description',
+          groupValuesLabel: 'Property descriptions',
+          operators: ['=', '!=', ':', '!:'],
+        },
+        {
+          key: 'creationDate',
+          propertyLabel: 'Creation date',
+          groupValuesLabel: 'Property creation dates',
+          operators: ['=', '!=', '<', '<=', '>', '>='],
+        },
+        {
+          key: 'lastUpdateDate',
+          propertyLabel: 'Last update date',
+          groupValuesLabel: 'Property last update dates',
+          operators: ['=', '!=', '<', '<=', '>', '>='],
+        },
+      ],
+    },
+    pagination: { pageSize: preferences.pageSize },
+    selection: {},
+    sorting: {},
+  });
+
+  return (
+    <>
+      <Table
+        {...collectionProps}
+        ariaLabels={{
+          itemSelectionLabel: (isNotSelected, asset) =>
+            isNotSelected ? `Select asset ${asset.name}` : `Deselect asset ${asset.name}`,
+        }}
+        items={items}
+        trackBy={({ id = '' }) => id}
+        header={<ResourceHierarchyPath client={client} onClickAssetName={onChangeAssetId} parentAssetId={assetId} />}
+        columnDefinitions={[
+          {
+            sortingField: 'name',
+            id: 'name',
+            header: 'Name',
+            cell: ({ name, id, hierarchies = [] }) => {
+              return hierarchies.length > 0 ? (
+                <Link
+                  ariaLabel='List child assets'
+                  onFollow={(event) => {
+                    event.preventDefault();
+                    onChangeAssetId(id);
+                  }}
+                >
+                  {name}
+                </Link>
+              ) : (
+                name
+              );
+            },
+          },
+
+          {
+            id: 'arn',
+            header: 'ARN',
+            cell: ({ arn }) => arn,
+          },
+          {
+            id: 'id',
+            header: 'ID',
+            cell: ({ id }) => id,
+          },
+          {
+            id: 'description',
+            header: 'Description',
+            cell: ({ description }) => description,
+            sortingField: 'description',
+          },
+          {
+            id: 'creationDate',
+            header: 'Creation date',
+            cell: ({ creationDate }) => creationDate?.toLocaleDateString(),
+            sortingField: 'creationDate',
+          },
+          {
+            id: 'lastUpdateDate',
+            header: 'Last update date',
+            cell: ({ lastUpdateDate }) => lastUpdateDate?.toLocaleDateString(),
+            sortingField: 'lastUpdateDate',
+          },
+        ]}
+        variant='embedded'
+        loading={isFetching}
+        loadingText='Loading assets...'
+        selectionType='multi'
+        selectedItems={selectedAssets}
+        stickyColumns={preferences.stickyColumns}
+        onSelectionChange={(event) => {
+          // tell user about selection
+          if (onSelect) {
+            onSelect(event.detail.selectedItems);
+          }
+
+          // pass event to `useCollection` for synchronization
+          if (collectionProps.onSelectionChange) {
+            collectionProps.onSelectionChange(event);
+          }
+        }}
+        empty={
+          <Box textAlign='center' color='inherit'>
+            <b>No assets.</b>
+
+            <Box padding={{ bottom: 's' }} variant='p' color='inherit'>
+              No assets to display.
+            </Box>
+          </Box>
+        }
+        resizableColumns
+        pagination={
+          <Pagination
+            {...paginationProps}
+            // only show open ended pagination on root assets
+            openEnd={assetId == null}
+            ariaLabels={{
+              nextPageLabel: 'Next page',
+              paginationLabel: 'Resource explorer pagination',
+              previousPageLabel: 'Previous page',
+              pageLabel: (pageNumber) => `Page ${pageNumber}`,
+            }}
+            onNextPageClick={() => fetchNextPage()}
+          />
+        }
+        filter={
+          <PropertyFilter
+            {...propertyFilterProps}
+            filteringLoadingText='Loading suggestions'
+            filteringErrorText='Error fetching suggestions.'
+            filteringRecoveryText='Retry'
+            filteringFinishedText='End of results'
+            filteringEmpty='No suggestions found'
+            i18nStrings={{
+              filteringAriaLabel: 'your choice',
+              dismissAriaLabel: 'Dismiss',
+              filteringPlaceholder: 'Filter assets by text, property or value',
+              groupValuesText: 'Values',
+              groupPropertiesText: 'Properties',
+              operatorsText: 'Operators',
+              operationAndText: 'and',
+              operationOrText: 'or',
+              operatorLessText: 'Less than',
+              operatorLessOrEqualText: 'Less than or equal',
+              operatorGreaterText: 'Greater than',
+              operatorGreaterOrEqualText: 'Greater than or equal',
+              operatorContainsText: 'Contains',
+              operatorDoesNotContainText: 'Does not contain',
+              operatorEqualsText: 'Equals',
+              operatorDoesNotEqualText: 'Does not equal',
+              editTokenHeader: 'Edit filter',
+              propertyText: 'Property',
+              operatorText: 'Operator',
+              valueText: 'Value',
+              cancelActionText: 'Cancel',
+              applyActionText: 'Apply',
+              allPropertiesLabel: 'All properties',
+              tokenLimitShowMore: 'Show more',
+              tokenLimitShowFewer: 'Show fewer',
+              clearFiltersText: 'Clear filters',
+              removeTokenButtonAriaLabel: (token) =>
+                `Remove token ${token.propertyKey} ${token.operator} ${token.value}`,
+              enteredTextLabel: (text) => `Use: "${text}"`,
+            }}
+          />
+        }
+        visibleColumns={preferences.visibleContent}
+        stripedRows={preferences.stripedRows}
+        wrapLines={preferences.wrapLines}
+        preferences={
+          <CollectionPreferences
+            title='Preferences'
+            confirmLabel='Confirm'
+            cancelLabel='Cancel'
+            preferences={preferences}
+            onConfirm={({ detail }) => {
+              setPreferences(detail as typeof preferences);
+            }}
+            pageSizePreference={{
+              title: 'Select page size',
+              options: [
+                { value: 10, label: '10' },
+                { value: 25, label: '25' },
+                { value: 100, label: '100' },
+                { value: 250, label: '250' },
+              ],
+            }}
+            wrapLinesPreference={{
+              label: 'Wrap lines',
+              description: 'Select to see all the text and wrap the lines',
+            }}
+            stripedRowsPreference={{
+              label: 'Striped rows',
+              description: 'Select to add alternating shaded rows',
+            }}
+            visibleContentPreference={{
+              title: 'Select visible content',
+              options: [
+                {
+                  label: `Asset fields`,
+                  options: [
+                    { id: 'arn', label: 'ARN' },
+                    { id: 'id', label: 'ID' },
+                    { id: 'name', label: 'Name' },
+                    { id: 'description', label: 'Description' },
+                    { id: 'creationDate', label: 'Creation date' },
+                    { id: 'lastUpdateDate', label: 'Last update date' },
+                  ],
+                },
+              ],
+            }}
+            stickyColumnsPreference={{
+              firstColumns: {
+                title: 'Stick first column(s)',
+                description: 'Keep the first column(s) visible while horizontally scrolling the table content.',
+                options: [
+                  { label: 'None', value: 0 },
+                  { label: 'First column', value: 1 },
+                ],
+              },
+            }}
+          />
+        }
+      />
+    </>
+  );
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/index.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/index.ts
@@ -1,0 +1,1 @@
+export { ResourceHierarchyPath, type ResourceHierarchyPathProps } from './resourceHierarchyPath';

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/resourceHierarchyPath.tsx
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/resourceHierarchyPath.tsx
@@ -1,0 +1,36 @@
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import React from 'react';
+
+import { useHierarchyCrumbs } from './useHierarchyCrumbs';
+import type { WithIoTSiteWiseClient } from '../../types';
+
+export interface ResourceHierarchyPathProps extends WithIoTSiteWiseClient {
+  /** Asset ID of the parent asset, or right-most asset in the breadcrumbs. */
+  parentAssetId?: string;
+  /** Callback fired when an asset name is clicked. This is used to navigate up the hierarchy. */
+  onClickAssetName: (assetId: string) => void;
+}
+
+/**
+ * Renders an asset hierarchy element for an asset. The hierarchy element
+ * displays the asset's parents up to the root of the asset hierarchy and
+ * features clickable navigation to the parent assets.
+ */
+export function ResourceHierarchyPath({ parentAssetId, onClickAssetName, client }: ResourceHierarchyPathProps) {
+  const { hierarchyPathCrumbs } = useHierarchyCrumbs({ parentAssetId, client });
+
+  return (
+    <BreadcrumbGroup
+      items={hierarchyPathCrumbs}
+      onClick={(event) => {
+        // cancel default event
+        event.preventDefault();
+
+        const assetId = event.detail.href;
+        onClickAssetName(assetId);
+      }}
+      ariaLabel='Asset hierarchy'
+      expandAriaLabel='Show more'
+    />
+  );
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/index.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/index.ts
@@ -1,0 +1,1 @@
+export { useHierarchyCrumbs, type UseHierarchyCrumbsProps } from './useHierarchyCrumbs';

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/listParentAssets/constants.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/listParentAssets/constants.ts
@@ -1,0 +1,2 @@
+export const MAX_ONE_PARENT = 1;
+export const PARENT_LIST_TRAVERSAL_DIRECTION = 'PARENT';

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/listParentAssets/getParentAsset.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/listParentAssets/getParentAsset.ts
@@ -1,0 +1,50 @@
+import { InvalidRequestException, ListAssociatedAssetsCommand } from '@aws-sdk/client-iotsitewise';
+import invariant from 'tiny-invariant';
+
+import { MAX_ONE_PARENT, PARENT_LIST_TRAVERSAL_DIRECTION } from './constants';
+import type { WithAbortSignal, WithIoTSiteWiseClient } from '../../../../types';
+
+export interface GetParentAssetInput extends WithAbortSignal, WithIoTSiteWiseClient {
+  /** The ID of the IoT SiteWise asset to get the parent of. */
+  assetId: string;
+}
+
+/** Get the parent of an asset with a given asset ID. */
+export async function getParentAsset({ assetId, signal, client }: GetParentAssetInput) {
+  invariant(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(assetId),
+    'Expected assetId to be a valid UUID. There is likely a bug in the calling code.'
+  );
+
+  try {
+    // https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssociatedAssets.html
+    const command = new ListAssociatedAssetsCommand({
+      traversalDirection: PARENT_LIST_TRAVERSAL_DIRECTION,
+      maxResults: MAX_ONE_PARENT,
+      assetId,
+    });
+    const { assetSummaries: [parentAsset] = [] } = await client.send(command, { abortSignal: signal });
+
+    return parentAsset;
+  } catch (error) {
+    handleGetParentAssetError({ error, assetId });
+  }
+}
+
+// return never to tell TS we're not returning undefined
+function handleGetParentAssetError({ error, assetId }: { error: unknown; assetId?: string }): never {
+  const errorMessage = `Failed to get parent of asset '${assetId}'. Error: ${error}`;
+  console.error(errorMessage);
+
+  if (error instanceof InvalidRequestException) {
+    console.error(`Expected request parameters to always be valid. There is likely a bug in the code.`);
+  }
+
+  if (error instanceof Error) {
+    // we do not want to change the error type by generalizing to `Error`
+    throw error;
+  }
+
+  // normalize non-Error exceptions to Error type
+  throw new Error(errorMessage);
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/listParentAssets/index.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/listParentAssets/index.ts
@@ -1,0 +1,1 @@
+export { listParentAssets, type ListParentAssetsInput } from './listParentAssets';

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/listParentAssets/listParentAssets.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/listParentAssets/listParentAssets.ts
@@ -1,0 +1,30 @@
+import { type AssetSummary } from '@aws-sdk/client-iotsitewise';
+import type { WithAbortSignal, WithIoTSiteWiseClient } from '../../../../types';
+
+import { getParentAsset } from './getParentAsset';
+
+export interface ListParentAssetsInput extends WithAbortSignal, WithIoTSiteWiseClient {
+  /** The ID of the asset to get the parent assets for. */
+  assetId: string;
+}
+
+/** List all of an assets parents up to the root of the asset hierarchy. */
+export function listParentAssets({ assetId, signal, client }: ListParentAssetsInput) {
+  async function recursivelyGetParentAssets(
+    assetId: string,
+    parentAssets: AssetSummary[] = []
+  ): Promise<AssetSummary[]> {
+    const parentAsset = await getParentAsset({ client, assetId, signal });
+
+    // termination condition
+    if (parentAsset == null || parentAsset.id == null) {
+      return parentAssets;
+    }
+
+    // build up the list of parent assets recursively
+    return recursivelyGetParentAssets(parentAsset.id, [parentAsset, ...parentAssets]);
+  }
+
+  // begin recursion
+  return recursivelyGetParentAssets(assetId);
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/transformAssetsToCrumbs.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/transformAssetsToCrumbs.ts
@@ -1,0 +1,8 @@
+import { type AssetSummary } from '@aws-sdk/client-iotsitewise';
+
+/** Turn assets into the correct form for rendering breadcrumbs. */
+export function transformAssetsToCrumbs(assets: AssetSummary[]): { href: string; text: string }[] {
+  const crumbs = assets.map(({ id = '', name = '' }) => ({ href: id, text: name }));
+
+  return crumbs;
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/useHierarchyCrumbs.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/resourceHierarchyPath/useHierarchyCrumbs/useHierarchyCrumbs.ts
@@ -1,0 +1,50 @@
+import { useQuery, type QueryFunctionContext } from '@tanstack/react-query';
+import invariant from 'tiny-invariant';
+
+import { listParentAssets } from './listParentAssets';
+import { transformAssetsToCrumbs } from './transformAssetsToCrumbs';
+import { useAssetDescription } from '../../useAssetDescription';
+import { assetKeys } from '../../../data/assets';
+import type { WithIoTSiteWiseClient } from '../../../types';
+
+export interface UseHierarchyCrumbsProps extends WithIoTSiteWiseClient {
+  /** The ID of the asset to create the hierarchy path for. */
+  parentAssetId?: string;
+}
+
+/** Use the hierarchy path for an asset with a given asset ID. */
+export function useHierarchyCrumbs({ parentAssetId, client }: UseHierarchyCrumbsProps) {
+  const { asset: { assetName = '' } = {} } = useAssetDescription({ assetId: parentAssetId, client });
+
+  const { data: crumbs = [], isFetching } = useQuery({
+    enabled: Boolean(parentAssetId),
+    // associated lists are used when listed assets by relationship
+    queryKey: assetKeys.associatedList({ assetId: parentAssetId, traversalDirection: 'PARENT' }),
+    queryFn: createUseHierarchyPathCrumbsQueryFn({ client }),
+    // transform the assets post-request to take advantage of cached assets
+    select: transformAssetsToCrumbs,
+  });
+
+  const loadingCrumb = isFetching ? [{ href: '', text: 'Loading...' }] : [];
+  const ancestorCrumbs = !isFetching ? [{ href: '', text: 'Root' }, ...crumbs] : [];
+  const parentAssetCrumb = !isFetching && parentAssetId ? [{ href: parentAssetId, text: assetName }] : [];
+
+  const hierarchyPathCrumbs: { href: string; text: string }[] = [
+    ...loadingCrumb,
+    ...ancestorCrumbs,
+    ...parentAssetCrumb,
+  ];
+
+  return { hierarchyPathCrumbs };
+}
+
+function createUseHierarchyPathCrumbsQueryFn({ client }: WithIoTSiteWiseClient) {
+  return async function ({
+    queryKey: [{ assetId }],
+    signal,
+  }: QueryFunctionContext<ReturnType<typeof assetKeys.associatedList>>) {
+    invariant(assetId != null, 'Expected assetId to be defined given the enabled condition.');
+
+    return listParentAssets({ assetId, client, signal });
+  };
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssetDescription/index.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssetDescription/index.ts
@@ -1,0 +1,1 @@
+export { useAssetDescription, type UseAssetDescriptionProps } from './useAssetDescription';

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssetDescription/useAssetDescription.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssetDescription/useAssetDescription.ts
@@ -1,0 +1,39 @@
+import { useQuery, type QueryFunctionContext } from '@tanstack/react-query';
+import invariant from 'tiny-invariant';
+
+import { describeAsset } from '../../shared/describeAsset';
+import { assetKeys } from '../../data/assets';
+import type { WithIoTSiteWiseClient } from '../../types';
+
+export interface UseAssetDescriptionProps extends WithIoTSiteWiseClient {
+  /** The ID of the asset to describe. Requests will only be made when `assetId` is defined. */
+  assetId?: string;
+}
+
+/** Use an AWS IoT SiteWise asset description. */
+export function useAssetDescription({ assetId, client }: UseAssetDescriptionProps) {
+  const {
+    data: asset,
+    status,
+    isFetching,
+  } = useQuery({
+    // only non-empty assetIds will enable the query
+    enabled: Boolean(assetId),
+    queryKey: assetKeys.description({ assetId }),
+    queryFn: createUseDescribeAssetQueryFn({ client }),
+  });
+
+  return { asset, status, isFetching };
+}
+
+// curried function to enable queryFn to pass in the function context
+function createUseDescribeAssetQueryFn({ client }: WithIoTSiteWiseClient) {
+  return async function ({
+    queryKey: [{ assetId }],
+    signal,
+  }: QueryFunctionContext<ReturnType<typeof assetKeys.description>>) {
+    invariant(assetId != null, 'Expected assetId to be defined as required by the enabled flag.');
+
+    return describeAsset({ assetId, signal, client });
+  };
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/index.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/index.ts
@@ -1,0 +1,1 @@
+export { useAssets, type UseAssetsProps } from './useAssets';

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useAssets.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useAssets.ts
@@ -1,0 +1,35 @@
+import { useChildAssets } from './useChildAssets';
+import { useRootAssets } from './useRootAssets';
+
+import { WithIoTSiteWiseClient } from '../../types';
+
+export interface UseAssetsProps extends WithIoTSiteWiseClient {
+  /** Optional asset ID for listing child assets of the asset for the given ID. */
+  assetId?: string;
+}
+
+/** Use a list of IoT SiteWise assets. */
+export function useAssets({ assetId, client }: UseAssetsProps) {
+  const {
+    rootAssets,
+    fetchNextPage: fetchNextPageRootAssets,
+    isError: isErrorRootAssets,
+    isFetching: isFetchingRootAssets,
+    isSuccess: isSuccessRootAssets,
+  } = useRootAssets({ client });
+  const {
+    childAssets,
+    isError: isErrorChildAssets,
+    isFetching: isFetchingChildAssets,
+    isSuccess: isSuccessChildAssets,
+  } = useChildAssets({ assetId, client });
+
+  const assets = assetId ? childAssets : rootAssets;
+  const isError = assetId ? isErrorChildAssets : isErrorRootAssets;
+  const isFetching = assetId ? isFetchingChildAssets : isFetchingRootAssets;
+  const isSuccess = assetId ? isSuccessChildAssets : isSuccessRootAssets;
+  // FIXME: I think there's a bug in the pagination. Test before release.
+  const fetchNextPage = assetId ? () => undefined : fetchNextPageRootAssets;
+
+  return { assets, isError, isFetching, isSuccess, fetchNextPage };
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useChildAssets/constants.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useChildAssets/constants.ts
@@ -1,0 +1,2 @@
+export const CHILD_ASSETS_LIST_TRAVERSAL_DIRECTION = 'CHILD'; // we need to traverse down the hierarchy
+export const MAX_CHILD_ASSETS_PAGE_SIZE = 250; // 250 is the max

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useChildAssets/index.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useChildAssets/index.ts
@@ -1,0 +1,1 @@
+export { useChildAssets, type UseChildAssetsProps } from './useChildAssets';

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useChildAssets/listChildAssets.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useChildAssets/listChildAssets.ts
@@ -1,0 +1,78 @@
+import { InvalidRequestException, type AssetSummary, ListAssociatedAssetsCommand } from '@aws-sdk/client-iotsitewise';
+import invariant from 'tiny-invariant';
+
+import { CHILD_ASSETS_LIST_TRAVERSAL_DIRECTION, MAX_CHILD_ASSETS_PAGE_SIZE } from './constants';
+import type { WithAbortSignal, WithIoTSiteWiseClient } from '../../../types';
+
+export interface ListChildAssetsProps extends WithAbortSignal, WithIoTSiteWiseClient {
+  assetId: string;
+  hierarchyId: string;
+}
+
+/** Get all child assets for a given asset and hierarchy. */
+export async function listChildAssets({ assetId, hierarchyId, signal, client }: ListChildAssetsProps) {
+  invariant(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(assetId),
+    'Expected assetId to be a valid UUID. There is likely a bug in the calling code.'
+  );
+  invariant(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(hierarchyId),
+    'Expected hierarchyId to be a valid UUID. There is likely a bug in the calling code.'
+  );
+
+  try {
+    // https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssociatedAssets.html
+    const command = new ListAssociatedAssetsCommand({
+      assetId,
+      hierarchyId,
+      traversalDirection: CHILD_ASSETS_LIST_TRAVERSAL_DIRECTION,
+      maxResults: MAX_CHILD_ASSETS_PAGE_SIZE,
+    });
+    const { assetSummaries = [], nextToken } = await client.send(command, { abortSignal: signal });
+    let paginationToken: string | undefined = nextToken;
+    const childAssets: AssetSummary[] = [...assetSummaries];
+    while (nextToken) {
+      const { assetSummaries: assetSummaryPage = [], nextToken: newToken } = await client.send(
+        new ListAssociatedAssetsCommand({
+          assetId,
+          hierarchyId,
+          traversalDirection: CHILD_ASSETS_LIST_TRAVERSAL_DIRECTION,
+          maxResults: MAX_CHILD_ASSETS_PAGE_SIZE,
+          nextToken: paginationToken,
+        }),
+        { abortSignal: signal }
+      );
+      childAssets.push(...assetSummaryPage);
+      paginationToken = newToken;
+    }
+
+    return childAssets;
+  } catch (error) {
+    handleListChildAssetsError({ error, assetId, hierarchyId });
+  }
+}
+
+function handleListChildAssetsError({
+  error,
+  assetId,
+  hierarchyId,
+}: {
+  error: unknown;
+  assetId: string;
+  hierarchyId: string;
+}): never {
+  const errorMessage = `Failed to list child assets for asset ID: ${assetId} and hierarchy ID: ${hierarchyId}. Error: ${error}`;
+  console.error(errorMessage);
+
+  if (error instanceof InvalidRequestException) {
+    console.error(`Expected hard-coded request parameters to always be valid. There is likely a bug in the code.`);
+  }
+
+  if (error instanceof Error) {
+    // we do not want to change the error type by generalizing to `Error`
+    throw error;
+  }
+
+  // normalize non-Error exceptions to Error type
+  throw new Error(errorMessage);
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useChildAssets/selectHierarchyIds.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useChildAssets/selectHierarchyIds.ts
@@ -1,0 +1,7 @@
+/** List all of the IDs across hierarchies. */
+export function selectHierarchyIds(hierarchies: { id?: string }[]): string[] {
+  const hierarchiesWithIds: { id: string }[] = hierarchies.filter((h): h is { id: string } => Boolean(h?.id));
+  const hierarchyIds: string[] = hierarchiesWithIds.map(({ id }) => id);
+
+  return hierarchyIds;
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useChildAssets/useChildAssets.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useChildAssets/useChildAssets.ts
@@ -1,0 +1,54 @@
+import { type AssetSummary } from '@aws-sdk/client-iotsitewise';
+import { useQueries, type QueryFunctionContext } from '@tanstack/react-query';
+import invariant from 'tiny-invariant';
+
+import { CHILD_ASSETS_LIST_TRAVERSAL_DIRECTION } from './constants';
+import { listChildAssets } from './listChildAssets';
+import { selectHierarchyIds } from './selectHierarchyIds';
+import { useAssetDescription } from '../../useAssetDescription';
+import { assetKeys } from '../../../data/assets';
+import type { WithIoTSiteWiseClient } from '../../../types';
+
+export interface UseChildAssetsProps extends WithIoTSiteWiseClient {
+  /** Asset ID to list children for. Queries are not active until the asset ID is set. */
+  assetId?: string;
+}
+
+/** Use the list of child assets for an asset with a given asset ID. */
+export function useChildAssets({ assetId, client }: UseChildAssetsProps) {
+  const { asset: { assetHierarchies = [] } = {} } = useAssetDescription({ assetId, client });
+  const hierarchyIds = selectHierarchyIds(assetHierarchies);
+
+  const queries =
+    useQueries({
+      queries: hierarchyIds.map((hierarchyId) => ({
+        // we need assetId and hierarchyId to make a successful request
+        enabled: Boolean(assetId) && Boolean(hierarchyId),
+        queryKey: assetKeys.associatedList({
+          assetId,
+          hierarchyId,
+          traversalDirection: CHILD_ASSETS_LIST_TRAVERSAL_DIRECTION,
+        }),
+        queryFn: createUseChildAssetsQueryFn({ client }),
+      })),
+    }) ?? [];
+
+  const childAssets: AssetSummary[] = queries.flatMap(({ data = [] }) => data);
+  const isError = queries.some(({ isError }) => isError);
+  const isFetching = queries.some(({ isFetching }) => isFetching);
+  const isSuccess = queries.every(({ isSuccess }) => isSuccess);
+
+  return { childAssets, isError, isFetching, isSuccess };
+}
+
+function createUseChildAssetsQueryFn({ client }: WithIoTSiteWiseClient) {
+  return async function ({
+    queryKey: [{ assetId, hierarchyId }],
+    signal,
+  }: QueryFunctionContext<ReturnType<typeof assetKeys.associatedList>>) {
+    invariant(assetId != null, 'Expected asset ID to be defined as required by the enabled flag.');
+    invariant(hierarchyId != null, 'Expected hierarchy ID to be defined as required by the enabled flag.');
+
+    return listChildAssets({ assetId, hierarchyId, signal, client });
+  };
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useRootAssets/constants.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useRootAssets/constants.ts
@@ -1,0 +1,2 @@
+export const ROOT_ASSETS_LIST_FILTER = 'TOP_LEVEL';
+export const MAX_ROOT_ASSETS_PER_PAGE = 250;

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useRootAssets/index.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useRootAssets/index.ts
@@ -1,0 +1,1 @@
+export { useRootAssets, type UseRootAssetsProps } from './useRootAssets';

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useRootAssets/listRootAssets.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useRootAssets/listRootAssets.ts
@@ -1,0 +1,46 @@
+import { InvalidRequestException, ListAssetsCommand } from '@aws-sdk/client-iotsitewise';
+
+import { ROOT_ASSETS_LIST_FILTER, MAX_ROOT_ASSETS_PER_PAGE } from './constants';
+import type { WithAbortSignal, WithIoTSiteWiseClient } from '../../../types';
+
+export interface ListRootAssetsInput extends WithAbortSignal, WithIoTSiteWiseClient {
+  /** Pagination token used to request the NEXT page of assets. */
+  nextToken?: string;
+}
+
+/**
+ * Returns a page of root assets and maybe a pagination token (`nextToke`). Call it again with
+ * the return pagination token and the next page of root assets will be returned.
+ */
+export async function listRootAssets({ nextToken, signal, client }: ListRootAssetsInput) {
+  try {
+    const command = new ListAssetsCommand({
+      nextToken,
+      filter: ROOT_ASSETS_LIST_FILTER,
+      maxResults: MAX_ROOT_ASSETS_PER_PAGE,
+    });
+    const assets = await client.send(command, { abortSignal: signal });
+
+    return assets;
+  } catch (error) {
+    handleListRootAssetsError(error);
+  }
+}
+
+// return never to tell TS we're not returning undefined
+function handleListRootAssetsError(error: unknown): never {
+  const errorMessage = `Failed to list root assets. Error: ${error}`;
+  console.error(errorMessage);
+
+  if (error instanceof InvalidRequestException) {
+    console.error(`Expected hard-coded request parameters to always be valid. There is likely a bug in the code.`);
+  }
+
+  if (error instanceof Error) {
+    // we do not want to change the error type by generalizing to `Error`
+    throw error;
+  }
+
+  // normalize non-Error exceptions to Error type
+  throw new Error(errorMessage);
+}

--- a/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useRootAssets/useRootAssets.ts
+++ b/packages/dashboard/src/components/queryEditor/resourceExplorer/useAssets/useRootAssets/useRootAssets.ts
@@ -1,0 +1,36 @@
+import { type AssetSummary } from '@aws-sdk/client-iotsitewise';
+import { useInfiniteQuery, type QueryFunctionContext } from '@tanstack/react-query';
+
+import { listRootAssets } from './listRootAssets';
+import { assetKeys } from '../../../data/assets';
+import type { WithIoTSiteWiseClient } from '../../../types';
+
+export type UseRootAssetsProps = WithIoTSiteWiseClient;
+
+/** Use the paginated list of root assets. */
+export function useRootAssets({ client }: UseRootAssetsProps) {
+  const {
+    data: { pages: rootAssetPages = [] } = {},
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isSuccess,
+    status,
+    isError,
+    error,
+  } = useInfiniteQuery({
+    queryKey: assetKeys.list({ filter: 'TOP_LEVEL' }),
+    queryFn: createUseListRootAssetsQueryFn({ client }),
+    getNextPageParam: ({ nextToken }) => nextToken,
+  });
+
+  const rootAssets: AssetSummary[] = rootAssetPages.flatMap(({ assetSummaries = [] }) => assetSummaries);
+
+  return { rootAssets, hasNextPage, fetchNextPage, isFetching, isSuccess, status, isError, error };
+}
+
+function createUseListRootAssetsQueryFn({ client }: WithIoTSiteWiseClient) {
+  return async function ({ pageParam: nextToken, signal }: QueryFunctionContext<ReturnType<typeof assetKeys.list>>) {
+    return listRootAssets({ nextToken, signal, client });
+  };
+}

--- a/packages/dashboard/src/components/queryEditor/shared/describeAsset.ts
+++ b/packages/dashboard/src/components/queryEditor/shared/describeAsset.ts
@@ -1,0 +1,43 @@
+import { InvalidRequestException, DescribeAssetCommand } from '@aws-sdk/client-iotsitewise';
+import invariant from 'tiny-invariant';
+
+import type { WithAbortSignal, WithIoTSiteWiseClient } from '../types';
+
+export interface DescribeAssetInput extends WithAbortSignal, WithIoTSiteWiseClient {
+  /** The ID of the IoT SiteWise asset to describe. */
+  assetId: string;
+}
+
+/** Return an IoT SiteWise asset description for a given asset ID. */
+export async function describeAsset({ assetId, signal, client }: DescribeAssetInput) {
+  invariant(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(assetId),
+    'Expected assetId to be a valid UUID. There is likely a bug in the calling code.'
+  );
+
+  try {
+    const describeAssetCommand = new DescribeAssetCommand({ assetId });
+    const asset = await client.send(describeAssetCommand, { abortSignal: signal });
+
+    return asset;
+  } catch (error) {
+    handleDescribeAssetError({ error, assetId });
+  }
+}
+
+// return never to tell TS we're not returning undefined
+function handleDescribeAssetError({ error, assetId }: { error: unknown; assetId?: string }): never {
+  const errorMessage = `Failed to describe asset '${assetId}'. Error: ${error}`;
+  console.error(errorMessage);
+
+  if (error instanceof InvalidRequestException) {
+    console.error(`Expected request parameters to always be valid. There is likely a bug in the code.`);
+  }
+
+  if (error instanceof Error) {
+    // we do not want to change the error type by generalizing to `Error`
+    throw error;
+  }
+
+  throw new Error(errorMessage);
+}

--- a/packages/dashboard/src/components/queryEditor/shared/useExplorerPreferences.ts
+++ b/packages/dashboard/src/components/queryEditor/shared/useExplorerPreferences.ts
@@ -1,0 +1,28 @@
+import { type CollectionPreferencesProps } from '@cloudscape-design/components/collection-preferences';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+
+const DEFAULT_PREFERENCES = {
+  pageSize: 10,
+  wrapLines: true,
+  stripedRows: false,
+  stickyColumns: { first: 1 },
+} as const satisfies CollectionPreferencesProps['preferences'];
+
+interface UsePreferencesProps {
+  defaultVisibleContent: string[];
+  resourceName: string;
+}
+
+/** Use to store <Explorer /> component preferences in local storage. */
+export function useExplorerPreferences({ defaultVisibleContent, resourceName }: UsePreferencesProps) {
+  const initializer = {
+    ...DEFAULT_PREFERENCES,
+    visibleContent: defaultVisibleContent,
+  };
+
+  // the storage name is unique to the resource name
+  const storageKey = `${resourceName}-preferences`;
+  const [preferences = initializer, setPreferences] = useLocalStorage(storageKey, initializer);
+
+  return [preferences, setPreferences] as const;
+}

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/index.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/index.ts
@@ -1,0 +1,1 @@
+export { StreamExplorer, type StreamExplorerProps } from './streamExplorer';

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/streamExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/streamExplorer.tsx
@@ -1,0 +1,320 @@
+import { useCollection } from '@cloudscape-design/collection-hooks';
+import Box from '@cloudscape-design/components/box';
+import CollectionPreferences from '@cloudscape-design/components/collection-preferences';
+import Header from '@cloudscape-design/components/header';
+import Pagination from '@cloudscape-design/components/pagination';
+import PropertyFilter from '@cloudscape-design/components/property-filter';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Table from '@cloudscape-design/components/table';
+import React from 'react';
+
+import { useLatestValues, isSuccessValue, isErrorValue } from './useLatestValues';
+import { useAssetProperties } from './useAssetProperties';
+import { useExplorerPreferences } from '../shared/useExplorerPreferences';
+import type { WithIoTSiteWiseClient } from '../types';
+
+export interface StreamExplorerProps extends WithIoTSiteWiseClient {
+  /** Query for requesting asset properties. */
+  assetIds: string[];
+}
+
+/** Explore your AWS IoT SiteWise asset properties. */
+export function StreamExplorer({ assetIds, client }: StreamExplorerProps) {
+  const [preferences, setPreferences] = useExplorerPreferences({
+    defaultVisibleContent: ['name', 'latestValue'],
+    resourceName: 'asset property',
+  });
+
+  const { assetProperties, isFetching: isFetchingAssetProperties } = useAssetProperties({ assetIds, client });
+  const {
+    latestValues,
+    isFetching: isFetchingLatestValues,
+    isError: isErrorLatestValues,
+  } = useLatestValues({
+    isEnabled:
+      preferences.visibleContent.includes('latestValue') || preferences.visibleContent.includes('latestValueTime'),
+    assetProperties,
+    client,
+  });
+
+  const assetPropertiesWithLatestValues = assetProperties.map((property) => {
+    const latestValue = latestValues.find((v) => v.propertyId === property.id && v.assetId === property.assetId);
+
+    if (latestValue == null) {
+      return {
+        ...property,
+        latestValue: 'No data',
+        latestValueTime: undefined,
+      };
+    }
+
+    if (isSuccessValue(latestValue)) {
+      return {
+        ...property,
+        latestValue: latestValue.value,
+        latestValueTime: new Date((latestValue.timestamp?.timeInSeconds ?? 0) * 1000),
+      };
+    }
+
+    if (isErrorValue(latestValue)) {
+      return {
+        ...property,
+        latestValue: latestValue.errorMessage,
+        latestValueTime: undefined,
+      };
+    }
+
+    return {
+      ...property,
+      latestValue: 'No data',
+      latestValueTime: undefined,
+    };
+  });
+
+  const { items, collectionProps, paginationProps, propertyFilterProps } = useCollection(
+    assetPropertiesWithLatestValues,
+    {
+      propertyFiltering: {
+        filteringProperties: [
+          {
+            key: 'id',
+            propertyLabel: 'ID',
+            groupValuesLabel: 'Property IDs',
+            operators: ['=', '!=', ':', '!:'],
+          },
+          {
+            key: 'alias',
+            propertyLabel: 'Alias',
+            groupValuesLabel: 'Property aliases',
+            operators: ['=', '!=', ':', '!:'],
+          },
+          {
+            key: 'name',
+            propertyLabel: 'Name',
+            groupValuesLabel: 'Property names',
+            operators: ['=', '!=', ':', '!:'],
+          },
+          {
+            key: 'assetName',
+            propertyLabel: 'Asset name',
+            groupValuesLabel: 'Asset names',
+            operators: ['=', '!=', ':', '!:'],
+          },
+          {
+            key: 'dataType',
+            propertyLabel: 'Data type',
+            groupValuesLabel: 'Data types',
+            operators: ['=', '!=', ':', '!:'],
+          },
+          {
+            key: 'dataTypeSpec',
+            propertyLabel: 'Data type spec',
+            groupValuesLabel: 'Data type specs',
+            operators: ['=', '!=', ':', '!:'],
+          },
+          {
+            key: 'unit',
+            propertyLabel: 'Unit',
+            groupValuesLabel: 'Units',
+            operators: ['=', '!=', ':', '!:'],
+          },
+          {
+            key: 'latestValue',
+            propertyLabel: 'Latest value',
+            groupValuesLabel: 'Latest values',
+            operators: ['=', '!=', '>', '>=', '<', '<='],
+          },
+        ],
+      },
+      pagination: { pageSize: preferences.pageSize },
+      selection: {},
+      sorting: {},
+    }
+  );
+
+  return (
+    <Table
+      {...collectionProps}
+      items={items}
+      trackBy={({ assetId, id }) => `${assetId}-${id}`}
+      header={
+        <Header
+          variant='h3'
+          actions={
+            isFetchingLatestValues ? (
+              <StatusIndicator type='loading'>Loading</StatusIndicator>
+            ) : isErrorLatestValues ? (
+              <StatusIndicator type='error'>Error</StatusIndicator>
+            ) : (
+              <StatusIndicator type='success'>Live</StatusIndicator>
+            )
+          }
+        >
+          Asset properties
+        </Header>
+      }
+      resizableColumns
+      columnDefinitions={[
+        {
+          id: 'id',
+          header: 'ID',
+          cell: ({ id }) => id,
+        },
+        {
+          id: 'alias',
+          header: 'Alias',
+          cell: ({ alias }) => alias,
+          sortingField: 'alias',
+        },
+        {
+          id: 'name',
+          header: 'Name',
+          cell: ({ name }) => name,
+          sortingField: 'name',
+        },
+        {
+          id: 'latestValue',
+          header: 'Latest value',
+          cell: ({ latestValue }) => latestValue,
+          sortingField: 'latestValue',
+        },
+        {
+          id: 'latestValueTime',
+          header: 'Latest value time',
+          cell: ({ latestValueTime }) => latestValueTime?.toLocaleDateString(),
+          sortingField: 'latestValueTime',
+        },
+        {
+          id: 'assetName',
+          header: 'Asset name',
+          cell: ({ assetName }) => assetName,
+          sortingField: 'assetName',
+        },
+        {
+          id: 'dataType',
+          header: 'Data type',
+          cell: ({ dataType }) => dataType,
+          sortingField: 'dataType',
+        },
+        {
+          id: 'dataTypeSpec',
+          header: 'Data type spec',
+          cell: ({ dataTypeSpec }) => dataTypeSpec,
+          sortingField: 'dataTypeSpec',
+        },
+        {
+          id: 'unit',
+          header: 'Unit',
+          cell: ({ unit }) => unit,
+          sortingField: 'unit',
+        },
+      ]}
+      variant='embedded'
+      loading={isFetchingAssetProperties}
+      loadingText='Loading asset properties...'
+      stickyColumns={preferences.stickyColumns}
+      empty={
+        <Box textAlign='center' color='inherit'>
+          <b>No asset properties.</b>
+
+          <Box padding={{ bottom: 's' }} variant='p' color='inherit'>
+            {assetIds.length === 0
+              ? 'Select an asset to see its properties.'
+              : 'No properties found for selected asset(s).'}
+          </Box>
+        </Box>
+      }
+      pagination={<Pagination {...paginationProps} />}
+      filter={
+        <PropertyFilter
+          {...propertyFilterProps}
+          filteringLoadingText='Loading suggestions'
+          filteringErrorText='Error fetching suggestions.'
+          filteringRecoveryText='Retry'
+          filteringFinishedText='End of results'
+          filteringEmpty='No suggestions found'
+          i18nStrings={{
+            filteringAriaLabel: 'your choice',
+            dismissAriaLabel: 'Dismiss',
+            filteringPlaceholder: 'Filter asset properties by text, property or value',
+            groupValuesText: 'Values',
+            groupPropertiesText: 'Properties',
+            operatorsText: 'Operators',
+            operationAndText: 'and',
+            operationOrText: 'or',
+            operatorLessText: 'Less than',
+            operatorLessOrEqualText: 'Less than or equal',
+            operatorGreaterText: 'Greater than',
+            operatorGreaterOrEqualText: 'Greater than or equal',
+            operatorContainsText: 'Contains',
+            operatorDoesNotContainText: 'Does not contain',
+            operatorEqualsText: 'Equals',
+            operatorDoesNotEqualText: 'Does not equal',
+            editTokenHeader: 'Edit filter',
+            propertyText: 'Property',
+            operatorText: 'Operator',
+            valueText: 'Value',
+            cancelActionText: 'Cancel',
+            applyActionText: 'Apply',
+            allPropertiesLabel: 'All properties',
+            tokenLimitShowMore: 'Show more',
+            tokenLimitShowFewer: 'Show fewer',
+            clearFiltersText: 'Clear filters',
+            removeTokenButtonAriaLabel: (token) => `Remove token ${token.propertyKey} ${token.operator} ${token.value}`,
+            enteredTextLabel: (text) => `Use: "${text}"`,
+          }}
+        />
+      }
+      visibleColumns={preferences.visibleContent}
+      stripedRows={preferences.stripedRows}
+      wrapLines={preferences.wrapLines}
+      preferences={
+        <CollectionPreferences
+          title='Preferences'
+          confirmLabel='Confirm'
+          cancelLabel='Cancel'
+          preferences={preferences}
+          onConfirm={({ detail }) => {
+            setPreferences(detail as typeof preferences);
+          }}
+          pageSizePreference={{
+            title: 'Select page size',
+            options: [
+              { value: 10, label: '10' },
+              { value: 25, label: '25' },
+              { value: 100, label: '100' },
+              { value: 250, label: '250' },
+            ],
+          }}
+          wrapLinesPreference={{
+            label: 'Wrap lines',
+            description: 'Select to see all the text and wrap the lines',
+          }}
+          stripedRowsPreference={{
+            label: 'Striped rows',
+            description: 'Select to add alternating shaded rows',
+          }}
+          visibleContentPreference={{
+            title: 'Select visible content',
+            options: [
+              {
+                label: `Asset property fields`,
+                options: [
+                  { id: 'id', label: 'ID' },
+                  { id: 'alias', label: 'Alias' },
+                  { id: 'name', label: 'Name' },
+                  { id: 'latestValue', label: 'Latest values' },
+                  { id: 'latestValueTime', label: 'Latest value times' },
+                  { id: 'assetName', label: 'Asset name' },
+                  { id: 'dataType', label: 'Data type' },
+                  { id: 'dataTypeSpec', label: 'Data type spec' },
+                  { id: 'unit', label: 'Unit' },
+                ],
+              },
+            ],
+          }}
+        />
+      }
+    />
+  );
+}

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useAssetProperties/extractPropertiesFromAsset.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useAssetProperties/extractPropertiesFromAsset.ts
@@ -1,0 +1,21 @@
+import { type DescribeAssetCommandOutput } from '@aws-sdk/client-iotsitewise';
+
+/** Grab all of the properties from the given asset. */
+export function extractPropertiesFromAsset({
+  assetId,
+  assetName,
+  assetProperties = [],
+  assetCompositeModels = [],
+}: DescribeAssetCommandOutput) {
+  // there may be multiple composite models with their own properties lists
+  const compositeProperties = assetCompositeModels.flatMap(({ properties = [] }) => properties);
+  const allProperties = [...assetProperties, ...compositeProperties];
+  // we add the assetId and assetName to provide consumers of the data with additional context
+  const allPropertiesWithAssetDetail = allProperties.map((property) => ({
+    assetId,
+    assetName,
+    ...property,
+  }));
+
+  return allPropertiesWithAssetDetail;
+}

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useAssetProperties/index.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useAssetProperties/index.ts
@@ -1,0 +1,1 @@
+export { useAssetProperties, type UseAssetPropertiesProps } from './useAssetProperties';

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useAssetProperties/useAssetProperties.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useAssetProperties/useAssetProperties.ts
@@ -1,0 +1,48 @@
+import { useQueries, type QueryFunctionContext } from '@tanstack/react-query';
+import invariant from 'tiny-invariant';
+
+import { extractPropertiesFromAsset } from './extractPropertiesFromAsset';
+import { assetKeys } from '../../data/assets';
+import { describeAsset } from '../../shared/describeAsset';
+import type { WithIoTSiteWiseClient } from '../../types';
+
+export interface UseAssetPropertiesProps extends WithIoTSiteWiseClient {
+  /** List of IoT SiteWise asset IDs to list properties for. */
+  assetIds: string[];
+}
+
+/**
+ * Use a list of asset properties for a given list of assets. The properties between assets are mixed
+ * together into a single list. The order of the properties is defined by the order of the asset IDs.
+ */
+export function useAssetProperties({ assetIds, client }: UseAssetPropertiesProps) {
+  const queries =
+    useQueries({
+      queries: assetIds.map((assetId) => ({
+        // we store the descriptions in the cache using the assetId as the key
+        queryKey: assetKeys.description({ assetId }),
+        queryFn: createUseAssetPropertiesQueryFn({ client }),
+        select: extractPropertiesFromAsset,
+      })),
+    }) ?? [];
+
+  // we flatten the queries into a single array of properties
+  const assetProperties = queries.flatMap(({ data = [] }) => data);
+  // if any of the queries are fetching, then we are fetching
+  const isFetching = queries.some(({ isFetching }) => isFetching);
+
+  return { assetProperties, isFetching };
+}
+
+// curried to allow Tanstack to pass in the function context
+function createUseAssetPropertiesQueryFn({ client }: WithIoTSiteWiseClient) {
+  return async function ({
+    queryKey: [{ assetId }],
+    signal,
+  }: QueryFunctionContext<ReturnType<typeof assetKeys.description>>) {
+    invariant(assetId, 'Expected assetId to be defined as required by the enabled flag.');
+
+    // asset descriptions include properties
+    return describeAsset({ assetId, signal, client });
+  };
+}

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/batchGetAssetPropertyValue.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/batchGetAssetPropertyValue.ts
@@ -1,0 +1,37 @@
+import { InvalidRequestException, BatchGetAssetPropertyValueCommand } from '@aws-sdk/client-iotsitewise';
+
+import type { BatchGetLatestValuesEntry } from './types';
+import type { WithAbortSignal, WithIoTSiteWiseClient } from '../../../types';
+
+export interface BatchGetAssetPropertyValueInput extends WithAbortSignal, WithIoTSiteWiseClient {
+  entries: BatchGetLatestValuesEntry[];
+}
+
+/** Get the latest values for a batch of asset properties. */
+export async function batchGetAssetPropertyValue({ entries, signal, client }: BatchGetAssetPropertyValueInput) {
+  try {
+    const command = new BatchGetAssetPropertyValueCommand({ entries });
+    const output = await client.send(command, { abortSignal: signal });
+
+    return output;
+  } catch (error) {
+    handleBatchGetAssetPropertyValueError({ error });
+  }
+}
+
+// return never to tell TS we're not returning undefined
+function handleBatchGetAssetPropertyValueError({ error }: { error: unknown }): never {
+  const errorMessage = `Failed to batch get asset properties values. Error: ${error}`;
+  console.error(errorMessage);
+
+  if (error instanceof InvalidRequestException) {
+    console.error(`Expected request parameters to always be valid. There is likely a bug in the code.`);
+  }
+
+  if (error instanceof Error) {
+    // we do not want to change the error type by generalizing to `Error`
+    throw error;
+  }
+
+  throw new Error(errorMessage);
+}

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/batchGetLatestValues.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/batchGetLatestValues.ts
@@ -1,0 +1,30 @@
+import { batchGetAssetPropertyValue } from './batchGetAssetPropertyValue';
+import { extractLatestValuesFromBatch } from './extractLatestValuesFromBatch';
+import type { BatchGetLatestValuesEntry, SuccessValue, SkippedValue, ErrorValue } from './types';
+import type { WithAbortSignal, WithIoTSiteWiseClient } from '../../../types';
+
+export interface BatchGetLatestValuesInput extends WithAbortSignal, WithIoTSiteWiseClient {
+  entries: BatchGetLatestValuesEntry[];
+}
+
+/** Get a list of the latest values for a list of given asset properties (entries). */
+export async function batchGetLatestValues({
+  entries,
+  signal,
+  client,
+}: BatchGetLatestValuesInput): Promise<(SuccessValue | SkippedValue | ErrorValue)[]> {
+  const {
+    successEntries = [],
+    skippedEntries = [],
+    errorEntries = [],
+  } = await batchGetAssetPropertyValue({ entries, signal, client });
+
+  const { successValues, skippedValues, errorValues } = extractLatestValuesFromBatch({
+    entries,
+    successEntries,
+    skippedEntries,
+    errorEntries,
+  });
+
+  return [...successValues, ...skippedValues, ...errorValues];
+}

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/constants.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_BATCH_SIZE = 128;

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/createBatches.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/createBatches.ts
@@ -1,0 +1,34 @@
+import { MAX_BATCH_SIZE } from './constants';
+import type { AssetPropertyIdentifier, BatchGetLatestValuesEntry } from './types';
+
+/** Create requests batches for BatchGetAssetPropertyValue. */
+export function createBatches(assetProperties: AssetPropertyIdentifier[]): BatchGetLatestValuesEntry[][] {
+  const entries = createBatchEntries(assetProperties);
+  const batches = chunkBatches(entries);
+
+  return batches;
+}
+
+function createBatchEntries(assetProperties: AssetPropertyIdentifier[]): BatchGetLatestValuesEntry[] {
+  const entries = assetProperties.map(({ propertyId, assetId }) => ({
+    // entry ID needs to be unique - property ID is not unique across assets
+    // the asset ID is pre-pended to the property ID to ensure uniqueness
+    entryId: `${(assetId ?? '').slice(0, 8)}--${propertyId}`,
+    assetId,
+    propertyId,
+  }));
+
+  return entries;
+}
+
+function chunkBatches(entries: BatchGetLatestValuesEntry[]): BatchGetLatestValuesEntry[][] {
+  const batches = [];
+
+  for (let i = 0; i < entries.length; i += MAX_BATCH_SIZE) {
+    const chunk = entries.slice(i, i + MAX_BATCH_SIZE);
+
+    batches.push(chunk);
+  }
+
+  return batches;
+}

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/extractLatestValuesFromBatch.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/extractLatestValuesFromBatch.ts
@@ -1,0 +1,94 @@
+import type {
+  BatchGetLatestValuesEntry,
+  BatchGetLatestValuesSuccessEntry,
+  BatchGetLatestValuesSkippedEntry,
+  BatchGetLatestValuesErrorEntry,
+  SuccessValue,
+  SkippedValue,
+  ErrorValue,
+} from './types';
+
+export function extractLatestValuesFromBatch({
+  entries,
+  successEntries,
+  skippedEntries,
+  errorEntries,
+}: {
+  entries: BatchGetLatestValuesEntry[];
+  successEntries: BatchGetLatestValuesSuccessEntry[];
+  skippedEntries: BatchGetLatestValuesSkippedEntry[];
+  errorEntries: BatchGetLatestValuesErrorEntry[];
+}) {
+  const successValues = extractSuccessValues({ entries, successEntries });
+  const skippedValues = extractSkippedValues({ entries, skippedEntries });
+  const errorValues = extractErrorValues({ entries, errorEntries });
+
+  return {
+    successValues,
+    skippedValues,
+    errorValues,
+  };
+}
+
+function extractSuccessValues({
+  entries,
+  successEntries,
+}: {
+  entries: BatchGetLatestValuesEntry[];
+  successEntries: BatchGetLatestValuesSuccessEntry[];
+}): SuccessValue[] {
+  const successValues = successEntries.map(({ entryId, assetPropertyValue: { timestamp, value = {} } = {} }) => {
+    const { assetId, propertyId } = entries.find(({ entryId: id }) => id === entryId) ?? {};
+    const latestValue: string | number | boolean | undefined = Object.values(value).find((v) => v != null);
+
+    return {
+      value: latestValue,
+      timestamp,
+      assetId,
+      propertyId,
+    };
+  });
+
+  return successValues;
+}
+
+function extractSkippedValues({
+  entries,
+  skippedEntries,
+}: {
+  entries: BatchGetLatestValuesEntry[];
+  skippedEntries: BatchGetLatestValuesSkippedEntry[];
+}): SkippedValue[] {
+  const skippedValues = skippedEntries.map(({ entryId: skippedEntryId, completionStatus }) => {
+    const { assetId, propertyId } = entries.find(({ entryId: id }) => id === skippedEntryId) ?? {};
+
+    return {
+      assetId,
+      propertyId,
+      completionStatus,
+    };
+  });
+
+  return skippedValues;
+}
+
+function extractErrorValues({
+  entries,
+  errorEntries,
+}: {
+  entries: BatchGetLatestValuesEntry[];
+  errorEntries: BatchGetLatestValuesErrorEntry[];
+}): ErrorValue[] {
+  const errorValues = errorEntries.map(({ entryId: errorEntryId, errorCode, errorMessage }) => {
+    const { assetId, propertyId } = entries.find(({ entryId: id }) => id === errorEntryId) ?? {};
+
+    return {
+      assetId,
+      propertyId,
+      errorCode,
+      errorMessage,
+    };
+  });
+
+  return errorValues;
+}

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/index.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/index.ts
@@ -1,0 +1,3 @@
+export { batchGetLatestValues, type BatchGetLatestValuesInput } from './batchGetLatestValues';
+export { createBatches } from './createBatches';
+export { isSuccessValue, isSkippedValue, isErrorValue } from './predicates';

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/predicates.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/predicates.ts
@@ -1,0 +1,13 @@
+import type { SuccessValue, SkippedValue, ErrorValue } from './types';
+
+export function isSuccessValue(latestValue: SuccessValue | SkippedValue | ErrorValue): latestValue is SuccessValue {
+  return latestValue != null && 'value' in latestValue;
+}
+
+export function isSkippedValue(latestValue: SuccessValue | SkippedValue | ErrorValue): latestValue is SkippedValue {
+  return latestValue != null && 'completionStatus' in latestValue;
+}
+
+export function isErrorValue(latestValue: SuccessValue | SkippedValue | ErrorValue): latestValue is ErrorValue {
+  return latestValue != null && 'errorMessage' in latestValue;
+}

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/types.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/batchGetLatestValues/types.ts
@@ -1,0 +1,36 @@
+import type {
+  AssetPropertyValue,
+  BatchGetAssetPropertyValueCommandInput,
+  BatchGetAssetPropertyValueCommandOutput,
+} from '@aws-sdk/client-iotsitewise';
+import type { ValueOf } from 'type-fest';
+
+/** Entries sent with BatchGetAssetPropertyValue requests. */
+export type BatchGetLatestValuesEntry = NonNullable<BatchGetAssetPropertyValueCommandInput['entries']>[number];
+
+// entries returned from BatchGetAssetPropertyValue requests
+export type BatchGetLatestValuesSuccessEntry = NonNullable<
+  BatchGetAssetPropertyValueCommandOutput['successEntries']
+>[number];
+export type BatchGetLatestValuesSkippedEntry = NonNullable<
+  BatchGetAssetPropertyValueCommandOutput['skippedEntries']
+>[number];
+export type BatchGetLatestValuesErrorEntry = NonNullable<
+  BatchGetAssetPropertyValueCommandOutput['errorEntries']
+>[number];
+
+// we need a way to link asset property information
+export interface AssetPropertyIdentifier {
+  assetId?: Readonly<string>;
+  propertyId?: Readonly<string>;
+}
+type Timestamp = NonNullable<AssetPropertyValue['timestamp']>;
+type Value = ValueOf<NonNullable<AssetPropertyValue['value']>>;
+
+export type ErrorValue = Pick<BatchGetLatestValuesErrorEntry, 'errorCode' | 'errorMessage'> & AssetPropertyIdentifier;
+export type SkippedValue = Pick<BatchGetLatestValuesSkippedEntry, 'completionStatus' | 'errorInfo'> &
+  AssetPropertyIdentifier;
+export interface SuccessValue extends AssetPropertyIdentifier {
+  timestamp?: Timestamp;
+  value: Value;
+}

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/index.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/index.ts
@@ -1,0 +1,2 @@
+export { useLatestValues, type UseLatestValueProps } from './useLatestValues';
+export { isSuccessValue, isSkippedValue, isErrorValue } from './batchGetLatestValues';

--- a/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/useLatestValues.ts
+++ b/packages/dashboard/src/components/queryEditor/streamExplorer/useLatestValues/useLatestValues.ts
@@ -1,0 +1,47 @@
+import { useQueries, type QueryFunctionContext } from '@tanstack/react-query';
+
+import { batchGetLatestValues, createBatches } from './batchGetLatestValues';
+import type { WithIoTSiteWiseClient } from '../../types';
+import { assetPropertyValueKeys } from '../../data/assetPropertyValues';
+
+export interface UseLatestValueProps extends WithIoTSiteWiseClient {
+  /** List of asset properties to request lastest values for. */
+  assetProperties: { assetId?: string; id?: string }[];
+  /** Externally control if requests are being made. */
+  isEnabled: boolean;
+}
+
+/** Regularly poll for and use the latest value for a given list of asset properties. */
+export function useLatestValues({ assetProperties, isEnabled, client }: UseLatestValueProps) {
+  // 10 second polling interval
+  const REFETCH_INTERVAL = 10000;
+
+  // prepare asset properties for batch requests
+  const batches = createBatches(assetProperties.map(({ assetId, id }) => ({ assetId, propertyId: id })));
+
+  const queries =
+    useQueries({
+      queries: batches.map((batch) => ({
+        refetchInterval: REFETCH_INTERVAL,
+        enabled: isEnabled && batch.length > 0,
+        queryKey: assetPropertyValueKeys.batchLatestValues({ entries: batch }),
+        queryFn: createUseLatestValuesQueryFn({ client }),
+      })),
+    }) ?? [];
+
+  const latestValues = queries.flatMap(({ data = [] }) => data);
+  const isFetching = queries.some(({ isFetching }) => isFetching);
+  const isError = queries.some(({ isError }) => isError);
+
+  return { latestValues, isFetching, isError };
+}
+
+// curried function to make it easier to pass in the client
+function createUseLatestValuesQueryFn({ client }: WithIoTSiteWiseClient) {
+  return async function ({
+    queryKey: [{ entries = [] }],
+    signal,
+  }: QueryFunctionContext<ReturnType<(typeof assetPropertyValueKeys)['batchLatestValues']>>) {
+    return batchGetLatestValues({ client, entries, signal });
+  };
+}

--- a/packages/dashboard/src/components/queryEditor/types/index.ts
+++ b/packages/dashboard/src/components/queryEditor/types/index.ts
@@ -1,0 +1,13 @@
+import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+
+/** Utility type for IoT SiteWise Client. */
+export interface WithIoTSiteWiseClient {
+  /** AWS SDK v3 IoT SiteWise client. */
+  client: IoTSiteWiseClient;
+}
+
+/** Utility type for AbortSignal. */
+export interface WithAbortSignal {
+  /** Optional AbortSignal instance to enable query cancellation. */
+  signal?: AbortSignal;
+}

--- a/packages/source-iottwinmaker/package.json
+++ b/packages/source-iottwinmaker/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@aws-sdk/client-iotsitewise": "3.353.0",
     "@aws-sdk/client-iottwinmaker": "3.335.0",
-    "@aws-sdk/client-kinesis-video": "3.352.0",
+    "@aws-sdk/client-kinesis-video": "3.353.0",
     "@aws-sdk/client-kinesis-video-archived-media": "3.353.0",
     "@aws-sdk/client-s3": "3.335.0",
     "@aws-sdk/client-secrets-manager": "3.353.0",

--- a/packages/tools-iottwinmaker/package.json
+++ b/packages/tools-iottwinmaker/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/client-cloudformation": "^3.353.0",
     "@aws-sdk/client-iam": "^3.292.0",
     "@aws-sdk/client-iottwinmaker": "^3.335.0",
-    "@aws-sdk/client-kinesis-video": "^3.352.0",
+    "@aws-sdk/client-kinesis-video": "^3.353.0",
     "@aws-sdk/client-s3": "^3.335.0",
     "@aws-sdk/client-sts": "^3.335.0",
     "@aws-sdk/types": "^3.310.0",


### PR DESCRIPTION
## Overview
The change includes the initial implementation of `<QueryEditor />`, a component which will be utilized to configure the data streams associated with a widget by updating a widget's `query`. 

The component is not being mounted anywhere, as the complete UX is still being finalized.

Note: The component is not setup to configure data streams. To enable, the selection state of `<StreamExplorer />` will need to edit the `query` property of the widget. See the current implementation of the properties and alarm configuration in the side panel for understanding for this works. 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
