### PR TITLE
feat(TM-source): flag static property data binding

### DIFF
--- a/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
+++ b/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
@@ -48,7 +48,7 @@ describe('serializationHelpers', () => {
     const component = {
       icon: 'testIcon',
       ruleBasedMapId: 42,
-      valueDataBinding: { dataBindingContext: 'dataBindingContext' },
+      valueDataBinding: { dataBindingContext: 'dataBindingContext', random: 'abc' },
       navLink: 'https://test-nav.link',
     };
     const resolver = jest.fn();

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -127,11 +127,6 @@ function createTagComponent(
 
   validateRuleBasedMapId(ruleBasedMapId, resolver, errorCollector);
 
-  let dataBindingContext: any;
-  if (valueDataBinding) {
-    dataBindingContext = valueDataBinding.dataBindingContext;
-  }
-
   return {
     ref: generateUUID(),
     type: 'Tag',
@@ -139,7 +134,7 @@ function createTagComponent(
     chosenColor: component.chosenColor,
     ruleBasedMapId,
     valueDataBinding: {
-      dataBindingContext,
+      ...(valueDataBinding || {}),
     },
     navLink: component.navLink,
     offset: component.offset,

--- a/packages/source-iottwinmaker/src/data-binding-provider/EntityPropertyBindingProviderStore.spec.ts
+++ b/packages/source-iottwinmaker/src/data-binding-provider/EntityPropertyBindingProviderStore.spec.ts
@@ -51,7 +51,10 @@ describe('EntityPropertyBindingProviderStore', () => {
     components: {
       'component-3': {
         componentTypeId: 'mock-componentTypeId',
-        properties: { alarm_key: { value: { stringValue: 'mock-alarm-key' } } },
+        properties: {
+          alarm_key: { value: { stringValue: 'mock-alarm-key' } },
+          alarm_id: { definition: { isTimeSeries: false }, value: { stringValue: 'mock-alarm-id' } },
+        },
       },
     },
   };
@@ -218,17 +221,40 @@ describe('EntityPropertyBindingProviderStore', () => {
     expect(mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0].selectedOptions[2].value).toBe('alarm_key');
   });
 
-  it('should create a correct data binding object when createBinding is called', async () => {
+  it('should create a correct data binding object when createBinding is called with timeseries property', async () => {
     providerStore.setBinding('a', mockDataBindingInput);
 
     await flushPromises();
 
     const result = await providerStore.createBinding();
 
-    expect(result?.dataBindingContext).toStrictEqual({
-      entityId: 'entity-option-1',
-      componentName: 'component-3',
-      propertyName: 'alarm_key',
+    expect(result).toStrictEqual({
+      isStaticData: false,
+      dataBindingContext: {
+        entityId: 'entity-option-1',
+        componentName: 'component-3',
+        propertyName: 'alarm_key',
+      },
+    });
+  });
+
+  it('should create a correct data binding object when createBinding is called with non timeseries property', async () => {
+    providerStore.setBinding('a', {
+      ...mockDataBindingInput,
+      dataBindingContext: { ...mockDataBindingInput.dataBindingContext, propertyName: 'alarm_id' },
+    });
+
+    await flushPromises();
+
+    const result = await providerStore.createBinding();
+
+    expect(result).toStrictEqual({
+      isStaticData: true,
+      dataBindingContext: {
+        entityId: 'entity-option-1',
+        componentName: 'component-3',
+        propertyName: 'alarm_id',
+      },
     });
   });
 

--- a/packages/source-iottwinmaker/src/data-binding-provider/EntityPropertyBindingProviderStore.ts
+++ b/packages/source-iottwinmaker/src/data-binding-provider/EntityPropertyBindingProviderStore.ts
@@ -220,9 +220,15 @@ export class EntityPropertyBindingProviderStore implements IValueDataBindingStor
       if (componentName) (dataBindingContext as ITwinMakerEntityDataBindingContext).componentName = componentName;
       if (propertyName) (dataBindingContext as ITwinMakerEntityDataBindingContext).propertyName = propertyName;
 
-      const dataBinding = {
+      const dataBinding: IValueDataBinding = {
         dataBindingContext,
       };
+
+      if (componentName && propertyName && this.selectedEntity) {
+        // Value of undefined will not be considered as isStaticData = true
+        dataBinding.isStaticData =
+          this.selectedEntity.components?.[componentName].properties?.[propertyName].definition?.isTimeSeries === false;
+      }
 
       this.dataBinding = dataBinding;
 

--- a/packages/source-iottwinmaker/src/data-binding-provider/createEntityPropertyBindingProvider.ts
+++ b/packages/source-iottwinmaker/src/data-binding-provider/createEntityPropertyBindingProvider.ts
@@ -28,6 +28,11 @@ export const createEntityPropertyBindingProvider = ({
         return undefined;
       }
 
+      if (dataBinding.isStaticData) {
+        // TODO: return property value query
+        return undefined;
+      }
+
       return timeSeriesDataQuery({
         entityId: context.entityId,
         componentName: context.componentName,

--- a/packages/source-iottwinmaker/src/data-binding-provider/types.ts
+++ b/packages/source-iottwinmaker/src/data-binding-provider/types.ts
@@ -13,6 +13,7 @@ export interface ITwinMakerEntityBinding {
 export type ITwinMakerDataBindingContext = ITwinMakerEntityDataBindingContext | ITwinMakerEntityBinding;
 export interface IValueDataBinding {
   dataBindingContext?: ITwinMakerDataBindingContext;
+  isStaticData?: boolean;
 }
 
 export type errorType = 'invalidEntityId';


### PR DESCRIPTION
## Overview
Add the isStaticData flag to data binding to help determine which UDQ API should be called when fetching data for the binding

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
