### PR TITLE
fix(scene-composer): fix ability to click on tags, revert disable on scroll

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/controls/OrbitControls.tsx
+++ b/packages/scene-composer/src/components/three-fiber/controls/OrbitControls.tsx
@@ -38,12 +38,8 @@ export const OrbitControls = forwardRef<OrbitControlsImpl, OrbitControlsProps>(
 
     events.filter = (items: THREE.Intersection[]): THREE.Intersection[] => {
       return items.filter((item: THREE.Intersection) => {
-        return !!item.face || !!item.faceIndex;
+        return !!item.face || !!item.faceIndex || item.object.type === 'Sprite';
       });
-    };
-
-    const toggleRaycaster = (enabled: boolean) => (event) => {
-      events.enabled = enabled;
     };
 
     useFrame(() => {
@@ -59,8 +55,6 @@ export const OrbitControls = forwardRef<OrbitControlsImpl, OrbitControlsProps>(
 
       // Disable raycaster on wheel, enable on pointerdown
       const domElement = explDomElement || gl.domElement;
-      domElement.addEventListener('wheel', toggleRaycaster(false));
-      domElement.addEventListener('pointerdown', toggleRaycaster(true));
 
       controls.connect(domElement);
       controls.addEventListener('change', callback);
@@ -69,8 +63,6 @@ export const OrbitControls = forwardRef<OrbitControlsImpl, OrbitControlsProps>(
       if (onEnd) controls.addEventListener('end', onEnd);
 
       return () => {
-        domElement.removeEventListener('wheel', toggleRaycaster(false));
-        domElement.removeEventListener('pointerdown', toggleRaycaster(true));
         controls.removeEventListener('change', callback);
         if (onStart) controls.removeEventListener('start', onStart);
         if (onEnd) controls.removeEventListener('end', onEnd);


### PR DESCRIPTION
Same as #1750 in release-3.x

## Overview
There is a bug where you cannot click on a tag because the raycaster is ignoring intersections for objects with a nullish face. Added logic to accept intersections with `Sprite` objects.

Removed logic to disable raycaster on a wheel/scroll event. This would mean users have to click twice after a scroll to select something in the scene.

## Verifying Changes
Tested with storybook. Added all widgets types to a complex object and was able to click on all of them. Scrolling is a little slow when directly on a complex object, but it is not too bad. Orbiting and panning is still very fast.

https://github.com/awslabs/iot-app-kit/assets/87385528/c9636a8e-8f50-445c-b2b1-26a8db86d482

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
