### PR TITLE
fix(scene-composer): update raycaster in OrbitControls

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/controls/OrbitControls.tsx
+++ b/packages/scene-composer/src/components/three-fiber/controls/OrbitControls.tsx
@@ -36,6 +36,17 @@ export const OrbitControls = forwardRef<OrbitControlsImpl, OrbitControlsProps>(
     const explDomElement = domElement || (typeof events.connected !== 'boolean' ? events.connected : gl.domElement);
     const controls = useMemo(() => new OrbitControlsImpl(explCamera), [explCamera]);
 
+    const raycaster = useThree(({ raycaster }) => raycaster);
+    raycaster.filter = (items: THREE.Intersection[]): THREE.Intersection[] => {
+      return items.filter((item: THREE.Intersection) => {
+        return !!item.face || !!item.faceIndex;
+      });
+    };
+
+    const toggleRaycaster = (enabled: boolean) => (event) => {
+      raycaster.enabled = enabled;
+    };
+
     useFrame(() => {
       if (controls.enabled) controls.update();
     });
@@ -47,13 +58,19 @@ export const OrbitControls = forwardRef<OrbitControlsImpl, OrbitControlsProps>(
         if (onChange) onChange(e);
       };
 
-      controls.connect(explDomElement!);
+      // Disable raycaster on wheel, enable on pointerdown
+      explDomElement.addEventListener('wheel', toggleRaycaster(false));
+      explDomElement.addEventListener('pointerdown', toggleRaycaster(true));
+
+      controls.connect(explDomElement || gl.domElement);
       controls.addEventListener('change', callback);
 
       if (onStart) controls.addEventListener('start', onStart);
       if (onEnd) controls.addEventListener('end', onEnd);
 
       return () => {
+        explDomElement.removeEventListener('wheel', toggleRaycaster(false));
+        explDomElement.removeEventListener('pointerdown', toggleRaycaster(true));
         controls.removeEventListener('change', callback);
         if (onStart) controls.removeEventListener('start', onStart);
         if (onEnd) controls.removeEventListener('end', onEnd);


### PR DESCRIPTION
## Overview
A customer brought a 3D model with complex geometry that caused a lot of lag when interacted with in the Scene Composer. The root cause is the raycaster intersection is taking too long.

Updated the Scene Composer's raycaster to ignore nullish faces when calculating intersections. The raycaster is also disabled on scroll since no other mouse interaction that would require the raycaster is necessary on scroll. It is re-enabled on mouse click/pointerdown.

## Verifying Changes

Added 3D models to a real TwinMaker scene that I loaded into storybook. The small but complex model with issues can be interacted with at 120 FPS with this change.

Also tested many other small, large, simple, and complex glTFs/glbs in the scene composer. There is a considerable difference with this change. This also improves the performance of large 3D Tiles models in a scene.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
