### PR TITLE
fix(react-component): removing the dependency of the yMin and Ymax and reading the series line markers for TC from echarts

### DIFF
--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -32,7 +32,7 @@ const Chart = ({ viewport, queries, size = { width: 500, height: 500 }, ...optio
 
   const chartId = options?.id ?? `chart-${uuid()}`;
 
-  const { series, yAxis, yMin, yMax } = useMemo(() => {
+  const { series, yAxis } = useMemo(() => {
     const { series, yAxis } = dataStreams
       .map(convertSeriesAndYAxis(options as ChartOptions))
       .reduce(reduceSeriesAndYAxis, { series: defaultSeries, yAxis: defaultYAxis });
@@ -86,8 +86,6 @@ const Chart = ({ viewport, queries, size = { width: 500, height: 500 }, ...optio
     isInCursorAddMode,
     setGraphic: setTrendCursors,
     series,
-    yMax,
-    yMin,
     chartId,
     viewport,
     groupId: options.groupId,

--- a/packages/react-components/src/components/chart/hooks/useTrendCursors.ts
+++ b/packages/react-components/src/components/chart/hooks/useTrendCursors.ts
@@ -11,8 +11,6 @@ const useTrendCursors = ({
   isInCursorAddMode,
   setGraphic,
   series,
-  yMax,
-  yMin,
   chartId,
   viewport,
   groupId,
@@ -32,18 +30,16 @@ const useTrendCursors = ({
     setGraphic,
     viewport,
     series,
-    yMin,
-    yMax,
     isInSyncMode,
     groupId,
     onContextMenu,
   });
 
   // for handling the resize of chart
-  handleResize({ series, size, yMin, yMax, graphic, setGraphic, viewport });
+  handleResize({ series, size, graphic, setGraphic, viewport, ref });
 
   // handling the trend cursor sync mode
-  handleSync({ ref, isInSyncMode, graphic, setGraphic, viewport, series, yMin, yMax, size, groupId });
+  handleSync({ ref, isInSyncMode, graphic, setGraphic, viewport, series, size, groupId });
 
   return { onContextMenuClickHandler };
 };

--- a/packages/react-components/src/components/chart/hooks/useTrendCursorsEvents.ts
+++ b/packages/react-components/src/components/chart/hooks/useTrendCursorsEvents.ts
@@ -19,8 +19,6 @@ const useTrendCursorsEvents = ({
   setGraphic,
   viewport,
   series,
-  yMin,
-  yMax,
   isInSyncMode,
   groupId,
   onContextMenu,
@@ -44,8 +42,6 @@ const useTrendCursorsEvents = ({
   const sizeRef = useRef(size);
   const isInCursorAddModeRef = useRef(isInCursorAddMode);
   const viewportRef = useRef(viewport);
-  const yMinRef = useRef(yMin);
-  const yMaxRef = useRef(yMax);
   const isInSyncModeRef = useRef(isInSyncMode);
   const graphicRef = useRef(graphic);
   const setGraphicRef = useRef(setGraphic);
@@ -54,15 +50,13 @@ const useTrendCursorsEvents = ({
   // these properties will be updated in every render so that the event handlers below is not re-rendered everytime
   useEffect(() => {
     seriesRef.current = series;
-    yMinRef.current = yMin;
-    yMaxRef.current = yMax;
     viewportRef.current = viewport;
     isInCursorAddModeRef.current = isInCursorAddMode;
     isInSyncModeRef.current = isInSyncMode;
     graphicRef.current = graphic;
     sizeRef.current = size;
     setGraphicRef.current = setGraphic;
-  }, [series, size, isInCursorAddMode, setGraphic, viewport, yMin, yMax, isInSyncMode, graphic]);
+  }, [series, size, isInCursorAddMode, setGraphic, viewport, isInSyncMode, graphic]);
 
   // shared add function between the context menu and on click action
   const addNewTrendCursor = ({ posX, ignoreHotKey }: { posX: number; ignoreHotKey: boolean }) => {
@@ -81,10 +75,9 @@ const useTrendCursorsEvents = ({
           size: sizeRef.current,
           tcHeaderColorIndex: trendCursorStaticIndex++,
           series: seriesRef.current,
-          yMin: yMinRef.current,
-          yMax: yMaxRef.current,
           viewport: viewportRef.current,
           x: posX,
+          ref,
         });
 
         setGraphicRef.current([...graphicRef.current, newTc]);
@@ -162,8 +155,7 @@ const useTrendCursorsEvents = ({
                 timeInMs,
                 size: sizeRef.current,
                 series: seriesRef.current,
-                yMax: yMaxRef.current,
-                yMin: yMinRef.current,
+                ref,
               });
               // update component state
               setGraphicRef.current([...graphicRef.current]);

--- a/packages/react-components/src/components/chart/tests/getTrendCursor.spec.tsx
+++ b/packages/react-components/src/components/chart/tests/getTrendCursor.spec.tsx
@@ -2,6 +2,7 @@ import { describe, expect } from '@jest/globals';
 import { ElementEvent, SeriesOption } from 'echarts';
 import { getNewTrendCursor, onDragUpdateTrendCursor } from '../utils/getTrendCursor';
 import { calculateXFromTimestamp } from '../utils/getInfo';
+import { createRef } from 'react';
 
 export const mockSeries = [
   {
@@ -33,7 +34,7 @@ export const mockViewport = {
   end: new Date('2023-07-13T16:30:00.000Z'),
 };
 export const mockSize = { width: 500, height: 500 };
-
+export const mockRef = createRef<HTMLDivElement>();
 describe('Testing getNewTrendCursor file', () => {
   describe('getNewTrendCursor', () => {
     const mockSize = { width: 500, height: 500 };
@@ -45,9 +46,8 @@ describe('Testing getNewTrendCursor file', () => {
         size: mockSize,
         tcHeaderColorIndex: 0,
         series: mockSeries,
-        yMax: 50,
-        yMin: 0,
         viewport: mockViewport,
+        ref: mockRef,
       });
 
       expect(newTrendCursor).not.toBeNull();
@@ -63,9 +63,8 @@ describe('Testing getNewTrendCursor file', () => {
         size: mockSize,
         tcHeaderColorIndex: 0,
         series: mockSeries,
-        yMax: 50,
-        yMin: 0,
         viewport: mockViewport,
+        ref: mockRef,
       });
 
       const timestamp = Date.parse('2023-07-13T16:00:00.000Z') + 1000 * 60 * 60 * 2; // 1689271200000
@@ -73,11 +72,10 @@ describe('Testing getNewTrendCursor file', () => {
       onDragUpdateTrendCursor({
         graphic: newTrendCursor,
         posX: calculateXFromTimestamp(timestamp, mockSize, mockViewport),
-        yMin: 0,
-        yMax: 30,
         timeInMs: timestamp,
         series: mockSeries,
         size: mockSize,
+        ref: mockRef,
       });
       expect(newTrendCursor).not.toBeNull();
       expect(newTrendCursor.timestampInMs).toBe(1689271200000);

--- a/packages/react-components/src/components/chart/tests/handleResize.spec.tsx
+++ b/packages/react-components/src/components/chart/tests/handleResize.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, expect } from '@jest/globals';
-import { mockSeries, mockSize, mockViewport } from './getTrendCursor.spec';
+import { mockRef, mockSeries, mockSize, mockViewport } from './getTrendCursor.spec';
 import { renderHook } from '@testing-library/react';
 import handleResize from '../utils/handleResize';
 import { InternalGraphicComponentGroupOption } from '../types';
@@ -17,10 +17,9 @@ describe('handleResize', () => {
     series: mockSeries,
     setGraphic: setGraphicStub,
     viewport: mockViewport,
-    yMax: 30,
-    yMin: 0,
     size: mockSize,
     groupId: 'group1',
+    ref: mockRef,
   };
 
   it('set state should not be called when there is no change in size ', () => {

--- a/packages/react-components/src/components/chart/tests/useTrendCursorsEvents.spec.tsx
+++ b/packages/react-components/src/components/chart/tests/useTrendCursorsEvents.spec.tsx
@@ -30,8 +30,6 @@ describe('useTrendCursorsEvents', () => {
         size: mockSize,
         viewport: mockViewport,
         series: mockSeries,
-        yMax: 30,
-        yMin: 0,
         isInSyncMode: false,
         onContextMenu: jest.fn(),
       })
@@ -51,8 +49,6 @@ describe('useTrendCursorsEvents', () => {
         size: mockSize,
         viewport: mockViewport,
         series: mockSeries,
-        yMax: 30,
-        yMin: 0,
         isInSyncMode: false,
         onContextMenu: jest.fn(),
       })
@@ -73,8 +69,6 @@ describe('useTrendCursorsEvents', () => {
         size: mockSize,
         viewport: mockViewport,
         series: mockSeries,
-        yMax: 30,
-        yMin: 0,
         isInSyncMode: false,
         onContextMenu: jest.fn(),
       })

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -1,5 +1,8 @@
 import { Threshold, ThresholdSettings, TimeSeriesDataQuery, Viewport } from '@iot-app-kit/core';
-import { GraphicComponentGroupOption } from 'echarts/types/src/component/graphic/GraphicModel';
+import {
+  GraphicComponentElementOption,
+  GraphicComponentGroupOption,
+} from 'echarts/types/src/component/graphic/GraphicModel';
 import { OptionId } from 'echarts/types/src/util/types';
 import React, { Dispatch, SetStateAction } from 'react';
 import { ElementEvent, SeriesOption } from 'echarts';
@@ -102,8 +105,6 @@ export interface TrendCursorProps {
   setGraphic: Dispatch<SetStateAction<InternalGraphicComponentGroupOption[]>>;
   viewport?: Viewport;
   series: SeriesOption[];
-  yMax: number;
-  yMin: number;
   groupId?: string;
 }
 
@@ -131,15 +132,28 @@ export interface GetNewTrendCursorProps {
   size: SizeConfig;
   tcHeaderColorIndex: number;
   series: SeriesOption[];
-  yMax: number;
-  yMin: number;
   viewport?: Viewport;
   tcId?: string;
   x?: number;
   timestamp?: number;
+  ref: React.RefObject<HTMLDivElement>;
 }
 
 export interface SyncChanges {
   graphic: InternalGraphicComponentGroupOption[];
   syncedTrendCursors?: TrendCursorGroup;
+}
+
+export interface ondragUpdateGraphicProps {
+  graphic: InternalGraphicComponentGroupOption;
+  posX: number;
+  timeInMs: number;
+  size: SizeConfig;
+  series: SeriesOption[];
+  ref: React.RefObject<HTMLDivElement>;
+}
+export interface ondragUpdateTrendCursorElementsProps {
+  elements: GraphicComponentElementOption[];
+  trendCursorsSeriesMakersInPixels: number[];
+  timeInMs: number;
 }

--- a/packages/react-components/src/components/chart/utils/getTrendCursor.ts
+++ b/packages/react-components/src/components/chart/utils/getTrendCursor.ts
@@ -17,7 +17,12 @@ import {
   TREND_CURSOR_Z_INDEX,
 } from '../eChartsConstants';
 import { LineSeriesOption, SeriesOption } from 'echarts';
-import { GetNewTrendCursorProps, InternalGraphicComponentGroupOption, SizeConfig } from '../types';
+import {
+  GetNewTrendCursorProps,
+  ondragUpdateGraphicProps,
+  ondragUpdateTrendCursorElementsProps,
+  SizeConfig,
+} from '../types';
 import close from '../close.svg';
 import {
   GraphicComponentElementOption,
@@ -31,21 +36,6 @@ import {
   getTrendCursorHeaderTimestampText,
   setXWithBounds,
 } from './getInfo';
-
-export type ondragUpdateGraphicProps = {
-  graphic: InternalGraphicComponentGroupOption;
-  posX: number;
-  timeInMs: number;
-  size: SizeConfig;
-  series: SeriesOption[];
-  yMin: number;
-  yMax: number;
-};
-export type ondragUpdateTrendCursorElementsProps = {
-  elements: GraphicComponentElementOption[];
-  trendCursorsSeriesMakersInPixels: number[];
-  timeInMs: number;
-};
 
 const onDragUpdateTrendCursorLine = (elements: GraphicComponentElementOption[]) => {
   // specifically setting the line graphic x value to 0 so that it follows the parent's X
@@ -93,22 +83,12 @@ const onDragUpdateTrendCursorElements = ({
     ),
   ];
 };
-export const onDragUpdateTrendCursor = ({
-  graphic,
-  posX,
-  timeInMs,
-  series,
-  size,
-  yMin,
-  yMax,
-}: ondragUpdateGraphicProps) => {
+export const onDragUpdateTrendCursor = ({ graphic, posX, timeInMs, series, size, ref }: ondragUpdateGraphicProps) => {
   // calculate the new Y for the series markers
   const { trendCursorsSeriesMakersInPixels, trendCursorsSeriesMakersValue } = calculateTrendCursorsSeriesMakers(
     series,
-    yMin,
-    yMax,
     timeInMs,
-    size.height
+    ref
   );
 
   // this section updates the internal data of graphic, this data is used to render the legend component data
@@ -221,12 +201,11 @@ export const getNewTrendCursor = ({
   size,
   tcHeaderColorIndex,
   series,
-  yMax,
-  yMin,
   viewport,
   tcId,
   x,
   timestamp,
+  ref,
 }: GetNewTrendCursorProps) => {
   const posX = e?.offsetX ?? x ?? 0;
   const uId = tcId ? tcId.split('trendCursor-')[1] : uuid();
@@ -237,10 +216,8 @@ export const getNewTrendCursor = ({
   // TODO: test this once echarts live mode is supported
   const { trendCursorsSeriesMakersValue, trendCursorsSeriesMakersInPixels } = calculateTrendCursorsSeriesMakers(
     series,
-    yMin,
-    yMax,
     timestampInMs,
-    size.height
+    ref
   );
   // rotate the colors in a round-robin fashion
   const headerColor = TREND_CURSOR_HEADER_COLORS[tcHeaderColorIndex % TREND_CURSOR_HEADER_COLORS.length];

--- a/packages/react-components/src/components/chart/utils/handleResize.ts
+++ b/packages/react-components/src/components/chart/utils/handleResize.ts
@@ -3,7 +3,14 @@ import { calculateTrendCursorsSeriesMakers, calculateXFromTimestamp } from './ge
 import { onResizeUpdateTrendCursorYValues } from './getTrendCursor';
 import { TrendCursorProps } from '../types';
 
-const handleResize = ({ size, series, yMin, yMax, graphic, setGraphic, viewport }: TrendCursorProps) => {
+const handleResize = ({
+  size,
+  series,
+  graphic,
+  setGraphic,
+  viewport,
+  ref,
+}: TrendCursorProps & { ref: React.RefObject<HTMLDivElement> }) => {
   const prevSize = useRef(size);
   // to avoid unnecessary re-rendering
   if (size.width !== prevSize.current.width || size.height !== prevSize.current.height) {
@@ -13,13 +20,7 @@ const handleResize = ({ size, series, yMin, yMax, graphic, setGraphic, viewport 
       // if height has changed, update Y values
       if (size.height !== prevSize.current.height) {
         // updating the series line marker's y value
-        const { trendCursorsSeriesMakersInPixels } = calculateTrendCursorsSeriesMakers(
-          series,
-          yMin,
-          yMax,
-          g.timestampInMs,
-          size.height
-        );
+        const { trendCursorsSeriesMakersInPixels } = calculateTrendCursorsSeriesMakers(series, g.timestampInMs, ref);
 
         g.children = onResizeUpdateTrendCursorYValues(g.children, trendCursorsSeriesMakersInPixels, size);
       }

--- a/packages/react-components/src/components/chart/utils/handleSync.ts
+++ b/packages/react-components/src/components/chart/utils/handleSync.ts
@@ -5,18 +5,7 @@ import { calculateXFromTimestamp } from './getInfo';
 import useDataStore from '../../../store';
 import { UseSyncProps } from '../types';
 
-const handleSync = ({
-  ref,
-  isInSyncMode,
-  graphic,
-  setGraphic,
-  viewport,
-  series,
-  yMin,
-  yMax,
-  size,
-  groupId,
-}: UseSyncProps) => {
+const handleSync = ({ ref, isInSyncMode, graphic, setGraphic, viewport, series, size, groupId }: UseSyncProps) => {
   const syncedTrendCursors = useDataStore((state) => state.trendCursorGroups[groupId ?? '']);
 
   if (ref.current && isInSyncMode && syncedTrendCursors) {
@@ -29,7 +18,7 @@ const handleSync = ({
     if (toBeAdded.length || toBeDeleted.length || toBeUpdated.length) {
       const chart = getInstanceByDom(ref.current);
 
-      // add a new trendcursor
+      // add a new trend cursor
       if (toBeAdded.length) {
         toBeAdded.forEach((tcId) => {
           const timestamp = (syncedTrendCursors ?? {})[tcId].timestamp;
@@ -40,16 +29,15 @@ const handleSync = ({
               size,
               tcHeaderColorIndex: (syncedTrendCursors ?? {})[tcId].tcHeaderColorIndex,
               series,
-              yMin,
-              yMax,
               viewport,
               x: calculateXFromTimestamp(timestamp, size, viewport),
+              ref,
             })
           );
         });
       }
 
-      // update if any of the timestamps are different i.e the TC is dragged
+      // update if any of the timestamps are different i.e. the TC is dragged
       if (toBeUpdated.length) {
         toBeUpdated.forEach((updateTC) => {
           graphic[updateTC.index] = onDragUpdateTrendCursor({
@@ -58,8 +46,7 @@ const handleSync = ({
             timeInMs: updateTC.newTimestamp,
             size,
             series,
-            yMax,
-            yMin,
+            ref,
           });
         });
       }


### PR DESCRIPTION
removing the dependency of the yMin and Ymax and reading the series line markers for TC from echarts
No net new changes except that instead of ymin and ymax, reading the pixel value from echarts

## Overview


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
