### PR TITLE
fix(scene composer): reverting breaking changes from dependabot & set…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@react-three"
+      - dependency-name: "3d-tiles-renderer"
+      - dependency-name: "three"
+      - dependency-name: "three-mesh-bvh"
+      - dependency-name: "three-stdlib"
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -162,7 +162,7 @@
     "string-to-arraybuffer": "1.0.2",
     "styled-components": "^5.3.11",
     "three": "^0.139.2",
-    "three-mesh-bvh": "0.6.0",
+    "three-mesh-bvh": "0.5.24",
     "three-stdlib": "2.23.9",
     "ts-custom-error": "^3.3.1",
     "tslib": "^2.5.3",


### PR DESCRIPTION
…ting up ignores

## Overview
Dependabot automatic updates modified our version of three.js & other associated dependencies. As these tend to break with updates we're opting to have dependabot ignore them & update manually. This also includes a dependency revision to resolve issues introduced in recent updates that break raycasting. 

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
