### PR TITLE
fix(Tag style): custom color to support icon rules

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
@@ -42,6 +42,7 @@ export interface AnchorWidgetProps {
   rule?: IRuleBasedMap;
   navLink?: INavLink;
 }
+type overrideCustomColorType = (rulevalue: string | undefined) => void;
 
 // Adds the custom objects to React Three Fiber
 extend({ Anchor, WidgetVisual, WidgetSprite });
@@ -85,6 +86,7 @@ export function AsyncLoadedAnchorWidget({
   const linesRef = useRef<THREE.LineSegments>(null);
 
   const [_parent, setParent] = useState<THREE.Object3D | undefined>(getObject3DFromSceneNodeRef(node.parentRef));
+  const [overrideCustomColor, setOverrideCustomColor] = useState<string | undefined>(undefined);
 
   const baseScale = useMemo(() => {
     // NOTE: For Fixed Size value was [0.05, 0.05, 1]
@@ -102,11 +104,14 @@ export function AsyncLoadedAnchorWidget({
   const visualState = useMemo(() => {
     const values: Record<string, unknown> = dataBindingValuesProvider(dataInput, valueDataBinding, dataBindingTemplate);
     const ruleTarget = ruleEvaluator(defaultIcon, values, rule);
+    // Evaluate if returned rule is a string type and value is custom icon color
+    getCustomIconColor(ruleTarget, setOverrideCustomColor);
     const ruleTargetInfo = getSceneResourceInfo(ruleTarget as string);
     // Anchor widget only accepts icon, otherwise, default to Info icon
     return ruleTargetInfo.type === SceneResourceType.Icon ? ruleTargetInfo.value : defaultIcon;
   }, [rule, dataInput, valueDataBinding, defaultIcon]);
 
+  const visualRuleCustomColor = overrideCustomColor !== undefined ? overrideCustomColor : chosenColor;
   const defaultVisualMap = useMemo(() => {
     // NOTE: Due to the refactor from a Widget Visual (SVG to Mesh) to a Widget Sprite (SVG to Sprite)
     //  we need a new way of showing selection. This is done by showing a transparent larger image BEHIND the
@@ -131,14 +136,20 @@ export function AsyncLoadedAnchorWidget({
       CustomIconSvgString,
     ];
     return iconStrings.map((iconString, index) => {
-      if (keys[index] === 'Custom') {
-        THREE.Cache.remove(keys[index]);
-        const modifiedSvg = modifySvgColor(iconString, chosenColor);
-        return svgIconToWidgetSprite(modifiedSvg, keys[index], isAlwaysVisible, !autoRescale);
+      const iconStyle = keys[index];
+      if (iconStyle === 'Custom') {
+        const modifiedSvg = modifySvgColor(iconString, visualRuleCustomColor);
+        return svgIconToWidgetSprite(
+          modifiedSvg,
+          iconStyle,
+          visualRuleCustomColor ? `${iconStyle}-${visualRuleCustomColor}` : iconStyle,
+          isAlwaysVisible,
+          !autoRescale,
+        );
       }
-      return svgIconToWidgetSprite(iconString, keys[index], isAlwaysVisible, !autoRescale);
+      return svgIconToWidgetSprite(iconString, iconStyle, iconStyle, isAlwaysVisible, !autoRescale);
     });
-  }, [autoRescale, chosenColor]);
+  }, [autoRescale, visualRuleCustomColor]);
 
   const isAnchor = (nodeRef?: string) => {
     const node = getSceneNodeByRef(nodeRef);
@@ -263,6 +274,19 @@ export const AnchorWidget: React.FC<AnchorWidgetProps> = (props: AnchorWidgetPro
     </React.Suspense>
   );
 };
+
+/**
+ * This method sets the custom icon color if it is returned from the rule.
+ * @param ruleTarget
+ * @param setOverrideCustomColor
+ */
+function getCustomIconColor(ruleTarget: string | number, setOverrideCustomColor: overrideCustomColorType) {
+  const ruleColor =
+    typeof ruleTarget === 'string' && ruleTarget.includes('Custom-')
+      ? ruleTarget.split(':')[1].split('-')[1]
+      : undefined;
+  setOverrideCustomColor(ruleColor);
+}
 /**
  * This method parse the svg string and fill the color
  * @param iconString

--- a/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.spec.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.spec.tsx
@@ -1,5 +1,4 @@
 import renderer from 'react-test-renderer';
-import React from 'react';
 
 import { DefaultAnchorStatus, SelectedAnchor } from '../../../..';
 import {

--- a/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.tsx
@@ -7,7 +7,8 @@ import { RenderOrder } from '../../../../common/constants';
 
 export default function svgIconToWidgetSprite(
   svg: string,
-  key: DefaultAnchorStatus | string,
+  name: DefaultAnchorStatus | string,
+  key: string,
   alwaysVisible,
   sizeAttenuation: boolean, // when true, tag size changes when zooming
   props?: WidgetSpriteProps,
@@ -27,7 +28,7 @@ export default function svgIconToWidgetSprite(
   const texture = THREE.Cache.get(key);
 
   return (
-    <widgetSprite key={key} name={key} {...props}>
+    <widgetSprite key={key} name={name} {...props}>
       <group attach='visual'>
         <sprite renderOrder={RenderOrder.DrawLate}>
           <spriteMaterial

--- a/packages/scene-composer/src/augmentations/components/three-fiber/common/__snapshots__/SvgIconToWidgetSprite.spec.tsx.snap
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/common/__snapshots__/SvgIconToWidgetSprite.spec.tsx.snap
@@ -10,8 +10,14 @@ exports[`svgIconToWidgetSprite it should render the Error correctly 1`] = `
     <sprite
       renderOrder={10}
     >
+      <spriteMaterial />
+    </sprite>
+    <sprite
+      renderOrder={10}
+    >
       <spriteMaterial
-        sizeAttenuation={true}
+        depthFunc={6}
+        opacity={0.5}
       />
     </sprite>
   </group>
@@ -28,8 +34,14 @@ exports[`svgIconToWidgetSprite it should render the Info correctly 1`] = `
     <sprite
       renderOrder={10}
     >
+      <spriteMaterial />
+    </sprite>
+    <sprite
+      renderOrder={10}
+    >
       <spriteMaterial
-        sizeAttenuation={true}
+        depthFunc={6}
+        opacity={0.5}
       />
     </sprite>
   </group>
@@ -46,8 +58,14 @@ exports[`svgIconToWidgetSprite it should render the Selected correctly 1`] = `
     <sprite
       renderOrder={10}
     >
+      <spriteMaterial />
+    </sprite>
+    <sprite
+      renderOrder={10}
+    >
       <spriteMaterial
-        sizeAttenuation={true}
+        depthFunc={6}
+        opacity={0.5}
       />
     </sprite>
   </group>
@@ -64,8 +82,14 @@ exports[`svgIconToWidgetSprite it should render the Video correctly 1`] = `
     <sprite
       renderOrder={10}
     >
+      <spriteMaterial />
+    </sprite>
+    <sprite
+      renderOrder={10}
+    >
       <spriteMaterial
-        sizeAttenuation={true}
+        depthFunc={6}
+        opacity={0.5}
       />
     </sprite>
   </group>
@@ -82,8 +106,14 @@ exports[`svgIconToWidgetSprite it should render the Warning correctly 1`] = `
     <sprite
       renderOrder={10}
     >
+      <spriteMaterial />
+    </sprite>
+    <sprite
+      renderOrder={10}
+    >
       <spriteMaterial
-        sizeAttenuation={true}
+        depthFunc={6}
+        opacity={0.5}
       />
     </sprite>
   </group>
@@ -100,9 +130,7 @@ exports[`svgIconToWidgetSprite it should render the always visible Error correct
     <sprite
       renderOrder={10}
     >
-      <spriteMaterial
-        sizeAttenuation={true}
-      />
+      <spriteMaterial />
     </sprite>
     <sprite
       renderOrder={10}
@@ -110,7 +138,6 @@ exports[`svgIconToWidgetSprite it should render the always visible Error correct
       <spriteMaterial
         depthFunc={6}
         opacity={0.5}
-        sizeAttenuation={true}
       />
     </sprite>
   </group>
@@ -127,9 +154,7 @@ exports[`svgIconToWidgetSprite it should render the always visible Info correctl
     <sprite
       renderOrder={10}
     >
-      <spriteMaterial
-        sizeAttenuation={true}
-      />
+      <spriteMaterial />
     </sprite>
     <sprite
       renderOrder={10}
@@ -137,7 +162,6 @@ exports[`svgIconToWidgetSprite it should render the always visible Info correctl
       <spriteMaterial
         depthFunc={6}
         opacity={0.5}
-        sizeAttenuation={true}
       />
     </sprite>
   </group>
@@ -154,9 +178,7 @@ exports[`svgIconToWidgetSprite it should render the always visible Selected corr
     <sprite
       renderOrder={10}
     >
-      <spriteMaterial
-        sizeAttenuation={true}
-      />
+      <spriteMaterial />
     </sprite>
     <sprite
       renderOrder={10}
@@ -164,7 +186,6 @@ exports[`svgIconToWidgetSprite it should render the always visible Selected corr
       <spriteMaterial
         depthFunc={6}
         opacity={0.5}
-        sizeAttenuation={true}
       />
     </sprite>
   </group>
@@ -181,9 +202,7 @@ exports[`svgIconToWidgetSprite it should render the always visible Video correct
     <sprite
       renderOrder={10}
     >
-      <spriteMaterial
-        sizeAttenuation={true}
-      />
+      <spriteMaterial />
     </sprite>
     <sprite
       renderOrder={10}
@@ -191,7 +210,6 @@ exports[`svgIconToWidgetSprite it should render the always visible Video correct
       <spriteMaterial
         depthFunc={6}
         opacity={0.5}
-        sizeAttenuation={true}
       />
     </sprite>
   </group>
@@ -208,9 +226,7 @@ exports[`svgIconToWidgetSprite it should render the always visible Warning corre
     <sprite
       renderOrder={10}
     >
-      <spriteMaterial
-        sizeAttenuation={true}
-      />
+      <spriteMaterial />
     </sprite>
     <sprite
       renderOrder={10}
@@ -218,7 +234,6 @@ exports[`svgIconToWidgetSprite it should render the always visible Warning corre
       <spriteMaterial
         depthFunc={6}
         opacity={0.5}
-        sizeAttenuation={true}
       />
     </sprite>
   </group>
@@ -235,9 +250,7 @@ exports[`svgIconToWidgetSprite it should render the constant sized Error correct
     <sprite
       renderOrder={10}
     >
-      <spriteMaterial
-        sizeAttenuation={false}
-      />
+      <spriteMaterial />
     </sprite>
   </group>
 </widgetSprite>
@@ -253,9 +266,7 @@ exports[`svgIconToWidgetSprite it should render the constant sized Info correctl
     <sprite
       renderOrder={10}
     >
-      <spriteMaterial
-        sizeAttenuation={false}
-      />
+      <spriteMaterial />
     </sprite>
   </group>
 </widgetSprite>
@@ -271,9 +282,7 @@ exports[`svgIconToWidgetSprite it should render the constant sized Selected corr
     <sprite
       renderOrder={10}
     >
-      <spriteMaterial
-        sizeAttenuation={false}
-      />
+      <spriteMaterial />
     </sprite>
   </group>
 </widgetSprite>
@@ -289,9 +298,7 @@ exports[`svgIconToWidgetSprite it should render the constant sized Video correct
     <sprite
       renderOrder={10}
     >
-      <spriteMaterial
-        sizeAttenuation={false}
-      />
+      <spriteMaterial />
     </sprite>
   </group>
 </widgetSprite>
@@ -307,9 +314,7 @@ exports[`svgIconToWidgetSprite it should render the constant sized Warning corre
     <sprite
       renderOrder={10}
     >
-      <spriteMaterial
-        sizeAttenuation={false}
-      />
+      <spriteMaterial />
     </sprite>
   </group>
 </widgetSprite>

--- a/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetEditor.tsx
@@ -95,7 +95,12 @@ export const SceneRuleTargetEditor: React.FC<ISceneRuleTargetEditorProps> = ({
           {isAllValid && (
             <ColorPicker
               color={chosenColor}
-              onSelectColor={(newColor) => setChosenColor(newColor)}
+              onSelectColor={(newColor) => {
+                const colorWithIcon =
+                  targetInfo.value === 'Custom' ? `${targetInfo.value}-${newColor}` : targetInfo.value;
+                onChange(convertToIotTwinMakerNamespace(targetInfo.type, colorWithIcon));
+                setChosenColor(newColor);
+              }}
               label={formatMessage({ defaultMessage: 'Colors', description: 'Colors' })}
             />
           )}


### PR DESCRIPTION
## Overview
This change contains the fix to rule with custom icon color.

Verify tag color changes if rule meets the criteria.
Verify tag color does not change if rule does not meet criteria.
Verify when rule does not meet, it shows default custom color for tags.
unit tests


Changes are already approved for main branch. Just pushing it to release-3.x.
## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
