### PR TITLE
fix(scene composer): fixes css issues related to storybook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
       - dependency-name: 'three'
       - dependency-name: 'three-mesh-bvh'
       - dependency-name: 'three-stdlib'
+      - dependency-name: 'sass'
+      - dependency-name: '@awsui'
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -59,7 +59,7 @@
     "postcss-initial": "^4.0.1",
     "react-app-rewired": "^2.2.1",
     "react-scripts": "5.0.1",
-    "sass": "^1.63.4",
+    "sass": "^1.62.1",
     "typescript": "^4.8.3"
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,9 +54,9 @@
     "react-dom": "^18"
   },
   "dependencies": {
-    "@awsui/collection-hooks": "^1.0.51",
+    "@awsui/collection-hooks": "^1.0.0",
     "@awsui/components-react": "^3.0.0",
-    "@awsui/design-tokens": "^3.0.44",
+    "@awsui/design-tokens": "^3.0.41",
     "@iot-app-kit/core": "6.2.0",
     "@iot-app-kit/related-table": "6.2.0",
     "@stencil/core": "^2.7.0",

--- a/packages/related-table/package.json
+++ b/packages/related-table/package.json
@@ -58,9 +58,9 @@
     "styled-components": "^5"
   },
   "devDependencies": {
-    "@awsui/collection-hooks": "^1.0.51",
+    "@awsui/collection-hooks": "^1.0.0",
     "@awsui/components-react": "^3.0.0",
-    "@awsui/design-tokens": "^3.0.44",
+    "@awsui/design-tokens": "^3.0.41",
     "@iot-app-kit/jest-config": "6.2.0",
     "@iot-app-kit/ts-config": "6.2.0",
     "@storybook/addon-essentials": "^6.5.16",

--- a/packages/scene-composer/.storybook/main.js
+++ b/packages/scene-composer/.storybook/main.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { fromIni } = require('@aws-sdk/credential-providers');
 module.exports = {
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/preset-scss'],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/preset-scss', 'storybook-dark-mode'],
   staticDirs: [
     '../dist',
     '../public',

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -121,7 +121,7 @@
     "react-intl": "^6.4.4",
     "react-test-renderer": "^18.2.0",
     "rimraf": "^5.0.1",
-    "sass": "^1.63.4",
+    "sass": "^1.62.1",
     "sass-loader": "^7.3.1",
     "svglint": "^2.4.0",
     "ts-jest": "^27.0.4",
@@ -130,9 +130,9 @@
     "webpack": "^5.87.0"
   },
   "dependencies": {
-    "@awsui/collection-hooks": "^1.0.51",
+    "@awsui/collection-hooks": "^1.0.0",
     "@awsui/components-react": "^3.0.0",
-    "@awsui/design-tokens": "^3.0.44",
+    "@awsui/design-tokens": "^3.0.41",
     "@awsui/global-styles": "^1.0.12",
     "@formatjs/ts-transformer": "3.13.3",
     "@iot-app-kit/core": "6.2.0",


### PR DESCRIPTION
## Overview
Reverts changes from dependabot that broke CSS in storybook & implements storybook dark mode feature. 

Before
![before](https://github.com/awslabs/iot-app-kit/assets/6610619/15d2afb9-e6cd-4939-8c6a-291169e1a537)

After - Dark Mode
![Screenshot 2023-06-23 at 4 50 53 PM](https://github.com/awslabs/iot-app-kit/assets/6610619/a9df0174-aaea-4b88-9edf-cc263af56523)

After - Bright Mode
![Screenshot 2023-06-23 at 4 51 05 PM](https://github.com/awslabs/iot-app-kit/assets/6610619/972f51fc-7b7f-471c-8ae7-9b01a0dd1175)


## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
