### PR TITLE
chore(composer): remove unused light shadow setting

### DIFF
--- a/packages/scene-composer/src/interfaces/components.ts
+++ b/packages/scene-composer/src/interfaces/components.ts
@@ -38,7 +38,7 @@ export interface IModelRefComponent extends ISceneComponent {
 
 export interface ISubModelRefComponent extends ISceneComponent {
   parentRef?: string;
-  selector: string | number;
+  selector: string;
 }
 
 export interface IAnchorComponent extends ISceneComponent {

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -140,7 +140,7 @@ export namespace Component {
 
   export interface SubModelRef extends IComponent {
     parentRef: string;
-    selector: string | number;
+    selector: string;
   }
 
   export interface Animation extends IComponent {
@@ -235,16 +235,6 @@ export namespace Component {
     valueDataBindings: ValueDataBindingNamedMap[];
   }
 
-  export interface ILightShadowSettings {
-    shadowBias?: number;
-    shadowCameraLeft?: number;
-    shadowCameraRight?: number;
-    shadowCameraTop?: number;
-    shadowCameraBottom?: number;
-    shadowMapSizeWidth?: number;
-    shadowMapSizeHeight?: number;
-  }
-
   interface ILightSettingsBase {
     color: Color;
     intensity: number;
@@ -252,7 +242,6 @@ export namespace Component {
 
   export interface IDirectionalLightSettings extends ILightSettingsBase {
     castShadow: boolean;
-    shadow?: ILightShadowSettings;
   }
 
   export interface IPointLightSettings extends ILightSettingsBase {
@@ -263,7 +252,6 @@ export namespace Component {
     decay?: number;
 
     castShadow: boolean;
-    shadow?: ILightShadowSettings;
   }
 
   export interface IAmbientLightSettings extends ILightSettingsBase {}


### PR DESCRIPTION
## Overview
- Remove `ILightShadowSettings` because it's not supported right now https://github.com/awslabs/iot-app-kit/blob/main/packages/scene-composer/src/components/three-fiber/LightComponent/lights/DirectionalLight.tsx#L14
- Make type of SubModelRefComponent.selector a string only

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
