### PR TITLE
fix(composer): fix infinite storybook component update

### DIFF
--- a/packages/scene-composer/stories/components/hooks/useSceneMetadataModule.ts
+++ b/packages/scene-composer/stories/components/hooks/useSceneMetadataModule.ts
@@ -41,7 +41,12 @@ const useSceneMetadataModule = (
       default:
         return undefined;
     }
-  }, [sceneMetadatModuleProps]);
+  }, [
+    sceneMetadatModuleProps.workspaceId,
+    sceneMetadatModuleProps.awsCredentials,
+    sceneMetadatModuleProps.sceneId,
+    sceneMetadatModuleProps.source,
+  ]);
 
   return sceneMetadataModule;
 };

--- a/packages/scene-composer/stories/components/theme-manager.tsx
+++ b/packages/scene-composer/stories/components/theme-manager.tsx
@@ -1,11 +1,12 @@
 import { Mode, Density, applyDensity, applyMode } from '@awsui/global-styles';
-import React, { FC, useEffect } from 'react';
+import React, { FC, ReactNode, useEffect } from 'react';
 
 import { setDebugMode } from '../../src';
 
 export interface ThemeManagerProps {
   theme?: 'light' | 'dark';
   density?: string;
+  children: ReactNode;
 }
 
 const ThemeManager: FC<ThemeManagerProps> = ({ theme = Mode.Dark, density = Density.Comfortable, children }) => {


### PR DESCRIPTION
## Overview
fix infinite storybook component update that's causing infinite getScene API call when visiting scene settings panel

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
