### PR TITLE
feat(dashboard): line symbol

### DIFF
--- a/packages/dashboard/src/customization/api.ts
+++ b/packages/dashboard/src/customization/api.ts
@@ -6,6 +6,7 @@ import type { DashboardWidget } from '~/types';
 import plugins from '~/customization/pluginsConfiguration';
 import { rectanglePlugin } from './widgets';
 import { useHasFeatureFlag } from '@iot-app-kit/react-components';
+import { linePlugin } from './widgets/lineSymbol/plugin';
 
 type RenderFunc<T extends DashboardWidget> = (widget: T) => React.ReactElement;
 
@@ -75,5 +76,6 @@ export const useDashboardPlugins = () => {
   plugins.forEach((plugin) => plugin.install({ registerWidget }));
   if (hasSymbolLibraryFeatureFlag) {
     rectanglePlugin.install({ registerWidget });
+    linePlugin.install({ registerWidget });
   }
 };

--- a/packages/dashboard/src/customization/widgets/lineSymbol/__snapshots__/component.test.tsx.snap
+++ b/packages/dashboard/src/customization/widgets/lineSymbol/__snapshots__/component.test.tsx.snap
@@ -1,0 +1,211 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LineWidgetComponent Rendering should render correctly with {"properties":{"lineStyle":"dashed","color":"black","thickness":5,"start":{"x":30,"y":20},"end":{"x":180,"y":190}},"isSelected":true} while selected 1`] = `
+<div>
+  <div
+    class="fit-full"
+  >
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 20px; top: 10px;"
+    />
+    <svg
+      class="fit-full"
+      pointer-events="none"
+    >
+      <line
+        stroke="black"
+        stroke-dasharray="10,5"
+        stroke-width="5"
+        x1="30"
+        x2="180"
+        y1="20"
+        y2="190"
+      />
+    </svg>
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 170px; top: 180px;"
+    />
+  </div>
+</div>
+`;
+
+exports[`LineWidgetComponent Rendering should render correctly with {"properties":{"lineStyle":"dashed","color":"blue","thickness":10,"start":{"x":180,"y":175},"end":{"x":20,"y":30}},"isSelected":true} while selected 1`] = `
+<div>
+  <div
+    class="fit-full"
+  >
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 170px; top: 165px;"
+    />
+    <svg
+      class="fit-full"
+      pointer-events="none"
+    >
+      <line
+        stroke="blue"
+        stroke-dasharray="10,5"
+        stroke-width="10"
+        x1="180"
+        x2="20"
+        y1="175"
+        y2="30"
+      />
+    </svg>
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 10px; top: 20px;"
+    />
+  </div>
+</div>
+`;
+
+exports[`LineWidgetComponent Rendering should render correctly with {"properties":{"lineStyle":"dotted","color":"black","thickness":5,"start":{"x":25,"y":5},"end":{"x":100,"y":120}},"isSelected":true} while selected 1`] = `
+<div>
+  <div
+    class="fit-full"
+  >
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 15px; top: -5px;"
+    />
+    <svg
+      class="fit-full"
+      pointer-events="none"
+    >
+      <line
+        stroke="black"
+        stroke-dasharray="3,3"
+        stroke-width="5"
+        x1="25"
+        x2="100"
+        y1="5"
+        y2="120"
+      />
+    </svg>
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 90px; top: 110px;"
+    />
+  </div>
+</div>
+`;
+
+exports[`LineWidgetComponent Rendering should render correctly with {"properties":{"lineStyle":"dotted","color":"green","thickness":15,"start":{"x":180,"y":175},"end":{"x":20,"y":30}},"isSelected":true} while selected 1`] = `
+<div>
+  <div
+    class="fit-full"
+  >
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 170px; top: 165px;"
+    />
+    <svg
+      class="fit-full"
+      pointer-events="none"
+    >
+      <line
+        stroke="green"
+        stroke-dasharray="3,3"
+        stroke-width="15"
+        x1="180"
+        x2="20"
+        y1="175"
+        y2="30"
+      />
+    </svg>
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 10px; top: 20px;"
+    />
+  </div>
+</div>
+`;
+
+exports[`LineWidgetComponent Rendering should render correctly with {"properties":{"lineStyle":"solid","color":"black","thickness":5,"start":{"x":20,"y":20},"end":{"x":180,"y":180}},"isSelected":true} while selected 1`] = `
+<div>
+  <div
+    class="fit-full"
+  >
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 10px; top: 10px;"
+    />
+    <svg
+      class="fit-full"
+      pointer-events="none"
+    >
+      <line
+        stroke="black"
+        stroke-dasharray="1,0"
+        stroke-width="5"
+        x1="20"
+        x2="180"
+        y1="20"
+        y2="180"
+      />
+    </svg>
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 170px; top: 170px;"
+    />
+  </div>
+</div>
+`;
+
+exports[`LineWidgetComponent Rendering should render correctly with {"properties":{"lineStyle":"solid","color":"red","thickness":5,"start":{"x":20,"y":20},"end":{"x":180,"y":180}},"isSelected":true} while selected 1`] = `
+<div>
+  <div
+    class="fit-full"
+  >
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 10px; top: 10px;"
+    />
+    <svg
+      class="fit-full"
+      pointer-events="none"
+    >
+      <line
+        stroke="red"
+        stroke-dasharray="1,0"
+        stroke-width="5"
+        x1="20"
+        x2="180"
+        y1="20"
+        y2="180"
+      />
+    </svg>
+    <div
+      class="line-anchor"
+      data-testid="line-anchor"
+      draggable="true"
+      style="position: absolute; left: 170px; top: 170px;"
+    />
+  </div>
+</div>
+`;

--- a/packages/dashboard/src/customization/widgets/lineSymbol/component.css
+++ b/packages/dashboard/src/customization/widgets/lineSymbol/component.css
@@ -1,0 +1,4 @@
+.fit-full {
+  width: 100%;
+  height: 100%;
+}

--- a/packages/dashboard/src/customization/widgets/lineSymbol/component.test.tsx
+++ b/packages/dashboard/src/customization/widgets/lineSymbol/component.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import LineWidgetComponent from './component';
+import { Provider } from 'react-redux';
+import { configureDashboardStore } from '~/store';
+import { DashboardState } from '~/store/state';
+import { LineProperties, LineWidget } from '../types';
+
+const mockWidgetPartial = {
+  id: 'mock-line-widget',
+  type: 'line-symbol',
+  x: 0,
+  y: 0,
+  z: 1,
+  width: 7,
+  height: 4,
+};
+
+const TestComponent = (object: { widget: LineWidget; isSelected: boolean }) => {
+  const { widget, isSelected } = object;
+
+  const initialState: Partial<DashboardState> = {
+    dashboardConfiguration: {
+      widgets: [widget],
+      viewport: { duration: '5m' },
+    },
+    selectedWidgets: isSelected ? [widget] : [],
+  };
+
+  return (
+    <Provider store={configureDashboardStore(initialState)}>
+      <DndProvider backend={HTML5Backend}>
+        <LineWidgetComponent {...widget} />
+      </DndProvider>
+    </Provider>
+  );
+};
+
+describe('LineWidgetComponent', () => {
+  describe('Rendering', () => {
+    [
+      {
+        properties: {
+          lineStyle: 'solid',
+          color: 'black',
+          thickness: 5,
+          start: { x: 20, y: 20 },
+          end: { x: 180, y: 180 },
+        } as LineProperties,
+        isSelected: true,
+      },
+      {
+        properties: {
+          lineStyle: 'dashed',
+          color: 'black',
+          thickness: 5,
+          start: { x: 30, y: 20 },
+          end: { x: 180, y: 190 },
+        } as LineProperties,
+        isSelected: true,
+      },
+      {
+        properties: {
+          lineStyle: 'dotted',
+          color: 'black',
+          thickness: 5,
+          start: { x: 25, y: 5 },
+          end: { x: 100, y: 120 },
+        } as LineProperties,
+        isSelected: true,
+      },
+      {
+        properties: {
+          lineStyle: 'solid',
+          color: 'red',
+          thickness: 5,
+          start: { x: 20, y: 20 },
+          end: { x: 180, y: 180 },
+        } as LineProperties,
+        isSelected: true,
+      },
+      {
+        properties: {
+          lineStyle: 'dashed',
+          color: 'blue',
+          thickness: 10,
+          start: { x: 180, y: 175 },
+          end: { x: 20, y: 30 },
+        } as LineProperties,
+        isSelected: true,
+      },
+      {
+        properties: {
+          lineStyle: 'dotted',
+          color: 'green',
+          thickness: 15,
+          start: { x: 180, y: 175 },
+          end: { x: 20, y: 30 },
+        } as LineProperties,
+        isSelected: true,
+      },
+    ].forEach((configuration) => {
+      const widget = { ...mockWidgetPartial, properties: { ...configuration.properties } };
+      const isSelected = configuration.isSelected;
+      it(`should render correctly with ${JSON.stringify(configuration)} while ${
+        isSelected ? 'selected' : 'not selected'
+      }`, () => {
+        const { container } = render(<TestComponent widget={widget} isSelected={isSelected} />);
+        expect(container).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('Anchor visibility', () => {
+    const widget = {
+      ...mockWidgetPartial,
+      properties: {
+        lineStyle: 'solid',
+        color: 'black',
+        thickness: 5,
+        start: { x: 180, y: 175 },
+        end: { x: 20, y: 30 },
+      },
+    } as LineWidget;
+
+    it('should display anchors when the widget is selected', async () => {
+      const { getAllByTestId } = render(<TestComponent widget={widget} isSelected={true} />);
+      expect(getAllByTestId('line-anchor')).toHaveLength(2);
+    });
+    it('should not display anchors when the widget is not selected', () => {
+      const { queryAllByTestId } = render(<TestComponent widget={widget} isSelected={false} />);
+      expect(queryAllByTestId('line-anchor')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/dashboard/src/customization/widgets/lineSymbol/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineSymbol/component.tsx
@@ -1,0 +1,103 @@
+import React, { CSSProperties } from 'react';
+import './component.css';
+import { LineWidget } from '~/customization/widgets/types';
+import { SVG_STROKE_DASHED, SVG_STROKE_DOTTED, SVG_STROKE_SOLID } from '../constants';
+import { LineAnchor } from './lineAnchor/component';
+import { useIsSelected } from '~/customization/hooks/useIsSelected';
+import { useWidgetActions } from '~/customization/hooks/useWidgetActions';
+import { DashboardWidget } from '~/types';
+import { XYCoord } from 'react-dnd';
+
+const ANCHOR_HALF_SIDE_LENGTH_PX = 10;
+
+const LineWidgetComponent: React.FC<LineWidget> = (widget) => {
+  const isSelected = useIsSelected(widget);
+
+  const {
+    lineStyle = 'solid',
+    color = 'black',
+    thickness = 5,
+    start = {
+      x: 25,
+      y: 200,
+    },
+    end = {
+      x: 375,
+      y: 200,
+    },
+  } = widget.properties;
+
+  let strokeString = SVG_STROKE_SOLID;
+
+  if (lineStyle === 'dashed') {
+    strokeString = SVG_STROKE_DASHED;
+  } else if (lineStyle === 'dotted') {
+    strokeString = SVG_STROKE_DOTTED;
+  }
+
+  // we need to subtract ANCHOR_HALF_SIDE_LENGTH_PX because otherwise the line ends match the anchors' top-left points
+  // whereas we want them to match their centers
+  const startAnchorStyle: CSSProperties = {
+    position: 'absolute',
+    left: `${start.x - ANCHOR_HALF_SIDE_LENGTH_PX}px`,
+    top: `${start.y - ANCHOR_HALF_SIDE_LENGTH_PX}px`,
+  };
+
+  const endAnchorStyle: CSSProperties = {
+    position: 'absolute',
+    left: `${end.x - ANCHOR_HALF_SIDE_LENGTH_PX}px`,
+    top: `${end.y - ANCHOR_HALF_SIDE_LENGTH_PX}px`,
+  };
+
+  const { update: updateWidget } = useWidgetActions<DashboardWidget>();
+
+  const updateAnchor = (anchorType: 'start' | 'end', newPoint: XYCoord) => {
+    const updatedProperties = {
+      ...widget.properties,
+      [anchorType]: {
+        x: newPoint.x,
+        y: newPoint.y,
+      },
+    };
+    const newWidget = { ...widget, properties: updatedProperties };
+    updateWidget(newWidget);
+  };
+
+  return (
+    <div className='fit-full'>
+      {isSelected && (
+        <LineAnchor
+          style={startAnchorStyle}
+          point={{ x: widget.properties.start.x, y: widget.properties.start.y }}
+          dimensions={{ height: widget.height, width: widget.width }}
+          updateWidget={(newPoint) => {
+            updateAnchor('start', newPoint);
+          }}
+        />
+      )}
+      <svg className='fit-full' pointerEvents='none'>
+        <line
+          x1={start.x}
+          y1={start.y}
+          x2={end.x}
+          y2={end.y}
+          stroke={color}
+          strokeWidth={thickness}
+          stroke-dasharray={strokeString}
+        />
+      </svg>
+      {isSelected && (
+        <LineAnchor
+          style={endAnchorStyle}
+          point={{ x: widget.properties.end.x, y: widget.properties.end.y }}
+          dimensions={{ height: widget.height, width: widget.width }}
+          updateWidget={(newPoint) => {
+            updateAnchor('end', newPoint);
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default LineWidgetComponent;

--- a/packages/dashboard/src/customization/widgets/lineSymbol/icon.tsx
+++ b/packages/dashboard/src/customization/widgets/lineSymbol/icon.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const LineSymbolIcon: React.FC = () => (
+  <svg viewBox='0 0 30 30' fill='none' xmlns='http://www.w3.org/2000/svg'>
+    <line x1='0' y1='30' x2='30' y2='0' stroke='black' strokeWidth='3' />
+  </svg>
+);
+
+export default LineSymbolIcon;

--- a/packages/dashboard/src/customization/widgets/lineSymbol/lineAnchor/component.css
+++ b/packages/dashboard/src/customization/widgets/lineSymbol/lineAnchor/component.css
@@ -1,0 +1,8 @@
+.line-anchor {
+  width: 20px;
+  height: 20px;
+  background-color: white;
+  border: 2px solid #0d99ff;
+  border-radius: 2px;
+  box-sizing: border-box;
+}

--- a/packages/dashboard/src/customization/widgets/lineSymbol/lineAnchor/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineSymbol/lineAnchor/component.tsx
@@ -1,0 +1,87 @@
+import React, { CSSProperties, useEffect, useRef } from 'react';
+import './component.css';
+import { XYCoord, useDrag } from 'react-dnd';
+import { useGridSettings } from '~/components/actions/useGridSettings';
+
+/**
+ * Compute the new position of the widget based on initial position, offset difference, and grid settings.
+ *
+ * @param {XYCoord} initialPosition - The initial position of the widget.
+ * @param {XYCoord} offsetDifference - The offset difference based on the drag event.
+ * @param {number} height - The height of the widget.
+ * @param {number} width - The width of the widget.
+ * @param {number} cellSize - The size of a cell in the grid.
+ * @return {XYCoord} - The new position (x, y) for the widget.
+ */
+const computeNewPosition = (
+  initialPosition: XYCoord,
+  offsetDifference: XYCoord,
+  height: number,
+  width: number,
+  cellSize: number
+): XYCoord => {
+  const { x: initialX, y: initialY } = initialPosition;
+  const { x: offsetX, y: offsetY } = offsetDifference;
+
+  const widthPixels = Math.round(width * cellSize);
+  const heightPixels = Math.round(height * cellSize);
+
+  const newX = Math.max(0, Math.min(initialX + offsetX, widthPixels));
+  const newY = Math.max(0, Math.min(initialY + offsetY, heightPixels));
+
+  return { x: newX, y: newY };
+};
+
+/**
+ * Custom hook to handle drag-and-drop for LineWidget anchors.
+ *
+ * This hook initializes drag functionality and updates the widget position
+ * whenever a drag event occurs on either anchor.
+ *
+ * @param {LineWidget} widget - The current LineWidget object that is being manipulated.
+ * @param {'start'|'end'} anchorType - Specifies which anchor ('start' or 'end') is being dragged.
+ * @return {ConnectDragSource} - A ref to be attached to the drag component.
+ */
+const useDragAndUpdate = (
+  point: XYCoord,
+  dimensions: { height: number; width: number },
+  updateWidget: (point: XYCoord) => void
+) => {
+  const initialPointRef = useRef({
+    x: 0,
+    y: 0,
+  });
+
+  const { cellSize } = useGridSettings();
+
+  const [{ diff, isDragging }, ref] = useDrag({
+    type: 'LineAnchor',
+    item: () => {
+      initialPointRef.current = point;
+      // we need to return an empty object at the minimum, even if no props are returned
+      return {};
+    },
+    collect: (monitor) => {
+      const offsetDifference = monitor.getDifferenceFromInitialOffset();
+      return { diff: offsetDifference, isDragging: monitor.isDragging() };
+    },
+  });
+
+  useEffect(() => {
+    if (isDragging && diff) {
+      const newPoint = computeNewPosition(initialPointRef.current, diff, dimensions.height, dimensions.width, cellSize);
+      updateWidget(newPoint);
+    }
+  }, [diff?.x, diff?.y]);
+  return ref;
+};
+
+export const LineAnchor: React.FC<{
+  style: CSSProperties;
+  point: XYCoord;
+  dimensions: { height: number; width: number };
+  updateWidget: (point: XYCoord) => void;
+}> = ({ style, point, dimensions, updateWidget }) => {
+  const dragRef = useDragAndUpdate(point, dimensions, updateWidget);
+  return <div data-testid='line-anchor' ref={dragRef} style={style} className='line-anchor' />;
+};

--- a/packages/dashboard/src/customization/widgets/lineSymbol/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/lineSymbol/plugin.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import LineWidgetComponent from './component';
+import LineSymbolIcon from './icon';
+import type { DashboardPlugin } from '~/customization/api';
+import { LineWidget } from '../types';
+
+export const linePlugin: DashboardPlugin = {
+  install: ({ registerWidget }) => {
+    registerWidget<LineWidget>('line', {
+      render: (widget) => <LineWidgetComponent {...widget} />,
+      componentLibrary: {
+        name: 'Line Symbol',
+        icon: LineSymbolIcon,
+      },
+      properties: () => ({
+        start: {
+          x: 25,
+          y: 200,
+        },
+        end: {
+          x: 375,
+          y: 200,
+        },
+      }),
+      initialSize: {
+        width: 400,
+        height: 400,
+      },
+    });
+  },
+};

--- a/packages/dashboard/src/customization/widgets/rectangleSymbol/component.tsx
+++ b/packages/dashboard/src/customization/widgets/rectangleSymbol/component.tsx
@@ -12,9 +12,9 @@ const RectangleWidgetComponent: React.FC<RectangleWidget> = (widget) => {
 
   let strokeString = SVG_STROKE_SOLID;
 
-  if (borderStyle == 'dashed') {
+  if (borderStyle === 'dashed') {
     strokeString = SVG_STROKE_DASHED;
-  } else if (borderStyle == 'dotted') {
+  } else if (borderStyle === 'dotted') {
     strokeString = SVG_STROKE_DOTTED;
   }
 

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -97,6 +97,19 @@ export type RectangleProperties = {
   borderThickness?: number;
 };
 
+type Point = {
+  x: number;
+  y: number;
+};
+
+export type LineProperties = {
+  start: Point;
+  end: Point;
+  lineStyle?: 'solid' | 'dashed' | 'dotted';
+  color?: string;
+  thickness?: number;
+};
+
 type ChartPropertiesUnion =
   | KPIProperties
   | StatusProperties
@@ -124,3 +137,4 @@ export type TableWidget = DashboardWidget<TableProperties>;
 export type TextWidget = DashboardWidget<TextProperties>;
 export type StatusTimelineWidget = DashboardWidget<StatusTimelineProperties>;
 export type RectangleWidget = DashboardWidget<RectangleProperties>;
+export type LineWidget = DashboardWidget<LineProperties>;

--- a/packages/dashboard/testing/mocks.ts
+++ b/packages/dashboard/testing/mocks.ts
@@ -4,6 +4,7 @@ import random from 'lodash/random';
 import {
   KPIWidget,
   LineChartWidget,
+  LineWidget,
   RectangleWidget,
   ScatterChartWidget,
   StatusWidget,
@@ -173,6 +174,29 @@ export const MOCK_RECTANGLE_WIDGET: RectangleWidget = {
     fill: 'none',
     borderColor: 'black',
     borderThickness: 5,
+  },
+};
+
+export const MOCK_LINE_WIDGET: LineWidget = {
+  id: 'mock-line-widget',
+  type: 'line-symbol',
+  x: 0,
+  y: 0,
+  z: 1,
+  width: 7,
+  height: 4,
+  properties: {
+    start: {
+      x: 25,
+      y: 200,
+    },
+    end: {
+      x: 375,
+      y: 200,
+    },
+    lineStyle: 'solid',
+    color: 'black',
+    thickness: 5,
   },
 };
 


### PR DESCRIPTION
## Overview
This PR is for the line symbol widget. It allows the user to drag and drop a line. The line can be manipulated using the anchors at its ends.

Currently, the line is limited to its bounding box: the bouding box has to be resized to allow a larger line. This is not the final state - in a future PR, the bounding box will be invisible except for during multiple selection and the line will be able to be placed anywhere regardless of it.

## Verifying Changes

Refer to the screen recording below:

https://github.com/awslabs/iot-app-kit/assets/34567765/3d885d29-2d1b-4168-af0b-52e529949029

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
