### PR TITLE
fix(TM-source): fix tanstack query import

### DIFF
--- a/packages/source-iottwinmaker/src/property-value/provider.ts
+++ b/packages/source-iottwinmaker/src/property-value/provider.ts
@@ -1,5 +1,5 @@
 import { DataRequest, Provider, ProviderObserver, DataBase, DataStreamBase } from '@iot-app-kit/core';
-import { QueryClient, QueryObserver } from '@tanstack/react-query';
+import { QueryClient, QueryObserver } from '@tanstack/query-core';
 
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import { getPropertyValueByEntity } from './client/getPropertyValueByEntity';


### PR DESCRIPTION
## Overview
fix tanstack query import to be from @tanstack/query-core instead of @tanstack/react-query

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
