### PR TITLE
chore: fix release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -55,7 +55,7 @@
     },
     {
       "type": "linked-versions",
-      "group-name": "iot-app-kit",
+      "groupName": "iot-app-kit",
       "components": [
         "root",
         "components",


### PR DESCRIPTION
## Overview
Update `group-name` to `groupName` to fix the `Cannot read properties of undefined (reading 'replace')` error.

The release-please action either has recently changed the field name or has this wrong doc for a while which caused the confusion https://github.com/googleapis/release-please/commit/bdd9b0158ce79d958da01ebf54cb6b07925bc125

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
