### PR TITLE
chore(scene): add DataQuery field to storybook for testing options

### DIFF
--- a/packages/scene-composer/README.md
+++ b/packages/scene-composer/README.md
@@ -39,6 +39,20 @@ Optionally, if you want to pre-load AWS credentials from a local profile, you ca
 AWS_PROFILE=AppKit npm run start -w packages/scene-composer
 ```
 
+If you want to have an AWS Scene pull live data from your TwinMaker workspace you can add a queryJson to the storybook arguments.  Becaues it's a JSON and not kept as part of the URL parameters the query will have to be reset if you refresh the page.  Below is an example query for a single TwinMaker property value.
+
+```bash
+[
+  {
+    "entityId": "f913470a-d011-45ca-ac84-3265f6327105",
+    "componentName": "MetabolicCageOne",
+    "properties": [{ "propertyName": "Temperature" }]
+  }
+]
+```
+
+When using an query for live data the default data range is the last 5 minutes.  You can change this by setting the viewportDurationSecs fields to a custom value.  The field expects a number in seconds.  It does not currently support setting a fixed start and end date range for a viewport so  it work best when you have a way to regularly inject live sample date.
+
 - [Storybook Intro](https://storybook.js.org/docs/react/get-started/introduction)
 
 ## Debugging

--- a/packages/scene-composer/stories/components/argTypes.ts
+++ b/packages/scene-composer/stories/components/argTypes.ts
@@ -21,6 +21,16 @@ export const viewerArgTypes = {
     table: { category: 'Scene' },
     control: 'text',
   },
+  queriesJSON: {
+    if: { arg: 'source', eq: 'aws' },
+    table: { category: 'Scene' },
+    control: 'text',
+  },
+  viewportDurationSecs: {
+    if: { arg: 'source', eq: 'aws' },
+    table: { category: 'Scene' },
+    control: 'text', //
+  },
   theme: {
     options: Object.values(Mode),
     control: 'inline-radio',

--- a/packages/scene-composer/stories/components/hooks/useDatasource.ts
+++ b/packages/scene-composer/stories/components/hooks/useDatasource.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { initialize } from '@iot-app-kit/source-iottwinmaker';
+import { CredentialProvider, Credentials } from '@aws-sdk/types';
+
+const region = 'us-east-1';
+const rociEndpoint = 'https://iottwinmaker.us-east-1.amazonaws.com';
+
+const useDataSource = (
+  awsCredentials: Credentials | CredentialProvider | undefined,
+  workspaceId: string | undefined,
+) => {
+  const datasource = useMemo(() => {
+    const datasource = initialize(workspaceId!, {
+      awsCredentials: awsCredentials!,
+      awsRegion: region,
+      tmEndpoint: rociEndpoint,
+    });
+    return datasource;
+  }, [awsCredentials, workspaceId]);
+
+  return datasource;
+};
+
+export default useDataSource;

--- a/packages/scene-composer/stories/components/hooks/useLoader.ts
+++ b/packages/scene-composer/stories/components/hooks/useLoader.ts
@@ -1,12 +1,9 @@
-import { SceneLoader, initialize } from '@iot-app-kit/source-iottwinmaker';
+import { SceneLoader } from '@iot-app-kit/source-iottwinmaker';
 import { useCallback, useMemo } from 'react';
 
 import scenes from '../../scenes';
 
-const region = 'us-east-1';
-const rociEndpoint = 'https://iottwinmaker.us-east-1.amazonaws.com';
-
-const useLoader = (source, scene, awsCredentials, workspaceId, sceneId) => {
+const useLoader = (source: string, scene: string, s3SceneLoader, sceneId: string | undefined) => {
   const getSceneObject = useCallback((uri: string) => {
     if (!Object.values(scenes).includes(uri)) {
       return null;
@@ -29,24 +26,18 @@ const useLoader = (source, scene, awsCredentials, workspaceId, sceneId) => {
   );
 
   const awsLoader = useMemo(() => {
-    const init = initialize(workspaceId!, {
-      awsCredentials: awsCredentials,
-      awsRegion: region,
-      tmEndpoint: rociEndpoint,
-    });
-    const loader = init.s3SceneLoader(sceneId!);
-
+    const loader = s3SceneLoader(sceneId!);
     return loader as SceneLoader;
-  }, [awsCredentials, workspaceId, sceneId]);
+  }, [s3SceneLoader, sceneId]);
 
   const loader = useMemo(() => {
     switch (source) {
       case 'aws':
-        return awsCredentials && workspaceId && sceneId ? awsLoader : null;
+        return s3SceneLoader && sceneId ? awsLoader : null;
       default:
         return scene ? localLoader : null;
     }
-  }, [scene, awsCredentials, workspaceId, sceneId, source]);
+  }, [scene, s3SceneLoader, sceneId, source]);
 
   return loader;
 };


### PR DESCRIPTION
## Overview
Add support for AWS Scenes in the Scene Composer storybook to pull live data from AWS via the iot-app-kit data query system.

## Verifying Changes
From the Readme update: 

If you want to have an AWS Scene pull live data from your TwinMaker workspace you can add a queryJson to the storybook arguments.  Because it's a JSON and not kept as part of the URL parameters the query will have to be reset if you refresh the page.  Below is an example query for a single TwinMaker property value.

```bash
[
  {
    "entityId": "f913470a-d011-45ca-ac84-3265f6327105",
    "componentName": "MetabolicCageOne",
    "properties": [{ "propertyName": "Temperature" }]
  }
]
```

When using an query for live data the default data range is the last 5 minutes.  You can change this by setting the viewportDurationSecs fields to a custom value.  The field expects a number in seconds.  It does not currently support setting a fixed start and end date range for a viewport so  it work best when you have a way to regularly inject live sample date.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
