### PR TITLE
fix(react-components): ensure provider is unsubscribed correctly

### DIFF
--- a/packages/react-components/src/hooks/useTimeSeriesData/providerStore.ts
+++ b/packages/react-components/src/hooks/useTimeSeriesData/providerStore.ts
@@ -1,0 +1,25 @@
+import { ProviderWithViewport, TimeSeriesData } from '@iot-app-kit/core';
+
+type ProviderMap = { [key in string]: ProviderWithViewport<TimeSeriesData[]> };
+const providerStore = () => {
+  const providerMap: ProviderMap = {};
+
+  const set = (id: keyof ProviderMap, provider: ProviderMap[keyof ProviderMap]) => {
+    providerMap[id] = provider;
+    return provider;
+  };
+
+  const get = (id: keyof ProviderMap): ProviderMap[keyof ProviderMap] | undefined => providerMap[id];
+
+  const remove = (id: keyof ProviderMap) => {
+    delete providerMap[id];
+  };
+
+  return {
+    get,
+    set,
+    remove,
+  };
+};
+
+export const ProviderStore = providerStore();


### PR DESCRIPTION
## Overview
Because the provider unsubscribe call must be done asynchronously, there is a bug where when the queries are updated, the provider ref is subscribed to and immediately unsubscribed to. This is because the ref utilized in the setTimeout gets updated to the new one. This leaves the previous provider orphaned. This change moves the provider from the react ref to a singleton store. This way we don't lose reference to it when the queries change. 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
