### PR TITLE
fix(scene-composer): updating dependabot.yml to properly ignore all @…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-      - dependency-name: "@react-three"
+      - dependency-name: "@react-three/*"
       - dependency-name: "3d-tiles-renderer"
       - dependency-name: "three"
       - dependency-name: "three-mesh-bvh"


### PR DESCRIPTION
…react-three dependencies

## Overview
Follow-up to #1582 to properly scope `@react-three` dependancies. 

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
