### PR TITLE
feat(composer): add hook to convert data bindings to queries

### DIFF
--- a/packages/scene-composer/src/hooks/useBindingQueries.spec.ts
+++ b/packages/scene-composer/src/hooks/useBindingQueries.spec.ts
@@ -1,0 +1,42 @@
+import { renderHook } from '@testing-library/react';
+
+import { useStore } from '../store';
+
+import useBindingQueries from './useBindingQueries';
+
+describe('useBindingQueries', () => {
+  const mockProvider = {
+    createQuery: jest.fn(),
+  };
+
+  beforeEach(() => {
+    useStore('default').setState({
+      getEditorConfig: jest.fn().mockReturnValue({ valueDataBindingProvider: mockProvider }),
+    });
+  });
+
+  it('should return undefined when bindings are empty', () => {
+    const queries = renderHook(() => useBindingQueries([])).result.current.queries;
+
+    expect(queries).toBeUndefined();
+  });
+
+  it('should return queries for each binding in the matching order', () => {
+    const expectedQueries = [{ entityId: 'AA' }, undefined, { entityId: 'BB' }];
+    const bindings = [
+      { dataBindingContext: { entityId: 'AA' } },
+      { dataBindingContext: { entityId: 'CC' } },
+      { dataBindingContext: { entityId: 'BB' } },
+    ];
+    mockProvider.createQuery.mockImplementation((binding) => {
+      const id = binding.dataBindingContext.entityId;
+      if (id === 'AA' || id === 'BB') {
+        return { entityId: id };
+      }
+      return undefined;
+    });
+    const queries = renderHook(() => useBindingQueries(bindings)).result.current.queries;
+
+    expect(queries).toEqual(expectedQueries);
+  });
+});

--- a/packages/scene-composer/src/hooks/useBindingQueries.ts
+++ b/packages/scene-composer/src/hooks/useBindingQueries.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import { Query, TimeSeriesData } from '@iot-app-kit/core';
+import { isEmpty } from 'lodash';
+
+import { useSceneComposerId } from '../common/sceneComposerIdContext';
+import { IValueDataBinding } from '../interfaces';
+import { useStore } from '../store';
+
+/**
+ * Create query objects for data bindings.
+ *
+ * @param bindings the data bindings to create query object
+ * @returns `queries` as an array of query objects for each data binding in the same order.
+ *          If the query object cannot be created for any of the bindings,
+ *          undefined will be returned in the result array at the same index.
+ */
+const useBindingQueries = (
+  bindings: IValueDataBinding[],
+): // TODO: add data type for static data when available
+{ queries: (Query<TimeSeriesData[]> | undefined)[] | undefined } => {
+  const sceneComposerId = useSceneComposerId();
+  const valueDataBindingProvider = useStore(sceneComposerId)(
+    (state) => state.getEditorConfig().valueDataBindingProvider,
+  );
+
+  const queries = useMemo(() => {
+    if (isEmpty(bindings) || !valueDataBindingProvider) {
+      return undefined;
+    }
+
+    return bindings.map((binding: IValueDataBinding) => valueDataBindingProvider.createQuery(binding));
+  }, [bindings]);
+
+  return { queries };
+};
+
+export default useBindingQueries;


### PR DESCRIPTION
## Overview
add hook to convert data bindings to queries

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
