### PR TITLE
fix(react-components): add memoization for chart reactivity and refactor echarts hook

### DIFF
--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -1,20 +1,26 @@
-import React, { SyntheticEvent, useMemo, useState } from 'react';
-import { useECharts } from '../../hooks/useECharts';
+import React, { useState } from 'react';
+import {
+  useECharts,
+  useResizeableEChart,
+  useGroupableEChart,
+  useLoadableEChart,
+  useEChartOptions,
+} from '../../hooks/useECharts';
 import { ChartOptions } from './types';
 import { useVisualizedDataStreams } from './hooks/useVisualizedDataStreams';
-import { convertOptions } from './converters/convertOptions';
-import { ElementEvent, SeriesOption, YAXisComponentOption } from 'echarts';
-import { convertYAxis } from './converters/convertAxis';
-import { convertSeriesAndYAxis, reduceSeriesAndYAxis } from './converters/convertSeriesAndYAxis';
+import { useConvertedOptions } from './converters/convertOptions';
+import { ElementEvent } from 'echarts';
+import { useSeriesAndYAxis } from './converters/convertSeriesAndYAxis';
 import { HotKeys, KeyMap } from 'react-hotkeys';
 import useTrendCursors from './hooks/useTrendCursors';
-import { calculateYMaxMin } from './utils/getInfo';
-import { Resizable, ResizeCallbackData } from 'react-resizable';
+import { Resizable } from 'react-resizable';
 import Legend from './legend/legend';
-import { CHART_RESIZE_INITIAL_FACTOR, CHART_RESIZE_MAX_FACTOR, CHART_RESIZE_MIN_FACTOR } from './eChartsConstants';
-import { v4 as uuid } from 'uuid';
-import './chart.css';
+import { useChartStyleSettings } from './converters/convertStyles';
 import ChartContextMenu, { Action } from './contextMenu/ChartContextMenu';
+import { useChartId } from './hooks/useChartId';
+import { useChartSetOptionSettings } from './hooks/useChartSetOptionSettings';
+
+import './chart.css';
 
 const keyMap: KeyMap = {
   commandDown: { sequence: 'command', action: 'keydown' },
@@ -22,55 +28,46 @@ const keyMap: KeyMap = {
 };
 
 /**
+ * Developer Notes:
+ *
+ * The general organization of the Chart follows this flow:
+ *
+ * 1. setup echarts instance using useECharts
+ * 2. get datastreams using useVisualizedDataStreams
+ * 3. use datastreams / chart options to compute datastructures
+ *    needed to implement various features and adapt them to the echarts api
+ * 4. set all of the options in echarts using useEChartOptions
+ */
+
+/**
  * Base chart to display Line, Scatter, and Bar charts.
  */
 const Chart = ({ viewport, queries, size = { width: 500, height: 500 }, ...options }: ChartOptions) => {
+  // Setup instance of echarts
+  const { ref, chartRef } = useECharts(options?.theme);
+
+  const chartId = useChartId(options.id);
+
+  // convert TimeSeriesDataQuery to TimeSeriesData
   const { isLoading, dataStreams } = useVisualizedDataStreams(queries, viewport);
-  const { axis } = options;
-  const defaultSeries: SeriesOption[] = [];
-  const defaultYAxis: YAXisComponentOption[] = [convertYAxis(axis)];
 
-  const chartId = options?.id ?? `chart-${uuid()}`;
+  // Setup resize container and calculate size for echart
+  const { width, height, chartWidth, onResize, minConstraints, maxConstraints } = useResizeableEChart(chartRef, size);
 
-  const { series, yAxis } = useMemo(() => {
-    const { series, yAxis } = dataStreams
-      .map(convertSeriesAndYAxis(options as ChartOptions))
-      .reduce(reduceSeriesAndYAxis, { series: defaultSeries, yAxis: defaultYAxis });
-    const { yMax, yMin } = calculateYMaxMin(series);
-    const updatedYAxis = yAxis.map((y) => ({ ...y, min: yMin, max: yMax }));
-    return { series, yAxis: updatedYAxis, yMin, yMax };
-  }, [dataStreams]);
+  // apply group to echart
+  useGroupableEChart(chartRef, options.groupId);
+
+  // apply loading animation to echart
+  useLoadableEChart(chartRef, isLoading);
+
+  // calculate style settings for all datastreams
+  const [styleSettingsMap] = useChartStyleSettings(dataStreams, options);
 
   const [trendCursors, setTrendCursors] = useState(options.graphic ?? []);
   const [isInCursorAddMode, setIsInCursorAddMode] = useState(false);
+  // TECHDEBT: let's try to refactor contet menu state into some hook associated with the component
   const [showContextMenu, setShowContextMenu] = useState(false);
   const [contextMenuPos, setContextMenuPos] = useState({ x: 0, y: 0 });
-
-  const option = {
-    ...convertOptions({
-      ...options,
-      viewport,
-      queries,
-      size,
-      seriesLength: series.length,
-    }),
-    series,
-    yAxis,
-    graphic: trendCursors,
-  };
-
-  const [width, setWidth] = useState(size.width * CHART_RESIZE_INITIAL_FACTOR);
-  const onResize = (_event: SyntheticEvent, data: ResizeCallbackData) => {
-    setWidth(data.size.width);
-  };
-
-  const { ref } = useECharts({
-    option,
-    loading: isLoading,
-    size: { width, height: size.height },
-    theme: options?.theme,
-    groupId: options?.groupId,
-  });
 
   const handleContextMenu = (e: ElementEvent) => {
     setContextMenuPos({ x: e.offsetX, y: e.offsetY });
@@ -78,11 +75,14 @@ const Chart = ({ viewport, queries, size = { width: 500, height: 500 }, ...optio
     e.stop();
   };
 
+  // adapt datastreams into echarts series and yAxis data
+  const { series, yAxis } = useSeriesAndYAxis(dataStreams, { styleSettings: styleSettingsMap, axis: options.axis });
+
   // this will handle all the Trend Cursors operations
   const { onContextMenuClickHandler } = useTrendCursors({
     ref,
     graphic: trendCursors,
-    size: { width, height: size.height },
+    size: { width: chartWidth, height },
     isInCursorAddMode,
     setGraphic: setTrendCursors,
     series,
@@ -102,18 +102,39 @@ const Chart = ({ viewport, queries, size = { width: 500, height: 500 }, ...optio
     setShowContextMenu(false);
   };
 
+  // adapt chart options into echarts options
+  const convertedOptions = useConvertedOptions({
+    ...options,
+    title: series.length === 0 ? 'No data present' : '',
+  });
+
+  // determine the set option settings
+  const settings = useChartSetOptionSettings(dataStreams);
+
+  // set all of the options on the echarts instance
+  useEChartOptions(
+    chartRef,
+    {
+      ...convertedOptions,
+      series,
+      yAxis,
+      graphic: trendCursors,
+    },
+    settings
+  );
+
   return (
     <div className='base-chart-container'>
       <Resizable
-        height={size.height}
-        width={width}
+        height={height}
+        width={chartWidth}
         onResize={onResize}
         axis='x'
-        minConstraints={[size.width * CHART_RESIZE_MIN_FACTOR, size.height]}
-        maxConstraints={[size.width * CHART_RESIZE_MAX_FACTOR, size.height]}
+        minConstraints={minConstraints}
+        maxConstraints={maxConstraints}
       >
         <HotKeys keyMap={keyMap} handlers={handlers} style={{ position: 'relative' }}>
-          <div ref={ref} className='base-chart-element' style={{ height: size.height, width: width }} />
+          <div ref={ref} className='base-chart-element' style={{ height, width: chartWidth }} />
           {/*TODO: should not show when in dashboard */}
           {showContextMenu && (
             <ChartContextMenu
@@ -125,7 +146,7 @@ const Chart = ({ viewport, queries, size = { width: 500, height: 500 }, ...optio
           )}
         </HotKeys>
       </Resizable>
-      <div style={{ height: size.height, width: size.width - width }}>
+      <div style={{ height, width: width - chartWidth }}>
         <Legend series={series} graphic={trendCursors} />
       </div>
     </div>

--- a/packages/react-components/src/components/chart/converters/convertOptions.ts
+++ b/packages/react-components/src/components/chart/converters/convertOptions.ts
@@ -5,12 +5,22 @@ import { convertLegend } from './convertLegend';
 import { convertXAxis } from './convertAxis';
 import { convertGrid } from './convertGrid';
 import { convertTooltip } from './convertTooltip';
+import { useMemo } from 'react';
 
-export const convertOptions = (options: ChartOptions & { seriesLength: number }): EChartsOption => {
-  const { backgroundColor, axis, gestures, legend, significantDigits } = options;
+type ConvertChartOptions = Pick<
+  ChartOptions,
+  'backgroundColor' | 'axis' | 'gestures' | 'legend' | 'significantDigits'
+> & { title?: string };
+
+/**
+ * @param options options object to adapt to the echarts
+ * @returns adapted echarts options
+ */
+export const convertOptions = (options: ConvertChartOptions): EChartsOption => {
+  const { backgroundColor, axis, gestures, legend, significantDigits, title } = options;
   return {
     title: {
-      text: options.seriesLength === 0 ? 'No data present' : '',
+      text: title, // options.seriesLength === 0 ? 'No data present' : '',
     },
     backgroundColor,
     xAxis: [convertXAxis(axis)],
@@ -19,4 +29,15 @@ export const convertOptions = (options: ChartOptions & { seriesLength: number })
     legend: convertLegend(legend),
     tooltip: convertTooltip(significantDigits),
   };
+};
+
+/**
+ * Hook that adapts chart options to echarts options.
+ *
+ * @param options options object to adapt to the echarts
+ * @returns memoized adapted echarts options
+ */
+export const useConvertedOptions = (options: ConvertChartOptions) => {
+  const { backgroundColor, axis, gestures, legend, significantDigits, title } = options;
+  return useMemo(() => convertOptions(options), [backgroundColor, axis, gestures, legend, significantDigits, title]);
 };

--- a/packages/react-components/src/components/chart/converters/convertStyles.spec.tsx
+++ b/packages/react-components/src/components/chart/converters/convertStyles.spec.tsx
@@ -1,0 +1,56 @@
+// const { result } = renderHook(() => useGridSettings(), {
+//   wrapper: ({ children }) => <TestProvider children={children} />,
+// });
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { getChartStyleSettingsFromMap, useChartStyleSettings } from './convertStyles';
+import { colorPalette } from '@iot-app-kit/core-util';
+import { ChartOptions } from '../types';
+
+const DATA_STREAM = { id: 'abc-1', data: [], resolution: 0, name: 'my-name' };
+const DATA_STREAM_WITH_REF = { id: 'abc-2', refId: 'custom', data: [], resolution: 0, name: 'my-name' };
+
+it('can get the correct style settings from the style settings map', () => {
+  const { result } = renderHook(() => useChartStyleSettings([DATA_STREAM, DATA_STREAM_WITH_REF], {}), {
+    wrapper: ({ children }) => <div>{children}</div>,
+  });
+  const [map] = result.current;
+  expect(getChartStyleSettingsFromMap(map)(DATA_STREAM)).toEqual(map[DATA_STREAM.id]);
+});
+
+it('converts default styles for all datastreams', () => {
+  const chartStyleSettings = {
+    // none
+  };
+  const { result } = renderHook(() => useChartStyleSettings([DATA_STREAM], chartStyleSettings), {
+    wrapper: ({ children }) => <div>{children}</div>,
+  });
+
+  const [styles, getStyles] = result.current;
+  expect(styles).toHaveProperty(DATA_STREAM.id);
+
+  const mappedStyles = getStyles(DATA_STREAM);
+  expect(mappedStyles).toHaveProperty('visualizationType', 'line');
+  expect(mappedStyles).toHaveProperty('color', colorPalette[0]);
+});
+
+it('converts styles with custom options for all datastreams', () => {
+  const chartStyleSettings: Pick<ChartOptions, 'defaultVisualizationType' | 'styleSettings'> = {
+    defaultVisualizationType: 'scatter',
+    styleSettings: {
+      custom: {
+        color: '#4a238b',
+      },
+    },
+  };
+  const { result } = renderHook(() => useChartStyleSettings([DATA_STREAM_WITH_REF], chartStyleSettings), {
+    wrapper: ({ children }) => <div>{children}</div>,
+  });
+
+  const [styles, getStyles] = result.current;
+  expect(styles).toHaveProperty(DATA_STREAM_WITH_REF.id);
+
+  const mappedStyles = getStyles(DATA_STREAM_WITH_REF);
+  expect(mappedStyles).toHaveProperty('visualizationType', 'scatter');
+  expect(mappedStyles).toHaveProperty('color', '#4a238b');
+});

--- a/packages/react-components/src/components/chart/converters/convertStyles.ts
+++ b/packages/react-components/src/components/chart/converters/convertStyles.ts
@@ -1,0 +1,71 @@
+import { useMemo, useRef } from 'react';
+import { DataStream } from '@iot-app-kit/core';
+import { ChartOptions, ChartStyleSettingsOptions } from '../types';
+import { getDefaultStyles, getStyles } from '../utils/getStyles';
+
+type ConvertChartOptions = Pick<ChartOptions, 'defaultVisualizationType' | 'styleSettings'>;
+
+export const convertStyles =
+  ({ defaultVisualizationType, styleSettings, colorIndex }: ConvertChartOptions & { colorIndex?: number }) =>
+  ({ refId }: DataStream): ChartStyleSettingsOptions => {
+    const defaultStyles = getDefaultStyles(colorIndex, defaultVisualizationType);
+    const userDefinedStyles = getStyles(refId, styleSettings);
+
+    return { ...defaultStyles, ...userDefinedStyles };
+  };
+
+export type StyleSettingsMap = {
+  [key in string]: ChartStyleSettingsOptions;
+};
+type ColorIndexMap = {
+  [key in string]: number;
+};
+
+export const getChartStyleSettingsFromMap =
+  (map: StyleSettingsMap) =>
+  (datastream: DataStream): ChartStyleSettingsOptions =>
+    map[datastream.id];
+
+/**
+ * Hook that provides a way to get configured ChartStyleSettingsOptions for a given datastream
+ *
+ * These ChartStyleSettingsOptions are stored in an object map where the key is the datastream.id and the value is ChartStyleSettingsOptions
+ *
+ * colors are kept consistent by mapping a number to the datastream.id
+ * the number is used to pick from a list of default colors
+ *
+ * @returns [StyleSettingsMap, (datastream: DataStream) => ChartStyleSettingsOptions]
+ */
+export const useChartStyleSettings = (datastreams: DataStream[], chartOptions: ConvertChartOptions) => {
+  const datastreamDeps = JSON.stringify(datastreams.map(({ id, refId }) => `${id}-${refId}`));
+  const optionsDeps = JSON.stringify(chartOptions);
+
+  const colorIndexRef = useRef(0);
+  const chartColorIndices = useRef<ColorIndexMap>({});
+
+  chartColorIndices.current = useMemo(() => {
+    const currentColorIndices = chartColorIndices.current;
+    let index = colorIndexRef.current;
+    const map = datastreams.reduce<ColorIndexMap>((indexMap, datastream) => {
+      const currentIndex = currentColorIndices[datastream.id];
+      if (currentIndex === undefined) {
+        indexMap[datastream.id] = index;
+        index = index + 1;
+      } else {
+        indexMap[datastream.id] = currentIndex;
+      }
+      return indexMap;
+    }, {});
+    colorIndexRef.current = index;
+    return map;
+  }, [datastreamDeps]);
+
+  return useMemo(() => {
+    const map = datastreams.reduce<StyleSettingsMap>((styleMap, datastream) => {
+      const colorIndex = chartColorIndices.current[datastream.id];
+      styleMap[datastream.id] = convertStyles({ ...chartOptions, colorIndex })(datastream);
+      return styleMap;
+    }, {});
+    return [map, getChartStyleSettingsFromMap(map)] as const;
+  }, [datastreamDeps, optionsDeps]);
+};

--- a/packages/react-components/src/components/chart/converters/converters.spec.ts
+++ b/packages/react-components/src/components/chart/converters/converters.spec.ts
@@ -7,6 +7,7 @@ import { convertLegend } from './convertLegend';
 import { convertOptions } from './convertOptions';
 import { convertSeriesAndYAxis } from './convertSeriesAndYAxis';
 import { convertTooltip } from './convertTooltip';
+import { convertStyles } from './convertStyles';
 
 const MOCK_AXIS = {
   yAxisLabel: 'Y Value',
@@ -75,15 +76,12 @@ it('converts legend to echarts legend', async () => {
 
 it('converts chart options to echarts options', async () => {
   const convertedOptions = convertOptions({
-    queries: [],
-    seriesLength: 0,
     backgroundColor: 'white',
     axis: MOCK_AXIS,
     legend: MOCK_LEGEND,
     significantDigits: 2,
   });
 
-  expect(convertedOptions).toHaveProperty('title.text', 'No data present');
   expect(convertedOptions).toHaveProperty('backgroundColor', 'white');
   expect(convertedOptions).toHaveProperty('xAxis[0].show', true);
   expect(convertedOptions).toHaveProperty('xAxis[0].type', 'time');
@@ -99,16 +97,19 @@ it('converts empty series data to echarts data', async () => {
     legend: MOCK_LEGEND,
     significantDigits: 2,
   };
-  const convertedSeriesAndYAxisFunc = convertSeriesAndYAxis({
-    ...options,
-    defaultVisualizationType: 'step-start',
-    styleSettings: { refId: { color: 'red' } },
-  });
-  const result = convertedSeriesAndYAxisFunc({ ...options, data: [], id: 'refId' });
+
+  const chartOptions = {
+    styleSettings: { 'abc-1': { color: 'red' } },
+    defaultVisualizationType: 'step-middle',
+  } as const;
+  const datastream = { ...options, data: [], id: 'abc-1' };
+  const styles = convertStyles(chartOptions)(datastream);
+  const convertedSeriesAndYAxisFunc = convertSeriesAndYAxis(styles);
+  const result = convertedSeriesAndYAxisFunc(datastream);
 
   expect(result.series.data).toBeArrayOfSize(0);
   expect(result).toHaveProperty('series.itemStyle.color', '#688ae8');
-  expect(result).toHaveProperty('series.step', 'start');
+  expect(result).toHaveProperty('series.step', 'middle');
 });
 
 it('converts non empty series data to echarts data', async () => {
@@ -121,12 +122,14 @@ it('converts non empty series data to echarts data', async () => {
     legend: MOCK_LEGEND,
     significantDigits: 2,
   };
-  const convertedSeriesAndYAxisFunc = convertSeriesAndYAxis({
-    ...options,
+  const chartOptions = {
     defaultVisualizationType: 'step-start',
     styleSettings: { 'abc-1': { color: 'red' } },
-  });
-  const result = convertedSeriesAndYAxisFunc({ ...options, data: [], id: 'abc-1' });
+  } as const;
+  const datastream = { ...options, data: [], id: 'abc-1' };
+  const styles = convertStyles(chartOptions)(datastream);
+  const convertedSeriesAndYAxisFunc = convertSeriesAndYAxis(styles);
+  const result = convertedSeriesAndYAxisFunc(datastream);
 
   expect(result.series.data).toBeArrayOfSize(0);
   expect(result).toHaveProperty('series.data', []);
@@ -143,11 +146,14 @@ it('converts non empty series data with no default vis type to echarts data', as
     legend: MOCK_LEGEND,
     significantDigits: 2,
   };
-  const convertedSeriesAndYAxisFunc = convertSeriesAndYAxis({
-    ...options,
+
+  const chartOptions = {
     styleSettings: { 'abc-1': { color: 'red' } },
-  });
-  const result = convertedSeriesAndYAxisFunc({ ...options, data: [], id: 'abc-1' });
+  } as const;
+  const datastream = { ...options, data: [], id: 'abc-1' };
+  const styles = convertStyles(chartOptions)(datastream);
+  const convertedSeriesAndYAxisFunc = convertSeriesAndYAxis(styles);
+  const result = convertedSeriesAndYAxisFunc(datastream);
 
   expect(result.series.data).toBeArrayOfSize(0);
   expect(result.series.name).toBeUndefined();

--- a/packages/react-components/src/components/chart/hooks/useChartId.ts
+++ b/packages/react-components/src/components/chart/hooks/useChartId.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+
+import { v4 as uuid } from 'uuid';
+
+const generateId = (id?: string) => (id && id.length > 0 ? id : `chart-${uuid()}`);
+
+/**
+ * Hook that provides a memoized id for the chart.
+ * Will use the given id if defined or generate a unique one
+ */
+export const useChartId = (id?: string) => {
+  return useMemo(() => generateId(id), [id]);
+};

--- a/packages/react-components/src/components/chart/hooks/useChartSetOptionSettings.ts
+++ b/packages/react-components/src/components/chart/hooks/useChartSetOptionSettings.ts
@@ -1,0 +1,25 @@
+import { useMemo, useRef } from 'react';
+import { DataStream } from '@iot-app-kit/core';
+
+const mapDatastreamsDeps = (datastreams: DataStream[]) =>
+  JSON.stringify(datastreams.map((datastream) => datastream.id));
+
+export const useChartSetOptionSettings = (datastreams: DataStream[]) => {
+  const datastreamsDeps = mapDatastreamsDeps(datastreams);
+  const datastreamsDepsRef = useRef(datastreamsDeps);
+
+  return useMemo(() => {
+    /**
+     * if the datastreams change update echarts using the replaceMerge stratgey
+     * so that it is ensured that orphaned data points are removed.
+     *
+     * see setOption api for more information on settings
+     * https://echarts.apache.org/en/api.html#echartsInstance.setOption
+     *
+     * NOTE: we can use this hook to refactor trend cursor set option also
+     */
+    const settings = datastreamsDepsRef.current !== datastreamsDeps ? { replaceMerge: ['series'] } : undefined;
+    datastreamsDepsRef.current = datastreamsDeps;
+    return settings;
+  }, [datastreams]);
+};

--- a/packages/react-components/src/components/chart/tests/getInfo.spec.tsx
+++ b/packages/react-components/src/components/chart/tests/getInfo.spec.tsx
@@ -1,6 +1,5 @@
 import { describe, expect } from '@jest/globals';
-import { calculateXFromTimestamp, calculateYMaxMin, setXWithBounds } from '../utils/getInfo';
-import { mockSeries } from './getTrendCursor.spec';
+import { calculateXFromTimestamp, setXWithBounds } from '../utils/getInfo';
 
 describe('Testing Charts getInfo', () => {
   const mockSize = { width: 500, height: 500 };
@@ -29,15 +28,6 @@ describe('Testing Charts getInfo', () => {
       const maxX = calculateXFromTimestamp(1689265200000, mockSize, mockViewport);
 
       expect(Number(maxX.toPrecision(2))).toBe(320);
-    });
-  });
-
-  describe('calculateYMaxMin', () => {
-    it('should return new x for a given timestamp', () => {
-      const { yMax, yMin } = calculateYMaxMin(mockSeries);
-
-      expect(yMax).toBe(30);
-      expect(yMin).toBe(0);
     });
   });
 });

--- a/packages/react-components/src/components/chart/tests/handleSync.spec.tsx
+++ b/packages/react-components/src/components/chart/tests/handleSync.spec.tsx
@@ -20,15 +20,7 @@ describe('handleSync', () => {
     groupId: 'group1',
   };
 
-  const ref = renderHook(() =>
-    useECharts({
-      option: {},
-      loading: false,
-      size: mockSize,
-      theme: 'dark',
-      groupId: 'group1',
-    })
-  );
+  const ref = renderHook(() => useECharts('dark'));
 
   it('set state should not be called when there are no changes ', () => {
     const ref = createRef<HTMLDivElement>();

--- a/packages/react-components/src/components/chart/tests/useTrendCursorsEvents.spec.tsx
+++ b/packages/react-components/src/components/chart/tests/useTrendCursorsEvents.spec.tsx
@@ -7,15 +7,7 @@ import React from 'react';
 import { InternalGraphicComponentGroupOption } from '../types';
 
 describe('useTrendCursorsEvents', () => {
-  const { result } = renderHook(() =>
-    useECharts({
-      option: {},
-      loading: false,
-      size: mockSize,
-      theme: 'dark',
-      groupId: 'group1',
-    })
-  );
+  const { result } = renderHook(() => useECharts('dark'));
 
   render(<div ref={result.current.ref} className='base-chart-element' data-testid='blah' style={mockSize} />);
 

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -10,8 +10,8 @@ import { TrendCursorGroup } from '../../store/trendCusorSlice';
 
 export type YAxisOptions = {
   yAxisLabel?: string;
-  yMin?: number; // if undefined we should pick best range
-  yMax?: number; // if undefined we should pick best range
+  yMin?: number;
+  yMax?: number;
 };
 
 export type ChartAxisOptions = YAxisOptions & {
@@ -93,7 +93,7 @@ export type ChartOptions = {
   fontSettings?: SimpleFontSettings;
   legend?: ChartLegend;
   significantDigits?: number;
-  graphic?: InternalGraphicComponentGroupOption[];
+  graphic?: InternalGraphicComponentGroupOption[]; // This needs to be removed from the public api
   theme?: string;
   groupId?: string;
   id?: string;

--- a/packages/react-components/src/components/chart/utils/getColor.ts
+++ b/packages/react-components/src/components/chart/utils/getColor.ts
@@ -3,6 +3,9 @@ import { colorPalette } from '@iot-app-kit/core-util';
 const defaultColorPicker = () => {
   let colorIndexOffset = 0;
 
-  return () => colorPalette[colorIndexOffset++ % colorPalette.length];
+  return (offset?: number) => {
+    const indexOffset = offset ?? colorIndexOffset++;
+    return colorPalette[indexOffset % colorPalette.length];
+  };
 };
 export const getColor = defaultColorPicker();

--- a/packages/react-components/src/components/chart/utils/getInfo.ts
+++ b/packages/react-components/src/components/chart/utils/getInfo.ts
@@ -132,26 +132,6 @@ export const roundUpYAxisMax = (yMax: number) => {
   return yMax;
 };
 
-export const calculateYMaxMin = (series: SeriesOption[]) => {
-  let yMax = Number.MIN_VALUE;
-  let yMin = 0;
-
-  series.forEach((s: SeriesOption) => {
-    (s.data as Array<number[]>).forEach((value) => {
-      if (value[1] && value[1] > yMax) {
-        yMax = value[1];
-      }
-      if (value[1] && value[1] < yMin) {
-        yMin = value[1];
-      }
-    });
-  });
-
-  // adding a 10% to accommodate TC header and rounding it to upper 10
-  yMax = roundUpYAxisMax(yMax);
-  return { yMin, yMax };
-};
-
 // this calculated the new X in pixels when the chart is resized.
 export const calculateXFromTimestamp = (timestampInMs: number, size: SizeConfig, viewport?: Viewport) => {
   const { widthInMs, initial } = viewportToMs(viewport);

--- a/packages/react-components/src/components/chart/utils/getStyles.ts
+++ b/packages/react-components/src/components/chart/utils/getStyles.ts
@@ -1,15 +1,18 @@
 import { ChartOptions, ChartStyleSettingsOptions } from '../types';
 import { getColor } from './getColor';
 
-export const getStyles = (refId?: string, styleSettings?: ChartOptions['styleSettings']) =>
-  refId && styleSettings ? styleSettings[refId] : undefined;
+export const getStyles = (
+  refId?: string,
+  styleSettings?: ChartOptions['styleSettings']
+): ChartStyleSettingsOptions | undefined => (refId && styleSettings ? styleSettings[refId] : undefined);
 
 export const getDefaultStyles = (
+  colorIndex?: number,
   defaultVisualizationType?: ChartStyleSettingsOptions['visualizationType']
 ): ChartStyleSettingsOptions => {
   return {
     visualizationType: defaultVisualizationType ?? 'line',
-    color: getColor(),
+    color: getColor(colorIndex),
     symbol: 'circle',
     symbolSize: 4,
     symbolColor: undefined, // will use color if undefined

--- a/packages/react-components/src/hooks/useECharts/index.ts
+++ b/packages/react-components/src/hooks/useECharts/index.ts
@@ -1,1 +1,5 @@
 export * from './useECharts';
+export * from './useEChartOptions';
+export * from './useGroupableEchart';
+export * from './useLoadableEChart';
+export * from './useResizeableEChart';

--- a/packages/react-components/src/hooks/useECharts/useEChartOptions.ts
+++ b/packages/react-components/src/hooks/useECharts/useEChartOptions.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import type { ECharts, EChartsOption, SetOptionOpts } from 'echarts';
+
+/**
+ *
+ * hook to update options on an echarts instance
+ *
+ * @param chartRef React ref to an initialized echarts object
+ * @param option - set options on an echarts instance
+ * @param settings - settings to be used when setting an option
+ * @returns void
+ */
+export const useEChartOptions = (
+  chartRef: React.MutableRefObject<ECharts | null>,
+  option: EChartsOption,
+  settings?: SetOptionOpts
+) => {
+  useEffect(() => {
+    chartRef.current?.setOption(option, settings);
+  }, [chartRef, option, settings]);
+};

--- a/packages/react-components/src/hooks/useECharts/useECharts.tsx
+++ b/packages/react-components/src/hooks/useECharts/useECharts.tsx
@@ -1,18 +1,20 @@
 import { useRef, useEffect } from 'react';
 import { init } from 'echarts';
-import type { EChartsOption, ECharts, SetOptionOpts } from 'echarts';
+import type { ECharts } from 'echarts';
 
 export interface EChartsWrapperProps {
-  option: EChartsOption;
-  settings?: SetOptionOpts;
-  loading?: boolean;
   theme?: string;
-  className?: string;
-  size?: { width?: number; height?: number };
-  groupId?: string;
 }
 
-export const useECharts = ({ option, settings, loading, theme, size = {}, groupId }: EChartsWrapperProps) => {
+/**
+ * Hook to initialize and attach an echart to the dom
+ *
+ * @param theme - theme applied to the echarts instance
+ * @returns
+ *  - ref: React ref to attach to an html element to bind echarts to
+ *  - chartRef: ref to an Echarts instance
+ */
+export const useECharts = (theme?: string) => {
   const ref = useRef<HTMLDivElement>(null);
   const chartRef = useRef<ECharts | null>(null);
 
@@ -25,26 +27,6 @@ export const useECharts = ({ option, settings, loading, theme, size = {}, groupI
       chartRef.current?.dispose();
     };
   }, [theme]);
-
-  useEffect(() => {
-    if (groupId && chartRef.current) {
-      chartRef.current.group = groupId;
-    }
-  }, [groupId]);
-
-  useEffect(() => {
-    chartRef.current?.setOption(option, settings);
-  }, [chartRef, option, settings]);
-
-  useEffect(() => {
-    const chart = chartRef.current;
-    loading === true ? chart?.showLoading() : chart?.hideLoading();
-  }, [chartRef, loading]);
-
-  useEffect(() => {
-    const chart = chartRef.current;
-    chart?.resize({ width: size.width, height: size.height });
-  }, [chartRef, size]);
 
   return { chartRef, ref };
 };

--- a/packages/react-components/src/hooks/useECharts/useGroupableEchart.ts
+++ b/packages/react-components/src/hooks/useECharts/useGroupableEchart.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import type { ECharts } from 'echarts';
+
+/**
+ * hook to update a group on an echarts instance
+ *
+ * @param chartRef React ref to an initialized echarts object
+ * @param groupId - set a group on an echarts instance
+ * @returns void
+ */
+export const useGroupableEChart = (chartRef: React.MutableRefObject<ECharts | null>, groupId?: string) => {
+  useEffect(() => {
+    if (groupId && chartRef.current) {
+      chartRef.current.group = groupId;
+    }
+  }, [groupId]);
+};

--- a/packages/react-components/src/hooks/useECharts/useLoadableEChart.ts
+++ b/packages/react-components/src/hooks/useECharts/useLoadableEChart.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import type { ECharts } from 'echarts';
+
+/**
+ * hook to toggle loading on an echarts instance
+ *
+ * @param chartRef React ref to an initialized echarts object
+ * @param loading - whether or not to set the loading animation on an echart
+ * @returns void
+ */
+export const useLoadableEChart = (chartRef: React.MutableRefObject<ECharts | null>, loading?: boolean) => {
+  useEffect(() => {
+    const chart = chartRef.current;
+    loading === true ? chart?.showLoading() : chart?.hideLoading();
+  }, [chartRef, loading]);
+};

--- a/packages/react-components/src/hooks/useECharts/useResizeableEChart.ts
+++ b/packages/react-components/src/hooks/useECharts/useResizeableEChart.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState, SyntheticEvent, useMemo } from 'react';
+import type { ECharts } from 'echarts';
+import {
+  CHART_RESIZE_INITIAL_FACTOR,
+  CHART_RESIZE_MAX_FACTOR,
+  CHART_RESIZE_MIN_FACTOR,
+} from '../../components/chart/eChartsConstants';
+import { ResizeCallbackData } from 'react-resizable';
+
+const getChartWidth = (width: number) => width * CHART_RESIZE_INITIAL_FACTOR;
+
+/**
+ * hook to set up the size of an echarts instance within the base chart component
+ * note: the chart sits along side a legend table which means that the
+ * echart is actually smaller in width than the overall base chart component
+ *
+ * @param chartRef React ref to an initialized echarts object
+ * @param size size of the chart
+ * @returns
+ *  - width: width of the component
+ *  - height: height of the component
+ *  - chartWidth: width of the chart minus the left legend
+ *  - onResize: handler to react to resizing the chart size
+ *  - minConstraints: min size of the chart within the component
+ *  - maxConstraints: max size of the chart within the component
+ */
+export const useResizeableEChart = (
+  chartRef: React.MutableRefObject<ECharts | null>,
+  size: { width: number; height: number }
+) => {
+  const { width, height } = size;
+  const [chartWidth, setWidth] = useState(getChartWidth(width));
+
+  const onResize = (_event: SyntheticEvent, data: ResizeCallbackData) => {
+    setWidth(data.size.width);
+  };
+
+  useEffect(() => {
+    setWidth(getChartWidth(width));
+  }, [width]);
+
+  useEffect(() => {
+    const chart = chartRef.current;
+    chart?.resize({ width: chartWidth, height: height });
+  }, [chartRef, width, height, chartWidth]);
+
+  const minConstraints: [number, number] = useMemo(() => {
+    return [width * CHART_RESIZE_MIN_FACTOR, height];
+  }, [width, height]);
+
+  const maxConstraints: [number, number] = useMemo(() => {
+    return [width * CHART_RESIZE_MAX_FACTOR, height];
+  }, [width, height]);
+
+  return { width, height, chartWidth, onResize, minConstraints, maxConstraints };
+};

--- a/packages/react-components/stories/chart/base-chart.stories.tsx
+++ b/packages/react-components/stories/chart/base-chart.stories.tsx
@@ -1,0 +1,107 @@
+import React, { FC } from 'react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { MOCK_TIME_SERIES_DATA_QUERY, VIEWPORT } from './mock-data';
+import { TimeSelection, TimeSync, useViewport } from '../../src';
+import Chart from '../../src/components/chart';
+import { getTimeSeriesDataQuery, queryConfigured } from '../utils/query';
+import { ChartOptions } from '../../src/components/chart/types';
+
+export default {
+  title: 'Widgets/Base Chart',
+  component: Chart,
+  argTypes: {
+    id: { control: { type: 'text' }, defaultValue: undefined },
+    defaultVisualizationType: {
+      control: 'select',
+      options: ['line', 'scatter', 'bar', 'step-start', 'step-middle', 'step-end'],
+      defaultValue: undefined,
+    },
+    size: { control: { type: 'object' }, defaultValue: { width: 800, height: 500 } },
+    styleSettings: { control: { type: 'object' }, defaultValue: undefined },
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Chart>;
+
+type StoryInputs = ChartOptions;
+
+export const BaseChartExample: ComponentStory<FC<StoryInputs>> = ({
+  id,
+  defaultVisualizationType,
+  size,
+  styleSettings,
+}) => {
+  const { viewport } = useViewport();
+
+  return (
+    <TimeSync>
+      <div id='story-container' style={{ width: '100vw', height: '100vh' }}>
+        <TimeSelection />
+        <Chart
+          id={id}
+          defaultVisualizationType={defaultVisualizationType}
+          size={size}
+          styleSettings={styleSettings}
+          viewport={viewport ?? VIEWPORT}
+          queries={[MOCK_TIME_SERIES_DATA_QUERY]}
+          theme='light'
+        />
+        <Chart
+          id={id}
+          defaultVisualizationType='bar'
+          size={size}
+          styleSettings={styleSettings}
+          viewport={viewport ?? VIEWPORT}
+          queries={[MOCK_TIME_SERIES_DATA_QUERY]}
+          theme='light'
+        />
+      </div>
+    </TimeSync>
+  );
+};
+
+export const SiteWiseConnectedBaseChartExample: ComponentStory<FC<StoryInputs>> = ({
+  id,
+  defaultVisualizationType,
+  size,
+  styleSettings,
+}) => {
+  if (!queryConfigured()) {
+    return (
+      <div>
+        <h1>All required Env variables not set</h1>
+        <p>Required:</p>
+        <ul>
+          <li>AWS_ACCESS_KEY_ID</li>
+          <li>AWS_SECRET_ACCESS_KEY</li>
+          <li>AWS_SESSION_TOKEN</li>
+          <li>AWS_REGION</li>
+          <li>ASSET_ID_1</li>
+          <li>PROPERTY_ID_1</li>
+          <li>PROPERTY_ID_2</li>
+          <li>PROPERTY_ID_3</li>
+        </ul>
+      </div>
+    );
+  }
+
+  const { viewport } = useViewport();
+
+  return (
+    <TimeSync>
+      <div id='story-container' style={{ width: '100vw', height: '100vh' }}>
+        <TimeSelection />
+        <Chart
+          id={id}
+          defaultVisualizationType={defaultVisualizationType}
+          size={size}
+          styleSettings={styleSettings}
+          viewport={viewport ?? { duration: '5m' }}
+          queries={[getTimeSeriesDataQuery()]}
+          theme='light'
+        />
+      </div>
+    </TimeSync>
+  );
+};

--- a/packages/react-components/stories/chart/chart.stories.tsx
+++ b/packages/react-components/stories/chart/chart.stories.tsx
@@ -3,8 +3,6 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import { MOCK_TIME_SERIES_DATA_QUERY, MOCK_TIME_SERIES_DATA_AGGREGATED_QUERY, VIEWPORT } from './mock-data';
 // Should be part of the public API, i.e. exported from src
 import { LineChart, ScatterChart, BarChart, StatusTimeline, WebglContext, TimeSync, useViewport } from '../../src';
-import Chart from '../../src/components/chart';
-import { getTimeSeriesDataQuery, queryConfigured } from '../utils/query';
 
 const ViewportConsumer = () => {
   const { viewport, setViewport } = useViewport();
@@ -81,58 +79,6 @@ export const StatusTimelineExample: ComponentStory<typeof StatusTimeline> = () =
     <div id='story-container' style={{ width: '500px', height: '300px' }}>
       <StatusTimeline viewport={VIEWPORT} queries={[MOCK_TIME_SERIES_DATA_QUERY]} />
       <WebglContext />
-    </div>
-  );
-};
-
-export const BaseChartExample: ComponentStory<typeof Chart> = () => {
-  return (
-    <div id='story-container' style={{ width: '100vw', height: '100vh' }}>
-      <Chart
-        viewport={VIEWPORT}
-        queries={[MOCK_TIME_SERIES_DATA_QUERY]}
-        size={{ width: 800, height: 500 }}
-        theme='light'
-      />
-      <Chart
-        viewport={VIEWPORT}
-        queries={[MOCK_TIME_SERIES_DATA_QUERY]}
-        size={{ width: 800, height: 500 }}
-        theme='light'
-        defaultVisualizationType='bar'
-      />
-    </div>
-  );
-};
-
-export const SiteWiseConnectedBaseChartExample: ComponentStory<typeof Chart> = () => {
-  if (!queryConfigured()) {
-    return (
-      <div>
-        <h1>All required Env variables not set</h1>
-        <p>Required:</p>
-        <ul>
-          <li>AWS_ACCESS_KEY_ID</li>
-          <li>AWS_SECRET_ACCESS_KEY</li>
-          <li>AWS_SESSION_TOKEN</li>
-          <li>AWS_REGION</li>
-          <li>ASSET_ID_1</li>
-          <li>PROPERTY_ID_1</li>
-          <li>PROPERTY_ID_2</li>
-          <li>PROPERTY_ID_3</li>
-        </ul>
-      </div>
-    );
-  }
-
-  return (
-    <div id='story-container' style={{ width: '100vw', height: '100vh' }}>
-      <Chart
-        viewport={{ duration: '5m' }}
-        queries={[getTimeSeriesDataQuery()]}
-        size={{ width: 800, height: 500 }}
-        theme='light'
-      />
     </div>
   );
 };


### PR DESCRIPTION
## Overview
Many structural changes included in this PR.

useECharts has been split into several smaller hooks.
1. useEcharts -> initializes echarts and attaches to the dom
2. useResizeableEChart -> handles resizing of the chart and updating echart
3. useGroupableEChart -> updates the echarts groupid
4. useLoadableEChart -> updates the loading animation state
5. useEChartOptions -> handles updating echarts options

* added a hook for deriving a chart id

* added a hook for calculated style settings for each datastream

* added a hook for converted series and yAxis

moved base chart stories into a separate story so that we can utilize styorbook argtypes which allow us to more easily test prop reactivity.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
