### PR TITLE
feat(scene composer): fixed entity search bug using free text

### DIFF
--- a/packages/scene-composer/src/components/panels/AddComponentMenu.spec.tsx
+++ b/packages/scene-composer/src/components/panels/AddComponentMenu.spec.tsx
@@ -118,10 +118,11 @@ describe('AddComponentMenu', () => {
       ],
     });
     render(<AddComponentMenu />);
-    expect(screen.getByTestId('add-component-data-binding')).not.toBeNull;
+    expect(screen.getByTestId('add-component-data-binding')).not.toBeNull();
     screen.getByTestId('add-component-data-binding').click();
     fireEvent.mouseOver(screen.getByTestId('add-component'));
-    expect(screen.getByTestId('add-component')).not.toContain('Add entity binding');
+    expect(addComponentInternal).not.toBeCalled();
+    expect(mockMetricRecorder.recordClick).not.toBeCalledWith('add-component-data-binding');
   });
 
   it('should not see add data binding item when feature is not enabled', () => {

--- a/packages/scene-composer/src/components/panels/AddComponentMenu.tsx
+++ b/packages/scene-composer/src/components/panels/AddComponentMenu.tsx
@@ -76,15 +76,14 @@ export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) 
           },
         ]
       : [];
-    const addDataBindingItem =
-      dataBindingComponentEnabled && !findComponentByType(selectedSceneNode, KnownComponentType.DataBinding)
-        ? [
-            {
-              uuid: ObjectTypes.DataBinding,
-              isDisabled: isDataBindingComponent,
-            },
-          ]
-        : [];
+    const addDataBindingItem = dataBindingComponentEnabled
+      ? [
+          {
+            uuid: ObjectTypes.DataBinding,
+            isDisabled: isDataBindingComponent,
+          },
+        ]
+      : [];
 
     return [
       {

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
@@ -91,7 +91,7 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
     // Initiate the provider
     const state = valueDataBindingStore.setBinding(componentRef, binding, dataBindingConfig);
     setBuilderState(filterBuilderState(state));
-    setAutoSuggestValue(state.selectedOptions[ENTITY_ID_INDEX]?.value || '');
+    setAutoSuggestValue(state.selectedOptions[ENTITY_ID_INDEX]?.value || autoSuggestValue);
   }, [componentRef, binding, valueDataBindingProvider, dataBindingConfig]);
 
   return (


### PR DESCRIPTION
## Overview
Entity search functionality for free text was broken for entity data binding. This cr contains the fix for this bug. 
## Verifying Changes
* npm run test
* npm run build
* Manual testing
### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
