### PR TITLE
fix(composer): fix issue displaying 0 in overlay

### DIFF
--- a/packages/scene-composer/src/utils/dataBindingVariableUtils.spec.ts
+++ b/packages/scene-composer/src/utils/dataBindingVariableUtils.spec.ts
@@ -1,7 +1,9 @@
 import { replaceBindingVariables } from './dataBindingVariableUtils';
 
 describe('replaceBindingVariables', () => {
-  const bindingValuesMap: Record<string, string> = {
+  const bindingValuesMap: Record<string, unknown> = {
+    zero: 0,
+    false: false,
     'binding a': '11',
     'binding~!@#$%^&*()': '22',
     '<随机>': '33',
@@ -10,6 +12,22 @@ describe('replaceBindingVariables', () => {
   it('should replace variable with value correctly', () => {
     const original = 'abc ${binding a} def,.';
     const expected = 'abc 11 def,.';
+
+    const result = replaceBindingVariables(original, bindingValuesMap);
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace variable with value 0 correctly', () => {
+    const original = 'abc ${zero} def,.';
+    const expected = 'abc 0 def,.';
+
+    const result = replaceBindingVariables(original, bindingValuesMap);
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace variable with value false correctly', () => {
+    const original = 'abc ${false} def,.';
+    const expected = 'abc false def,.';
 
     const result = replaceBindingVariables(original, bindingValuesMap);
     expect(result).toEqual(expected);

--- a/packages/scene-composer/src/utils/dataBindingVariableUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingVariableUtils.ts
@@ -2,7 +2,7 @@
 const bindingVariableRegex = /\$\{.+?\}/gi;
 const UNAVAILABLE_DATA = '-';
 
-export function replaceBindingVariables(content: string, bindingValuesMap: Record<string, string>): string {
+export function replaceBindingVariables(content: string, bindingValuesMap: Record<string, unknown>): string {
   let result = content;
 
   const variableMatches = content.match(bindingVariableRegex) || [];
@@ -10,8 +10,8 @@ export function replaceBindingVariables(content: string, bindingValuesMap: Recor
   // Only support replace variable with their latest property value for now.
   variables.forEach((variable, index) => {
     // Display "-" when value not available
-    const value = bindingValuesMap[variable] || UNAVAILABLE_DATA;
-    result = result.replaceAll(variableMatches[index], value);
+    const value = bindingValuesMap[variable] ?? UNAVAILABLE_DATA;
+    result = result.replaceAll(variableMatches[index], String(value));
   });
 
   return result;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -40,7 +40,7 @@
     },
     {
       "type": "linked-versions",
-      "group-name": "iot-app-kit",
+      "groupName": "iot-app-kit",
       "components": [
         "root",
         "components",


### PR DESCRIPTION
## Overview
Merge https://github.com/awslabs/iot-app-kit/pull/1770 into release-3.x
- fix the issue where 0 will be displayed as "-" in overlay

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
