### PR TITLE
fix(react-component): removing transition animation for trend cursors

### DIFF
--- a/packages/react-components/src/components/chart/hooks/useTrendCursorsEvents.ts
+++ b/packages/react-components/src/components/chart/hooks/useTrendCursorsEvents.ts
@@ -1,10 +1,6 @@
 import { RefObject, useEffect, useRef } from 'react';
-import { EChartsType, ElementEvent, getInstanceByDom } from 'echarts';
-import {
-  MAX_TREND_CURSORS,
-  TREND_CURSOR_CLOSE_GRAPHIC_INDEX,
-  TREND_CURSOR_LINE_GRAPHIC_INDEX,
-} from '../eChartsConstants';
+import { EChartsType, getInstanceByDom } from 'echarts';
+import { MAX_TREND_CURSORS, TREND_CURSOR_CLOSE_GRAPHIC_INDEX } from '../eChartsConstants';
 import { calculateNearestTcIndex, calculateTimeStamp, formatCopyData } from '../utils/getInfo';
 import { v4 as uuid } from 'uuid';
 import { getNewTrendCursor, onDragUpdateTrendCursor } from '../utils/getTrendCursor';
@@ -111,19 +107,6 @@ const useTrendCursorsEvents = ({
     const toBeDeletedGraphicIndex = calculateNearestTcIndex(graphicRef.current, timestampOfClick);
     deleteTrendCursor(toBeDeletedGraphicIndex);
   };
-
-  const dragStartEndHandler = (e: ElementEvent) => {
-    if (graphicRef.current.length) {
-      const updatedGraphics = graphicRef.current.map((g) => {
-        // when the TC's line is dragged, turn off the animations
-        if (g.children[TREND_CURSOR_LINE_GRAPHIC_INDEX].id === e?.target?.id) {
-          g.transition = e.type === 'dragstart' ? [] : ['x'];
-        }
-        return g;
-      });
-      setGraphicRef.current(updatedGraphics);
-    }
-  };
   // The below event handlers will handle both sync and standalone mode
   // sync mode --> dispatches the actions from the store
   // standalone mode --> updates the local state
@@ -150,11 +133,6 @@ const useTrendCursorsEvents = ({
             addNewTrendCursor({ posX: e.offsetX ?? 0, ignoreHotKey: false });
           }
         });
-
-        // to turn off transition during dragging
-        chart?.getZr().on('dragstart', dragStartEndHandler);
-        // to turn off transition during dragging
-        chart?.getZr().on('dragend', dragStartEndHandler);
 
         // this is the ondrag handler of the trend cursor
         chart?.getZr().on('drag', (event) => {
@@ -196,9 +174,6 @@ const useTrendCursorsEvents = ({
           chart?.getZr().off('mouseover', () => mouseoverHandler(isInCursorAddModeRef.current, chart));
           chart?.getZr().off('drag');
           chart?.getZr().off('contextmenu');
-          // to turn off transition during dragging
-          chart?.getZr().off('dragstart', dragStartEndHandler);
-          chart?.getZr().off('dragend', dragStartEndHandler);
         }
       };
     }

--- a/packages/react-components/src/components/chart/utils/getTrendCursor.ts
+++ b/packages/react-components/src/components/chart/utils/getTrendCursor.ts
@@ -251,6 +251,5 @@ export const getNewTrendCursor = ({
       addTCDeleteButton(uId),
       ...addTCMarkers(uId, trendCursorsSeriesMakersInPixels, series),
     ],
-    transition: ['x' as const],
   };
 };

--- a/packages/react-components/src/components/chart/utils/handleViewport.ts
+++ b/packages/react-components/src/components/chart/utils/handleViewport.ts
@@ -19,14 +19,13 @@ export const handleViewport = ({ graphic, setGraphic, size, viewportInMs }: hand
   ) {
     const newG = graphic.map((g) => {
       // disabled during dragging, transition will be an empty array when user is dragging
-      if (g.transition?.length) {
-        const x = calculateXFromTimestamp(g.timestampInMs, size, viewportInMs);
-        if (x < DEFAULT_MARGIN) {
-          // hiding the TC
-          g.ignore = true;
-        } else {
-          g.x = x;
-        }
+
+      const x = calculateXFromTimestamp(g.timestampInMs, size, viewportInMs);
+      if (x < DEFAULT_MARGIN) {
+        // hiding the TC
+        g.ignore = true;
+      } else {
+        g.x = x;
       }
       return g;
     });


### PR DESCRIPTION
## Overview
adding transition for TCs is causing lot of issues for resizing and sync functionalities, removing it for now, will circle back after getting some user back. 
right now, UX - @navita is ok to not have a smooth transition

## Verifying Changes


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
