### PR TITLE
fix: Revert "fix(dashboard): fixed the flash of graphs on change in query(s)"

### DIFF
--- a/packages/dashboard/src/customization/widgets/barChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/component.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { BarChart } from '@iot-app-kit/react-components';
 
+import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { BarChartWidget } from '.././types';
 import { useQueries } from '~/components/dashboard/queryContext';
@@ -26,12 +27,14 @@ const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
   const { iotSiteWiseQuery } = useQueries();
 
   const queries = iotSiteWiseQuery && queryConfig.query ? [iotSiteWiseQuery?.timeSeriesData(queryConfig.query)] : [];
+  const key = computeQueryConfigKey(viewport, queryConfig);
   const aggregation = getAggregation(queryConfig);
 
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
 
   return (
     <BarChart
+      key={key}
       queries={queries}
       viewport={viewport}
       gestures={readOnly}

--- a/packages/dashboard/src/customization/widgets/kpi/component.tsx
+++ b/packages/dashboard/src/customization/widgets/kpi/component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import { KPI } from '@iot-app-kit/react-components';
+import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { KPIWidget } from '../types';
 import { Box } from '@cloudscape-design/components';
@@ -32,6 +33,7 @@ const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
 
   const { iotSiteWiseQuery } = useQueries();
   const query = iotSiteWiseQuery && queryConfig.query ? iotSiteWiseQuery?.timeSeriesData(queryConfig.query) : undefined;
+  const key = computeQueryConfigKey(viewport, queryConfig);
   const aggregation = getAggregation(queryConfig);
 
   const shouldShowEmptyState = query == null || !iotSiteWiseQuery;
@@ -58,6 +60,7 @@ const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
 
   return (
     <KPI
+      key={key}
       query={query}
       viewport={viewport}
       styles={styleSettings}

--- a/packages/dashboard/src/customization/widgets/lineChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineChart/component.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { LineChart } from '@iot-app-kit/react-components';
 
+import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { LineChartWidget } from '../types';
 import { useQueries } from '~/components/dashboard/queryContext';
@@ -25,13 +26,14 @@ const LineChartWidgetComponent: React.FC<LineChartWidget> = (widget) => {
 
   const { iotSiteWiseQuery } = useQueries();
   const queries = iotSiteWiseQuery && queryConfig.query ? [iotSiteWiseQuery?.timeSeriesData(queryConfig.query)] : [];
-
+  const key = computeQueryConfigKey(viewport, queryConfig);
   const aggregation = getAggregation(queryConfig);
 
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
 
   return (
     <LineChart
+      key={key}
       queries={queries}
       viewport={viewport}
       gestures={readOnly}

--- a/packages/dashboard/src/customization/widgets/scatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/scatterChart/component.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { ScatterChart } from '@iot-app-kit/react-components';
 
+import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { ScatterChartWidget } from '../types';
 import { useQueries } from '~/components/dashboard/queryContext';
@@ -25,12 +26,14 @@ const ScatterChartWidgetComponent: React.FC<ScatterChartWidget> = (widget) => {
 
   const { iotSiteWiseQuery } = useQueries();
   const queries = iotSiteWiseQuery && queryConfig.query ? [iotSiteWiseQuery?.timeSeriesData(queryConfig.query)] : [];
+  const key = computeQueryConfigKey(viewport, queryConfig);
   const aggregation = getAggregation(queryConfig);
 
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
 
   return (
     <ScatterChart
+      key={key}
       queries={queries}
       viewport={viewport}
       gestures={readOnly}

--- a/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
+++ b/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { DashboardState } from '~/store/state';
 import { StatusTimelineWidget } from '../types';
 import { useQueries } from '~/components/dashboard/queryContext';
+import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
 import { getAggregation } from '../utils/widgetAggregationUtils';
 
@@ -22,12 +23,14 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (widget) =
 
   const { iotSiteWiseQuery } = useQueries();
   const queries = iotSiteWiseQuery && queryConfig.query ? [iotSiteWiseQuery?.timeSeriesData(queryConfig.query)] : [];
+  const key = computeQueryConfigKey(viewport, queryConfig);
   const aggregation = getAggregation(queryConfig);
 
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
 
   return (
     <StatusTimeline
+      key={key}
       queries={queries}
       viewport={viewport}
       gestures={readOnly}

--- a/packages/dashboard/src/customization/widgets/status/component.tsx
+++ b/packages/dashboard/src/customization/widgets/status/component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import { Status } from '@iot-app-kit/react-components';
+import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { StatusWidget } from '../types';
 import { Box } from '@cloudscape-design/components';
@@ -33,6 +34,7 @@ const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
   const query = iotSiteWiseQuery && queryConfig.query ? iotSiteWiseQuery?.timeSeriesData(queryConfig.query) : undefined;
 
   const shouldShowEmptyState = query == null || !iotSiteWiseQuery;
+  const key = computeQueryConfigKey(viewport, queryConfig);
   const aggregation = getAggregation(queryConfig);
 
   if (shouldShowEmptyState) {
@@ -56,6 +58,7 @@ const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
 
   return (
     <Status
+      key={key}
       query={query}
       viewport={viewport}
       styles={styleSettings}

--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -3,6 +3,8 @@ import { useSelector } from 'react-redux';
 
 import { Table, TableColumnDefinition } from '@iot-app-kit/react-components';
 
+import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
+
 import type { DashboardState } from '~/store/state';
 import type { TableWidget } from '../types';
 import { useQueries } from '~/components/dashboard/queryContext';
@@ -39,12 +41,14 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
 
   const { iotSiteWiseQuery } = useQueries();
   const queries = iotSiteWiseQuery && queryConfig.query ? [iotSiteWiseQuery?.timeSeriesData(queryConfig.query)] : [];
+  const key = computeQueryConfigKey(viewport, widget.properties.queryConfig);
 
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
 
   return (
     <Table
       resizableColumns
+      key={key}
       queries={queries}
       viewport={viewport}
       columnDefinitions={columnDefinitions}

--- a/packages/dashboard/src/customization/widgets/utils/computeQueryConfigKey.ts
+++ b/packages/dashboard/src/customization/widgets/utils/computeQueryConfigKey.ts
@@ -1,0 +1,6 @@
+import type { Viewport } from '@iot-app-kit/core';
+import type { QueryProperties } from '../types';
+
+export const computeQueryConfigKey = (viewport: Viewport, { query, source }: QueryProperties['queryConfig']) => {
+  return `${JSON.stringify(viewport)}_${source}__${JSON.stringify(query?.assets)}`;
+};

--- a/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.ts
+++ b/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.ts
@@ -59,6 +59,7 @@ export const useTimeSeriesData = ({
     provider.current.subscribe({
       next: (timeSeriesDataCollection: TimeSeriesData[]) => {
         const timeSeriesData = combineTimeSeriesData(timeSeriesDataCollection, viewport);
+
         setTimeSeriesData({
           ...timeSeriesData,
           viewport,
@@ -67,10 +68,15 @@ export const useTimeSeriesData = ({
     });
 
     return () => {
-      provider.current?.unsubscribe();
-      provider.current = undefined;
-      prevViewport.current = undefined;
-      setTimeSeriesData(undefined);
+      // provider subscribe is asynchronous and will not be complete until the next frame stack, so we
+      // defer the unsubscription to ensure that the subscription is always complete before unsubscribed.
+      setTimeout(() => {
+        if (provider.current) {
+          provider.current.unsubscribe();
+        }
+        provider.current = undefined;
+        prevViewport.current = undefined;
+      });
     };
   }, [queriesString]);
 


### PR DESCRIPTION
Reverts awslabs/iot-app-kit#1659

looks like the change in the `useTimeSeriesData` hook removed a `setTimeout` which handled unsubscribing from the data provider which caused a regression

sev2 ticket opened as it is customer impacting.
