### PR TITLE
chore(composer): removed unused scene component types

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -46,7 +46,7 @@
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --index-template tools/index-template.js -- src/assets/icons/",
     "release": "run-s compile copy-assets",
     "copy-assets": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" dist/",
-    "lint": "eslint . --max-warnings=699",
+    "lint": "eslint . --max-warnings=676",
     "fix": "eslint --fix .",
     "test": "jest --config jest.config.ts --coverage --silent",
     "test:dev": "jest --config jest.config.ts --coverage",

--- a/packages/scene-composer/src/hooks/useBindingData.spec.ts
+++ b/packages/scene-composer/src/hooks/useBindingData.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 
 import { useStore } from '../store';
 
@@ -39,7 +39,7 @@ describe('useBindingData', () => {
     expect(data).toBeUndefined();
   });
 
-  it('should return data for each binding in the matching order', () => {
+  it('should return data for each binding in the matching order', async () => {
     const expectedData = [{ prop: 'AA' }, undefined, { prop: 'BB' }];
     const bindings = [
       { dataBindingContext: { entityId: 'AA', propertyName: 'prop' } },
@@ -60,11 +60,9 @@ describe('useBindingData', () => {
       }
       return undefined;
     });
-    let hook;
-    act(() => {
-      hook = renderHook(() => useBindingData(bindings));
-    });
 
-    expect(hook.result.current.data).toEqual(expectedData);
+    const hook = renderHook(() => useBindingData(bindings));
+
+    await waitFor(() => expect(hook.result.current.data).toEqual(expectedData));
   });
 });

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -112,9 +112,7 @@ export namespace Component {
     Animation = 'Animation',
     Tag = 'Tag',
     ModelShader = 'ModelShader',
-    OpacityFilter = 'OpacityFilter',
     MotionIndicator = 'MotionIndicator',
-    Space = 'Space',
     DataOverlay = 'DataOverlay',
     EntityBinding = 'EntityBinding',
   }
@@ -129,13 +127,6 @@ export namespace Component {
 
   export interface IDataBindingRuleMap extends IDataBindingMap {
     ruleBasedMapId?: string;
-  }
-
-  export interface Space extends IComponent {
-    spaceId: string;
-    parentSpaceEntityId: string;
-    bounds: Vector3;
-    boundsOffset: Vector3;
   }
 
   export interface ModelRef extends IComponent {
@@ -170,7 +161,6 @@ export namespace Component {
   }
 
   export interface ModelShader extends IComponent, IDataBindingRuleMap {}
-  export interface OpacityFilter extends IComponent, IDataBindingRuleMap {}
 
   export interface EntityBindingComponent extends IComponent {
     valueDataBinding: ValueDataBinding;

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -177,13 +177,6 @@ function createModelShaderComponent(
   return Object.assign({}, { ref: generateUUID() }, { ...component });
 }
 
-function createOpacityFilterComponent(
-  component: Component.OpacityFilter,
-  errorCollector: ISerializationErrorDetails[],
-): IColorOverlayComponentInternal {
-  return Object.assign({}, { ref: generateUUID() }, { ...component });
-}
-
 function createMotionIndicatorComponent(
   component: Component.MotionIndicator,
   resolver: IndexedObjectResolver,
@@ -248,9 +241,6 @@ function deserializeComponent(
     }
     case Component.Type.ModelShader: {
       return createModelShaderComponent(component as Component.ModelShader, errorCollector);
-    }
-    case Component.Type.OpacityFilter: {
-      return createOpacityFilterComponent(component as Component.OpacityFilter, errorCollector);
     }
     case Component.Type.MotionIndicator: {
       if (options.disableMotionIndicator) {


### PR DESCRIPTION
## Overview
removed unused `OpacityFilter` and `Space` scene component types

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
