### PR TITLE
fix(scene composer): fix for broken rule panel

### DIFF
--- a/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/__snapshots__/SceneRuleTargetEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/__snapshots__/SceneRuleTargetEditor.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
   >
     <div
       data-mocked="Select"
-      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Animation\\"}]"
+      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"}]"
       selectedarialabel="test message"
       selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"}"
     />
@@ -25,7 +25,7 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
   >
     <div
       data-mocked="Select"
-      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Animation\\"}]"
+      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"}]"
       selectedarialabel="test message"
       selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"}"
     />
@@ -42,7 +42,7 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
   >
     <div
       data-mocked="Select"
-      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Animation\\"}]"
+      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"}]"
       selectedarialabel="test message"
       selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Opacity\\"}"
     />
@@ -58,7 +58,7 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
   >
     <div
       data-mocked="Select"
-      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Opacity\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Animation\\"}]"
+      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Opacity\\"}]"
       selectedarialabel="test message"
       selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"}"
     />
@@ -75,7 +75,7 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
   >
     <div
       data-mocked="Select"
-      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Opacity\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Animation\\"}]"
+      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Opacity\\"}]"
       selectedarialabel="test message"
       selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"}"
     />
@@ -92,7 +92,7 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
   >
     <div
       data-mocked="Select"
-      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Opacity\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Animation\\"}]"
+      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Opacity\\"}]"
       selectedarialabel="test message"
       selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Opacity\\"}"
     />

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -107,7 +107,6 @@ export const IotTwinMakerIconNamespace = `${IotTwinMakerNamespace}.icon`;
 export const IotTwinMakerColorNamespace = `${IotTwinMakerNamespace}.color`;
 export const IotTwinMakerNumberNamespace = `${IotTwinMakerNamespace}.number`;
 export const IotTwinMakerOpacityNamespace = `${IotTwinMakerNamespace}.opacity`;
-export const IotTwinMakerAnimationNamespace = `${IotTwinMakerNamespace}.animation`;
 /************************************************
  * Scene Resource
  ************************************************/
@@ -117,7 +116,6 @@ export enum SceneResourceType {
   Color = 'Color',
   Number = 'Number',
   Opacity = 'Opacity',
-  Animation = 'Animation',
 }
 
 export interface SceneResourceInfo {

--- a/packages/scene-composer/src/utils/sceneResourceUtils.ts
+++ b/packages/scene-composer/src/utils/sceneResourceUtils.ts
@@ -36,8 +36,6 @@ export const getSceneResourceDefaultValue = (type: SceneResourceType): string =>
       return IotTwinMakerNumberNamespace;
     case SceneResourceType.Opacity:
       return '1';
-    case SceneResourceType.Animation:
-      return '';
   }
 };
 


### PR DESCRIPTION
## Overview
* remove unused animation option from the rule option. 
## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
