### PR TITLE
fix(composer): fix warning and cached onChange

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
@@ -132,11 +132,16 @@ export function AsyncLoadedAnchorWidget({
     ];
     return iconStrings.map((iconString, index) => {
       if (keys[index] === 'Custom') {
-        THREE.Cache.remove(keys[index]);
         const modifiedSvg = modifySvgColor(iconString, chosenColor);
-        return svgIconToWidgetSprite(modifiedSvg, keys[index], isAlwaysVisible, !autoRescale);
+        return svgIconToWidgetSprite(
+          modifiedSvg,
+          keys[index],
+          chosenColor ? `${keys[index]}-${chosenColor}` : keys[index],
+          isAlwaysVisible,
+          !autoRescale,
+        );
       }
-      return svgIconToWidgetSprite(iconString, keys[index], isAlwaysVisible, !autoRescale);
+      return svgIconToWidgetSprite(iconString, keys[index], keys[index], isAlwaysVisible, !autoRescale);
     });
   }, [autoRescale, chosenColor]);
 

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
@@ -15,7 +15,7 @@ import { ISceneNodeInternal, useStore } from '../../../../../store/Store';
 import { AnchorWidget, AsyncLoadedAnchorWidget } from '../AnchorWidget';
 
 jest.mock('../../common/SvgIconToWidgetSprite', () =>
-  jest.fn((_, name, __, props) => <div data-test-id={name} {...props} />),
+  jest.fn((_, __, key, ___, props) => <div data-test-id={key} {...props} />),
 );
 
 jest.mock('../../../../../hooks/useTagSettings', () => jest.fn());

--- a/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.spec.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.spec.tsx
@@ -1,5 +1,4 @@
 import renderer from 'react-test-renderer';
-import React from 'react';
 
 import { DefaultAnchorStatus, SelectedAnchor } from '../../../..';
 import {
@@ -28,7 +27,7 @@ describe('svgIconToWidgetSprite', () => {
     it(`it should render the ${value[0]} correctly`, () => {
       jest.spyOn(window.Math, 'random').mockReturnValue(0.1);
       const { key, icon } = value[1] as Icons;
-      const container = renderer.create(svgIconToWidgetSprite(icon, key, false, true));
+      const container = renderer.create(svgIconToWidgetSprite(icon, key, key, false, true));
 
       expect(container).toMatchSnapshot();
     });
@@ -38,7 +37,7 @@ describe('svgIconToWidgetSprite', () => {
     it(`it should render the always visible ${value[0]} correctly`, () => {
       jest.spyOn(window.Math, 'random').mockReturnValue(0.1);
       const { key, icon } = value[1] as Icons;
-      const container = renderer.create(svgIconToWidgetSprite(icon, key, true, true));
+      const container = renderer.create(svgIconToWidgetSprite(icon, key, key, true, true));
 
       expect(container).toMatchSnapshot();
     });
@@ -48,7 +47,7 @@ describe('svgIconToWidgetSprite', () => {
     it(`it should render the constant sized ${value[0]} correctly`, () => {
       jest.spyOn(window.Math, 'random').mockReturnValue(0.1);
       const { key, icon } = value[1] as Icons;
-      const container = renderer.create(svgIconToWidgetSprite(icon, key, false, false));
+      const container = renderer.create(svgIconToWidgetSprite(icon, key, key, false, false));
 
       expect(container).toMatchSnapshot();
     });

--- a/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.tsx
@@ -7,7 +7,8 @@ import { RenderOrder } from '../../../../common/constants';
 
 export default function svgIconToWidgetSprite(
   svg: string,
-  key: DefaultAnchorStatus | string,
+  name: DefaultAnchorStatus | string,
+  key: string,
   alwaysVisible,
   sizeAttenuation: boolean, // when true, tag size changes when zooming
   props?: WidgetSpriteProps,
@@ -27,7 +28,7 @@ export default function svgIconToWidgetSprite(
   const texture = THREE.Cache.get(key);
 
   return (
-    <widgetSprite key={key} name={key} {...props}>
+    <widgetSprite key={key} name={name} {...props}>
       <group attach='visual'>
         <sprite renderOrder={RenderOrder.DrawLate}>
           <spriteMaterial

--- a/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.tsx
@@ -131,7 +131,7 @@ export const AnchorComponentEditor: React.FC<IAnchorComponentEditorProps> = ({
           value: sceneIcon,
         };
       });
-  }, []);
+  }, [tagStyle]);
 
   const iconSelectedOptionIndex = useMemo(() => {
     if (!anchorComponent.icon) {

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
@@ -122,7 +122,7 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
         });
       }
     },
-    [valueDataBindingStore, allowPartialBinding],
+    [valueDataBindingStore, allowPartialBinding, onChange],
   );
 
   const onSelectChange = useCallback(
@@ -141,7 +141,7 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
         });
       }
     },
-    [valueDataBindingStore, allowPartialBinding],
+    [valueDataBindingStore, allowPartialBinding, onChange],
   );
 
   return (

--- a/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
@@ -23,6 +23,7 @@ export const defaultArgs = {
     COMPOSER_FEATURES.DataBinding,
     COMPOSER_FEATURES.TagResize,
     COMPOSER_FEATURES.Matterport,
+    COMPOSER_FEATURES.TagStyle,
   ]
 }
 


### PR DESCRIPTION
## Overview
Add missing dependency to ValueDataBindingBuilder so it won't revert changes unexpectedly.
Fix warning caused by THREE.Cache.remove().

Tag custom style after change is still working

https://github.com/awslabs/iot-app-kit/assets/9315598/1a0974c3-3ec6-43fb-977a-f34e2c62d713



## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
