### PR TITLE
fix(composer): unsubscribe to queries when unmounting

### DIFF
--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -335,9 +335,6 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
   }, [queriedStreams, dataStreams]);
 
   useEffect(() => {
-    if (dataProviderRef.current) {
-      dataProviderRef.current.unsubscribe();
-    }
     if (queries && viewport) {
       dataProviderRef.current = combineProviders(
         queries.map((query) =>
@@ -357,6 +354,11 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
         },
       });
     }
+
+    return () => {
+      dataProviderRef.current?.unsubscribe();
+      dataProviderRef.current = undefined;
+    };
   }, [queries, viewport]);
 
   useEffect(() => {

--- a/packages/scene-composer/tests/StateManager.spec.tsx
+++ b/packages/scene-composer/tests/StateManager.spec.tsx
@@ -342,6 +342,26 @@ describe('StateManager', () => {
     expect(mockBuild).toBeCalledTimes(3);
     expect(mockCombinedPrvider.subscribe).toBeCalledTimes(2);
     expect(mockCombinedPrvider.unsubscribe).toBeCalledTimes(1);
+
+    // unsubscribe after unmount
+    await act(async () => {
+      container.unmount(
+        <StateManager
+          viewport={viewport}
+          sceneLoader={mockSceneLoader}
+          sceneMetadataModule={mockSceneMetadataModule}
+          config={sceneConfig}
+          queries={[{ build: mockBuild, toQueryString: () => 'mockQueryString' }]}
+          onSceneUpdated={jest.fn()}
+        />,
+      );
+      // Wait for async call
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    expect(mockBuild).toBeCalledTimes(3);
+    expect(mockCombinedPrvider.subscribe).toBeCalledTimes(2);
+    expect(mockCombinedPrvider.unsubscribe).toBeCalledTimes(2);
   });
 
   it('should call setActiveCameraSettings if selected node has camera component', async () => {


### PR DESCRIPTION
## Overview
Merge https://github.com/awslabs/iot-app-kit/pull/1304 into release 3.x
- Fix the issue when the composer is unmounted, the queries are still happening

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
