### PR TITLE
feat(composer): auto query support for Model Shader

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
@@ -59,6 +59,7 @@ describe('AnchorWidget', () => {
     },
   };
 
+  const getSceneRuleMapByIdMock = jest.fn();
   const setStore = (
     selectedSceneNodeRef: string,
     highlightedSceneNodeRef: string,
@@ -66,6 +67,7 @@ describe('AnchorWidget', () => {
     tagVisible = true,
   ) => {
     useStore('default').setState({
+      getSceneRuleMapById: getSceneRuleMapByIdMock,
       selectedSceneNodeRef,
       setSelectedSceneNodeRef,
       highlightedSceneNodeRef,
@@ -113,19 +115,20 @@ describe('AnchorWidget', () => {
 
   it('should render correctly with data binding rule', () => {
     setStore('test-ref', 'test-ref');
+    getSceneRuleMapByIdMock.mockImplementation((id) =>
+      id == 'rule-id'
+        ? {
+            statements: [
+              {
+                expression: "alarm_status == 'ACTIVE'",
+                target: 'iottwinmaker.common.icon:Error',
+              },
+            ],
+          }
+        : undefined,
+    );
     const container = renderer.create(
-      <AnchorWidget
-        node={node}
-        defaultIcon={DefaultAnchorStatus.Info}
-        rule={{
-          statements: [
-            {
-              expression: "alarm_status == 'ACTIVE'",
-              target: 'iottwinmaker.common.icon:Error',
-            },
-          ],
-        }}
-      />,
+      <AnchorWidget node={node} defaultIcon={DefaultAnchorStatus.Info} ruleBasedMapId='rule-id' />,
     );
 
     expect(container.root.findByType('anchor').props.visualState).toEqual('Error');
@@ -276,8 +279,6 @@ describe('AnchorWidget onWidgetClick', () => {
         propertyName: 'prop',
       },
     };
-    const rule = undefined;
-    const navLink = undefined;
 
     const component = renderer.create(
       <AnchorWidget
@@ -285,8 +286,6 @@ describe('AnchorWidget onWidgetClick', () => {
         defaultIcon={defaultIcon}
         chosenColor={chosenColor}
         valueDataBinding={mockValueDataBinding}
-        rule={rule}
-        navLink={navLink}
       />,
     );
 

--- a/packages/scene-composer/src/components/three-fiber/AnchorComponent/__tests__/__snapshots__/AnchorComponent.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/AnchorComponent/__tests__/__snapshots__/AnchorComponent.spec.tsx.snap
@@ -12,13 +12,7 @@ exports[`AnchorComponent should render correctly with default icon 1`] = `
         "ref": "testRef",
       }
     }
-    rule={
-      Object {
-        "rule": Object {
-          "expression": "test",
-        },
-      }
-    }
+    ruleBasedMapId="testId"
     valueDataBinding={
       Object {
         "test": "test",
@@ -40,13 +34,7 @@ exports[`AnchorComponent should render correctly with set icon 1`] = `
         "ref": "testRef",
       }
     }
-    rule={
-      Object {
-        "rule": Object {
-          "expression": "test",
-        },
-      }
-    }
+    ruleBasedMapId="testId"
     valueDataBinding={
       Object {
         "test": "test",

--- a/packages/scene-composer/src/components/three-fiber/AnchorComponent/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/AnchorComponent/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import { AnchorWidget } from '../../../augmentations/components/three-fiber/anchor/AnchorWidget';
-import { ISceneNodeInternal, IAnchorComponentInternal, useStore } from '../../../store';
-import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
+import { ISceneNodeInternal, IAnchorComponentInternal } from '../../../store';
 import { getComponentGroupName } from '../../../utils/objectThreeUtils';
 import { DefaultAnchorStatus } from '../../../interfaces';
 
@@ -12,15 +11,13 @@ interface IAnchorComponentProps {
 }
 
 const AnchorComponent: React.FC<IAnchorComponentProps> = ({ node, component }: IAnchorComponentProps) => {
-  const sceneComposerId = useSceneComposerId();
-  const rule = useStore(sceneComposerId)((state) => state.getSceneRuleMapById(component.ruleBasedMapId));
   return (
     <group name={getComponentGroupName(node.ref, 'TAG')}>
       <AnchorWidget
         node={node}
         defaultIcon={component.icon ?? DefaultAnchorStatus.Info}
         navLink={component.navLink}
-        rule={rule}
+        ruleBasedMapId={component.ruleBasedMapId}
         valueDataBinding={component.valueDataBinding}
         chosenColor={component.chosenColor}
       />

--- a/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/__tests__/ColorOverlayComponent.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/__tests__/ColorOverlayComponent.spec.tsx
@@ -59,10 +59,6 @@ describe('ColorOverlayComponent', () => {
     (ruleEvaluator as jest.Mock).mockReturnValue('info');
   });
 
-  const createComponent = (overrides?) => {
-    return <ColorOverlayComponent node={mockNode} component={mockComponent} {...overrides} />;
-  };
-
   it('should change color', async () => {
     useStore('default').setState(baseState);
     const transform = jest.fn();

--- a/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/index.tsx
@@ -24,7 +24,7 @@ const ColorOverlayComponent: React.FC<IColorOverlayComponentProps> = ({
   const entityObject3D = useStore(sceneComposerId)((state) => state.getObject3DBySceneNodeRef(node.ref));
   const [{ variation: opacityRuleEnabled }] = useFeature(COMPOSER_FEATURES[COMPOSER_FEATURES.OpacityRule]);
 
-  const ruleResult = useRuleResult(ruleBasedMapId!, valueDataBinding!);
+  const ruleResult = useRuleResult({ ruleMapId: ruleBasedMapId, dataBinding: valueDataBinding });
 
   const ruleColor = useMemo(() => {
     const { type, value } = getSceneResourceInfo(ruleResult as string);

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayDataRow.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayDataRow.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
+import { Primitive } from '@iot-app-kit/core';
 
 import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
 import { ITwinMakerEntityDataBindingContext } from '../../../interfaces';
@@ -35,7 +36,7 @@ export const DataOverlayDataRow = ({
       if (!binding.valueDataBinding) {
         return;
       }
-      const values: Record<string, unknown> = dataBindingValuesProvider(
+      const values: Record<string, Primitive> = dataBindingValuesProvider(
         dataInput,
         binding.valueDataBinding,
         dataBindingTemplate,

--- a/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/MotionIndicatorComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/MotionIndicatorComponent.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { Color } from 'three';
+import { Primitive } from '@iot-app-kit/core';
 
 import { ISceneNodeInternal, IMotionIndicatorComponentInternal, useStore, useViewOptionState } from '../../../store';
 import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
@@ -51,7 +52,7 @@ const MotionIndicatorComponent: React.FC<IMotionIndicatorComponentProps> = ({
     ) {
       return component.config.defaultSpeed;
     }
-    const values: Record<string, any> = dataBindingValuesProvider(
+    const values: Record<string, Primitive> = dataBindingValuesProvider(
       dataInput,
       component.valueDataBindings[Component.MotionIndicatorDataBindingName.Speed]?.valueDataBinding,
       dataBindingTemplate,
@@ -76,7 +77,7 @@ const MotionIndicatorComponent: React.FC<IMotionIndicatorComponentProps> = ({
       return new Color(defaultColor);
     }
 
-    const values: Record<string, any> = dataBindingValuesProvider(
+    const values: Record<string, Primitive> = dataBindingValuesProvider(
       dataInput,
       component.valueDataBindings[Component.MotionIndicatorDataBindingName.ForegroundColor]?.valueDataBinding,
       dataBindingTemplate,
@@ -105,7 +106,7 @@ const MotionIndicatorComponent: React.FC<IMotionIndicatorComponentProps> = ({
       return new Color(defaultColor);
     }
 
-    const values: Record<string, any> = dataBindingValuesProvider(
+    const values: Record<string, Primitive> = dataBindingValuesProvider(
       dataInput,
       component.valueDataBindings[Component.MotionIndicatorDataBindingName.BackgroundColor]?.valueDataBinding,
       dataBindingTemplate,

--- a/packages/scene-composer/src/hooks/useRuleResult.spec.ts
+++ b/packages/scene-composer/src/hooks/useRuleResult.spec.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+
+import { useStore } from '../store';
+
+import useRuleResult from './useRuleResult';
+
+jest.mock('./useBindingData', () =>
+  jest.fn().mockImplementation((param) => (param ? { data: [{ alarm_status: 'ACTIVE' }] } : { data: undefined })),
+);
+
+describe('useRuleResult', () => {
+  beforeEach(() => {
+    useStore('default').setState({
+      getSceneRuleMapById: jest.fn().mockImplementation((id) =>
+        id == 'rule-id'
+          ? {
+              statements: [
+                {
+                  expression: "alarm_status == 'ACTIVE'",
+                  target: 'iottwinmaker.common.icon:Error',
+                },
+              ],
+            }
+          : undefined,
+      ),
+    });
+  });
+
+  it('should return default when binding is empty', () => {
+    const data = renderHook(() => useRuleResult({ ruleMapId: 'rule-id', defaultValue: 'default' })).result.current;
+
+    expect(data).toEqual('default');
+  });
+
+  it('should return default when rule is not found', () => {
+    const data = renderHook(() =>
+      useRuleResult({
+        ruleMapId: 'rule-id-random',
+        defaultValue: 'default',
+        dataBinding: { dataBindingContext: { entityId: 'entity-id' } },
+      }),
+    ).result.current;
+
+    expect(data).toEqual('default');
+  });
+
+  it('should return expected target value ', () => {
+    const expectedData = 'iottwinmaker.common.icon:Error';
+    const data = renderHook(() =>
+      useRuleResult({
+        ruleMapId: 'rule-id',
+        defaultValue: 'default',
+        dataBinding: { dataBindingContext: { entityId: 'entity-id' } },
+      }),
+    ).result.current;
+
+    expect(data).toEqual(expectedData);
+  });
+});

--- a/packages/scene-composer/src/hooks/useRuleResult.ts
+++ b/packages/scene-composer/src/hooks/useRuleResult.ts
@@ -1,20 +1,34 @@
 import { useMemo } from 'react';
+import { Primitive } from '@iot-app-kit/core';
 
 import { IValueDataBinding } from '../interfaces';
 import { useSceneDocument, useDataStore } from '../store';
 import { useSceneComposerId } from '../common/sceneComposerIdContext';
 import { dataBindingValuesProvider, ruleEvaluator } from '../utils/dataBindingUtils';
 
-const useRuleResult = (ruleMapId: string, dataBinding: IValueDataBinding) => {
+import useBindingData from './useBindingData';
+
+const useRuleResult = ({
+  ruleMapId,
+  dataBinding,
+  defaultValue,
+}: {
+  ruleMapId?: string;
+  dataBinding?: IValueDataBinding;
+  defaultValue?: string;
+}) => {
   const sceneComposerId = useSceneComposerId();
   const { getSceneRuleMapById } = useSceneDocument(sceneComposerId);
   const { dataBindingTemplate, dataInput } = useDataStore(sceneComposerId);
   const rule = getSceneRuleMapById(ruleMapId);
+  const bindings = useMemo(() => (dataBinding ? [dataBinding] : undefined), [dataBinding]);
+  const bindingData = useBindingData(bindings).data?.at(0);
 
   const ruleResult = useMemo(() => {
-    const values: Record<string, any> = dataBindingValuesProvider(dataInput, dataBinding, dataBindingTemplate);
-    return ruleEvaluator('', values, rule);
-  }, [rule, dataInput, dataBinding]);
+    const values: Record<string, Primitive> =
+      bindingData ?? dataBindingValuesProvider(dataInput, dataBinding, dataBindingTemplate);
+    return ruleEvaluator(defaultValue || '', values, rule);
+  }, [rule, dataInput, dataBinding, bindingData, dataBindingTemplate, defaultValue]);
 
   return ruleResult;
 };

--- a/packages/scene-composer/src/utils/dataBindingUtils.spec.ts
+++ b/packages/scene-composer/src/utils/dataBindingUtils.spec.ts
@@ -1,5 +1,6 @@
-import { IDataFrame, IDataInput, IotTwinMakerNumberNamespace, IRuleBasedMap } from '../../src/interfaces';
-import { dataBindingValuesProvider, ruleEvaluator } from '../../src/utils/dataBindingUtils';
+import { IDataFrame, IDataInput, IotTwinMakerNumberNamespace, IRuleBasedMap } from '../interfaces';
+
+import { dataBindingValuesProvider, ruleEvaluator } from './dataBindingUtils';
 
 describe('dataBindingValuesProvider', () => {
   const createMockDataFrames = (desc = true): IDataFrame[] => {

--- a/packages/scene-composer/src/utils/dataBindingUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingUtils.ts
@@ -1,5 +1,6 @@
 import jexl from 'jexl';
 import { isEqual, pick } from 'lodash';
+import { Primitive } from '@iot-app-kit/core';
 
 import DebugLogger from '../logger/DebugLogger';
 import { DataBindingLabelKeys } from '../common/constants';
@@ -81,7 +82,7 @@ export const dataBindingValuesProvider = (
   dataInput?: IDataInput,
   dataBinding?: IValueDataBinding,
   dataBindingTemplate?: IDataBindingTemplate,
-): Record<string, unknown> => {
+): Record<string, Primitive> => {
   if (!dataBinding || !dataInput || !dataBinding.dataBindingContext) {
     return {};
   } else if (
@@ -117,10 +118,12 @@ export const dataBindingValuesProvider = (
 /**
  * Currently, the jexl in TwinMaker can't handle "-", while the TwinMaker property can accept "-". This function will escape the special character
  */
-const escapeRestrictedKeys = (value: Record<string, unknown>): [Record<string, string>, Record<string, unknown>] => {
+const escapeRestrictedKeys = (
+  value: Record<string, Primitive>,
+): [Record<string, string>, Record<string, Primitive>] => {
   const restrictedCharRegex = /-/g;
   const escapedKeyMap: Record<string, string> = {};
-  const escapedValues: Record<string, unknown> = {};
+  const escapedValues: Record<string, Primitive> = {};
 
   const valueKeys = Object.keys(value);
   for (let i = 0; i < valueKeys.length; ++i) {
@@ -138,7 +141,11 @@ const escapeRestrictedKeys = (value: Record<string, unknown>): [Record<string, s
 
 // A rough implementation of expression based rule evaluation
 // Returns a string that represent the output of the evaluation
-export const ruleEvaluator = (defaultState: string | number, value: Record<string, any>, rule?: IRuleBasedMap) => {
+export const ruleEvaluator = (
+  defaultState: string | number,
+  value: Record<string, Primitive>,
+  rule?: IRuleBasedMap,
+) => {
   if (!rule) {
     LOG.verbose('No rule provided, evaluate as default state', defaultState);
     return defaultState;

--- a/packages/scene-composer/src/utils/dataBindingVariableUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingVariableUtils.ts
@@ -1,8 +1,10 @@
+import { Primitive } from '@iot-app-kit/core';
+
 // Match ${xyz} where xyz can be anything except new line, and as few as possible
 const bindingVariableRegex = /\$\{.+?\}/gi;
 const UNAVAILABLE_DATA = '-';
 
-export function replaceBindingVariables(content: string, bindingValuesMap: Record<string, unknown>): string {
+export function replaceBindingVariables(content: string, bindingValuesMap: Record<string, Primitive>): string {
   let result = content;
 
   const variableMatches = content.match(bindingVariableRegex) || [];


### PR DESCRIPTION
## Overview
support auto query feature for model shader component


https://github.com/awslabs/iot-app-kit/assets/9315598/09abd434-4035-4768-a65e-5ba08c61474a



## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
