### PR TITLE
fix(Load manager): fixed the downloaded bytes onProgress call

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/hooks/useProgress.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/hooks/useProgress.spec.tsx
@@ -74,6 +74,7 @@ describe('useProgress', () => {
     // Assert
     expect(setMock).toBeCalledWith({
       active: true,
+      downloaded: 25,
       item,
       loaded,
       total,
@@ -86,6 +87,7 @@ describe('useProgress', () => {
     const item = 'test-url';
     const loaded = 100;
     const total = 100;
+
     const setMock = jest.fn();
     useProgressImpl(setMock);
 
@@ -98,6 +100,7 @@ describe('useProgress', () => {
       item,
       loaded,
       total,
+      downloaded: 0,
       progress: 100,
     });
   });

--- a/packages/scene-composer/src/components/three-fiber/hooks/useProgress.tsx
+++ b/packages/scene-composer/src/components/three-fiber/hooks/useProgress.tsx
@@ -16,6 +16,7 @@ type Data = {
   downloadProgress: number;
 };
 let saveLastTotalLoaded = 0;
+const downloaded = 0;
 
 export const useProgressImpl = (set) => {
   [DefaultLoadingManager, ...tmLoadingManagers].forEach((manager) => {
@@ -40,6 +41,7 @@ export const useProgressImpl = (set) => {
         active: true,
         item,
         loaded,
+        downloaded: downloaded + (loaded - saveLastTotalLoaded),
         total,
         progress: ((loaded - saveLastTotalLoaded) / (total - saveLastTotalLoaded)) * 100 || 100,
       });


### PR DESCRIPTION
## Overview
This change contains fix for showing asset bytes downloading status. Initially we were hardcoding it to 0. Now are calculating based on downloaded and already loaded bytes. 
## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
