### PR TITLE
feat(composer): integrate scene viewer with TimeSync viewport

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
       - dependency-name: 'three'
       - dependency-name: 'three-mesh-bvh'
       - dependency-name: 'three-stdlib'
+      - dependency-name: '@awsui'
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/examples/react-app/src/components/SceneViewer.tsx
+++ b/examples/react-app/src/components/SceneViewer.tsx
@@ -1,9 +1,8 @@
-import { FC, useCallback } from 'react';
+import { FC } from 'react';
 
 import { SceneViewer as SceneViewerComp } from '@iot-app-kit/scene-composer';
 import { dataSource } from '../dataSource';
-import { sceneId, componentTypeQueries, viewport, entityQueries, dataBindingTemplate } from '../configs';
-import './SceneViewer.scss';
+import { sceneId, componentTypeQueries, entityQueries, dataBindingTemplate } from '../configs';
 
 const sceneLoader = dataSource.s3SceneLoader(sceneId);
 
@@ -32,7 +31,6 @@ const SceneViewer: FC<SceneViewerProps> = ({ onSelectionChanged, onWidgetClick }
         onSelectionChanged={onSelectionChanged}
         onWidgetClick={onWidgetClick}
         queries={queries}
-        viewport={viewport}
         dataBindingTemplate={dataBindingTemplate}
         sceneComposerId={sceneId}
       />

--- a/examples/react-app/src/configs.ts
+++ b/examples/react-app/src/configs.ts
@@ -12,10 +12,6 @@ export const workspaceId = 'CookieFactory';
 
 // SceneViewer
 export const sceneId = 'CookieFactory';
-export const viewport: Viewport = {
-  start: new Date('<your-start-time>'), // the start time to query data from your workspace
-  end: new Date('<your-end-time>'), // the end time to query data from your workspace
-};
 export const componentTypeQueries: TwinMakerQuery[] = [
   {
     componentTypeId: 'com.example.cookiefactory.alarm',

--- a/examples/react-app/src/pages/Home/index.tsx
+++ b/examples/react-app/src/pages/Home/index.tsx
@@ -1,16 +1,15 @@
 import React, { useCallback, useState } from 'react';
 
-import { sceneId, componentTypeQueries, viewport, entityQueries, dataBindingTemplate } from '../../configs';
+import { sceneId } from '../../configs';
 import { AppLayout } from '../../layouts/AppLayout';
 import SceneViewer from '../../components/SceneViewer';
 import VideoPlayer from '../../components/VideoPlayer';
 import DashboardManager from '../../components/DashboardManager';
-import ViewportControls from '../../components/ViewPort/Controls';
 import KnowledgeGraph from '../../components/KnowledgeGraph';
 
 import { Container, Header, SpaceBetween } from '@cloudscape-design/components';
 
-import { TimeSync, NodeData, EdgeData, IQueryData } from '@iot-app-kit/react-components';
+import { TimeSync, NodeData, EdgeData, IQueryData, TimeSelection } from '@iot-app-kit/react-components';
 import { KnownComponentType, StyleTarget, useSceneComposerApi } from '@iot-app-kit/scene-composer';
 
 const greenStyle = {
@@ -163,7 +162,7 @@ const ScenePage = () => {
         <DashboardManager>
           <SpaceBetween size={'s'}>
             <Container>
-              <ViewportControls />
+              <TimeSelection />
             </Container>
             <Container header={<Header>Scene</Header>}>
               <SceneViewer onSelectionChanged={onSelectionChanged} onWidgetClick={onWidgetClick} />

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@awsui/collection-hooks": "^1.0.51",
     "@awsui/components-react": "^3.0.0",
-    "@awsui/design-tokens": "^3.0.44",
+    "@awsui/design-tokens": "^3.0.41",
     "@iot-app-kit/core": "6.3.1",
     "@iot-app-kit/related-table": "6.3.1",
     "@stencil/core": "^2.7.0",

--- a/packages/related-table/package.json
+++ b/packages/related-table/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@awsui/collection-hooks": "^1.0.51",
     "@awsui/components-react": "^3.0.0",
-    "@awsui/design-tokens": "^3.0.44",
+    "@awsui/design-tokens": "^3.0.41",
     "@iot-app-kit/jest-config": "6.3.1",
     "@iot-app-kit/ts-config": "6.3.1",
     "@storybook/addon-essentials": "^6.5.16",

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -131,10 +131,11 @@
   "dependencies": {
     "@awsui/collection-hooks": "^1.0.51",
     "@awsui/components-react": "^3.0.0",
-    "@awsui/design-tokens": "^3.0.44",
+    "@awsui/design-tokens": "^3.0.41",
     "@awsui/global-styles": "^1.0.12",
     "@formatjs/ts-transformer": "3.13.3",
     "@iot-app-kit/core": "6.3.1",
+    "@iot-app-kit/react-components": "6.3.1",
     "@iot-app-kit/related-table": "6.3.1",
     "@iot-app-kit/source-iottwinmaker": "6.3.1",
     "@matterport/r3f": "^0.2.6",

--- a/packages/scene-composer/src/components/SceneComposerInternal.tsx
+++ b/packages/scene-composer/src/components/SceneComposerInternal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { applyMode, Mode } from '@awsui/global-styles';
 import { cloneDeep } from 'lodash';
+import { useViewport } from '@iot-app-kit/react-components';
 
 import { SCENE_BODY_CLASS } from '../common/constants';
 import { sceneComposerIdContext } from '../common/sceneComposerIdContext';
@@ -28,6 +29,7 @@ export const SceneComposerInternal: React.FC<SceneComposerInternalProps> = ({
   ...props
 }: SceneComposerInternalProps) => {
   const currentSceneComposerId = useMemo(() => sceneComposerId ?? generateUUID(), [sceneComposerId]);
+  const { viewport } = useViewport();
 
   const ErrorFallback = ErrorView || DefaultErrorFallback;
 
@@ -51,7 +53,7 @@ export const SceneComposerInternal: React.FC<SceneComposerInternalProps> = ({
       <LogProvider namespace='SceneComposerInternal' logger={config.logger} ErrorView={ErrorFallback} onError={onError}>
         <IntlProvider locale={config.locale}>
           <sceneComposerIdContext.Provider value={currentSceneComposerId}>
-            <StateManager config={config} {...props} />
+            <StateManager config={config} {...props} viewport={props.viewport || viewport} />
           </sceneComposerIdContext.Provider>
         </IntlProvider>
       </LogProvider>

--- a/packages/scene-composer/stories/components/scene-composer.tsx
+++ b/packages/scene-composer/stories/components/scene-composer.tsx
@@ -3,6 +3,7 @@ import { Mode, Density } from '@awsui/global-styles';
 import styled from 'styled-components';
 import { CredentialProvider, Credentials } from '@aws-sdk/types';
 import { Viewport } from '@iot-app-kit/core';
+import { TimeSync, TimeSelection } from '@iot-app-kit/react-components';
 
 import {
   COMPOSER_FEATURES,
@@ -126,22 +127,24 @@ const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
 
   if (loader) {
     return (
-      <ThemeManager theme={theme} density={density}>
-        <SceneComposerContainer data-testid='webgl-root' className='sceneViewer'>
-          <SceneComposerInternal
-            sceneLoader={loader}
-            sceneMetadataModule={sceneMetadataModule}
-            config={config}
-            externalLibraryConfig={externalLibraryConfig}
-            viewport={viewport}
-            queries={queries}
-            valueDataBindingProviders={bindingProvider}
-            onSceneUpdated={handleSceneUpdated}
-            dataStreams={convertDataInputToDataStreams(getTestDataInputContinuous())}
-            {...props}
-          />
-        </SceneComposerContainer>
-      </ThemeManager>
+      <TimeSync group='scene-composer' initialViewport={viewport}>
+        <ThemeManager theme={theme} density={density}>
+          <SceneComposerContainer data-testid='webgl-root' className='sceneViewer'>
+            <TimeSelection />
+            <SceneComposerInternal
+              sceneLoader={loader}
+              sceneMetadataModule={sceneMetadataModule}
+              config={config}
+              externalLibraryConfig={externalLibraryConfig}
+              queries={queries}
+              valueDataBindingProviders={bindingProvider}
+              onSceneUpdated={handleSceneUpdated}
+              dataStreams={convertDataInputToDataStreams(getTestDataInputContinuous())}
+              {...props}
+            />
+          </SceneComposerContainer>
+        </ThemeManager>
+      </TimeSync>
     );
   }
 

--- a/packages/scene-composer/tests/setup-jest.ts
+++ b/packages/scene-composer/tests/setup-jest.ts
@@ -1,5 +1,7 @@
 import 'jest-styled-components';
 
 window.URL.createObjectURL = jest.fn();
+// Cannot find module 'react-cytoscapejs' error will be thrown without this mock
+jest.mock('@iot-app-kit/react-components', () => ({ useViewport: jest.fn().mockReturnValue({ viewport: undefined }) }));
 
 export {};


### PR DESCRIPTION
## Overview
Integrate scene viewer with TimeSync viewport so that consumers can use TimeSync and TimeSelection to control the viewport used by SceneViewer, instead of passing viewport into SceneViewer.

Also downgraded @awsui/design-tokens to fix dark mode.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
