### PR TITLE
feat(dashboard): add advanced search using knowledge graph to query editor

### DIFF
--- a/packages/dashboard/src/components/queryEditor/__tests__/advancedSearch.spec.tsx
+++ b/packages/dashboard/src/components/queryEditor/__tests__/advancedSearch.spec.tsx
@@ -1,0 +1,299 @@
+import { QueryEditor } from '../queryEditor';
+import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TwinMakerKGQueryDataModule } from '@iot-app-kit/source-iottwinmaker';
+
+const queryClient = new QueryClient();
+
+const Wrapper = ({ children }: React.PropsWithChildren) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+const mockResults = {
+  columnDescriptions: [
+    {
+      name: 'assetName',
+      type: 'VALUE',
+    },
+    {
+      name: 'propertyId',
+      type: 'VALUE',
+    },
+    {
+      name: 'propertyName',
+      type: 'VALUE',
+    },
+    {
+      name: 'displayName',
+      type: 'VALUE',
+    },
+  ],
+  rows: [
+    {
+      rowData: ['asset1', 'propertyId1', 'property1', 'temperature'],
+    },
+    {
+      rowData: ['Asset2', 'PropertyId2', 'property2', 'speed'],
+    },
+    {
+      rowData: ['Asset3', 'PropertyId3', 'property3'],
+    },
+    {
+      rowData: ['TestAsset', null, 'sitewiseAssetId', null],
+    },
+    {
+      rowData: ['TestAsset', null, 'sitewiseAssetModelId', null],
+    },
+  ],
+};
+
+describe('Advanced Search', () => {
+  afterEach(() => {
+    // don't cache between tests
+    queryClient.clear();
+  });
+
+  it('should display advanced search table when kGDatamodule is provided', async () => {
+    const mockClient = {
+      send: jest.fn().mockResolvedValueOnce([]),
+    } as unknown as IoTSiteWiseClient;
+
+    const mockDataModule = {} as TwinMakerKGQueryDataModule;
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <QueryEditor client={mockClient} kGDatamodule={mockDataModule} />
+      </Wrapper>
+    );
+
+    await waitFor(() => expect(screen.queryByText('Loading assets...')).not.toBeInTheDocument());
+    expect(screen.getByRole('tab', { name: 'Advanced search' })).toBeVisible();
+    await user.click(screen.getByRole('tab', { name: 'Advanced search' }));
+    expect(screen.getByRole('textbox', { name: 'Search Term' })).toBeVisible();
+  });
+
+  it('should display results as displayName when searching for a property', async () => {
+    const mockClient = {
+      send: jest.fn().mockResolvedValueOnce([]),
+    } as unknown as IoTSiteWiseClient;
+
+    const mockDataModule = {
+      executeQuery: jest.fn().mockResolvedValueOnce(mockResults),
+    } as TwinMakerKGQueryDataModule;
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <QueryEditor client={mockClient} kGDatamodule={mockDataModule} />
+      </Wrapper>
+    );
+
+    await waitFor(() => expect(screen.queryByText('Loading assets...')).not.toBeInTheDocument());
+    expect(screen.getByRole('tab', { name: 'Advanced search' })).toBeVisible();
+    await user.click(screen.getByRole('tab', { name: 'Advanced search' }));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => expect(screen.queryByText('No results')).not.toBeInTheDocument());
+    expect(screen.queryByText('temperature')).toBeVisible();
+    expect(screen.queryByText('speed')).toBeVisible();
+  });
+
+  it('should allow selection of multiple results with pagination', async () => {
+    const mockPaginatedResults = {
+      columnDescriptions: [
+        {
+          name: 'assetName',
+          type: 'VALUE',
+        },
+        {
+          name: 'propertyId',
+          type: 'VALUE',
+        },
+        {
+          name: 'propertyName',
+          type: 'VALUE',
+        },
+        {
+          name: 'displayName',
+          type: 'VALUE',
+        },
+      ],
+      rows: [
+        {
+          rowData: ['asset1', 'propertyId1', 'propertyName1', 'temperature1'],
+        },
+        {
+          rowData: ['asset2', 'propertyId2', 'propertyName2', 'temperature2'],
+        },
+        {
+          rowData: ['asset3', 'propertyId3', 'propertyName3', 'temperature3'],
+        },
+        {
+          rowData: ['asset4', 'propertyId4', 'propertyName4', 'temperature4'],
+        },
+        {
+          rowData: ['asset5', 'propertyId5', 'propertyName5', 'temperature15'],
+        },
+        {
+          rowData: ['asset6', 'propertyId6', 'propertyName6', 'temperature16'],
+        },
+        {
+          rowData: ['asset7', 'propertyId7', 'propertyName7', 'temperature17'],
+        },
+        {
+          rowData: ['asset8', 'propertyId8', 'propertyName8', 'temperature18'],
+        },
+        {
+          rowData: ['asset9', 'propertyId9', 'propertyName9', 'temperature19'],
+        },
+        {
+          rowData: ['asset10', 'propertyId10', 'propertyName10', 'temperature110'],
+        },
+        {
+          rowData: ['asset11', 'propertyId11', 'propertyName11', 'temperature11'],
+        },
+        {
+          rowData: ['TestAsset', null, 'sitewiseAssetId', null],
+        },
+        {
+          rowData: ['TestAsset', null, 'sitewiseAssetModelId', null],
+        },
+      ],
+    };
+    const mockClient = {
+      send: jest.fn().mockResolvedValueOnce([]),
+    } as unknown as IoTSiteWiseClient;
+
+    const mockDataModule = {
+      executeQuery: jest.fn().mockResolvedValueOnce(mockPaginatedResults),
+    } as TwinMakerKGQueryDataModule;
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <QueryEditor client={mockClient} kGDatamodule={mockDataModule} />
+      </Wrapper>
+    );
+
+    await waitFor(() => expect(screen.queryByText('Loading assets...')).not.toBeInTheDocument());
+    expect(screen.getByRole('tab', { name: 'Advanced search' })).toBeVisible();
+    await user.click(screen.getByRole('tab', { name: 'Advanced search' }));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => expect(screen.queryByText('No results')).not.toBeInTheDocument());
+    await user.click(screen.getByRole('checkbox', { name: 'Select property temperature1' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Select property temperature2' }));
+
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Select property temperature11' }));
+  });
+
+  it('should allow changing preferences like enabling propertyName column', async () => {
+    const mockClient = {
+      send: jest.fn().mockResolvedValueOnce([]),
+    } as unknown as IoTSiteWiseClient;
+
+    const mockDataModule = {
+      executeQuery: jest.fn().mockResolvedValueOnce(mockResults),
+    } as TwinMakerKGQueryDataModule;
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <QueryEditor client={mockClient} kGDatamodule={mockDataModule} />
+      </Wrapper>
+    );
+
+    await waitFor(() => expect(screen.queryByText('Loading assets...')).not.toBeInTheDocument());
+    expect(screen.getByRole('tab', { name: 'Advanced search' })).toBeVisible();
+    await user.click(screen.getByRole('tab', { name: 'Advanced search' }));
+    await user.click(screen.getByRole('button', { name: 'Preferences' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Property Name' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => expect(screen.queryByText('No results')).not.toBeInTheDocument());
+
+    expect(screen.queryByText('property1')).toBeVisible();
+    expect(screen.queryByText('property2')).toBeVisible();
+    expect(screen.queryByText('-')).toBeVisible(); // property without DisplayName
+  });
+
+  it('should handle an error if KG resposne cannot be parsed', async () => {
+    // No assetName column should result in an error
+    const mockInvalidResults = {
+      columnDescriptions: [
+        {
+          name: 'propertyId',
+          type: 'VALUE',
+        },
+        {
+          name: 'propertyName',
+          type: 'VALUE',
+        },
+        {
+          name: 'displayName',
+          type: 'VALUE',
+        },
+      ],
+      rows: [
+        {
+          rowData: ['asset1', 'propertyId1', 'property1', 'temperature'],
+        },
+        {
+          rowData: ['Asset2', 'PropertyId2', 'property2', 'speed'],
+        },
+        {
+          rowData: ['Asset3', 'PropertyId3', 'property3'],
+        },
+        {
+          rowData: ['TestAsset', null, 'sitewiseAssetId', null],
+        },
+        {
+          rowData: ['TestAsset', null, 'sitewiseAssetModelId', null],
+        },
+      ],
+    };
+    const mockClient = {
+      send: jest.fn().mockResolvedValueOnce([]),
+    } as unknown as IoTSiteWiseClient;
+
+    const mockDataModule = {
+      executeQuery: jest.fn().mockResolvedValueOnce(mockInvalidResults),
+    } as TwinMakerKGQueryDataModule;
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <QueryEditor client={mockClient} kGDatamodule={mockDataModule} />
+      </Wrapper>
+    );
+
+    await waitFor(() => expect(screen.queryByText('Loading assets...')).not.toBeInTheDocument());
+    expect(screen.getByRole('tab', { name: 'Advanced search' })).toBeVisible();
+    await user.click(screen.getByRole('tab', { name: 'Advanced search' }));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => expect(screen.queryByText('No results')).toBeVisible());
+  });
+});

--- a/packages/dashboard/src/components/queryEditor/advancedSearch/advancedResultsTable/advancedResultsTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/advancedSearch/advancedResultsTable/advancedResultsTable.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+import Pagination from '@cloudscape-design/components/pagination';
+import Header from '@cloudscape-design/components/header';
+import { Property } from '../model/property';
+import { useCollection } from '@cloudscape-design/collection-hooks';
+import { CollectionPreferences, CollectionPreferencesProps } from '@cloudscape-design/components';
+import { columnDefinitions, collectionPreferencesProps, paginationLabels } from './tableConfig';
+
+interface AdvancedResultsTableProps {
+  data: Property[];
+  onSelect: (properties: Property[]) => void;
+}
+
+export function AdvancedResultsTable({ data, onSelect }: AdvancedResultsTableProps) {
+  const [preferences, setPreferences] = useState<CollectionPreferencesProps.Preferences>({
+    pageSize: 10,
+    visibleContent: ['displayName', 'assetName'],
+  });
+  const [selectedProperties, setSelectedProperties] = useState<Property[]>([]);
+
+  const { items, collectionProps, paginationProps } = useCollection(data, {
+    pagination: { pageSize: preferences.pageSize },
+    sorting: {},
+    selection: {
+      keepSelection: true,
+    },
+  });
+
+  return (
+    <Table
+      {...collectionProps}
+      onSelectionChange={({ detail }) => {
+        setSelectedProperties(detail.selectedItems);
+        onSelect(detail.selectedItems);
+      }}
+      ariaLabels={{
+        itemSelectionLabel: (isNotSelected, property) =>
+          isNotSelected ? `Select property ${property.displayName}` : `Deselect property ${property.displayName}`,
+      }}
+      header={<Header counter={data.length ? '(' + data.length + ')' : '(0)'}>Results</Header>}
+      pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
+      variant='embedded'
+      sortingDisabled
+      columnDefinitions={columnDefinitions}
+      visibleColumns={preferences.visibleContent}
+      selectedItems={selectedProperties}
+      items={items}
+      loadingText='Loading results'
+      selectionType='multi'
+      trackBy='propertyId'
+      preferences={
+        <CollectionPreferences
+          {...collectionPreferencesProps}
+          preferences={preferences}
+          onConfirm={({ detail }) => setPreferences(detail)}
+        />
+      }
+      empty={
+        <Box textAlign='center' color='inherit'>
+          <b>No results</b>
+          <Box padding={{ bottom: 's' }} variant='p' color='inherit'>
+            No results to display.
+          </Box>
+        </Box>
+      }
+    />
+  );
+}

--- a/packages/dashboard/src/components/queryEditor/advancedSearch/advancedResultsTable/index.ts
+++ b/packages/dashboard/src/components/queryEditor/advancedSearch/advancedResultsTable/index.ts
@@ -1,0 +1,1 @@
+export { AdvancedResultsTable } from './advancedResultsTable';

--- a/packages/dashboard/src/components/queryEditor/advancedSearch/advancedResultsTable/tableConfig.ts
+++ b/packages/dashboard/src/components/queryEditor/advancedSearch/advancedResultsTable/tableConfig.ts
@@ -1,0 +1,65 @@
+import { Property } from '../model/property';
+
+export const columnDefinitions = [
+  {
+    id: 'displayName',
+    header: 'Display name',
+    cell: (e: Property) => e.displayName,
+    ariaLabel: () => 'Display name',
+    sortingField: 'displayName',
+    isRowHeader: true,
+  },
+  {
+    id: 'propertyName',
+    header: 'Property name',
+    cell: (e: Property) => e.propertyName,
+    ariaLabel: () => 'Property name',
+    sortingField: 'propertyName',
+  },
+  {
+    id: 'assetName',
+    header: 'Asset name',
+    cell: (e: Property) => e.assetName,
+    ariaLabel: () => 'Asset name',
+    sortingField: 'assetName',
+  },
+];
+
+const pageSizePreference = {
+  title: 'Select page size',
+  options: [
+    { value: 10, label: '10 resources' },
+    { value: 20, label: '20 resources' },
+    { value: 30, label: '30 resources' },
+    { value: 50, label: '50 resources' },
+    { value: 100, label: '100 resources' },
+  ],
+};
+
+const visibleContentPreference = {
+  title: 'Select visible content',
+  options: [
+    {
+      label: 'Property fields',
+      options: [
+        { id: 'displayName', label: 'Display Name' },
+        { id: 'propertyName', label: 'Property Name' },
+        { id: 'assetName', label: 'Asset Name' },
+      ],
+    },
+  ],
+};
+
+export const paginationLabels = {
+  nextPageLabel: 'Next page',
+  pageLabel: (pageNumber: number) => `Go to page ${pageNumber}`,
+  previousPageLabel: 'Previous page',
+};
+
+export const collectionPreferencesProps = {
+  pageSizePreference,
+  visibleContentPreference,
+  cancelLabel: 'Cancel',
+  confirmLabel: 'Confirm',
+  title: 'Preferences',
+};

--- a/packages/dashboard/src/components/queryEditor/advancedSearch/advancedSearch.tsx
+++ b/packages/dashboard/src/components/queryEditor/advancedSearch/advancedSearch.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Button from '@cloudscape-design/components/button';
+import FormField from '@cloudscape-design/components/form-field';
+import Input from '@cloudscape-design/components/input';
+import { useState, useMemo, useCallback } from 'react';
+import { ExecuteQueryCommandOutput } from '@aws-sdk/client-iottwinmaker';
+import { createKnowledgeGraphQueryClient } from '@iot-app-kit/react-components/src/components/knowledge-graph/KnowledgeGraphQueries';
+import { TwinMakerKGQueryDataModule } from '@iot-app-kit/source-iottwinmaker';
+import { AdvancedResultsTable } from './advancedResultsTable';
+import { Property } from './model/property';
+
+export interface AdvancedSearchProps {
+  kGDatamodule: TwinMakerKGQueryDataModule;
+  onSelect: (properties: Property[]) => void;
+}
+
+/**
+ * When SiteWise sync is turned on with Knowledge Graph
+ * it adds a definition field for the propertyId and displayName
+ * and adds propertyName as a field.
+ */
+function executeQueryToProperty(res: ExecuteQueryCommandOutput) {
+  const properties: Property[] = [];
+
+  const rows = res.rows;
+  const columnDescriptions = res.columnDescriptions;
+
+  let propertyIdIndex, propertyNameIndex, displayNameIndex, assetNameIndex;
+
+  if (rows && columnDescriptions) {
+    // First get the index of each property in the rowData
+    for (let columnNumber = 0; columnNumber < columnDescriptions.length; columnNumber++) {
+      const itemName = columnDescriptions[columnNumber].name;
+      switch (itemName) {
+        case 'propertyId':
+          propertyIdIndex = columnNumber;
+          break;
+        case 'propertyName':
+          propertyNameIndex = columnNumber;
+          break;
+        case 'displayName':
+          displayNameIndex = columnNumber;
+          break;
+        case 'assetName':
+          assetNameIndex = columnNumber;
+          break;
+      }
+    }
+
+    // Construct the properties using the previously determined index
+    if (
+      propertyIdIndex != undefined &&
+      propertyNameIndex != undefined &&
+      displayNameIndex != undefined &&
+      assetNameIndex != undefined
+    ) {
+      for (const row of rows) {
+        const rowData = row.rowData;
+        if (rowData) {
+          // Knowledge Graph returns rows that aren't actual properties
+          // that contain assetId and don't have a propertyName so we don't want to include those
+          if (rowData[propertyIdIndex]) {
+            properties.push({
+              propertyId: rowData[propertyIdIndex] as string,
+              propertyName: rowData[propertyNameIndex] as string,
+              displayName: rowData[displayNameIndex] ? (rowData[displayNameIndex] as string) : '-',
+              assetName: rowData[assetNameIndex] as string,
+            });
+          }
+        }
+      }
+    } else {
+      console.log('Error parsing Knowledge Graph response. Unable to determine field indices.');
+    }
+  }
+
+  return properties;
+}
+
+/** Advanced search for exploring your AWS IoT SiteWise properties. */
+export function AdvancedSearch({ kGDatamodule, onSelect }: AdvancedSearchProps) {
+  const [searchTermInput, setSearchTermInput] = useState('');
+  const [properties, setProperties] = useState<Property[]>([]);
+
+  const kGResponse = (res: ExecuteQueryCommandOutput) => {
+    setProperties(executeQueryToProperty(res));
+  };
+
+  const knowledgeGraphQueryClient = useMemo(() => {
+    return createKnowledgeGraphQueryClient(kGDatamodule, kGResponse);
+  }, [kGDatamodule, kGResponse]);
+
+  const onSearchClicked = useCallback(() => {
+    if (searchTermInput) {
+      knowledgeGraphQueryClient.findPropertiesByEntityOrPropertyNameOrDisplayName(searchTermInput);
+    }
+  }, [knowledgeGraphQueryClient, searchTermInput]);
+
+  return (
+    <SpaceBetween direction='vertical' size='l'>
+      <FormField
+        label='Search Term'
+        description='This will search across all assets and properties and return all properties that have a field containing the search term.'
+      >
+        <Input value={searchTermInput} onChange={({ detail }) => setSearchTermInput(detail.value)} />
+      </FormField>
+      <Button iconName='search' onClick={onSearchClicked}>
+        Search
+      </Button>
+      <AdvancedResultsTable data={properties} onSelect={onSelect}></AdvancedResultsTable>
+    </SpaceBetween>
+  );
+}

--- a/packages/dashboard/src/components/queryEditor/advancedSearch/model/property.ts
+++ b/packages/dashboard/src/components/queryEditor/advancedSearch/model/property.ts
@@ -1,0 +1,6 @@
+export interface Property {
+  propertyId: string;
+  propertyName: string;
+  displayName: string;
+  assetName: string;
+}

--- a/packages/dashboard/src/components/queryEditor/queryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/queryEditor.tsx
@@ -1,13 +1,21 @@
-import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import SpaceBetween from '@cloudscape-design/components/space-between';
+import Tabs from '@cloudscape-design/components/tabs';
+import TextContent from '@cloudscape-design/components/text-content';
+import { TwinMakerKGQueryDataModule } from '@iot-app-kit/source-iottwinmaker';
+import Box from '@cloudscape-design/components/box';
 import React, { useState } from 'react';
 
 import { QueryEditorErrorBoundary } from './queryEditorErrorBoundary';
 import { ResourceExplorer, ResourceExplorerProps } from './resourceExplorer';
 import { StreamExplorer } from './streamExplorer';
+import { AdvancedSearch } from './advancedSearch/advancedSearch';
+import { Property } from './advancedSearch/model/property';
 
 export interface QueryEditorProps {
   client: IoTSiteWiseClient;
+  // Enables Advanced Search if provided
+  kGDatamodule?: TwinMakerKGQueryDataModule;
 }
 
 /**
@@ -15,30 +23,71 @@ export interface QueryEditorProps {
  *
  * @remarks
  *
- * At this highest level, the QueryEditor's responsibility is to manage the state synchronizing the
- * ResourceExplorer and StreamExplorer components.
+ * At this highest level, the Que lorer components.
  */
-export function QueryEditor({ client }: QueryEditorProps) {
+export function QueryEditor({ client, kGDatamodule }: QueryEditorProps) {
   const [selectedAssets, setSelectedAssets] = useState<ResourceExplorerProps['selectedAssets']>([]);
   const [assetId, setAssetId] = useState<string | undefined>(undefined);
+
+  // TODO: Use selectedProperties to add properties to dashboard when "Add" is clicked
+  const [selectedProperties, setSelectedProperties] = useState<Property[]>([]);
+
+  // TODO: Remove once we add the "add" button
+  console.log(selectedProperties);
 
   // these assets will be described and their asset properties listed by the stream explorer
   const selectedAssetIds = selectedAssets
     .filter((asset): asset is typeof asset & { id: string } => asset.id != null)
     .map(({ id }) => id);
 
-  return (
-    <QueryEditorErrorBoundary>
-      <SpaceBetween size='l'>
-        <ResourceExplorer
-          client={client}
-          selectedAssets={selectedAssets}
-          onSelect={setSelectedAssets}
-          assetId={assetId}
-          onChangeAssetId={setAssetId}
-        />
-        <StreamExplorer client={client} assetIds={selectedAssetIds} />
-      </SpaceBetween>
-    </QueryEditorErrorBoundary>
-  );
+  const resourceExplorerTab = {
+    label: 'Browse assets',
+    id: 'first',
+    content: (
+      <Box padding='s'>
+        <SpaceBetween size='m' direction='vertical'>
+          <TextContent>
+            <h3>Browse Assets</h3>
+          </TextContent>
+          <ResourceExplorer
+            client={client}
+            selectedAssets={selectedAssets}
+            onSelect={setSelectedAssets}
+            assetId={assetId}
+            onChangeAssetId={setAssetId}
+          />
+          <StreamExplorer client={client} assetIds={selectedAssetIds} />
+        </SpaceBetween>
+      </Box>
+    ),
+  };
+
+  if (kGDatamodule) {
+    const advancedSearchTab = {
+      label: 'Advanced search',
+      id: 'second',
+      content: (
+        <Box padding='s'>
+          <SpaceBetween size='m' direction='vertical'>
+            <TextContent>
+              <h2>Search</h2>
+            </TextContent>
+            <AdvancedSearch kGDatamodule={kGDatamodule} onSelect={setSelectedProperties} />
+          </SpaceBetween>
+        </Box>
+      ),
+    };
+
+    return (
+      <QueryEditorErrorBoundary>
+        <Tabs tabs={[resourceExplorerTab, advancedSearchTab]} />
+      </QueryEditorErrorBoundary>
+    );
+  } else {
+    return (
+      <QueryEditorErrorBoundary>
+        <Tabs tabs={[resourceExplorerTab]} />
+      </QueryEditorErrorBoundary>
+    );
+  }
 }

--- a/packages/react-components/src/components/knowledge-graph/KnowledgeGraphQueries.ts
+++ b/packages/react-components/src/components/knowledge-graph/KnowledgeGraphQueries.ts
@@ -1,6 +1,7 @@
 import { TwinMakerKGQueryDataModule } from '@iot-app-kit/source-iottwinmaker';
 import { ExecuteQueryCommandOutput } from '@aws-sdk/client-iottwinmaker';
 export interface KnowledgeGraphQueryInterface {
+  findPropertiesByEntityOrPropertyNameOrDisplayName(searchTerm: string): Promise<void>;
   findEntitiesByName(name: string): Promise<void>;
   findRelatedEntities(entityId: string): Promise<void>;
   executeExternalEntityQuery(entityId: string): Promise<void>;
@@ -10,6 +11,11 @@ export const createKnowledgeGraphQueryClient = function (
   updateQueryResults: (result: ExecuteQueryCommandOutput) => void
 ) {
   const knowledgeGraphQuery: KnowledgeGraphQueryInterface = {
+    findPropertiesByEntityOrPropertyNameOrDisplayName: async (searchTerm: string): Promise<void> => {
+      const queryStatement = `SELECT e.entityName as assetName, p.definition.configuration.sitewisePropertyId as propertyId, p.propertyName as propertyName, p.definition.displayName as displayName FROM EntityGraph MATCH (e), e.components AS c, c.properties AS p WHERE p.definition.displayName LIKE '%${searchTerm}%' OR p.propertyName LIKE '%${searchTerm}%' OR e.entityName LIKE '%${searchTerm}%'`;
+      const result = await dataSource.executeQuery({ queryStatement });
+      updateQueryResults(result);
+    },
     findEntitiesByName: async (name: string): Promise<void> => {
       const result = await dataSource.executeQuery({
         queryStatement: `SELECT e FROM EntityGraph MATCH (e) WHERE e.entityName like '%${name}%'`,


### PR DESCRIPTION
## Overview
Adding advanced search mode to the query editor. This change adds two tabs to the resource exploration experience. The first is the existing query editor experience that allows drill-down exploration of assets and multi selection to choose properties. The second tab is the new advanced search which uses TwinMaker's KnowledgeGraph API's for efficiently searching through a large number of assets and properties to aid in selecting a property to add to a dashboard.

Some followups I will do:
* Using i18n strings
* Including assetName in table

## Verifying Changes
`<QueryEditor />` can replace `<ResourceExplorer /> ` in the internal dashboard implementation to view an example in our storybook or use in other components. QueryEditor will require a sitewise client and optionally the TwinMaker data source to work.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
