### PR TITLE
feat(dashboard): initial implementation of static tooltips(scooters) …

### DIFF
--- a/packages/react-components/src/components/BaseECharts/eChartsConstants.ts
+++ b/packages/react-components/src/components/BaseECharts/eChartsConstants.ts
@@ -30,17 +30,18 @@ export const DEFAULT_LEGEND: LegendComponentOption = {
   bottom: '0',
   padding: [5, 20],
 };
-
+export const DEFAULT_MARGIN = '50';
 export const DEFAULT_GRID: GridComponentOption = {
-  left: '16',
-  top: '8%',
-  right: '16',
-  bottom: '32',
-  containLabel: true,
+  left: DEFAULT_MARGIN,
+  top: DEFAULT_MARGIN,
+  right: DEFAULT_MARGIN,
+  bottom: DEFAULT_MARGIN,
+  containLabel: false,
 };
 
 export const DEFAULT_TOOLTIP: TooltipComponentOption = {
   trigger: 'axis',
+  show: true,
 };
 
 export const DEFAULT_DATA_ZOOM: DataZoomComponentOption = {
@@ -53,6 +54,12 @@ export const DEFAULT_DATA_ZOOM: DataZoomComponentOption = {
   moveOnMouseWheel: false,
 };
 
+// tool tip constants
+export const tooltipColors = ['#DA7596', '#2EA597', '#688AE8'];
+export const tooltipLineColor = '#5F6B7A';
+export const tooltipNameWidth = 60;
+export const tooltipNameHeight = 20;
+
 export const DEFAULT_ECHART_OPTIONS: EChartsOption = {
   xAxis: DEFAULT_X_AXIS,
   yAxis: DEFAULT_Y_AXIS,
@@ -60,4 +67,5 @@ export const DEFAULT_ECHART_OPTIONS: EChartsOption = {
   grid: DEFAULT_GRID,
   tooltip: DEFAULT_TOOLTIP,
   dataZoom: DEFAULT_DATA_ZOOM,
+  graphic: [],
 };

--- a/packages/react-components/src/components/BaseECharts/eChartsUtlis.ts
+++ b/packages/react-components/src/components/BaseECharts/eChartsUtlis.ts
@@ -1,0 +1,107 @@
+import { ECElementEvent, EChartsOption, EChartsType, SeriesOption } from 'echarts';
+import { DataStream } from '@iot-app-kit/charts-core';
+import { StreamType } from '../../common/constants';
+import { DataPoint } from '@iot-app-kit/core';
+import {
+  DEFAULT_MARGIN,
+  tooltipColors,
+  tooltipLineColor,
+  tooltipNameHeight,
+  tooltipNameWidth,
+} from './eChartsConstants';
+import { v4 as uuid } from 'uuid';
+
+// specifically converts dataStreams to series for bar, scatter, line charts
+export const dataStreamsToEChartSeries = (dataStreams: DataStream[], chartType: string): SeriesOption[] =>
+  dataStreams
+    .filter(({ streamType }) => streamType !== StreamType.ALARM) // need to filter out alarm streams. not supported in bar, scatter, line
+    .map(
+      (stream) =>
+        ({
+          name: stream.name ?? '',
+          data: stream.data.map((point: DataPoint) => [point.x, point.y]),
+          type: chartType,
+          itemStyle: { color: stream.color } ?? {},
+          lineStyle: { color: stream.color } ?? {},
+        } as SeriesOption)
+    );
+
+export type GraphicInternal = { timestamp: number[] } & {
+  children: Array<{ shape: { x1: number; x2: number; x: number } }>;
+};
+
+export type SeriesInternal = Array<{ data: Array<number[]> }>;
+
+export const updatePositions = (option: EChartsOption, series: SeriesOption[], chart?: EChartsType) => {
+  const graphic = option.graphic as GraphicInternal[];
+  if (graphic?.length === 0) {
+    return [];
+  }
+  const timestamps = new Set();
+
+  (series as SeriesInternal).forEach((stream) => {
+    stream.data.forEach((data) => {
+      timestamps.add(data[0]);
+    });
+  });
+  const timestampsArray = Array.from(timestamps);
+
+  const widthPerTime = ((chart?.getWidth() ?? 0) - Number(DEFAULT_MARGIN) * 2) / (timestamps.size - 1);
+
+  return graphic?.map((g) => {
+    const index = timestampsArray.indexOf(g.timestamp[0]);
+    const newX = widthPerTime * index + Number(DEFAULT_MARGIN);
+
+    g.children[0].shape.x1 = newX;
+    g.children[0].shape.x2 = newX;
+    g.children[1].shape.x = newX - 30;
+    return g;
+  });
+};
+
+export const getToolTipGraphic = (
+  e: ECElementEvent,
+  length: number,
+  chart?: EChartsType | undefined,
+  size?: { width: number; height: number }
+) => {
+  return {
+    id: `tooltip-${uuid()}`,
+    action: '$merge',
+    type: 'group',
+    draggable: 'horizontal',
+    timestamp: e.data as number[],
+    children: [
+      {
+        type: 'line',
+        id: `line-${uuid()}`,
+        shape: {
+          x1: (e.event?.offsetX ?? 0) - 1,
+          x2: (e.event?.offsetX ?? 0) - 1,
+          y1: Number(DEFAULT_MARGIN),
+          y2: (chart?.getHeight() ?? size?.width ?? 0) - Number(DEFAULT_MARGIN),
+        },
+        style: {
+          stroke: tooltipLineColor,
+          lineWidth: 2,
+        },
+      },
+      {
+        type: 'rect',
+        z: 1,
+        id: `rect-${uuid()}`,
+        shape: {
+          x: (e.event?.offsetX ?? 0) - tooltipNameWidth / 2,
+          y: Number(DEFAULT_MARGIN) - tooltipNameHeight,
+          width: tooltipNameWidth,
+          height: tooltipNameHeight,
+        },
+        style: {
+          fill: tooltipColors[length],
+        },
+        textContent: { z: 2, style: { text: `SCOOTER ${length}`, fill: 'white', fontSize: 9 } },
+        textConfig: { position: 'inside' },
+      },
+    ],
+  };
+};


### PR DESCRIPTION
## Overview
this is an initial implementation of scooters
1. user can double click to enter the add scooter mode
2. user can click on any node to add a scooter
3. scooter moves along with that node when there is new data, 

things to do
1. the draggability is not available because React dnd seems to take over the chart
2. the default behaviour of the tooltip (show on hover) seems to be broken, but still shows on click

## Verifying Changes
refer to the screen shot and screen capture

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).


https://github.com/awslabs/iot-app-kit/assets/135036199/a636d1f0-674a-497c-9300-3f6cd355486b

![Screenshot 2023-06-27 at 11 44 50 AM](https://github.com/awslabs/iot-app-kit/assets/135036199/17758c29-a8cb-4a69-9d52-d3c9f6a3bb50)
