### PR TITLE
feat(Knowledge Graph): adding clear and render graph results events

### DIFF
--- a/packages/react-components/src/components/knowledge-graph/KnowledgeGraphPanel.tsx
+++ b/packages/react-components/src/components/knowledge-graph/KnowledgeGraphPanel.tsx
@@ -21,6 +21,8 @@ export interface KnowledgeGraphInterface extends HTMLAttributes<HTMLDivElement> 
   onRelationshipSelected?: (e: EdgeData) => void;
   onEntityUnSelected?: (e: NodeData) => void;
   onRelationshipUnSelected?: (e: EdgeData) => void;
+  onGraphResultChange?: (nodes: NodeData[], edges?: EdgeData[]) => void;
+  onClearGraph?: (nodes: NodeData[], edges?: EdgeData[]) => void;
   queryData?: IQueryData;
 }
 export const ZOOM_INTERVAL = 0.1;
@@ -32,6 +34,8 @@ export const KnowledgeGraphContainer: React.FC<KnowledgeGraphInterface> = ({
   onRelationshipSelected,
   onEntityUnSelected,
   onRelationshipUnSelected,
+  onGraphResultChange,
+  onClearGraph,
   queryData,
   ...props
 }) => {
@@ -123,6 +127,14 @@ export const KnowledgeGraphContainer: React.FC<KnowledgeGraphInterface> = ({
     };
   }, [cy.current]);
 
+  useEffect(() => {
+    if (onGraphResultChange && nodeData) {
+      edgeData
+        ? onGraphResultChange([...nodeData.values()], [...edgeData.values()])
+        : onGraphResultChange([...nodeData.values()]);
+    }
+  }, [queryResult]);
+
   const knowledgeGraphQueryClient = useMemo(() => {
     return createKnowledgeGraphQueryClient(kgDataSource, setQueryResult);
   }, [kgDataSource, setQueryResult]);
@@ -140,8 +152,11 @@ export const KnowledgeGraphContainer: React.FC<KnowledgeGraphInterface> = ({
   }, [selectedGraphNodeEntityId, knowledgeGraphQueryClient]);
 
   const onClearClicked = useCallback(() => {
+    if (onClearGraph && nodeData) {
+      edgeData ? onClearGraph([...nodeData.values()], [...edgeData.values()]) : onClearGraph([...nodeData.values()]);
+    }
     clearGraphResults(true);
-  }, [clearGraphResults]);
+  }, [clearGraphResults, onClearGraph, nodeData, edgeData]);
 
   useEffect(() => {
     if (queryData?.entityId) {

--- a/packages/react-components/src/components/knowledge-graph/index.ts
+++ b/packages/react-components/src/components/knowledge-graph/index.ts
@@ -1,1 +1,3 @@
 export { KnowledgeGraph } from './KnowledgeGraphPanel';
+export type { NodeData, EdgeData } from './graph/types';
+export type { IQueryData } from './interfaces';


### PR DESCRIPTION
## Overview
- Emit and event that other widgets (like the scene viewer) can listen to so that they know to clear their graph based visual items (like 3D highlights)
- Update graph result events to support emitting multiple entities.
This will allow a react developer to highlight multiple items in a linked scene such as 'all roof top units'.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
