### PR TITLE
fix(scene composer): sets up refs to track visibility of data overlay…

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/viewpoint/ViewCursorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/viewpoint/ViewCursorWidget.tsx
@@ -35,7 +35,6 @@ export const ViewCursorWidget = () => {
     return convertSvgToMesh(data, INIT_SVG_SCALE);
   }, [data]);
 
-  /* istanbul ignore next */
   useFrame(({ raycaster, scene }) => {
     const sceneObjects: THREEObject3D[] = [];
     scene.traverse((child) => {

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneNodeLabel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneNodeLabel.tsx
@@ -16,9 +16,8 @@ export interface SceneNodeLabelProps {
 }
 
 const SceneNodeLabel: FC<SceneNodeLabelProps> = ({ objectRef, labelText, componentTypes }) => {
-  const { show, hide, remove, validationErrors } = useSceneHierarchyData();
+  const { toggleObjectVisibility, remove, validationErrors } = useSceneHierarchyData();
   const [visible, setVisible] = useState(true);
-
   const error = validationErrors[objectRef];
 
   const componentTypeIcons = componentTypes
@@ -27,15 +26,10 @@ const SceneNodeLabel: FC<SceneNodeLabelProps> = ({ objectRef, labelText, compone
 
   const toggleVisibility = useCallback(
     (newVisibility) => {
-      if (newVisibility) {
-        show(objectRef);
-      } else {
-        hide(objectRef);
-      }
-
+      toggleObjectVisibility(objectRef);
       setVisible(newVisibility);
     },
-    [objectRef, visible, show, hide],
+    [objectRef, visible, toggleObjectVisibility],
   );
 
   const onDelete = useCallback(() => {

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/SceneNodeLabel.specs.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/SceneNodeLabel.specs.tsx
@@ -19,8 +19,7 @@ jest.mock('react', () => ({
 }));
 
 describe('SceneNodeLabel', () => {
-  const show = jest.fn();
-  const hide = jest.fn();
+  const toggleObjectVisibility = jest.fn();
   const remove = jest.fn();
   const validationErrors = jest.fn();
   let callbacks: any[] = [];
@@ -30,8 +29,7 @@ describe('SceneNodeLabel', () => {
 
     (useSceneHierarchyData as unknown as jest.Mock).mockImplementation(() => {
       return {
-        show,
-        hide,
+        toggleObjectVisibility,
         remove,
         validationErrors,
       };
@@ -81,11 +79,11 @@ describe('SceneNodeLabel', () => {
 
     toggleVisibility(true);
 
-    expect(show).toBeCalledWith(batmanParams.objectRef);
+    expect(toggleObjectVisibility).toBeCalledWith(batmanParams.objectRef);
 
     toggleVisibility(false);
 
-    expect(hide).toBeCalledWith(batmanParams.objectRef);
+    expect(toggleObjectVisibility).toBeCalledWith(batmanParams.objectRef);
   });
 
   it('should delete node when delete button is clicked', () => {

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext, useRef } from 'react';
 import { Html } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import { Group, Object3D } from 'three';
 
 import { ISceneNodeInternal } from '../../../store';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
@@ -15,6 +17,8 @@ export interface DataOverlayComponentProps {
 
 export const DataOverlayComponent = ({ node, component }: DataOverlayComponentProps): ReactElement => {
   const sceneComposerId = useContext(sceneComposerIdContext);
+  const htmlRef = useRef<HTMLDivElement>(null);
+  const groupRef = useRef<Group>(null);
 
   const getOffsetFromTag = () => {
     const tagComponent: IAnchorComponentInternal | undefined = node.components.find(
@@ -25,9 +29,15 @@ export const DataOverlayComponent = ({ node, component }: DataOverlayComponentPr
     }
   };
 
+  useFrame(() => {
+    if (!htmlRef.current || !groupRef.current) return;
+    htmlRef.current.hidden = !groupRef.current.visible;
+  });
+
   return (
-    <group>
+    <group ref={groupRef} userData={{ componentType: KnownComponentType.DataOverlay }}>
       <Html
+        ref={htmlRef}
         className='tm-html-wrapper'
         // TODO: add position after finding proper way to always display overlay right above tag
         position={getOffsetFromTag()}

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayComponentSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/DataOverlayComponentSnap.spec.tsx
@@ -1,14 +1,27 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { BoxGeometry, Group, Mesh } from 'three';
+import { Canvas } from '@react-three/fiber';
+import ReactThreeTestRenderer from '@react-three/test-renderer';
 
 import { DataOverlayComponent } from '../DataOverlayComponent';
 import { Component } from '../../../../models/SceneModels';
 import { KnownComponentType } from '../../../../interfaces';
 import { IDataOverlayComponentInternal, ISceneNodeInternal, useStore } from '../../../../store';
 
+jest.mock('@react-three/fiber', () => {
+  const originalModule = jest.requireActual('@react-three/fiber');
+  return {
+    ...originalModule,
+    useLoader: jest.fn(),
+    useFrame: jest.fn().mockImplementation((func) => {
+      func();
+    }),
+  };
+});
+
 jest.mock('../DataOverlayContainer', () => ({
-  DataOverlayContainer: (...props: unknown[]) => <div data-testid='container'>{JSON.stringify(props)}</div>,
+  DataOverlayContainer: (...props: unknown[]) => <div data-testid='container'>{JSON.stringify(props, null, '\t')}</div>,
 }));
 
 describe('DataOverlayComponent', () => {
@@ -52,15 +65,6 @@ describe('DataOverlayComponent', () => {
       <DataOverlayComponent node={mockNode as ISceneNodeInternal} component={mockComponent} />,
     );
     expect(container.getElementsByClassName('tm-html-wrapper').length).toBe(1);
-    expect(container).toMatchSnapshot();
-  });
-
-  it('should render the component correctly with object 3D size', () => {
-    getObject3DBySceneNodeRef.mockReturnValue(group);
-    const { container } = render(
-      <DataOverlayComponent node={mockNode as ISceneNodeInternal} component={mockComponent} />,
-    );
-    // expect(container.querySelector('[position="{\\"x\\":0,\\"y\\":1.7,\\"z\\":0}"]')).not.toBeNull();
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayComponentSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayComponentSnap.spec.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`DataOverlayComponent should render the component correctly 1`] = `
 <div>
-  <group>
+  <group
+    userdata="[object Object]"
+  >
     <div
       class="tm-html-wrapper"
       data-mocked="Html"
@@ -11,25 +13,71 @@ exports[`DataOverlayComponent should render the component correctly 1`] = `
       <div
         data-testid="container"
       >
-        [{"node":{"ref":"node-ref","transform":{"position":[1,2,3],"rotation":[0,0,0],"scale":[0,0,0]},"components":[{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[{"bindingName":"bindingA","valueDataBinding":{"dataBindingContext":"dataBindingContext"}}]}]},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[{"bindingName":"bindingA","valueDataBinding":{"dataBindingContext":"dataBindingContext"}}]}},{}]
-      </div>
-    </div>
-  </group>
-</div>
-`;
-
-exports[`DataOverlayComponent should render the component correctly with object 3D size 1`] = `
-<div>
-  <group>
-    <div
-      class="tm-html-wrapper"
-      data-mocked="Html"
-      style="transform: translate3d(-50%,-100%,0);"
-    >
-      <div
-        data-testid="container"
-      >
-        [{"node":{"ref":"node-ref","transform":{"position":[1,2,3],"rotation":[0,0,0],"scale":[0,0,0]},"components":[{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[{"bindingName":"bindingA","valueDataBinding":{"dataBindingContext":"dataBindingContext"}}]}]},"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[{"bindingName":"bindingA","valueDataBinding":{"dataBindingContext":"dataBindingContext"}}]}},{}]
+        [
+	{
+		"node": {
+			"ref": "node-ref",
+			"transform": {
+				"position": [
+					1,
+					2,
+					3
+				],
+				"rotation": [
+					0,
+					0,
+					0
+				],
+				"scale": [
+					0,
+					0,
+					0
+				]
+			},
+			"components": [
+				{
+					"ref": "comp-ref",
+					"type": "DataOverlay",
+					"subType": "OverlayPanel",
+					"dataRows": [
+						{
+							"rowType": "Markdown",
+							"content": "content"
+						}
+					],
+					"valueDataBindings": [
+						{
+							"bindingName": "bindingA",
+							"valueDataBinding": {
+								"dataBindingContext": "dataBindingContext"
+							}
+						}
+					]
+				}
+			]
+		},
+		"component": {
+			"ref": "comp-ref",
+			"type": "DataOverlay",
+			"subType": "OverlayPanel",
+			"dataRows": [
+				{
+					"rowType": "Markdown",
+					"content": "content"
+				}
+			],
+			"valueDataBindings": [
+				{
+					"bindingName": "bindingA",
+					"valueDataBinding": {
+						"dataBindingContext": "dataBindingContext"
+					}
+				}
+			]
+		}
+	},
+	{}
+]
       </div>
     </div>
   </group>

--- a/packages/scene-composer/tests/utils/sceneResourceUtils.spec.ts
+++ b/packages/scene-composer/tests/utils/sceneResourceUtils.spec.ts
@@ -28,7 +28,7 @@ describe('sceneResourceUtils', () => {
     });
 
     it('should return the original string for unknown type', () => {
-      const result = convertToIotTwinMakerNamespace('UnknownTyped' as any, 'UnknownValue');
+      const result = convertToIotTwinMakerNamespace('UnknownTyped' as SceneResourceType, 'UnknownValue');
       expect(result).toBe('UnknownValue');
     });
   });


### PR DESCRIPTION
… & parent

## Overview
Sets up `ref`s to track associated object visibility through `useFrame` hook. 

* Includes refactor of `show`/`hide` functions to create single `toggleObjectVisibility` function. 

https://github.com/awslabs/iot-app-kit/assets/6610619/8656d8c3-3289-4983-89ef-6042ffa906aa



## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
