### PR TITLE
feat(composer): support enhanced editing in Matterport scene

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -138,7 +138,7 @@
     "@formatjs/ts-transformer": "3.9.11",
     "@iot-app-kit/core": "3.3.0",
     "@iot-app-kit/related-table": "3.3.0",
-    "@matterport/r3f": "0.2.5",
+    "@matterport/r3f": "0.2.6",
     "@matterport/webcomponent": "0.1.26",
     "@react-three/drei": "8.11.0",
     "@react-three/fiber": "7.0.26",

--- a/packages/scene-composer/src/components/WebGLCanvasManager.tsx
+++ b/packages/scene-composer/src/components/WebGLCanvasManager.tsx
@@ -3,6 +3,7 @@ import * as awsui from '@awsui/design-tokens';
 import React, { useContext, useEffect, useRef } from 'react';
 import { GizmoHelper, GizmoViewport } from '@react-three/drei';
 import { ThreeEvent, useThree } from '@react-three/fiber';
+import { MatterportModel } from '@matterport/r3f/dist';
 
 import { KnownSceneProperty } from '../interfaces';
 import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLogging';
@@ -121,6 +122,7 @@ export const WebGLCanvasManager: React.FC = () => {
               <planeGeometry args={[1000, 1000]} />
               <meshBasicMaterial colorWrite={false} />
             </mesh>
+            {enableMatterportViewer && <MatterportModel onClick={onClick} />}
           </React.Fragment>
           <IntlProvider locale={getGlobalSettings().locale}>
             <SceneInfoView />


### PR DESCRIPTION
## Overview

- Support enhanced editing for the Matterport scenes

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
