### PR TITLE
fix(reactExample): fix removed css in Scene Viewer Component

### DIFF
--- a/examples/react-app/src/components/SceneViewer.tsx
+++ b/examples/react-app/src/components/SceneViewer.tsx
@@ -3,6 +3,7 @@ import { FC } from 'react';
 import { SceneViewer as SceneViewerComp } from '@iot-app-kit/scene-composer';
 import { dataSource } from '../dataSource';
 import { sceneId, componentTypeQueries, entityQueries, dataBindingTemplate } from '../configs';
+import './SceneViewer.scss';
 
 const sceneLoader = dataSource.s3SceneLoader(sceneId);
 


### PR DESCRIPTION
## Overview
A css was added to the react example's scene viewer component but it got removed in a merge conflict.

## Verifying Changes
Run react-example and verify that the scene panel displays with full height and isn't squished down.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
