### PR TITLE
fix(Tag style): custom color to support icon rules

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
@@ -132,6 +132,27 @@ describe('AnchorWidget', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should render correctly with data binding custom rule', () => {
+    setStore('test-ref', 'test-ref');
+    const container = renderer.create(
+      <AnchorWidget
+        node={node}
+        defaultIcon={DefaultAnchorStatus.Info}
+        rule={{
+          statements: [
+            {
+              expression: "alarm_status == 'ACTIVE'",
+              target: 'iottwinmaker.common.icon:Custom-#CD5C5C',
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(container.root.findByType('anchor').props.visualState).toEqual('Custom');
+    expect(container).toMatchSnapshot();
+  });
+
   it('should render correctly with non default tag settings', () => {
     setStore('test-ref', 'test-ref');
     (useTagSettings as jest.Mock).mockReturnValue({ scale: 3, autoRescale: true });

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/__snapshots__/AnchorWidget.spec.tsx.snap
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/__snapshots__/AnchorWidget.spec.tsx.snap
@@ -189,6 +189,69 @@ exports[`AnchorWidget should render correctly with an offset 1`] = `
 </group>
 `;
 
+exports[`AnchorWidget should render correctly with data binding custom rule 1`] = `
+<group
+  visible={true}
+>
+  <group
+    scale={
+      Vector3 {
+        "x": 1,
+        "y": 1,
+        "z": 1,
+      }
+    }
+  >
+    <lineSegments>
+      <lineBasicMaterial
+        color="#ffffff"
+      />
+      <bufferGeometry
+        attach="geometry"
+      />
+    </lineSegments>
+    <anchor
+      isSelected={true}
+      onClick={[Function]}
+      position={
+        Array [
+          0,
+          0,
+          0,
+        ]
+      }
+      scale={
+        Array [
+          0.5,
+          0.5,
+          1,
+        ]
+      }
+      visualState="Custom"
+    >
+      <div
+        data-test-id="Selected"
+      />
+      <div
+        data-test-id="Info"
+      />
+      <div
+        data-test-id="Warning"
+      />
+      <div
+        data-test-id="Error"
+      />
+      <div
+        data-test-id="Video"
+      />
+      <div
+        data-test-id="Custom"
+      />
+    </anchor>
+  </group>
+</group>
+`;
+
 exports[`AnchorWidget should render correctly with data binding rule 1`] = `
 <group
   visible={true}

--- a/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetEditor.tsx
@@ -95,7 +95,12 @@ export const SceneRuleTargetEditor: React.FC<ISceneRuleTargetEditorProps> = ({
           {isAllValid && (
             <ColorPicker
               color={chosenColor}
-              onSelectColor={(newColor) => setChosenColor(newColor)}
+              onSelectColor={(newColor) => {
+                const colorWithIcon =
+                  targetInfo.value === 'Custom' ? `${targetInfo.value}-${newColor}` : targetInfo.value;
+                onChange(convertToIotTwinMakerNamespace(targetInfo.type, colorWithIcon));
+                setChosenColor(newColor);
+              }}
               label={formatMessage({ defaultMessage: 'Colors', description: 'Colors' })}
             />
           )}


### PR DESCRIPTION
## Overview
* This change contains the fix to rule with custom icon color.
* unit tests
## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/54058998/23ee03f8-29e9-4730-ae6d-acb64fc2a8b0


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
