### PR TITLE
fix(actions): lock release please to version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@3.7.9
         id: release
         with:
           command: manifest


### PR DESCRIPTION
## Overview
The latest release for the release-please action is not running correctly. This locks the version to the last working version so we can continue to release code while the action is debugged.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
