### PR TITLE
chore: dependabot updates weekly on tuesdays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,18 @@ updates:
     directory: /
     versioning-strategy: increase
     schedule:
-      interval: daily
-    open-pull-requests-limit: 25
+      interval: weekly
+      day: tuesday
+    open-pull-requests-limit: 5
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@react-three/*"
-      - dependency-name: "3d-tiles-renderer"
-      - dependency-name: "three"
-      - dependency-name: "three-mesh-bvh"
-      - dependency-name: "three-stdlib"
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@react-three/*'
+      - dependency-name: '3d-tiles-renderer'
+      - dependency-name: 'three'
+      - dependency-name: 'three-mesh-bvh'
+      - dependency-name: 'three-stdlib'
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
-


### PR DESCRIPTION
## Overview
Too many Dependabot changes coming in and failing. This change updates the frequency to weekly on Tuesdays (https://en.wikipedia.org/wiki/Patch_Tuesday).

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
