### PR TITLE
fix: use REGION env variable in dashboard testing environment

### DIFF
--- a/packages/dashboard/testing/clients.ts
+++ b/packages/dashboard/testing/clients.ts
@@ -2,15 +2,14 @@ import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
 
 import { getEnvCredentials } from './getEnvCredentials';
-
-const REGION = 'us-west-2';
+import { TEST_REGION } from './constants';
 
 export const iotSiteWiseClient = new IoTSiteWiseClient({
   credentials: getEnvCredentials(),
-  region: REGION,
+  region: TEST_REGION,
 });
 
 export const iotEventsClient = new IoTEventsClient({
   credentials: getEnvCredentials(),
-  region: REGION,
+  region: TEST_REGION,
 });

--- a/packages/dashboard/testing/constants.ts
+++ b/packages/dashboard/testing/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Region used for testing.
+ *
+ * Configure the value within `.env` at the root of the dashboard package.
+ */
+export const TEST_REGION = process.env.REGION ?? 'us-west-2';

--- a/packages/dashboard/testing/siteWiseQueries.ts
+++ b/packages/dashboard/testing/siteWiseQueries.ts
@@ -3,8 +3,9 @@ import { initialize, SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
 import noop from 'lodash/noop';
 import { getEnvCredentials } from './getEnvCredentials';
 import { generateMockTimeSeriesData } from './mocks';
+import { TEST_REGION } from './constants';
 
-export const REGION = 'us-west-2';
+export const REGION = TEST_REGION;
 
 const STRING_ASSET_ID = '';
 

--- a/turbo.json
+++ b/turbo.json
@@ -29,7 +29,7 @@
     },
     "start": {
       "dependsOn": [],
-      "env": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+      "env": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "REGION"]
     },
     "version": {
       "dependsOn": [],


### PR DESCRIPTION
## Overview
This change is a fix to enable the dashboard testing environment to correctly consume the REGION env variable.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
