### PR TITLE
feat(dashboard): add basic modal with knowledge graph hooks to query editor

### DIFF
--- a/packages/dashboard/src/components/queryEditor/advancedSearch/advancedSearch.tsx
+++ b/packages/dashboard/src/components/queryEditor/advancedSearch/advancedSearch.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import Modal from '@cloudscape-design/components/modal';
+import Box from '@cloudscape-design/components/box';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Button from '@cloudscape-design/components/button';
+import FormField from '@cloudscape-design/components/form-field';
+import Input from '@cloudscape-design/components/input';
+import TextContent from '@cloudscape-design/components/text-content';
+import Checkbox from '@cloudscape-design/components/checkbox';
+import { useState, useMemo, useCallback } from 'react';
+import { ExecuteQueryCommandOutput } from '@aws-sdk/client-iottwinmaker';
+import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { createKnowledgeGraphQueryClient } from '@iot-app-kit/react-components/src/components/knowledge-graph/KnowledgeGraphQueries';
+import { ResponseParser } from '@iot-app-kit/react-components/src/components/knowledge-graph/responseParser';
+import { initialize } from '@iot-app-kit/source-iottwinmaker';
+
+interface Props {
+  client: IoTSiteWiseClient;
+  onDismiss: () => void;
+  onSubmit: (assetIds?: string[]) => void;
+}
+
+/** Advanced search for exploring your AWS IoT SiteWise properties. */
+export function AdvancedSearch(props: Props) {
+  const [searchTermInput, setSearchTermInput] = useState('');
+  const [assetsChecked, setAssetsChecked] = useState(false);
+  const [propertiesChecked, setPropertiesChecked] = useState(false);
+
+  // TODO: get creds/region differently. KG data module requires either awsCreds or multiple sdk clients (twinmaker, sitewise, s3, kinesis, secrets manager)
+  const { kGDatamodule } = initialize('CenturionTest', {
+    awsCredentials: props.client.config.credentials,
+    awsRegion: 'us-east-1',
+  });
+
+  const kGResponse = (res: ExecuteQueryCommandOutput) => {
+    const { nodeData, edgeData } = ResponseParser.parse(
+      res ? res['rows'] : null,
+      res ? res['columnDescriptions'] : null
+    );
+
+    // Assets
+    console.log('Assets');
+    console.log(nodeData);
+
+    // Propreties
+    console.log('Properties');
+    console.log(edgeData);
+  };
+
+  const knowledgeGraphQueryClient = useMemo(() => {
+    return createKnowledgeGraphQueryClient(kGDatamodule(), kGResponse);
+  }, [kGDatamodule(), kGResponse]);
+
+  const onSearchClicked = useCallback(() => {
+    if (searchTermInput) {
+      knowledgeGraphQueryClient.findEntitiesByName(searchTermInput);
+    }
+  }, [knowledgeGraphQueryClient, searchTermInput]);
+
+  return (
+    <Modal
+      onDismiss={props.onDismiss}
+      visible={true}
+      footer={
+        <Box float='right'>
+          <SpaceBetween direction='horizontal' size='xs'>
+            <Button onClick={props.onDismiss} variant='link'>
+              Cancel
+            </Button>
+            <Button onClick={onSearchClicked} variant='primary'>
+              Search
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+      header='Advanced Search'
+    >
+      <SpaceBetween direction='vertical' size='l'>
+        <FormField label='Search term' description='This will search across all assets within the root'>
+          <Input value={searchTermInput} onChange={({ detail }) => setSearchTermInput(detail.value)} />
+        </FormField>
+        <TextContent>
+          <SpaceBetween direction='vertical' size='xxxs'>
+            <strong>Result Types</strong>
+            <small>Specify which things you're searching for</small>
+            <Checkbox onChange={({ detail }) => setAssetsChecked(detail.checked)} checked={assetsChecked}>
+              Assets
+            </Checkbox>
+            <Checkbox onChange={({ detail }) => setPropertiesChecked(detail.checked)} checked={propertiesChecked}>
+              Properties
+            </Checkbox>
+          </SpaceBetween>
+        </TextContent>
+      </SpaceBetween>
+    </Modal>
+  );
+}

--- a/packages/dashboard/src/components/queryEditor/advancedSearch/index.ts
+++ b/packages/dashboard/src/components/queryEditor/advancedSearch/index.ts
@@ -1,0 +1,1 @@
+export { AdvancedSearch } from './advancedSearch';

--- a/packages/dashboard/src/components/queryEditor/advancedSearch/useKnowledgeGraphQuery/index.ts
+++ b/packages/dashboard/src/components/queryEditor/advancedSearch/useKnowledgeGraphQuery/index.ts
@@ -1,0 +1,1 @@
+export { useKnowledgeGraphQuery, type UseKnowledgeGraphQueryProps } from './useKnowledgeGraphQuery';

--- a/packages/dashboard/src/components/queryEditor/advancedSearch/useKnowledgeGraphQuery/useKnowledgeGraphQuery.ts
+++ b/packages/dashboard/src/components/queryEditor/advancedSearch/useKnowledgeGraphQuery/useKnowledgeGraphQuery.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { ExecuteQueryCommand, IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
+
+export interface UseKnowledgeGraphQueryProps {
+  queryStatement: string;
+  workspaceId: string;
+  client: IoTTwinMakerClient;
+}
+
+export const useKnowledgeGraphQuery = (props: UseKnowledgeGraphQueryProps) => {
+  const executeQuery = async () => {
+    if (!props.client) return; // TODO: add input check
+    return props.client.send(new ExecuteQueryCommand({ ...props }));
+  };
+
+  return useQuery({
+    queryKey: [props.queryStatement, props.workspaceId],
+    queryFn: () => executeQuery(),
+    select: (data) => data,
+    enabled: !!props.workspaceId,
+  });
+};

--- a/packages/dashboard/src/components/queryEditor/queryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/queryEditor.tsx
@@ -1,10 +1,12 @@
 import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import Button from '@cloudscape-design/components/button';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import React, { useState } from 'react';
 
 import { QueryEditorErrorBoundary } from './queryEditorErrorBoundary';
 import { ResourceExplorer, ResourceExplorerProps } from './resourceExplorer';
 import { StreamExplorer } from './streamExplorer';
+import { AdvancedSearch } from './advancedSearch/advancedSearch';
 
 export interface QueryEditorProps {
   client: IoTSiteWiseClient;
@@ -21,6 +23,20 @@ export interface QueryEditorProps {
 export function QueryEditor({ client }: QueryEditorProps) {
   const [selectedAssets, setSelectedAssets] = useState<ResourceExplorerProps['selectedAssets']>([]);
   const [assetId, setAssetId] = useState<string | undefined>(undefined);
+  const [showModel, setShowModal] = useState<boolean>(false);
+
+  const onClick = () => {
+    setShowModal(true);
+  };
+
+  const onDismissModal = () => {
+    setShowModal(false);
+  };
+
+  // TODO: pass assets and properties to <ResourceExplorer> and <StreamExplorer>
+  const onSubmitModal = () => {
+    setShowModal(false);
+  };
 
   // these assets will be described and their asset properties listed by the stream explorer
   const selectedAssetIds = selectedAssets
@@ -29,7 +45,9 @@ export function QueryEditor({ client }: QueryEditorProps) {
 
   return (
     <QueryEditorErrorBoundary>
+      {showModel && <AdvancedSearch client={client} onDismiss={onDismissModal} onSubmit={onSubmitModal} />}
       <SpaceBetween size='l'>
+        <Button onClick={onClick}>Advanced search</Button>
         <ResourceExplorer
           client={client}
           selectedAssets={selectedAssets}

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -1,5 +1,6 @@
 import Dashboard from './components/dashboard';
 import DashboardView from './components/dashboard/view';
+import { QueryEditor } from './components/queryEditor';
 import type { DashboardProperties } from './components/dashboard';
 import type { DashboardViewProperties } from './components/dashboard/view';
 import type {
@@ -10,6 +11,7 @@ import type {
 } from './types';
 
 export {
+  QueryEditor,
   Dashboard,
   DashboardProperties,
   DashboardView,

--- a/packages/react-components/src/components.ts
+++ b/packages/react-components/src/components.ts
@@ -5,6 +5,7 @@ import type { JSX } from '@iot-app-kit/components';
 
 const { defineCustomElements } = require('@iot-app-kit/components/loader');
 const { defineCustomElements: defineSynchroChartsElements } = require('@iot-app-kit/charts-core/dist/loader');
+
 defineCustomElements();
 defineSynchroChartsElements()
 

--- a/packages/react-components/src/components/knowledge-graph/KnowledgeGraphQueries.ts
+++ b/packages/react-components/src/components/knowledge-graph/KnowledgeGraphQueries.ts
@@ -2,6 +2,8 @@ import { TwinMakerKGQueryDataModule } from '@iot-app-kit/source-iottwinmaker';
 import { ExecuteQueryCommandOutput } from '@aws-sdk/client-iottwinmaker';
 export interface KnowledgeGraphQueryInterface {
   findEntitiesByName(name: string): Promise<void>;
+  findEntitesByEntityOrPropertyName(entityName?: string, propertyName?: string): Promise<void>;
+  findPropertiesByEntityOrPropertyName(entityName?: string, propertyName?: string): Promise<void>;
   findRelatedEntities(entityId: string): Promise<void>;
   executeExternalEntityQuery(entityId: string): Promise<void>;
 }
@@ -10,6 +12,16 @@ export const createKnowledgeGraphQueryClient = function (
   updateQueryResults: (result: ExecuteQueryCommandOutput) => void
 ) {
   const knowledgeGraphQuery: KnowledgeGraphQueryInterface = {
+    findEntitesByEntityOrPropertyName: async (entityName?: string, propertyName?: string): Promise<void> => {
+      const queryStatement = `SELECT e FROM EntityGraph MATCH (e), e.components AS c, c.properties as p WHERE c.entityName LIKE '%${entityName}%' or p.propertyName LIKE '%${propertyName}%'`;
+      const result = await dataSource.executeQuery({ queryStatement });
+      updateQueryResults(result);
+    },
+    findPropertiesByEntityOrPropertyName: async (entityName?: string, propertyName?: string): Promise<void> => {
+      const queryStatement = `SELECT p FROM EntityGraph MATCH (e), e.components AS c, c.properties AS p WHERE p.propertyName LIKE '%${propertyName}%' OR c.entityName LIKE '%${entityName}%'`;
+      const result = await dataSource.executeQuery({ queryStatement });
+      updateQueryResults(result);
+    },
     findEntitiesByName: async (name: string): Promise<void> => {
       const result = await dataSource.executeQuery({
         queryStatement: `SELECT e FROM EntityGraph MATCH (e) WHERE e.entityName like '%${name}%'`,


### PR DESCRIPTION
## Overview
* Adding a button and modal to the QueryEditor component for Advanced Search, which will use TwinMaker's Knowledge Graph for more advanced asset/property querying when selecting properties to add to a dashboard.

## Verifying Changes

TODO: Either expose QueryEditor in storybook or add a Dashboard example using QueryEditor to show the advanced search mode.
TODO: We are in the process of refining the UX so it is subject to change.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
