### PR TITLE
chore(deps-dev): Revert "build(deps-dev): bump @storybook/addon-styling from 1.3.1 to 1.3.7"

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -46,7 +46,7 @@
     "@storybook/addon-essentials": "^6.5.16",
     "@storybook/addon-interactions": "^6.5.16",
     "@storybook/addon-links": "^6.5.16",
-    "@storybook/addon-styling": "1.3.7",
+    "@storybook/addon-styling": "1.3.1",
     "@storybook/builder-webpack5": "^6.5.16",
     "@storybook/manager-webpack5": "^6.5.16",
     "@storybook/react": "^6.5.16",


### PR DESCRIPTION
Reverts awslabs/iot-app-kit#1838 as  `@storybook/addon-styling` version 1.3.7 does not exists internally