### PR TITLE
feat(react-component): adding context menu per chart

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -99,6 +99,7 @@
     "@iot-app-kit/core-util": "7.1.0",
     "@iot-app-kit/source-iottwinmaker": "7.1.0",
     "color": "^4.2.3",
+    "copy-to-clipboard": "^3.3.3",
     "d3-array": "^3.2.3",
     "d3-format": "^3.1.0",
     "d3-shape": "^3.2.0",

--- a/packages/react-components/src/components/chart/contextMenu/ChartContextMenu.spec.tsx
+++ b/packages/react-components/src/components/chart/contextMenu/ChartContextMenu.spec.tsx
@@ -1,0 +1,20 @@
+import { describe, expect } from '@jest/globals';
+import { render } from '@testing-library/react';
+import React from 'react';
+import ChartContextMenu from './ChartContextMenu';
+
+describe('ChartContextMenu', () => {
+  const menuOptionClickHandler = jest.fn();
+  const onOutSideClickHandler = jest.fn();
+  const component = render(
+    <ChartContextMenu
+      menuOptionClickHandler={menuOptionClickHandler}
+      onOutSideClickHandler={onOutSideClickHandler}
+      position={{ x: 100, y: 100 }}
+      trendCursors={[]}
+    />
+  );
+  it('renders', () => {
+    expect(component).not.toBeNull();
+  });
+});

--- a/packages/react-components/src/components/chart/contextMenu/ChartContextMenu.tsx
+++ b/packages/react-components/src/components/chart/contextMenu/ChartContextMenu.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Menu, MenuOption } from '../../menu';
+import { InternalGraphicComponentGroupOption } from '../types';
+import { MAX_TREND_CURSORS } from '../eChartsConstants';
+
+export type Action = 'add' | 'delete' | 'copy';
+interface ChartContextMenu {
+  position: { x: number; y: number };
+  menuOptionClickHandler: ({ action, e }: { action: Action; e: React.MouseEvent }) => void;
+  onOutSideClickHandler: (e: PointerEvent) => void;
+  trendCursors: InternalGraphicComponentGroupOption[];
+}
+const ChartContextMenu = ({
+  position,
+  menuOptionClickHandler,
+  onOutSideClickHandler,
+  trendCursors,
+}: ChartContextMenu) => {
+  return (
+    <Menu
+      styles={{ position: 'absolute', top: `${position.y}px`, left: `${position.x}px` }}
+      onClickOutside={onOutSideClickHandler}
+    >
+      <MenuOption
+        label='Add trend cursor'
+        onClick={(e) => menuOptionClickHandler({ action: 'add', e })}
+        disabled={trendCursors.length >= MAX_TREND_CURSORS}
+      />
+      <MenuOption
+        label='Copy to clipboard'
+        onClick={(e) => menuOptionClickHandler({ action: 'copy', e })}
+        disabled={trendCursors.length === 0}
+      />
+      <MenuOption
+        label='Delete trend cursor'
+        onClick={(e) => menuOptionClickHandler({ action: 'delete', e })}
+        disabled={trendCursors.length === 0}
+      />
+    </Menu>
+  );
+};
+
+export default ChartContextMenu;

--- a/packages/react-components/src/components/chart/hooks/useTrendCursors.ts
+++ b/packages/react-components/src/components/chart/hooks/useTrendCursors.ts
@@ -16,6 +16,7 @@ const useTrendCursors = ({
   chartId,
   viewport,
   groupId,
+  onContextMenu,
 }: UseTrendCursorsProps) => {
   // for debugging purposes
   console.log(`useTrendCursors for chart id : ${chartId}`);
@@ -23,7 +24,7 @@ const useTrendCursors = ({
   const isInSyncMode = useDataStore((state) => (groupId ? !!state.trendCursorGroups[groupId] : false));
 
   // hook for handling all user events
-  useTrendCursorsEvents({
+  const { onContextMenuClickHandler } = useTrendCursorsEvents({
     ref,
     graphic,
     size,
@@ -35,6 +36,7 @@ const useTrendCursors = ({
     yMax,
     isInSyncMode,
     groupId,
+    onContextMenu,
   });
 
   // for handling the resize of chart
@@ -42,6 +44,8 @@ const useTrendCursors = ({
 
   // handling the trend cursor sync mode
   handleSync({ ref, isInSyncMode, graphic, setGraphic, viewport, series, yMin, yMax, size, groupId });
+
+  return { onContextMenuClickHandler };
 };
 
 export default useTrendCursors;

--- a/packages/react-components/src/components/chart/hooks/useTrendCursorsEvents.ts
+++ b/packages/react-components/src/components/chart/hooks/useTrendCursorsEvents.ts
@@ -1,11 +1,13 @@
 import { RefObject, useEffect, useRef } from 'react';
 import { EChartsType, getInstanceByDom } from 'echarts';
 import { MAX_TREND_CURSORS, TREND_CURSOR_CLOSE_GRAPHIC_INDEX } from '../eChartsConstants';
-import { calculateTimeStamp } from '../utils/getInfo';
+import { calculateNearestTcIndex, calculateTimeStamp, formatCopyData } from '../utils/getInfo';
 import { v4 as uuid } from 'uuid';
 import { getNewTrendCursor, onDragUpdateTrendCursor } from '../utils/getTrendCursor';
 import { UseEventsProps } from '../types';
 import useDataStore from '../../../store';
+import { Action } from '../contextMenu/ChartContextMenu';
+import copy from 'copy-to-clipboard';
 
 let trendCursorStaticIndex = 0;
 
@@ -21,6 +23,7 @@ const useTrendCursorsEvents = ({
   yMax,
   isInSyncMode,
   groupId,
+  onContextMenu,
 }: UseEventsProps) => {
   // sync mode actions
   const addTrendCursorsToSyncState = useDataStore((state) => state.addTrendCursors);
@@ -46,6 +49,7 @@ const useTrendCursorsEvents = ({
   const isInSyncModeRef = useRef(isInSyncMode);
   const graphicRef = useRef(graphic);
   const setGraphicRef = useRef(setGraphic);
+  const onContextMenuRef = useRef(onContextMenu);
 
   // these properties will be updated in every render so that the event handlers below is not re-rendered everytime
   useEffect(() => {
@@ -60,6 +64,58 @@ const useTrendCursorsEvents = ({
     setGraphicRef.current = setGraphic;
   }, [series, size, isInCursorAddMode, setGraphic, viewport, yMin, yMax, isInSyncMode, graphic]);
 
+  // shared add function between the context menu and on click action
+  const addNewTrendCursor = ({ posX, ignoreHotKey }: { posX: number; ignoreHotKey: boolean }) => {
+    // when adding through the context menu, we can ignore the hot key press
+    if ((ignoreHotKey || isInCursorAddModeRef.current) && graphicRef.current.length < MAX_TREND_CURSORS) {
+      if (isInSyncModeRef.current) {
+        const timestampInMs = calculateTimeStamp(posX, sizeRef.current.width, viewportRef.current);
+        addTrendCursorsToSyncState({
+          groupId: groupId ?? '',
+          tcId: `trendCursor-${uuid()}`,
+          timestamp: timestampInMs,
+          tcHeaderColorIndex: trendCursorStaticIndex++,
+        });
+      } else {
+        const newTc = getNewTrendCursor({
+          size: sizeRef.current,
+          tcHeaderColorIndex: trendCursorStaticIndex++,
+          series: seriesRef.current,
+          yMin: yMinRef.current,
+          yMax: yMaxRef.current,
+          viewport: viewportRef.current,
+          x: posX,
+        });
+
+        setGraphicRef.current([...graphicRef.current, newTc]);
+      }
+    }
+  };
+
+  // shared delete function between the context menu and on click actions
+  const deleteTrendCursor = (toBeDeletedGraphicIndex: number) => {
+    if (isInSyncModeRef.current) {
+      deleteTrendCursorsInSyncState({
+        groupId: groupId ?? '',
+        tcId: graphicRef.current[toBeDeletedGraphicIndex].id as string,
+      });
+    } else {
+      let chart;
+      if (ref.current !== null) {
+        chart = getInstanceByDom(ref.current);
+      }
+      graphicRef.current[toBeDeletedGraphicIndex].$action = 'remove';
+      graphicRef.current[toBeDeletedGraphicIndex].children = []; // Echarts will throw error if children are not empty
+      chart?.setOption({ graphic: graphicRef.current });
+      graphicRef.current.splice(toBeDeletedGraphicIndex, 1);
+      setGraphicRef.current([...graphicRef.current]);
+    }
+  };
+  const deleteTrendCursorByPosition = (clickedPosX: number) => {
+    const timestampOfClick = calculateTimeStamp(clickedPosX, sizeRef.current.width, viewportRef.current);
+    const toBeDeletedGraphicIndex = calculateNearestTcIndex(graphicRef.current, timestampOfClick);
+    deleteTrendCursor(toBeDeletedGraphicIndex);
+  };
   // The below event handlers will handle both sync and standalone mode
   // sync mode --> dispatches the actions from the store
   // standalone mode --> updates the local state
@@ -79,46 +135,11 @@ const useTrendCursorsEvents = ({
           const graphicIndex = graphicRef.current.findIndex(
             (g) => g.children[TREND_CURSOR_CLOSE_GRAPHIC_INDEX].id === e?.target?.id
           );
-
-          // delete tc
           if (graphicIndex !== -1) {
-            if (isInSyncModeRef.current) {
-              deleteTrendCursorsInSyncState({
-                groupId: groupId ?? '',
-                tcId: graphicRef.current[graphicIndex].id as string,
-              });
-            } else {
-              graphicRef.current[graphicIndex].$action = 'remove';
-              graphicRef.current[graphicIndex].children = []; // Echarts will throw error if children are not empty
-              chart?.setOption({ graphic: graphicRef.current });
-              graphicRef.current.splice(graphicIndex, 1);
-              setGraphicRef.current([...graphicRef.current]);
-            }
-          }
-
-          // add TC
-          if (isInCursorAddModeRef.current && graphicRef.current.length < MAX_TREND_CURSORS) {
-            if (isInSyncModeRef.current) {
-              const timestampInMs = calculateTimeStamp(e?.offsetX ?? 0, sizeRef.current.width, viewportRef.current);
-              addTrendCursorsToSyncState({
-                groupId: groupId ?? '',
-                tcId: `trendCursor-${uuid()}`,
-                timestamp: timestampInMs,
-                tcHeaderColorIndex: trendCursorStaticIndex++,
-              });
-            } else {
-              const newTc = getNewTrendCursor({
-                e,
-                size: sizeRef.current,
-                tcHeaderColorIndex: trendCursorStaticIndex++,
-                series: seriesRef.current,
-                yMin: yMinRef.current,
-                yMax: yMaxRef.current,
-                viewport: viewportRef.current,
-              });
-
-              setGraphicRef.current([...graphicRef.current, newTc]);
-            }
+            deleteTrendCursor(graphicIndex);
+            return;
+          } else {
+            addNewTrendCursor({ posX: e.offsetX ?? 0, ignoreHotKey: false });
           }
         });
 
@@ -151,17 +172,46 @@ const useTrendCursorsEvents = ({
         });
       }
 
+      chart?.getZr().on('contextmenu', (event) => {
+        onContextMenuRef.current(event);
+      });
+
       return () => {
         if (ref.current !== null) {
           chart?.getZr().off('click');
           // passing the function so that it will NOT remove all the mouseover behaviour, namely default tooltip
           chart?.getZr().off('mouseover', () => mouseoverHandler(isInCursorAddModeRef.current, chart));
           chart?.getZr().off('drag');
+          chart?.getZr().off('contextmenu');
         }
       };
     }
     prevRef.current = ref;
   }, [ref]);
+
+  const copyTrendCursorData = (posX: number) => {
+    const timestampOfClick = calculateTimeStamp(posX, sizeRef.current.width, viewportRef.current);
+    const toBeCopiedGraphicIndex = calculateNearestTcIndex(graphicRef.current, timestampOfClick);
+    // using copy-to-clipboard library to copy in a Excel sheet pastable format
+    copy(formatCopyData(graphicRef.current[toBeCopiedGraphicIndex], seriesRef.current), { format: 'text/plain' });
+  };
+
+  // this handles the user interaction via context menu
+  const onContextMenuClickHandler = ({ action, posX }: { action: Action; posX: number }) => {
+    switch (action) {
+      case 'add':
+        addNewTrendCursor({ posX: posX, ignoreHotKey: true });
+        break;
+      case 'delete':
+        deleteTrendCursorByPosition(posX);
+        break;
+      case 'copy':
+        copyTrendCursorData(posX);
+        break;
+    }
+  };
+
+  return { onContextMenuClickHandler };
 };
 
 export default useTrendCursorsEvents;

--- a/packages/react-components/src/components/chart/tests/useTrendCursorsEvents.spec.tsx
+++ b/packages/react-components/src/components/chart/tests/useTrendCursorsEvents.spec.tsx
@@ -4,6 +4,7 @@ import useTrendCursorsEvents from '../hooks/useTrendCursorsEvents';
 import { mockSeries, mockSize, mockViewport } from './getTrendCursor.spec';
 import { useECharts } from '../../../hooks/useECharts';
 import React from 'react';
+import { InternalGraphicComponentGroupOption } from '../types';
 
 describe('useTrendCursorsEvents', () => {
   const { result } = renderHook(() =>
@@ -32,9 +33,54 @@ describe('useTrendCursorsEvents', () => {
         yMax: 30,
         yMin: 0,
         isInSyncMode: false,
+        onContextMenu: jest.fn(),
       })
     );
 
     expect(mockSetGraphic).not.toBeCalled();
+  });
+
+  it('when user click on add Trend Cursor, set state should not be called', () => {
+    const mockSetGraphic = jest.fn();
+    const hook = renderHook(() =>
+      useTrendCursorsEvents({
+        isInCursorAddMode: false,
+        ref: result.current.ref,
+        setGraphic: mockSetGraphic,
+        graphic: [],
+        size: mockSize,
+        viewport: mockViewport,
+        series: mockSeries,
+        yMax: 30,
+        yMin: 0,
+        isInSyncMode: false,
+        onContextMenu: jest.fn(),
+      })
+    );
+
+    hook.result.current.onContextMenuClickHandler({ action: 'add', posX: 100 });
+    expect(mockSetGraphic).toBeCalled();
+  });
+
+  it('when user click on delete Trend Cursor, set state should not be called', () => {
+    const mockSetGraphic = jest.fn();
+    const hook = renderHook(() =>
+      useTrendCursorsEvents({
+        isInCursorAddMode: false,
+        ref: result.current.ref,
+        setGraphic: mockSetGraphic,
+        graphic: [{ timestampInMs: 1689264600000 } as InternalGraphicComponentGroupOption],
+        size: mockSize,
+        viewport: mockViewport,
+        series: mockSeries,
+        yMax: 30,
+        yMin: 0,
+        isInSyncMode: false,
+        onContextMenu: jest.fn(),
+      })
+    );
+
+    hook.result.current.onContextMenuClickHandler({ action: 'delete', posX: 100 });
+    expect(mockSetGraphic).toBeCalled();
   });
 });

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -111,6 +111,7 @@ export interface UseEventsProps extends TrendCursorProps {
   ref: React.RefObject<HTMLDivElement>;
   isInCursorAddMode: boolean;
   isInSyncMode: boolean;
+  onContextMenu: (e: ElementEvent) => void;
 }
 
 export interface UseSyncProps extends TrendCursorProps {
@@ -122,6 +123,7 @@ export interface UseTrendCursorsProps extends TrendCursorProps {
   ref: React.RefObject<HTMLDivElement>;
   isInCursorAddMode: boolean;
   chartId?: string;
+  onContextMenu: (e: ElementEvent) => void;
 }
 
 export interface GetNewTrendCursorProps {

--- a/packages/react-components/src/components/chart/utils/getInfo.ts
+++ b/packages/react-components/src/components/chart/utils/getInfo.ts
@@ -1,7 +1,7 @@
 import { DurationViewport, Viewport } from '@iot-app-kit/core/src';
 import { DEFAULT_MARGIN, Y_AXIS_INTERPOLATED_VALUE_PRECISION } from '../eChartsConstants';
 import { SeriesOption } from 'echarts';
-import { SizeConfig } from '../types';
+import { InternalGraphicComponentGroupOption, SizeConfig } from '../types';
 import { parseDuration } from '../../../utils/time';
 
 export const isDurationViewport = (viewport: Viewport): viewport is DurationViewport =>
@@ -150,4 +150,40 @@ export const calculateXFromTimestamp = (timestampInMs: number, size: SizeConfig,
   // TODO: precision should be updated here
   const x = ((size.width - 100) * (timestampInMs - initial)) / widthInMs;
   return x + DEFAULT_MARGIN;
+};
+
+// for a given user's right click co-ordinate's timestamp, find the nearest trend cursor
+// all trend cursors is associated with a timestamp,
+// we use that to see which TC is the closest to user's right click
+export const calculateNearestTcIndex = (graphic: InternalGraphicComponentGroupOption[], clickTimestamp: number) => {
+  const tcTimestamps = graphic.map((g) => g.timestampInMs);
+  let closest = -1;
+  let min = Number.MAX_VALUE;
+  tcTimestamps.forEach((tcTimestamp, index) => {
+    const diff = Math.abs(tcTimestamp - clickTimestamp);
+    if (diff < min) {
+      min = diff;
+      closest = index;
+    }
+  });
+  return closest;
+};
+
+// formatting the copy data so that it paste-able in an Excel sheet
+// \t adds a tab and \n add a new line
+// this is in the format of
+// TC timestamp
+// Cop timestamp
+// Series name : value
+export const formatCopyData = (graphic: InternalGraphicComponentGroupOption, series: SeriesOption[]) => {
+  let output = `Trend cursor timestamp \t ${new Date(graphic.timestampInMs).toLocaleDateString()}${new Date(
+    graphic.timestampInMs
+  ).toLocaleTimeString()} \n`;
+
+  const currDate = new Date();
+  output = output + `Copy timestamp \t ${currDate.toLocaleDateString()} ${currDate.toLocaleTimeString()} \n`;
+  series.forEach((s, index) => {
+    output = output + `${s.name} \t ${graphic.yAxisMarkerValue[index]} \n`;
+  });
+  return output;
 };


### PR DESCRIPTION
## Overview
Adding context menu for charts. this will be per chart i.e when in dashboard this will not be shown instead the dashboard will be updated with the TC options in the follow up CR. 

## Verifying Changes
Refer to the screen capture

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

https://github.com/awslabs/iot-app-kit/assets/135036199/76a8f5e2-6daa-45b6-9fb6-e46372f96cd0

