### PR TITLE
fix(scene tags): fix anchor stems not triggering onWidgetClick

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
@@ -183,7 +183,7 @@ export function AsyncLoadedAnchorWidget({
     (event: ThreeEvent<MouseEvent>) => {
       // Anchor only has special onClick handling in viewing mode
       if (isViewing) {
-        if (event.eventObject instanceof Anchor) {
+        if (event.eventObject instanceof Anchor || event.eventObject instanceof THREE.LineSegments) {
           if (onWidgetClick) {
             const dataBindingContext = applyDataBindingTemplate(valueDataBinding, dataBindingTemplate);
             const componentTypes = node.components.map((component) => component.type) ?? [];
@@ -247,7 +247,7 @@ export function AsyncLoadedAnchorWidget({
   return (
     <group ref={rootGroupRef} visible={tagVisible}>
       <group scale={finalScale}>
-        <lineSegments ref={linesRef}>
+        <lineSegments ref={linesRef} onClick={onClick}>
           <lineBasicMaterial color='#ffffff' />
           <bufferGeometry ref={bufferGeometryRef} attach='geometry' />
         </lineSegments>

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
@@ -332,5 +332,24 @@ describe('AnchorWidget onWidgetClick', () => {
         },
       ],
     });
+
+    const lineSegmentElement = asyncLoadedAnchorWidget.findByType('lineSegments');
+    lineSegmentElement.props.onClick(event);
+    expect(onWidgetClickMock).toHaveBeenCalledTimes(2);
+    expect(onWidgetClickMock).toHaveBeenCalledWith({
+      componentTypes: ['Tag'],
+      nodeRef: 'test-ref',
+      additionalComponentData: [
+        {
+          chosenColor: '#ffffff',
+          navLink: undefined,
+          dataBindingContext: {
+            componentName: 'comp',
+            entityId: 'ent',
+            propertyName: 'prop',
+          },
+        },
+      ],
+    });
   });
 });

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/__snapshots__/AnchorWidget.spec.tsx.snap
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/__snapshots__/AnchorWidget.spec.tsx.snap
@@ -13,7 +13,9 @@ exports[`AnchorWidget should render correctly 1`] = `
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -76,7 +78,9 @@ exports[`AnchorWidget should render correctly when not visible 1`] = `
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -139,7 +143,9 @@ exports[`AnchorWidget should render correctly with an offset 1`] = `
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -202,7 +208,9 @@ exports[`AnchorWidget should render correctly with data binding custom rule 1`] 
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -265,7 +273,9 @@ exports[`AnchorWidget should render correctly with data binding rule 1`] = `
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -328,7 +338,9 @@ exports[`AnchorWidget should render correctly with non default tag settings 1`] 
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -391,7 +403,9 @@ exports[`AnchorWidget should render with a countered size when parent is scaled 
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />


### PR DESCRIPTION
## Overview
Problem: Tags don't consistently triggering onWidgetClicked even though they do onSelectionChange reliably.  
Cause: an Anchor is actually a group with two parts in it: the anchor (circle) and a LineSegment (the white stem ). Only the anchor has onClick eventing.
Solution:  Adding the same onClick handler to the line segment as well allows the onWidgetClick to trigger no matter what part of the anchor is clicked.  

## Verifying Changes
1. Story book scene composer scene with an entity bound tag
2. Move camera to where you can see the tag AND the white stem
3. Click on both the tag and the white stem and observe that both the selectionChanged and widgetClicked events fire in the story book action log.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
