### PR TITLE
fix(propertyName): added copy button and textArea for long propertyNa…

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useState } from 'react';
-import { AttributeEditor, Box, Button, FormField, Input, SpaceBetween } from '@awsui/components-react';
+import { AttributeEditor, Box, Button, FormField, Input, SpaceBetween, Textarea } from '@awsui/components-react';
 import { useIntl } from 'react-intl';
 
 import { useSceneDocument } from '../../store';
@@ -82,7 +82,7 @@ const SceneRuleMapExpandableInfoSection: React.FC<React.PropsWithChildren<IScene
           {
             label: intl.formatMessage({ defaultMessage: 'Expression', description: 'Input field label' }),
             control: (item, itemIndex) => (
-              <Input
+              <Textarea
                 value={item.expression}
                 placeholder={intl.formatMessage({
                   defaultMessage: 'e.g. value > 0',

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
@@ -71,12 +71,23 @@ exports[`AnchorComponentEditor should render with no tag style 1`] = `
           </div>
         </div>
         <div
-          data-mocked="Select"
-          data-testid="value-data-binding-builder-select"
-          options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-          placeholder="Select an option"
-          selectedoption="null"
-        />
+          class="copy-select-flex"
+        >
+          <div
+            data-mocked="Box"
+          />
+          <div
+            class="full-width"
+          >
+            <div
+              data-mocked="Select"
+              data-testid="value-data-binding-builder-select"
+              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+              placeholder="Select an option"
+              selectedoption="null"
+            />
+          </div>
+        </div>
       </div>
     </div>
     <div
@@ -191,12 +202,23 @@ exports[`AnchorComponentEditor should render with tag style 1`] = `
           </div>
         </div>
         <div
-          data-mocked="Select"
-          data-testid="value-data-binding-builder-select"
-          options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-          placeholder="Select an option"
-          selectedoption="null"
-        />
+          class="copy-select-flex"
+        >
+          <div
+            data-mocked="Box"
+          />
+          <div
+            class="full-width"
+          >
+            <div
+              data-mocked="Select"
+              data-testid="value-data-binding-builder-select"
+              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+              placeholder="Select an option"
+              selectedoption="null"
+            />
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.scss
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.scss
@@ -1,0 +1,8 @@
+.copy-select-flex {
+    display: flex;
+    flex-wrap: nowrap;
+}
+
+.full-width {
+    width: 100%;
+}

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
@@ -1,4 +1,13 @@
-import { Autosuggest, Box, FormField, Select, SpaceBetween } from '@awsui/components-react';
+import {
+  Autosuggest,
+  Box,
+  FormField,
+  Select,
+  SpaceBetween,
+  Button,
+  Popover,
+  StatusIndicator,
+} from '@awsui/components-react';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -14,6 +23,8 @@ import useLifecycleLogging from '../../../../logger/react-logger/hooks/useLifecy
 import { useStore } from '../../../../store';
 import { dataBindingConfigSelector } from '../../../../utils/dataBindingTemplateUtils';
 import { pascalCase } from '../../../../utils/stringUtils';
+
+import './ValueDataBindingBuilder.scss';
 
 export const ENTITY_ID_INDEX = 0;
 export const COMPONENT_NAME_INDEX = 1;
@@ -193,14 +204,53 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
               }
               key={definition.fieldName}
             >
-              <Select
-                data-testid='value-data-binding-builder-select'
-                selectedOption={selectedOption}
-                onChange={onSelectChange(definition.fieldName, index)}
-                options={options}
-                disabled={disabled}
-                placeholder={intl.formatMessage({ defaultMessage: 'Select an option', description: 'placeholder' })}
-              />
+              {definition.fieldName === 'propertyName' && (
+                <div className='copy-select-flex'>
+                  <Box>
+                    {selectedOption && (
+                      <Popover
+                        size='small'
+                        position='top'
+                        triggerType='custom'
+                        dismissButton={false}
+                        content={<StatusIndicator type='success'>{selectedOption.label + ' copied'} </StatusIndicator>}
+                      >
+                        <Button
+                          variant='icon'
+                          iconName='copy'
+                          ariaLabel='Copy property name'
+                          onClick={() => {
+                            navigator.clipboard.writeText(selectedOption!.label ? selectedOption!.label : '');
+                          }}
+                        />
+                      </Popover>
+                    )}
+                  </Box>
+                  <div className='full-width'>
+                    <Select
+                      data-testid='value-data-binding-builder-select'
+                      selectedOption={selectedOption}
+                      onChange={onSelectChange(definition.fieldName, index)}
+                      options={options}
+                      disabled={disabled}
+                      placeholder={intl.formatMessage({
+                        defaultMessage: 'Select an option',
+                        description: 'placeholder',
+                      })}
+                    />
+                  </div>
+                </div>
+              )}
+              {definition.fieldName !== 'propertyName' && (
+                <Select
+                  data-testid='value-data-binding-builder-select'
+                  selectedOption={selectedOption}
+                  onChange={onSelectChange(definition.fieldName, index)}
+                  options={options}
+                  disabled={disabled}
+                  placeholder={intl.formatMessage({ defaultMessage: 'Select an option', description: 'placeholder' })}
+                />
+              )}
             </FormField>
           );
         })}

--- a/packages/scene-composer/src/components/panels/scene-components/common/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/common/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
@@ -82,12 +82,23 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="copy-select-flex"
+            >
+              <div
+                data-mocked="Box"
+              />
+              <div
+                class="full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -159,12 +170,23 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="copy-select-flex"
+            >
+              <div
+                data-mocked="Box"
+              />
+              <div
+                class="full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -241,12 +263,23 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="copy-select-flex"
+            >
+              <div
+                data-mocked="Box"
+              />
+              <div
+                class="full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -307,12 +340,23 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="copy-select-flex"
+            >
+              <div
+                data-mocked="Box"
+              />
+              <div
+                class="full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION

## Overview
Customers are facing issues with long propertyNames: 1) not being able to copy them over to rule expressions easily, and 2) not being able to read their rule expressions due to the long names taking up the entire text input field.

To resolve this, a copy button for propertyName has been added, and the rule expression input is now a textArea, providing customers with more space to type and view their rule expressions.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
