### PR TITLE
feat(scene composer): color picker changes

### DIFF
--- a/packages/scene-composer/src/assets/anchors/IconSvgs.tsx
+++ b/packages/scene-composer/src/assets/anchors/IconSvgs.tsx
@@ -60,3 +60,12 @@ export const SelectedIconSvgString = `
     </g>
   </svg>
 `;
+
+export const CustomIconSvgString = `
+  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52' width='256' height='256'>
+    <g fill='none' fillRule='evenodd' transform='translate(1 1)'>
+      <ellipse cx='25' cy='25' rx='21' ry='21' stroke='${colors.customBlue}' stroke-width='2' />
+      <circle cx='25' cy='25' r='16' fill='${colors.customBlue}' />
+    </g>
+  </svg>
+`;

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/__snapshots__/AnchorWidget.spec.tsx.snap
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/__snapshots__/AnchorWidget.spec.tsx.snap
@@ -55,6 +55,9 @@ exports[`AnchorWidget should render correctly 1`] = `
       <div
         data-test-id="Video"
       />
+      <div
+        data-test-id="Custom"
+      />
     </anchor>
   </group>
 </group>
@@ -114,6 +117,9 @@ exports[`AnchorWidget should render correctly when not visible 1`] = `
       />
       <div
         data-test-id="Video"
+      />
+      <div
+        data-test-id="Custom"
       />
     </anchor>
   </group>
@@ -175,6 +181,9 @@ exports[`AnchorWidget should render correctly with an offset 1`] = `
       <div
         data-test-id="Video"
       />
+      <div
+        data-test-id="Custom"
+      />
     </anchor>
   </group>
 </group>
@@ -235,6 +244,9 @@ exports[`AnchorWidget should render correctly with non default tag settings 1`] 
       <div
         data-test-id="Video"
       />
+      <div
+        data-test-id="Custom"
+      />
     </anchor>
   </group>
 </group>
@@ -294,6 +306,9 @@ exports[`AnchorWidget should render with a countered size when parent is scaled 
       />
       <div
         data-test-id="Video"
+      />
+      <div
+        data-test-id="Custom"
       />
     </anchor>
   </group>

--- a/packages/scene-composer/src/common/constants.ts
+++ b/packages/scene-composer/src/common/constants.ts
@@ -1,7 +1,13 @@
 import * as THREE from 'three';
 
 import { Component, LightType } from '../models/SceneModels';
-import { InfoIconSvgString, WarningIconSvgString, ErrorIconSvgString, VideoIconSvgString } from '../assets';
+import {
+  InfoIconSvgString,
+  WarningIconSvgString,
+  ErrorIconSvgString,
+  VideoIconSvgString,
+  CustomIconSvgString,
+} from '../assets';
 import {
   IValueDataBindingProviderState,
   DefaultAnchorStatus,
@@ -104,6 +110,7 @@ export const SCENE_ICONS: Record<DefaultAnchorStatus, string> = {
   [DefaultAnchorStatus.Warning]: WarningIconSvgString,
   [DefaultAnchorStatus.Error]: ErrorIconSvgString,
   [DefaultAnchorStatus.Video]: VideoIconSvgString,
+  [DefaultAnchorStatus.Custom]: CustomIconSvgString,
 };
 
 export enum RenderOrder {

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -154,7 +154,6 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
     if (prevSelection.current === selectedSceneNodeRef) return;
 
     prevSelection.current = selectedSceneNodeRef;
-
     if (onSelectionChanged) {
       const node = getSceneNodeByRef(selectedSceneNodeRef);
       const componentTypes = node?.components.map((component) => component.type) ?? [];
@@ -167,6 +166,7 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       const additionalComponentData: AdditionalComponentData[] = [];
       if (tagComponent) {
         additionalComponentData.push({
+          chosenColor: tagComponent.chosenColor,
           navLink: tagComponent.navLink,
           dataBindingContext: !tagComponent.valueDataBinding?.dataBindingContext
             ? undefined

--- a/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.spec.tsx
@@ -8,6 +8,8 @@ import {
   mockComponent,
   mockProvider,
 } from '../../../../tests/components/panels/scene-components/MockComponents';
+import { COMPOSER_FEATURES } from '../../../interfaces';
+import { getGlobalSettings } from '../../../common/GlobalSettings';
 
 import { AnchorComponentEditor, convertParamsToKeyValuePairs } from './AnchorComponentEditor';
 
@@ -15,6 +17,8 @@ jest.mock('react', () => ({
   ...jest.requireActual('react'),
   useCallback: jest.fn(),
 }));
+
+jest.mock('../../../common/GlobalSettings');
 
 const updateComponentInternalFn = jest.fn();
 
@@ -58,9 +62,20 @@ describe('AnchorComponentEditor', () => {
     jest.clearAllMocks();
   });
 
-  it('should render as expected', () => {
+  it('should render with no tag style', () => {
     useStore('default').setState(baseState);
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    const mockFeatureConfig = { [COMPOSER_FEATURES.TagStyle]: false };
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfig });
+    const { container } = render(<AnchorComponentEditor node={mockNode} component={anchorComponent} />);
+    expect(container).toMatchSnapshot();
+  });
 
+  it('should render with tag style', () => {
+    useStore('default').setState(baseState);
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    const mockFeatureConfig = { [COMPOSER_FEATURES.TagStyle]: true };
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfig });
     const { container } = render(<AnchorComponentEditor node={mockNode} component={anchorComponent} />);
     expect(container).toMatchSnapshot();
   });

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AnchorComponentEditor should render as expected 1`] = `
+exports[`AnchorComponentEditor should render with no tag style 1`] = `
 <div>
   <div
     data-mocked="SpaceBetween"
@@ -17,6 +17,126 @@ exports[`AnchorComponentEditor should render as expected 1`] = `
           data-mocked="Select"
           data-testid="anchor-default-icon-select"
           options="[{\\"label\\":\\"Info\\",\\"value\\":\\"Info\\"},{\\"label\\":\\"Warning\\",\\"value\\":\\"Warning\\"},{\\"label\\":\\"Error\\",\\"value\\":\\"Error\\"},{\\"label\\":\\"Video\\",\\"value\\":\\"Video\\"}]"
+          placeholder="Choose an icon"
+          selectedarialabel="Selected"
+          selectedoption="{\\"label\\":\\"Info\\",\\"value\\":\\"Info\\"}"
+        />
+        <img
+          height="32px"
+          src="data:image/svg+xml;base64,CiAgPHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA1MiA1Micgd2lkdGg9JzI1NicgaGVpZ2h0PScyNTYnPgogICAgPGcgZmlsbD0nbm9uZScgZmlsbFJ1bGU9J2V2ZW5vZGQnIHRyYW5zZm9ybT0ndHJhbnNsYXRlKDEgMSknPgogICAgICA8ZWxsaXBzZSBjeD0nMjUnIGN5PScyNScgcng9JzIxJyByeT0nMjEnIHN0cm9rZT0nIzAwMDAwMCcgc3Ryb2tlLXdpZHRoPScyJyAvPgogICAgICA8Y2lyY2xlIGN4PScyNScgY3k9JzI1JyByPScxNicgZmlsbD0nIzAwMDAwMCcgLz4KICAgIDwvZz4KICA8L3N2Zz4K"
+          width="32px"
+        />
+      </div>
+    </div>
+    <div
+      data-mocked="SpaceBetween"
+    >
+      <div
+        data-mocked="FormField"
+        label="Entity Id"
+      >
+        <div
+          data-mocked="Autosuggest"
+          data-testid="select-entityId"
+          options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+          value="value1"
+        />
+      </div>
+      <div
+        data-mocked="FormField"
+      >
+        <div>
+          <div
+            data-mocked="Box"
+          >
+            Component Name
+          </div>
+        </div>
+        <div
+          data-mocked="Select"
+          data-testid="value-data-binding-builder-select"
+          options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+          placeholder="Select an option"
+          selectedoption="null"
+        />
+      </div>
+      <div
+        data-mocked="FormField"
+      >
+        <div>
+          <div
+            data-mocked="Box"
+          >
+            Property Name
+          </div>
+        </div>
+        <div
+          data-mocked="Select"
+          data-testid="value-data-binding-builder-select"
+          options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+          placeholder="Select an option"
+          selectedoption="null"
+        />
+      </div>
+    </div>
+    <div
+      data-mocked="FormField"
+      label="Rule Id"
+    >
+      <div
+        data-mocked="Select"
+        data-testid="anchor-rule-id-select"
+        options="[{\\"label\\":\\"rule1\\",\\"value\\":\\"rule1\\"},{\\"label\\":\\"No Rule\\",\\"value\\":\\"No Rule\\"}]"
+        placeholder="Choose a rule"
+        selectedarialabel="Selected"
+        selectedoption="{\\"label\\":\\"rule1\\",\\"value\\":\\"rule1\\"}"
+      />
+    </div>
+    <div
+      data-mocked="FormField"
+      label="Link Target"
+    >
+      <div
+        data-mocked="Input"
+        data-testid="anchor-link-target-input"
+        value="dest1"
+      />
+    </div>
+    <div
+      data-mocked="TextContent"
+    >
+      Link Parameters
+    </div>
+    <div
+      addbuttontext="Add parameter"
+      data-mocked="AttributeEditor"
+      data-testid="anchor-attribute-editor-select"
+      definition="[{\\"label\\":\\"Key\\"},{\\"label\\":\\"Value\\"}]"
+      empty="No parameter"
+      items="[]"
+      removebuttontext="Remove parameter"
+    />
+  </div>
+</div>
+`;
+
+exports[`AnchorComponentEditor should render with tag style 1`] = `
+<div>
+  <div
+    data-mocked="SpaceBetween"
+  >
+    <div
+      data-mocked="FormField"
+      label="Default Icon"
+    >
+      <div
+        data-mocked="Grid"
+        griddefinition="[{\\"colspan\\":10},{\\"colspan\\":2}]"
+      >
+        <div
+          data-mocked="Select"
+          data-testid="anchor-default-icon-select"
+          options="[{\\"label\\":\\"Info\\",\\"value\\":\\"Info\\"},{\\"label\\":\\"Warning\\",\\"value\\":\\"Warning\\"},{\\"label\\":\\"Error\\",\\"value\\":\\"Error\\"},{\\"label\\":\\"Video\\",\\"value\\":\\"Video\\"},{\\"label\\":\\"Custom style\\",\\"value\\":\\"Custom\\"}]"
           placeholder="Choose an icon"
           selectedarialabel="Selected"
           selectedoption="{\\"label\\":\\"Info\\",\\"value\\":\\"Info\\"}"

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPicker.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPicker.spec.tsx
@@ -1,0 +1,39 @@
+import wrapper from '@awsui/components-react/test-utils/dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { ColorPicker } from './ColorPicker';
+
+jest.mock('@awsui/components-react', () => ({
+  ...jest.requireActual('@awsui/components-react'),
+}));
+
+describe('ColorPicker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls onSelectColor when color is selected', () => {
+    const onSelectColorMock = jest.fn();
+    render(<ColorPicker color='#FFFFFF' onSelectColor={onSelectColorMock} label='Colors' />);
+    const colorElement = screen.getByTestId('color-preview');
+    fireEvent.click(colorElement);
+    fireEvent.click(screen.getAllByTitle('#000000')[0]);
+    expect(onSelectColorMock).toHaveBeenCalledWith('#000000');
+  });
+
+  it('calls handleHexCodeChange when hex code is entered', async () => {
+    const onSelectColorMock1 = jest.fn();
+    const { container } = render(<ColorPicker color='#FFFFFF' onSelectColor={onSelectColorMock1} label='Colors' />);
+    const polarisWrapper = wrapper(container);
+    const input = polarisWrapper.findInput();
+    expect(input).toBeDefined();
+
+    const newColor = '#FF0000';
+    act(() => {
+      input?.setInputValue(newColor);
+    });
+    // Assert that onSelectColor is called with the entered hex code
+    expect(onSelectColorMock1).toHaveBeenCalledWith('#FF0000');
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPicker.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPicker.tsx
@@ -1,0 +1,111 @@
+import { Button, FormField, Icon, Input, InputProps, SpaceBetween } from '@awsui/components-react';
+import { NonCancelableCustomEvent } from '@awsui/components-react/internal/events';
+import React, { useCallback, useState } from 'react';
+import { ChromePicker, CirclePicker } from 'react-color';
+import { useIntl } from 'react-intl';
+
+import { IColorPickerProps } from '../interface';
+
+import {
+  tmAddButton,
+  tmColorPickerContainer,
+  tmColorPickerPopover,
+  tmCover,
+  tmDivider,
+  tmPopover,
+} from './ColorPickerUtils/ColorPickerStyles';
+import { colorPickerPreviewSvg } from './ColorPickerUtils/SvgParserHelper';
+import { palleteColors } from './ColorPickerUtils/TagColors';
+
+export const ColorPicker = ({ color, onSelectColor, label }: IColorPickerProps): JSX.Element => {
+  const [showPicker, setShowPicker] = useState<boolean>(false);
+  const [showChromePicker, setShowChromePicker] = useState<boolean>(false);
+  const intl = useIntl();
+
+  const handleClick = useCallback(() => {
+    setShowPicker(!showPicker);
+  }, []);
+
+  const handleColorChange = useCallback(
+    (color) => {
+      onSelectColor(color.hex);
+    },
+    [color],
+  );
+
+  const handleHexCodeChange = useCallback(
+    (event: NonCancelableCustomEvent<InputProps.ChangeDetail>) => {
+      onSelectColor(event.detail.value);
+    },
+    [color],
+  );
+
+  const handleShowChromePicker = useCallback(() => {
+    setShowChromePicker(true);
+    setShowPicker(false);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setShowPicker(false);
+    setShowChromePicker(false);
+  }, []);
+
+  const handleCloseChromePicker = useCallback(() => {
+    setShowChromePicker(false);
+  }, []);
+
+  return (
+    <SpaceBetween size='m'>
+      <SpaceBetween size='m' direction='horizontal'>
+        <FormField label={label} />
+        <Button
+          data-testid='color-preview'
+          ariaLabel={intl.formatMessage({ defaultMessage: 'colorPreview', description: 'color picker preview' })}
+          variant='inline-icon'
+          iconSvg={<Icon size='big' svg={colorPickerPreviewSvg(color)} />}
+          onClick={() => {
+            handleClick();
+            onSelectColor(color);
+          }}
+        />
+        <Input
+          ariaLabel={intl.formatMessage({ defaultMessage: 'Hex code', description: 'color picker label' })}
+          data-testid='hexcode'
+          value={color}
+          onChange={handleHexCodeChange}
+        />
+        <div style={tmColorPickerContainer}>
+          {showPicker && !showChromePicker && (
+            <div style={tmColorPickerPopover}>
+              <div>
+                <div style={tmCover} onClick={handleClose} />
+                <CirclePicker
+                  width='300px'
+                  data-testid='circlePicker'
+                  aria-label={intl.formatMessage({ defaultMessage: 'circlePicker', description: 'circle picker' })}
+                  colors={Object.values(palleteColors)}
+                  color={color}
+                  onChange={handleColorChange}
+                />
+              </div>
+              <div style={tmDivider} />
+              <button style={tmAddButton} onClick={handleShowChromePicker}>
+                <Icon name='add-plus' />
+              </button>
+            </div>
+          )}
+        </div>
+      </SpaceBetween>
+      {showChromePicker && (
+        <div style={tmPopover}>
+          <div
+            aria-label={intl.formatMessage({ defaultMessage: 'chromePicker', description: 'chrome picker' })}
+            style={tmCover}
+            onClick={handleCloseChromePicker}
+          />
+          <ChromePicker disableAlpha color={color} onChangeComplete={(newColor) => onSelectColor(newColor.hex)} />
+        </div>
+      )}
+    </SpaceBetween>
+  );
+};

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/ColorPickerStyles.ts
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/ColorPickerStyles.ts
@@ -1,0 +1,51 @@
+import { colorBackgroundHomeHeader, colorChartsStatusNeutral } from '@awsui/design-tokens';
+import { CSSProperties } from 'styled-components';
+
+export const tmColorPickerPopover: CSSProperties = {
+  position: 'absolute',
+  zIndex: 1,
+  top: '100%',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  background: colorBackgroundHomeHeader,
+  borderRadius: '4px',
+  padding: '10px',
+  boxShadow: '0 2px 5px rgba(0, 0, 0, 0.3)',
+  border: `1px solid ${colorBackgroundHomeHeader}`,
+};
+
+export const tmColorPickerContainer: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+export const tmAddButton: CSSProperties = {
+  width: '24px',
+  height: '24px',
+  borderRadius: '50%',
+  border: 'none',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: colorChartsStatusNeutral,
+  color: 'white',
+  fontWeight: 'bold',
+};
+export const tmDivider: CSSProperties = {
+  width: '100%',
+  height: '1px',
+  background: colorChartsStatusNeutral,
+  margin: '8px 0',
+};
+export const tmPopover: CSSProperties = {
+  position: 'absolute',
+  zIndex: '2',
+};
+export const tmCover: CSSProperties = {
+  position: 'fixed',
+  top: '0px',
+  right: '0px',
+  bottom: '0px',
+  left: '0px',
+};

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/DecodeSvgString.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/DecodeSvgString.spec.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { DecodeSvgString } from './DecodeSvgString';
+import { useSvgParser } from './useSvgParser';
+
+jest.mock('./useSvgParser'); // Mocking the useSvgParser module
+
+describe('DecodeSvgString', () => {
+  const mockSvgCode = '<svg>...</svg>'; // Mocked svgCode value
+
+  beforeEach(() => {
+    useSvgParser.mockReturnValue({
+      svgCode: mockSvgCode,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders component with all required props and correct img attributes', () => {
+    const mockSelectedColor = '#FF0000';
+    const mockIconString = '<svg>...</svg>';
+    const width = '100';
+    const height = '100';
+
+    render(
+      <DecodeSvgString selectedColor={mockSelectedColor} iconString={mockIconString} width={width} height={height} />,
+    );
+    expect(useSvgParser).toHaveBeenCalledWith({
+      selectedColor: mockSelectedColor,
+      iconString: mockIconString,
+    });
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/DecodeSvgString.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/DecodeSvgString.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { useSvgParser } from './useSvgParser';
+
+interface IConvertComponentProps {
+  selectedColor: string;
+  iconString: string;
+  width?: string;
+  height?: string;
+}
+
+export const DecodeSvgString = ({ selectedColor, iconString, width, height }: IConvertComponentProps): JSX.Element => {
+  const svgCode = useSvgParser({ selectedColor, iconString });
+  return <img src={`data:image/svg+xml;base64,${btoa(svgCode)}`} width={width} height={height} />;
+};

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/SvgParserHelper.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/SvgParserHelper.spec.tsx
@@ -1,0 +1,19 @@
+import { replaceFillAttribute } from './SvgParserHelper';
+
+describe('replaceFillAttribute', () => {
+  let element: Element;
+  it('should replace the stroke attribute with the selected color for ellipse elements', () => {
+    element = document.createElement('ellipse');
+    const selectedColor = 'blue';
+    const setAttributeMock = jest.spyOn(element, 'setAttribute');
+    replaceFillAttribute(element, selectedColor);
+    expect(setAttributeMock).toHaveBeenCalledWith('stroke', selectedColor);
+  });
+  it('should replace the fill attribute with the selected color for circle elements', () => {
+    element = document.createElement('circle');
+    const selectedColor = 'red';
+    const setAttributeMock = jest.spyOn(element, 'setAttribute');
+    replaceFillAttribute(element, selectedColor);
+    expect(setAttributeMock).toHaveBeenCalledWith('fill', selectedColor);
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/SvgParserHelper.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/SvgParserHelper.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export const replaceFillAttribute = (element: Element, selectedColor: string): void => {
+  if (element === undefined || selectedColor === undefined) {
+    return;
+  }
+  const tagName = element.tagName.toLowerCase();
+  if (tagName === 'ellipse') {
+    element.setAttribute('stroke', selectedColor);
+  }
+  if (tagName === 'circle') {
+    element.setAttribute('fill', selectedColor!);
+  }
+};
+
+export const traverseSvg = (element: Element, selectedColor: string): void => {
+  replaceFillAttribute(element, selectedColor);
+  const children = element.children;
+  for (let i = 0; i < children.length; i++) {
+    traverseSvg(children[i], selectedColor);
+  }
+};
+
+export const colorPickerPreviewSvg = (color: string): JSX.Element => {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52' width='52px' height='52px'>
+      <g fill='none' fillRule='evenodd' transform='translate(1 1)'>
+        <circle cx='30' cy='20' r='16' fill={color} />
+      </g>
+    </svg>
+  );
+};

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/TagColors.ts
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/TagColors.ts
@@ -1,0 +1,35 @@
+import {
+  colorChartsBlue1500,
+  colorChartsBlue2300,
+  colorChartsGreen500,
+  colorChartsOrange300,
+  colorChartsOrange600,
+  colorChartsPink500,
+  colorChartsPink800,
+  colorChartsPurple500,
+  colorChartsRed300,
+  colorChartsRed500,
+  colorChartsStatusNeutral,
+  colorChartsTeal300,
+  colorChartsTeal600,
+  colorChartsYellow700,
+} from '@awsui/design-tokens';
+
+import { hexColorFromDesignToken } from '../../../../../../utils/styleUtils';
+
+export const palleteColors = {
+  blue: hexColorFromDesignToken(colorChartsBlue1500 || '#08aad2'),
+  red: hexColorFromDesignToken(colorChartsRed300 || '#d63f38'),
+  softRed: hexColorFromDesignToken(colorChartsRed500 || '#fe6e73'),
+  orange: hexColorFromDesignToken(colorChartsOrange600 || '#f89256'),
+  yellow: hexColorFromDesignToken(colorChartsYellow700 || '#dfb52c'),
+  softGreen: hexColorFromDesignToken(colorChartsGreen500 || '#69ae34'),
+  grey: hexColorFromDesignToken(colorChartsStatusNeutral || '#879596'),
+  pink: hexColorFromDesignToken(colorChartsPink500 || '#e07f9d'),
+  lightPink: hexColorFromDesignToken(colorChartsPink800 || '#ffb0c8'),
+  paletteBlue: hexColorFromDesignToken(colorChartsBlue2300 || '#486de8'),
+  purple: hexColorFromDesignToken(colorChartsPurple500 || '#b088f5'),
+  darkOrange: hexColorFromDesignToken(colorChartsOrange300 || '#c55305'),
+  teal: hexColorFromDesignToken(colorChartsTeal300 || '#018977'),
+  softTeal: hexColorFromDesignToken(colorChartsTeal600 || '#40bfa9'),
+};

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/useSvgParser.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/useSvgParser.spec.tsx
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useSvgParser } from './useSvgParser';
+
+describe('useSvgParser', () => {
+  it('should have a valid SVG string with selected color ', () => {
+    const mockIconString =
+      'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAiIGhlaWdodD0iMTAwIj4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjUwIiByPSI1MCIgc3R5bGU9ImZpbGw6cmVkOyIgLz4KPC9zdmc+Cg==';
+    const mockSelectedColor = '#FF0000';
+
+    const { result } = renderHook(() =>
+      useSvgParser({
+        selectedColor: mockSelectedColor,
+        iconString: mockIconString,
+      }),
+    );
+
+    // Retrieve the values from the hook result
+    const svgCode = result.current;
+
+    // Assertions
+    expect(svgCode).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">\n' +
+        '  <circle cx="50" cy="50" r="50" style="fill:red;" fill="#FF0000"/>\n' +
+        '</svg>',
+    );
+  });
+
+  it('should handle invalid SVG string', () => {
+    const mockIconString = '';
+    const mockSelectedColor = '#00FF00';
+    const { result } = renderHook(() =>
+      useSvgParser({
+        selectedColor: mockSelectedColor,
+        iconString: mockIconString,
+      }),
+    );
+
+    // Retrieve the values from the hook result
+    const svgCode = result.current;
+
+    // Assertions
+    expect(svgCode).toBe(
+      '<parsererror xmlns="http://www.mozilla.org/newlayout/xml/parsererror.xml">1:0: document must contain a root element.</parsererror>',
+    );
+  });
+
+  it('should parse SVG with no selected color', () => {
+    const mockIconString =
+      'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAiIGhlaWdodD0iMTAwIj4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjUwIiByPSI1MCIgc3R5bGU9ImZpbGw6cmVkOyIgLz4KPC9zdmc+Cg==';
+    const mockSelectedColor = '';
+
+    const { result } = renderHook(() =>
+      useSvgParser({
+        selectedColor: mockSelectedColor,
+        iconString: mockIconString,
+      }),
+    );
+
+    // Retrieve the values from the hook result
+    const svgCode = result.current;
+
+    // Assertions
+    expect(svgCode).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">\n' +
+        '  <circle cx="50" cy="50" r="50" style="fill:red;" fill=""/>\n' +
+        '</svg>',
+    );
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/useSvgParser.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/useSvgParser.tsx
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+
+import { traverseSvg } from './SvgParserHelper';
+
+interface IConvertComponentProps {
+  selectedColor: string;
+  iconString: string;
+}
+
+export const useSvgParser = ({ selectedColor, iconString }: IConvertComponentProps) => {
+  const [svgCode, setSvgCode] = useState<string>('');
+
+  useEffect(() => {
+    try {
+      const decodeBase64 = (str: string) => {
+        if (typeof atob === 'function') {
+          return atob(str);
+        } else {
+          return Buffer.from(str, 'base64').toString('binary');
+        }
+      };
+
+      // Extract the SVG element from the base64 encoded string
+      const svgString = decodeBase64(iconString!);
+      const parser = new DOMParser();
+      const svgDocument = parser.parseFromString(svgString, 'image/svg+xml');
+      const svgRoot = svgDocument.documentElement;
+
+      traverseSvg(svgRoot, selectedColor);
+      const modifiedSvg = svgRoot.outerHTML;
+      if (!svgRoot) {
+        throw new Error('Invalid SVG string');
+      }
+      setSvgCode(modifiedSvg);
+    } catch (error) {
+      console.error('Error parsing SVG', error);
+    }
+  }, [selectedColor, iconString]);
+
+  return svgCode;
+};

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/interface.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/interface.tsx
@@ -1,0 +1,11 @@
+export interface TagStyle {
+  colorPicker?: React.ReactNode;
+  colorPickerProps?: IColorPickerProps;
+}
+
+export interface IColorPickerProps {
+  color: string;
+  onSelectColor: (color: string) => void;
+  iconSvg?: string;
+  label?: string;
+}

--- a/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetIconEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetIconEditor.tsx
@@ -1,9 +1,10 @@
+import { Grid, Select } from '@awsui/components-react';
 import React, { useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { Grid, Select } from '@awsui/components-react';
 
+import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { SCENE_ICONS } from '../../../common/constants';
-import { DefaultAnchorStatus } from '../../../interfaces';
+import { COMPOSER_FEATURES, DefaultAnchorStatus } from '../../../interfaces';
 import { i18nSceneIconsKeysStrings } from '../../../utils/polarisUtils';
 
 interface ISceneRuleTargetIconEditorProps {
@@ -17,12 +18,16 @@ export const SceneRuleTargetIconEditor: React.FC<ISceneRuleTargetIconEditorProps
 }: ISceneRuleTargetIconEditorProps) => {
   const propsSelectedIcon = DefaultAnchorStatus[targetValue] ?? DefaultAnchorStatus.Info;
   const [selectedIcon, setSelectedIcon] = useState<DefaultAnchorStatus>(propsSelectedIcon);
+  const tagStyle = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagStyle];
+
   const intl = useIntl();
 
-  const options = Object.keys(SCENE_ICONS).map((sceneIcon) => ({
-    label: intl.formatMessage(i18nSceneIconsKeysStrings[sceneIcon]) || sceneIcon,
-    value: sceneIcon,
-  }));
+  const options = Object.keys(SCENE_ICONS)
+    .filter((icon) => (!tagStyle && icon !== 'Custom') || tagStyle)
+    .map((sceneIcon) => ({
+      label: intl.formatMessage(i18nSceneIconsKeysStrings[sceneIcon]) || sceneIcon,
+      value: sceneIcon,
+    }));
 
   const iconString = useMemo(() => {
     return btoa(SCENE_ICONS[selectedIcon]);

--- a/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/SceneRuleTargetIconEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/SceneRuleTargetIconEditor.spec.tsx
@@ -4,11 +4,15 @@ import { render } from '@testing-library/react';
 import wrapper from '@awsui/components-react/test-utils/dom';
 
 import { SceneRuleTargetIconEditor } from '../SceneRuleTargetIconEditor';
-import { DefaultAnchorStatus } from '../../../../';
+import { getGlobalSettings } from '../../../../common/GlobalSettings';
+import { COMPOSER_FEATURES } from '../../../../interfaces/feature';
+import { DefaultAnchorStatus } from '../../../../interfaces/components';
 
 jest.mock('@awsui/components-react', () => ({
   ...jest.requireActual('@awsui/components-react'),
 }));
+
+jest.mock('../../../../common/GlobalSettings');
 
 describe('SceneRuleTargetIconEditor', () => {
   const onChange = jest.fn();
@@ -18,6 +22,9 @@ describe('SceneRuleTargetIconEditor', () => {
   });
 
   it('should change target Icon on click', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    const mockFeatureConfig = { [COMPOSER_FEATURES.TagStyle]: true };
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfig });
     const { container } = render(
       <SceneRuleTargetIconEditor targetValue={DefaultAnchorStatus.Info} onChange={onChange} />,
     );
@@ -28,5 +35,34 @@ describe('SceneRuleTargetIconEditor', () => {
     select!.selectOption(2);
 
     expect(onChange).toBeCalledWith(DefaultAnchorStatus.Warning);
+  });
+
+  it('should render SceneRuleTargetIconEditor with custom icon', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    const mockFeatureConfig = { [COMPOSER_FEATURES.TagStyle]: true };
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfig });
+    const { container } = render(
+      <SceneRuleTargetIconEditor targetValue={DefaultAnchorStatus.Info} onChange={onChange} />,
+    );
+    const polarisWrapper = wrapper(container);
+    const select = polarisWrapper.findSelect();
+
+    select?.openDropdown();
+    select?.selectOption(5);
+    expect(onChange).toBeCalledWith(DefaultAnchorStatus.Custom);
+  });
+
+  it('should render SceneRuleTargetIconEditor with no custom icon', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    const mockFeatureConfig = { [COMPOSER_FEATURES.TagStyle]: false };
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfig });
+    const { container } = render(
+      <SceneRuleTargetIconEditor targetValue={DefaultAnchorStatus.Info} onChange={onChange} />,
+    );
+    const polarisWrapper = wrapper(container);
+    const select = polarisWrapper.findSelect();
+
+    select?.openDropdown();
+    expect(select?.findDropdown().findOptions().length).toEqual(4);
   });
 });

--- a/packages/scene-composer/src/components/three-fiber/AnchorComponent/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/AnchorComponent/index.tsx
@@ -14,7 +14,6 @@ interface IAnchorComponentProps {
 const AnchorComponent: React.FC<IAnchorComponentProps> = ({ node, component }: IAnchorComponentProps) => {
   const sceneComposerId = useSceneComposerId();
   const rule = useStore(sceneComposerId)((state) => state.getSceneRuleMapById(component.ruleBasedMapId));
-
   return (
     <group name={getComponentGroupName(node.ref, 'TAG')}>
       <AnchorWidget
@@ -23,6 +22,7 @@ const AnchorComponent: React.FC<IAnchorComponentProps> = ({ node, component }: I
         navLink={component.navLink}
         rule={rule}
         valueDataBinding={component.valueDataBinding}
+        chosenColor={component.chosenColor}
       />
     </group>
   );

--- a/packages/scene-composer/src/interfaces/components.ts
+++ b/packages/scene-composer/src/interfaces/components.ts
@@ -46,6 +46,7 @@ export interface IAnchorComponent extends ISceneComponent {
   ruleBasedMapId?: string;
   navLink?: INavLink;
   offset?: Vector3;
+  chosenColor?: string;
 }
 
 /**
@@ -56,6 +57,7 @@ export enum DefaultAnchorStatus {
   Warning = 'Warning',
   Error = 'Error',
   Video = 'Video',
+  Custom = 'Custom',
 }
 
 /**
@@ -67,6 +69,7 @@ export const SelectedAnchor = 'Selected';
  * Additional Tag Component Data to be given when a tag node is clicked or changed
  */
 export interface ITagData {
+  chosenColor?: string;
   navLink?: INavLink;
   dataBindingContext?: unknown;
 }

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -162,6 +162,7 @@ export namespace Component {
     icon?: string;
     navLink?: NavLink;
     offset?: Vector3;
+    chosenColor?: string;
   }
 
   export interface ModelShader extends IComponent, IDataBindingRuleMap {}

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -136,6 +136,7 @@ function createTagComponent(
     ref: generateUUID(),
     type: 'Tag',
     icon,
+    chosenColor: component.chosenColor,
     ruleBasedMapId,
     valueDataBinding: {
       dataBindingContext,

--- a/packages/scene-composer/src/utils/polarisUtils.ts
+++ b/packages/scene-composer/src/utils/polarisUtils.ts
@@ -1,7 +1,6 @@
 import { defineMessages } from 'react-intl';
 
 export const mapToSelectOption = (item: string) => ({ label: item, value: item });
-
 export const i18nSceneIconsKeysStrings = defineMessages({
   Info: {
     defaultMessage: 'Info',
@@ -17,6 +16,10 @@ export const i18nSceneIconsKeysStrings = defineMessages({
   },
   Video: {
     defaultMessage: 'Video',
+    description: 'Scene Icon types in a dropdown menu',
+  },
+  Custom: {
+    defaultMessage: 'Custom style',
     description: 'Scene Icon types in a dropdown menu',
   },
 });

--- a/packages/scene-composer/src/utils/sceneResourceUtils.ts
+++ b/packages/scene-composer/src/utils/sceneResourceUtils.ts
@@ -55,10 +55,10 @@ export const getSceneResourceInfo = (target: string | undefined): SceneResourceI
     if (mapKey) {
       type = map[mapKey];
       const newValue = target.substring(mapKey.length);
-
+      const statuses = DefaultAnchorStatus;
       switch (type) {
         case SceneResourceType.Icon:
-          value = DefaultAnchorStatus[newValue] ?? getSceneResourceDefaultValue(type);
+          value = statuses[newValue] ?? getSceneResourceDefaultValue(type);
           break;
         case SceneResourceType.Color:
           value = newValue && newValue.length > 0 ? newValue : getSceneResourceDefaultValue(type);

--- a/packages/scene-composer/src/utils/styleUtils.ts
+++ b/packages/scene-composer/src/utils/styleUtils.ts
@@ -5,6 +5,7 @@ import {
   colorTextNotificationDefault,
   colorBackgroundNotificationRed,
   colorBorderButtonNormalDefault,
+  colorChartsBlue1500,
 } from '@awsui/design-tokens';
 
 const designTokenRegex = /^var\(([0-9a-zA-Z-]+),\s*(#[0-9a-z]+)\)$/;
@@ -33,4 +34,5 @@ export const colors = {
   infoRingWhite: hexColorFromDesignToken(colorTextNotificationDefault || '#fafafa'),
   symbolWhite: hexColorFromDesignToken(colorForegroundControlDefault || '#fafafa'),
   containerBorderWhite: hexColorFromDesignToken(colorBorderButtonNormalDefault || '#fafafa'),
+  customBlue: hexColorFromDesignToken(colorChartsBlue1500 || '#08aad2'),
 };

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -87,6 +87,10 @@
     "note": "placeholder",
     "text": "Choose a color"
   },
+  "2ZWQG0": {
+    "note": "color picker preview",
+    "text": "colorPreview"
+  },
   "31K3U4": {
     "note": "add new rule Button Text",
     "text": "Add New Rule"
@@ -162,6 +166,10 @@
   "7OIPQG": {
     "note": "Section title",
     "text": "Properties"
+  },
+  "7Qrkle": {
+    "note": "Scene Icon types in a dropdown menu",
+    "text": "Custom style"
   },
   "7TxQn1": {
     "note": "50mm lens",
@@ -290,6 +298,10 @@
   "FeC0Eo": {
     "note": "rule Id label",
     "text": "Rule Id"
+  },
+  "FvIdJC": {
+    "note": "chrome picker",
+    "text": "chromePicker"
   },
   "Fy5tAf": {
     "note": "Sub-Section Header",
@@ -427,6 +439,10 @@
     "note": "Label clarifying the exact text a user is searching for.",
     "text": "Use: {value}"
   },
+  "PLTmIg": {
+    "note": "circle picker",
+    "text": "circlePicker"
+  },
   "PQ0+rL": {
     "note": "Expandable section title",
     "text": "Transform"
@@ -542,6 +558,10 @@
   "WgHblZ": {
     "note": "Menu Item label",
     "text": "Add entity binding"
+  },
+  "X0B/sj": {
+    "note": "Colors",
+    "text": "Colors"
   },
   "X4zSHQ": {
     "note": "Form Field label",
@@ -990,6 +1010,10 @@
   "yXdV0F": {
     "note": "ExpandableInfoSection Title",
     "text": "3rd Party Resources"
+  },
+  "yhy2xw": {
+    "note": "color picker label",
+    "text": "Hex code"
   },
   "ylDLGq": {
     "note": "FormField label",


### PR DESCRIPTION
## Overview
* Added fac flag to toggle the feature.
* Addec color picker component to show basic colors and advanced colors using react-color.
* Added a hook that fills the color and return an img 
* Added logic reflect the chosen color on the 3D object.
* Added all unit test cases.
## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
