### PR TITLE
feat(3D Knowledge Graph): update DataBinding to EntityBinding

### DIFF
--- a/packages/scene-composer/public/CookieFactoryWaterTank.scene.json
+++ b/packages/scene-composer/public/CookieFactoryWaterTank.scene.json
@@ -54,7 +54,7 @@
           "unitOfMeasure": "meters"
         },
         {
-          "type": "DataBinding",
+          "type": "EntityBinding",
           "valueDataBinding": {
             "dataBindingContext":{
               "entityId": "WaterTank"
@@ -200,7 +200,7 @@
           "type": "SubModelRef"
         },
         {
-          "type": "DataBinding",
+          "type": "EntityBinding",
           "valueDataBinding": {
             "dataBindingContext":{
               "entityId": "MainPipe"

--- a/packages/scene-composer/src/SceneViewer.spec.tsx
+++ b/packages/scene-composer/src/SceneViewer.spec.tsx
@@ -101,7 +101,7 @@ describe('SceneViewer', () => {
 
     // called after scene is loaded
     expect(mockSceneComposerApi.findSceneNodeRefBy).toBeCalledTimes(1);
-    expect(mockSceneComposerApi.findSceneNodeRefBy).toBeCalledWith(mockLabel, [KnownComponentType.DataBinding]);
+    expect(mockSceneComposerApi.findSceneNodeRefBy).toBeCalledWith(mockLabel, [KnownComponentType.EntityBinding]);
     expect(mockSceneComposerApi.setCameraTarget).toBeCalledTimes(1);
     expect(mockSceneComposerApi.setCameraTarget).toBeCalledWith(mockNodeRef[0], 'transition');
     expect(mockSceneComposerApi.setSelectedSceneNodeRef).toBeCalledTimes(1);

--- a/packages/scene-composer/src/SceneViewer.tsx
+++ b/packages/scene-composer/src/SceneViewer.tsx
@@ -45,7 +45,7 @@ export const SceneViewer: React.FC<SceneViewerProps> = ({ sceneComposerId, confi
 
     const filterType = props.selectedDataBinding.componentName
       ? [KnownComponentType.Tag]
-      : [KnownComponentType.DataBinding];
+      : [KnownComponentType.EntityBinding];
     const nodeRefs = composerApis.findSceneNodeRefBy(props.selectedDataBinding || '', filterType);
     if (nodeRefs && nodeRefs.length > 0) {
       // TODO: auto select the first node for now, handle multiple nodes selection later.

--- a/packages/scene-composer/src/components/SceneComposerInternal.tsx
+++ b/packages/scene-composer/src/components/SceneComposerInternal.tsx
@@ -70,7 +70,7 @@ export function useSceneComposerApi(sceneComposerId: string) {
   const [materialMaps, dispatch] = useReducer(materialReducer, initialMaterialMaps);
 
   const findBindingComponent = (components: ISceneComponentInternal[], dataBindingContext: unknown) => {
-    const bindingComponentTypeFilter = [KnownComponentType.DataBinding];
+    const bindingComponentTypeFilter = [KnownComponentType.EntityBinding];
     return components.find((component) => {
       if (bindingComponentTypeFilter.includes(component.type as KnownComponentType)) {
         const dataBoundComponent = component as IDataBoundSceneComponentInternal;

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -34,7 +34,7 @@ import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLoggin
 import {
   IAnchorComponentInternal,
   ICameraComponentInternal,
-  IDataBindingComponentInternal,
+  IEntityBindingComponentInternal,
   RootState,
   useStore,
   useViewOptionState,
@@ -162,8 +162,8 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       const tagComponent = findComponentByType(node, KnownComponentType.Tag) as IAnchorComponentInternal;
       const entityBindingComponent = findComponentByType(
         node,
-        KnownComponentType.DataBinding,
-      ) as IDataBindingComponentInternal;
+        KnownComponentType.EntityBinding,
+      ) as IEntityBindingComponentInternal;
       const additionalComponentData: AdditionalComponentData[] = [];
       if (tagComponent) {
         additionalComponentData.push({

--- a/packages/scene-composer/src/components/panels/AddComponentMenu.spec.tsx
+++ b/packages/scene-composer/src/components/panels/AddComponentMenu.spec.tsx
@@ -101,7 +101,7 @@ describe('AddComponentMenu', () => {
 
     expect(addComponentInternal).toBeCalledWith(selectedSceneNodeRef, {
       ref: expect.any(String),
-      type: KnownComponentType.DataBinding,
+      type: KnownComponentType.EntityBinding,
       valueDataBinding: { dataBindingContext: '' },
     });
     expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);

--- a/packages/scene-composer/src/components/panels/AddComponentMenu.tsx
+++ b/packages/scene-composer/src/components/panels/AddComponentMenu.tsx
@@ -8,7 +8,7 @@ import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
 import { COMPOSER_FEATURES, KnownComponentType } from '../../interfaces';
 import { Component } from '../../models/SceneModels';
 import { IDataOverlayComponentInternal, useStore } from '../../store';
-import { IDataBindingComponentInternal } from '../../store/internalInterfaces';
+import { IEntityBindingComponentInternal } from '../../store/internalInterfaces';
 import { findComponentByType } from '../../utils/nodeUtils';
 import { ToolbarItem } from '../toolbars/common/ToolbarItem';
 import { ToolbarItemOptionRaw, ToolbarItemOptions } from '../toolbars/common/types';
@@ -47,11 +47,11 @@ export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) 
   const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
   const { formatMessage } = useIntl();
   const selectedSceneNode = getSceneNodeByRef(selectedSceneNodeRef);
-  const dataBindingComponentEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.DataBinding];
+  const entityBindingComponentEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.DataBinding];
 
   const isTagComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.Tag);
   const isOverlayComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.DataOverlay);
-  const isDataBindingComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.DataBinding);
+  const isEntityBindingComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.EntityBinding);
   const mapToMenuItem = useCallback(
     (item: ToolbarItemOptionRaw): AddComponentMenuItem => {
       const typeId: ObjectTypes = item.uuid as ObjectTypes;
@@ -76,11 +76,11 @@ export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) 
           },
         ]
       : [];
-    const addDataBindingItem = dataBindingComponentEnabled
+    const addDataBindingItem = entityBindingComponentEnabled
       ? [
           {
             uuid: ObjectTypes.DataBinding,
-            isDisabled: isDataBindingComponent,
+            isDisabled: isEntityBindingComponent,
           },
         ]
       : [];
@@ -93,7 +93,7 @@ export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) 
       ...addOverlayItem,
       ...addDataBindingItem,
     ].map(mapToMenuItem);
-  }, [selectedSceneNodeRef, selectedSceneNode, isOverlayComponent, isTagComponent, dataBindingComponentEnabled]);
+  }, [selectedSceneNodeRef, selectedSceneNode, isOverlayComponent, isTagComponent, entityBindingComponentEnabled]);
 
   const handleAddOverlay = useCallback(() => {
     if (!selectedSceneNodeRef) return;
@@ -117,17 +117,17 @@ export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) 
   const handleAddDataBinding = useCallback(() => {
     if (!selectedSceneNodeRef) return;
 
-    const dataBindingComponent = findComponentByType(selectedSceneNode, KnownComponentType.DataBinding);
+    const entityBindingComponent = findComponentByType(selectedSceneNode, KnownComponentType.EntityBinding);
 
-    if (dataBindingComponent) {
+    if (entityBindingComponent) {
       // TODO: Can we remove this? This is not updating anything
-      updateComponentInternal(selectedSceneNodeRef, dataBindingComponent);
+      updateComponentInternal(selectedSceneNodeRef, entityBindingComponent);
       return;
     }
 
-    const component: IDataBindingComponentInternal = {
+    const component: IEntityBindingComponentInternal = {
       ref: THREE.MathUtils.generateUUID(),
-      type: KnownComponentType.DataBinding,
+      type: KnownComponentType.EntityBinding,
       valueDataBinding: { dataBindingContext: '' },
     };
 

--- a/packages/scene-composer/src/components/panels/ComponentEditMenu.spec.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditMenu.spec.tsx
@@ -35,13 +35,13 @@ describe('ComponentEditMenu', () => {
   });
 
   it('should not add additional data binding to data binding component', () => {
-    const component = { type: KnownComponentType.DataBinding, ref: 'comp-ref', valueDataBindings: [{}] };
+    const component = { type: KnownComponentType.EntityBinding, ref: 'comp-ref', valueDataBindings: [{}] };
     render(<ComponentEditMenu nodeRef={nodeRef} currentComponent={component} />);
     expect(wrapper().getElement().innerHTML).not.toContain('Add entity binding');
   });
 
   it('should correctly remove data binding component', () => {
-    const component = { type: KnownComponentType.DataBinding, ref: 'comp-ref', valueDataBindings: [{}] };
+    const component = { type: KnownComponentType.EntityBinding, ref: 'comp-ref', valueDataBindings: [{}] };
     const { getByTestId } = render(<ComponentEditMenu nodeRef={nodeRef} currentComponent={component} />);
     const removeEntityBinding = getByTestId('remove-entity-binding');
 
@@ -53,7 +53,7 @@ describe('ComponentEditMenu', () => {
     expect(removeComponent).toBeCalledTimes(1);
     expect(removeComponent).toBeCalledWith(nodeRef, component.ref);
     expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
-    expect(mockMetricRecorder.recordClick).toBeCalledWith('DataBinding-remove-entity-binding');
+    expect(mockMetricRecorder.recordClick).toBeCalledWith('EntityBinding-remove-entity-binding');
   });
 
   it('should correctly add additional data binding to overlay component', () => {

--- a/packages/scene-composer/src/components/panels/ComponentEditMenu.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditMenu.tsx
@@ -9,7 +9,7 @@ import { KnownComponentType } from '../../interfaces';
 import { ToolbarItem } from '../toolbars/common/ToolbarItem';
 import { getGlobalSettings } from '../../common/GlobalSettings';
 import { Component } from '../../models/SceneModels';
-import { IDataBindingComponentInternal, ISceneComponentInternal } from '../../store/internalInterfaces';
+import { IEntityBindingComponentInternal, ISceneComponentInternal } from '../../store/internalInterfaces';
 import { generateUUID } from '../../utils/mathUtils';
 
 interface ComponentEditMenuProps {
@@ -69,7 +69,7 @@ export const ComponentEditMenu: React.FC<ComponentEditMenuProps> = ({ nodeRef, c
 
   const componentItems = useMemo(() => {
     switch (currentComponent.type) {
-      case KnownComponentType.DataBinding:
+      case KnownComponentType.EntityBinding:
         return [
           {
             uuid: ObjectTypes.RemoveEntityBinding,
@@ -108,7 +108,7 @@ export const ComponentEditMenu: React.FC<ComponentEditMenuProps> = ({ nodeRef, c
 
   const handleAddDataBinding = useCallback(() => {
     switch (currentComponent.type) {
-      case KnownComponentType.DataBinding: {
+      case KnownComponentType.EntityBinding: {
         updateComponentInternal(nodeRef, currentComponent);
         return;
       }
@@ -129,7 +129,7 @@ export const ComponentEditMenu: React.FC<ComponentEditMenuProps> = ({ nodeRef, c
   }, [nodeRef, currentComponent]);
 
   const handleRemoveAllDataBinding = useCallback(() => {
-    if (currentComponent.type == KnownComponentType.DataBinding) {
+    if (currentComponent.type == KnownComponentType.EntityBinding) {
       removeComponent(nodeRef, currentComponent.ref);
       return;
     }

--- a/packages/scene-composer/src/components/panels/ComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditor.spec.tsx
@@ -35,8 +35,10 @@ jest.mock('./scene-components/DataOverlayComponentEditor', () => ({
   DataOverlayComponentEditor: (props) => <div data-mocked='DataOverlayComponentEditor'>{JSON.stringify(props)}</div>,
 }));
 
-jest.mock('./scene-components/DataBindingComponentEditor', () => ({
-  DataBindingComponentEditor: (props) => <div data-mocked='DataBindingComponentEditor'>{JSON.stringify(props)}</div>,
+jest.mock('./scene-components/EntityBindingComponentEditor', () => ({
+  EntityBindingComponentEditor: (props) => (
+    <div data-mocked='EntityBindingComponentEditor'>{JSON.stringify(props)}</div>
+  ),
 }));
 
 describe('ComponentEditor renders correct component', () => {

--- a/packages/scene-composer/src/components/panels/ComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditor.tsx
@@ -4,7 +4,7 @@ import { FormField, Input, SpaceBetween } from '@awsui/components-react';
 import { IDataOverlayComponentInternal, ISceneComponentInternal, ISceneNodeInternal } from '../../store';
 import { KnownComponentType } from '../../interfaces';
 import { pascalCase } from '../../utils/stringUtils';
-import { IDataBindingComponentInternal } from '../../store/internalInterfaces';
+import { IEntityBindingComponentInternal } from '../../store/internalInterfaces';
 
 import { AnchorComponentEditor } from './scene-components/AnchorComponentEditor';
 import { LightComponentEditor } from './scene-components/LightComponentEditor';
@@ -13,7 +13,7 @@ import { ModelRefComponentEditor } from './scene-components/ModelRefComponentEdi
 import { MotionIndicatorComponentEditor } from './scene-components/MotionIndicatorComponentEditor';
 import CameraComponentEditor from './scene-components/CameraComponentEditor';
 import { DataOverlayComponentEditor } from './scene-components/DataOverlayComponentEditor';
-import { DataBindingComponentEditor } from './scene-components/DataBindingComponentEditor';
+import { EntityBindingComponentEditor } from './scene-components/EntityBindingComponentEditor';
 
 export interface IComponentEditorProps {
   node: ISceneNodeInternal;
@@ -56,8 +56,8 @@ export const ComponentEditor: React.FC<IComponentEditorProps> = ({ node, compone
       return <MotionIndicatorComponentEditor node={node} component={component} />;
     case KnownComponentType.DataOverlay:
       return <DataOverlayComponentEditor node={node} component={component as IDataOverlayComponentInternal} />;
-    case KnownComponentType.DataBinding:
-      return <DataBindingComponentEditor node={node} component={component as IDataBindingComponentInternal} />;
+    case KnownComponentType.EntityBinding:
+      return <EntityBindingComponentEditor node={node} component={component as IEntityBindingComponentInternal} />;
     default:
       return <DefaultComponentEditor node={node} component={component} />;
   }

--- a/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
@@ -56,7 +56,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
       defaultMessage: 'Tag',
       description: 'Expandable Section title',
     },
-    [KnownComponentType.DataBinding]: {
+    [KnownComponentType.EntityBinding]: {
       defaultMessage: 'Entity data binding',
       description: 'Expandable Section title',
     },

--- a/packages/scene-composer/src/components/panels/__snapshots__/ComponentEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__snapshots__/ComponentEditor.spec.tsx.snap
@@ -39,22 +39,22 @@ exports[`ComponentEditor renders correct component should render the "Camera" ed
 </div>
 `;
 
-exports[`ComponentEditor renders correct component should render the "DataBinding" editor correctly 1`] = `
-<div>
-  <div
-    data-mocked="DataBindingComponentEditor"
-  >
-    {"node":{},"component":{"ref":"refId","type":"DataBinding"}}
-  </div>
-</div>
-`;
-
 exports[`ComponentEditor renders correct component should render the "DataOverlay" editor correctly 1`] = `
 <div>
   <div
     data-mocked="DataOverlayComponentEditor"
   >
     {"node":{},"component":{"ref":"refId","type":"DataOverlay"}}
+  </div>
+</div>
+`;
+
+exports[`ComponentEditor renders correct component should render the "EntityBinding" editor correctly 1`] = `
+<div>
+  <div
+    data-mocked="EntityBindingComponentEditor"
+  >
+    {"node":{},"component":{"ref":"refId","type":"EntityBinding"}}
   </div>
 </div>
 `;

--- a/packages/scene-composer/src/components/panels/scene-components/EntityBindingComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/EntityBindingComponentEditor.spec.tsx
@@ -3,18 +3,18 @@ import React from 'react';
 
 import { mockProvider } from '../../../../tests/components/panels/scene-components/MockComponents';
 import { KnownComponentType } from '../../../interfaces';
-import { IDataBindingComponentInternal, ISceneNodeInternal, useStore } from '../../../store';
+import { IEntityBindingComponentInternal, ISceneNodeInternal, useStore } from '../../../store';
 
-import { DataBindingComponentEditor } from './DataBindingComponentEditor';
+import { EntityBindingComponentEditor } from './EntityBindingComponentEditor';
 
 jest.mock('@awsui/components-react', () => ({
   ...jest.requireActual('@awsui/components-react'),
 }));
 
-describe('DataBindingComponentEditor', () => {
-  const component: IDataBindingComponentInternal = {
+describe('EntityindingComponentEditor', () => {
+  const component: IEntityBindingComponentInternal = {
     ref: 'comp-ref',
-    type: KnownComponentType.DataBinding,
+    type: KnownComponentType.EntityBinding,
     valueDataBinding: {
       dataBindingContext: { entityId: 'abcd' },
     },
@@ -38,14 +38,14 @@ describe('DataBindingComponentEditor', () => {
 
   it('should not have remove button', async () => {
     useStore('default').setState(baseState);
-    render(<DataBindingComponentEditor node={node} component={component} />);
+    render(<EntityBindingComponentEditor node={node} component={component} />);
     expect(screen.queryByText('remove-binding-button')).toBeNull();
     expect(updateComponentInternalMock).toBeCalledTimes(0);
   });
 
   it('should have entity search field', async () => {
     useStore('default').setState(baseState);
-    render(<DataBindingComponentEditor node={node} component={component} />);
+    render(<EntityBindingComponentEditor node={node} component={component} />);
     expect(screen.getByTestId('select-entityId')).toBeTruthy();
     expect(updateComponentInternalMock).toBeCalledTimes(0);
   });

--- a/packages/scene-composer/src/components/panels/scene-components/EntityBindingComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/EntityBindingComponentEditor.tsx
@@ -3,19 +3,19 @@ import React, { useCallback, useContext } from 'react';
 
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { useStore } from '../../../store';
-import { IDataBindingComponentInternal } from '../../../store/internalInterfaces';
+import { IEntityBindingComponentInternal } from '../../../store/internalInterfaces';
 import { IComponentEditorProps } from '../ComponentEditor';
 
 import { ComponentWithDataBindings, DataBindingMapEditor } from './common/DataBindingMapEditor';
 
-export interface IDataBindingComponentEditorProps extends IComponentEditorProps {
-  component: IDataBindingComponentInternal;
+export interface IEntityBindingComponentEditorProps extends IComponentEditorProps {
+  component: IEntityBindingComponentInternal;
 }
 
-export const DataBindingComponentEditor: React.FC<IDataBindingComponentEditorProps> = ({
+export const EntityBindingComponentEditor: React.FC<IEntityBindingComponentEditorProps> = ({
   node,
   component,
-}: IDataBindingComponentEditorProps) => {
+}: IEntityBindingComponentEditorProps) => {
   const sceneComposerId = useContext(sceneComposerIdContext);
   const updateComponentInternal = useStore(sceneComposerId)((state) => state.updateComponentInternal);
   const removeComponent = useStore(sceneComposerId)((state) => state.removeComponent);

--- a/packages/scene-composer/src/interfaces/components.ts
+++ b/packages/scene-composer/src/interfaces/components.ts
@@ -16,7 +16,7 @@ export enum KnownComponentType {
   ModelShader = 'ModelShader',
   MotionIndicator = 'MotionIndicator',
   DataOverlay = 'DataOverlay',
-  DataBinding = 'DataBinding',
+  EntityBinding = 'EntityBinding',
 }
 
 export interface ISceneComponent {
@@ -131,4 +131,4 @@ export interface IMotionIndicatorComponent extends ISceneComponent, SceneModels.
 
 export interface IDataOverlayComponent extends ISceneComponent, SceneModels.Component.DataOverlay {}
 
-export interface IDataBindingComponent extends ISceneComponent, SceneModels.Component.DataBindingComponent {}
+export interface IEntityBindingComponent extends ISceneComponent, SceneModels.Component.EntityBindingComponent {}

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -118,7 +118,7 @@ export namespace Component {
     MotionIndicator = 'MotionIndicator',
     Space = 'Space',
     DataOverlay = 'DataOverlay',
-    DataBinding = 'DataBinding',
+    EntityBinding = 'EntityBinding',
   }
 
   export interface IComponent {
@@ -167,7 +167,7 @@ export namespace Component {
   export interface ModelShader extends IComponent, IDataBindingRuleMap {}
   export interface OpacityFilter extends IComponent, IDataBindingRuleMap {}
 
-  export interface DataBindingComponent extends IComponent {
+  export interface EntityBindingComponent extends IComponent {
     valueDataBinding: IValueDataBinding;
   }
 

--- a/packages/scene-composer/src/store/Store.ts
+++ b/packages/scene-composer/src/store/Store.ts
@@ -22,7 +22,7 @@ import {
   isISceneNodeInternal,
   IMotionIndicatorComponentInternal,
   IDataOverlayComponentInternal,
-  IDataBindingComponentInternal,
+  IEntityBindingComponentInternal,
 } from './internalInterfaces';
 
 export type {
@@ -39,7 +39,7 @@ export type {
   IColorOverlayComponentInternal,
   IMotionIndicatorComponentInternal,
   IDataOverlayComponentInternal,
-  IDataBindingComponentInternal,
+  IEntityBindingComponentInternal,
 };
 
 export interface ISharedState {

--- a/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
+++ b/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
@@ -194,23 +194,21 @@ describe('serializationHelpers', () => {
     });
   });
 
-  it('should appropriately create data binding components when calling createDataBindingComponent', () => {
+  it('should appropriately create entity binding components when calling createEntityBindingComponent', () => {
     (generateUUID as jest.Mock).mockReturnValue('test-uuid');
 
-    const component: Component.DataBindingComponent = {
-      type: KnownComponentType.DataBinding,
-      valueDataBindings: [
-        {
-          valueDataBinding: { dataBindingContext: 'dataBindingContext' },
-        },
-      ],
+    const component: Component.EntityBindingComponent = {
+      type: KnownComponentType.EntityBinding,
+      valueDataBinding: {
+        dataBindingContext: 'dataBindingContext',
+      },
     };
-    const binding = exportsForTesting.createDataBindingComponent(component);
+    const binding = exportsForTesting.createEntityBindingComponent(component);
 
     expect(binding).toEqual({
       ref: 'test-uuid',
-      type: KnownComponentType.DataBinding,
-      valueDataBindings: component.valueDataBindings,
+      type: KnownComponentType.EntityBinding,
+      valueDataBinding: component.valueDataBinding,
     });
   });
 

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -30,7 +30,7 @@ import {
   IMotionIndicatorComponentInternal,
   ISubModelRefComponentInternal,
   IDataOverlayComponentInternal,
-  IDataBindingComponentInternal,
+  IEntityBindingComponentInternal,
 } from '../internalInterfaces';
 
 import { addComponentToComponentNodeMap } from './componentMapHelpers';
@@ -213,9 +213,9 @@ function createDataOverlayComponent(
   return Object.assign({}, { ref: generateUUID() }, { ...component });
 }
 
-function createDataBindingComponent(
-  component: Component.DataBindingComponent,
-): IDataBindingComponentInternal | undefined {
+function createEntityBindingComponent(
+  component: Component.EntityBindingComponent,
+): IEntityBindingComponentInternal | undefined {
   return Object.assign({}, { ref: generateUUID() }, { ...component });
 }
 
@@ -263,8 +263,8 @@ function deserializeComponent(
     case Component.Type.DataOverlay: {
       return createDataOverlayComponent(component as Component.DataOverlay, resolver, errorCollector);
     }
-    case Component.Type.DataBinding: {
-      return createDataBindingComponent(component as Component.DataBindingComponent);
+    case Component.Type.EntityBinding: {
+      return createEntityBindingComponent(component as Component.EntityBindingComponent);
     }
     default: {
       LOG.warn(`component not supported type[${component.type}]. It will be ignored.`);
@@ -747,7 +747,7 @@ export const exportsForTesting = {
   createModelShaderComponent,
   createMotionIndicatorComponent,
   createDataOverlayComponent,
-  createDataBindingComponent,
+  createEntityBindingComponent,
   deserializeComponent,
   parseSceneContent,
   createSceneNodeInternal,

--- a/packages/scene-composer/src/store/internalInterfaces.ts
+++ b/packages/scene-composer/src/store/internalInterfaces.ts
@@ -23,7 +23,7 @@ import {
   WidgetClickEventCallback,
   ISubModelRefComponent,
   IDataOverlayComponent,
-  IDataBindingComponent,
+  IEntityBindingComponent,
 } from '../interfaces';
 import { MapControls as MapControlsImpl, OrbitControls as OrbitControlsImpl } from '../three/OrbitControls';
 
@@ -119,7 +119,7 @@ export type IMotionIndicatorComponentInternal = ISceneComponentInternal & IMotio
 
 export type IDataOverlayComponentInternal = ISceneComponentInternal & IDataOverlayComponent;
 
-export type IDataBindingComponentInternal = IDataBoundSceneComponentInternal & IDataBindingComponent;
+export type IEntityBindingComponentInternal = IDataBoundSceneComponentInternal & IEntityBindingComponent;
 
 /******************************************************************************
  * Type magic...

--- a/packages/scene-composer/tests/scenes/CookieFactoryWaterTank.json
+++ b/packages/scene-composer/tests/scenes/CookieFactoryWaterTank.json
@@ -54,7 +54,7 @@
           "unitOfMeasure": "meters"
         },
         {
-          "type": "DataBinding",
+          "type": "EntityBinding",
           "valueDataBinding": {
             "dataBindingContext":{
               "entityId": "WaterTank"


### PR DESCRIPTION
## Overview
Rename DataBinding Component to EntityBinding.  Some UX that are generic DataBinding will still be named that.
This will change the Scene.json text strings and BREAK all existing demo scene using 'DataBinding' as the string for EntityBinding

## Verifying Changes
Unit test passes now
Storybook manual test for Highlight passes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
