### PR TITLE
fix(propertyName): added copy button and textArea for long propertyNa…

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
@@ -182,7 +182,7 @@ export function AsyncLoadedAnchorWidget({
     (event: ThreeEvent<MouseEvent>) => {
       // Anchor only has special onClick handling in viewing mode
       if (isViewing) {
-        if (event.eventObject instanceof Anchor) {
+        if (event.eventObject instanceof Anchor || event.eventObject instanceof THREE.LineSegments) {
           if (onWidgetClick) {
             const dataBindingContext = applyDataBindingTemplate(valueDataBinding, dataBindingTemplate);
             const componentTypes = node.components.map((component) => component.type) ?? [];
@@ -246,7 +246,7 @@ export function AsyncLoadedAnchorWidget({
   return (
     <group ref={rootGroupRef} visible={tagVisible}>
       <group scale={finalScale}>
-        <lineSegments ref={linesRef}>
+        <lineSegments ref={linesRef} onClick={onClick}>
           <lineBasicMaterial color='#ffffff' />
           <bufferGeometry ref={bufferGeometryRef} attach='geometry' />
         </lineSegments>

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
@@ -332,5 +332,24 @@ describe('AnchorWidget onWidgetClick', () => {
         },
       ],
     });
+
+    const lineSegmentElement = asyncLoadedAnchorWidget.findByType('lineSegments');
+    lineSegmentElement.props.onClick(event);
+    expect(onWidgetClickMock).toHaveBeenCalledTimes(2);
+    expect(onWidgetClickMock).toHaveBeenCalledWith({
+      componentTypes: ['Tag'],
+      nodeRef: 'test-ref',
+      additionalComponentData: [
+        {
+          chosenColor: '#ffffff',
+          navLink: undefined,
+          dataBindingContext: {
+            componentName: 'comp',
+            entityId: 'ent',
+            propertyName: 'prop',
+          },
+        },
+      ],
+    });
   });
 });

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/__snapshots__/AnchorWidget.spec.tsx.snap
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/__snapshots__/AnchorWidget.spec.tsx.snap
@@ -13,7 +13,9 @@ exports[`AnchorWidget should render correctly 1`] = `
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -76,7 +78,9 @@ exports[`AnchorWidget should render correctly when not visible 1`] = `
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -139,7 +143,9 @@ exports[`AnchorWidget should render correctly with an offset 1`] = `
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -202,7 +208,9 @@ exports[`AnchorWidget should render correctly with data binding custom rule 1`] 
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -265,7 +273,9 @@ exports[`AnchorWidget should render correctly with data binding rule 1`] = `
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -328,7 +338,9 @@ exports[`AnchorWidget should render correctly with non default tag settings 1`] 
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />
@@ -391,7 +403,9 @@ exports[`AnchorWidget should render with a countered size when parent is scaled 
       }
     }
   >
-    <lineSegments>
+    <lineSegments
+      onClick={[Function]}
+    >
       <lineBasicMaterial
         color="#ffffff"
       />

--- a/packages/scene-composer/src/components/panels/SceneRulesPanel.spec.tsx
+++ b/packages/scene-composer/src/components/panels/SceneRulesPanel.spec.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-import { SceneRulesPanel } from './SceneRulesPanel';
+import { IRuleBasedMapInternal, IRuleStatementInternal } from '../../store/internalInterfaces';
+import { IRuleBasedMap } from '../../interfaces';
+
+import { SceneRuleMapExpandableInfoSection, SceneRulesPanel } from './SceneRulesPanel';
 
 jest.mock('../../logger/react-logger/log-provider', () => (props) => <div {...props} />);
 jest.mock('./CommonPanelComponents', () => ({

--- a/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useState } from 'react';
-import { AttributeEditor, Box, Button, FormField, Input, SpaceBetween } from '@awsui/components-react';
+import { AttributeEditor, Box, Button, FormField, Input, SpaceBetween, Textarea } from '@awsui/components-react';
 import { useIntl } from 'react-intl';
 
 import { useSceneDocument } from '../../store';
@@ -16,10 +16,9 @@ interface ISceneRuleMapExpandableInfoSectionProps {
   ruleMap: IRuleBasedMapInternal;
 }
 
-const SceneRuleMapExpandableInfoSection: React.FC<React.PropsWithChildren<ISceneRuleMapExpandableInfoSectionProps>> = ({
-  ruleBasedMapId,
-  ruleMap,
-}: ISceneRuleMapExpandableInfoSectionProps) => {
+export const SceneRuleMapExpandableInfoSection: React.FC<
+  React.PropsWithChildren<ISceneRuleMapExpandableInfoSectionProps>
+> = ({ ruleBasedMapId, ruleMap }: ISceneRuleMapExpandableInfoSectionProps) => {
   const sceneComposerId = useContext(sceneComposerIdContext);
   const { removeSceneRuleMapById, updateSceneRuleMapById } = useSceneDocument(sceneComposerId);
   const [newRule, setNewRule] = useState<IRuleStatementInternal | undefined>(undefined);
@@ -82,7 +81,8 @@ const SceneRuleMapExpandableInfoSection: React.FC<React.PropsWithChildren<IScene
           {
             label: intl.formatMessage({ defaultMessage: 'Expression', description: 'Input field label' }),
             control: (item, itemIndex) => (
-              <Input
+              <Textarea
+                data-testid='rule-expression'
                 value={item.expression}
                 placeholder={intl.formatMessage({
                   defaultMessage: 'e.g. value > 0',

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
@@ -53,12 +53,20 @@ exports[`AnchorComponentEditor should render with no tag style 1`] = `
           </div>
         </div>
         <div
-          data-mocked="Select"
-          data-testid="value-data-binding-builder-select"
-          options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-          placeholder="Select an option"
-          selectedoption="null"
-        />
+          class="tm-copy-select-flex"
+        >
+          <div
+            class="tm-full-width"
+          >
+            <div
+              data-mocked="Select"
+              data-testid="value-data-binding-builder-select"
+              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+              placeholder="Select an option"
+              selectedoption="null"
+            />
+          </div>
+        </div>
       </div>
       <div
         data-mocked="FormField"
@@ -71,12 +79,23 @@ exports[`AnchorComponentEditor should render with no tag style 1`] = `
           </div>
         </div>
         <div
-          data-mocked="Select"
-          data-testid="value-data-binding-builder-select"
-          options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-          placeholder="Select an option"
-          selectedoption="null"
-        />
+          class="tm-copy-select-flex"
+        >
+          <div
+            data-mocked="Box"
+          />
+          <div
+            class="tm-full-width"
+          >
+            <div
+              data-mocked="Select"
+              data-testid="value-data-binding-builder-select"
+              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+              placeholder="Select an option"
+              selectedoption="null"
+            />
+          </div>
+        </div>
       </div>
     </div>
     <div
@@ -173,12 +192,20 @@ exports[`AnchorComponentEditor should render with tag style 1`] = `
           </div>
         </div>
         <div
-          data-mocked="Select"
-          data-testid="value-data-binding-builder-select"
-          options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-          placeholder="Select an option"
-          selectedoption="null"
-        />
+          class="tm-copy-select-flex"
+        >
+          <div
+            class="tm-full-width"
+          >
+            <div
+              data-mocked="Select"
+              data-testid="value-data-binding-builder-select"
+              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+              placeholder="Select an option"
+              selectedoption="null"
+            />
+          </div>
+        </div>
       </div>
       <div
         data-mocked="FormField"
@@ -191,12 +218,23 @@ exports[`AnchorComponentEditor should render with tag style 1`] = `
           </div>
         </div>
         <div
-          data-mocked="Select"
-          data-testid="value-data-binding-builder-select"
-          options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-          placeholder="Select an option"
-          selectedoption="null"
-        />
+          class="tm-copy-select-flex"
+        >
+          <div
+            data-mocked="Box"
+          />
+          <div
+            class="tm-full-width"
+          >
+            <div
+              data-mocked="Select"
+              data-testid="value-data-binding-builder-select"
+              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+              placeholder="Select an option"
+              selectedoption="null"
+            />
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.scss
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.scss
@@ -1,0 +1,8 @@
+.tm-copy-select-flex {
+    display: flex;
+    flex-wrap: nowrap;
+}
+
+.tm-full-width {
+    width: 100%;
+}

--- a/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/ValueDataBindingBuilder.tsx
@@ -1,4 +1,13 @@
-import { Autosuggest, Box, FormField, Select, SpaceBetween } from '@awsui/components-react';
+import {
+  Autosuggest,
+  Box,
+  FormField,
+  Select,
+  SpaceBetween,
+  Button,
+  Popover,
+  StatusIndicator,
+} from '@awsui/components-react';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -14,6 +23,8 @@ import useLifecycleLogging from '../../../../logger/react-logger/hooks/useLifecy
 import { useStore } from '../../../../store';
 import { dataBindingConfigSelector } from '../../../../utils/dataBindingTemplateUtils';
 import { pascalCase } from '../../../../utils/stringUtils';
+
+import './ValueDataBindingBuilder.scss';
 
 export const ENTITY_ID_INDEX = 0;
 export const COMPONENT_NAME_INDEX = 1;
@@ -193,14 +204,46 @@ export const ValueDataBindingBuilder: React.FC<IValueDataBindingBuilderProps> = 
               }
               key={definition.fieldName}
             >
-              <Select
-                data-testid='value-data-binding-builder-select'
-                selectedOption={selectedOption}
-                onChange={onSelectChange(definition.fieldName, index)}
-                options={options}
-                disabled={disabled}
-                placeholder={intl.formatMessage({ defaultMessage: 'Select an option', description: 'placeholder' })}
-              />
+              <div className='tm-copy-select-flex'>
+                {definition.fieldName === 'propertyName' && (
+                  <Box>
+                    {selectedOption && (
+                      <Popover
+                        size='small'
+                        position='top'
+                        triggerType='custom'
+                        dismissButton={false}
+                        content={<StatusIndicator type='success'>{selectedOption.label + ' copied'} </StatusIndicator>}
+                      >
+                        <Button
+                          variant='icon'
+                          iconName='copy'
+                          ariaLabel={intl.formatMessage({
+                            defaultMessage: 'Copy button',
+                            description: 'Copies the property name',
+                          })}
+                          onClick={async () => {
+                            await navigator.clipboard.writeText(selectedOption!.label ? selectedOption!.label : '');
+                          }}
+                        />
+                      </Popover>
+                    )}
+                  </Box>
+                )}
+                <div className='tm-full-width'>
+                  <Select
+                    data-testid='value-data-binding-builder-select'
+                    selectedOption={selectedOption}
+                    onChange={onSelectChange(definition.fieldName, index)}
+                    options={options}
+                    disabled={disabled}
+                    placeholder={intl.formatMessage({
+                      defaultMessage: 'Select an option',
+                      description: 'placeholder',
+                    })}
+                  />
+                </div>
+              </div>
             </FormField>
           );
         })}

--- a/packages/scene-composer/src/components/panels/scene-components/common/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/common/__snapshots__/DataBindingMapEditorSnap.spec.tsx.snap
@@ -64,12 +64,20 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="tm-copy-select-flex"
+            >
+              <div
+                class="tm-full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
           <div
             data-mocked="FormField"
@@ -82,12 +90,23 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="tm-copy-select-flex"
+            >
+              <div
+                data-mocked="Box"
+              />
+              <div
+                class="tm-full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -141,12 +160,20 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="tm-copy-select-flex"
+            >
+              <div
+                class="tm-full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
           <div
             data-mocked="FormField"
@@ -159,12 +186,23 @@ exports[`DataBindingMapEditor should render existing maps with bindings 1`] = `
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="tm-copy-select-flex"
+            >
+              <div
+                data-mocked="Box"
+              />
+              <div
+                class="tm-full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -223,12 +261,20 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="tm-copy-select-flex"
+            >
+              <div
+                class="tm-full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
           <div
             data-mocked="FormField"
@@ -241,12 +287,23 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="tm-copy-select-flex"
+            >
+              <div
+                data-mocked="Box"
+              />
+              <div
+                class="tm-full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -289,12 +346,20 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="tm-copy-select-flex"
+            >
+              <div
+                class="tm-full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
           <div
             data-mocked="FormField"
@@ -307,12 +372,23 @@ exports[`DataBindingMapEditor should render existing maps with bindings without 
               </div>
             </div>
             <div
-              data-mocked="Select"
-              data-testid="value-data-binding-builder-select"
-              options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
-              placeholder="Select an option"
-              selectedoption="null"
-            />
+              class="tm-copy-select-flex"
+            >
+              <div
+                data-mocked="Box"
+              />
+              <div
+                class="tm-full-width"
+              >
+                <div
+                  data-mocked="Select"
+                  data-testid="value-data-binding-builder-select"
+                  options="[{\\"label\\":\\"label1\\",\\"value\\":\\"value1\\"},{\\"label\\":\\"label2\\",\\"value\\":\\"value2\\"}]"
+                  placeholder="Select an option"
+                  selectedoption="null"
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -767,6 +767,10 @@
     "note": "Menu Item label",
     "text": "Add object"
   },
+  "hFIpcF": {
+    "note": "Copies the property name",
+    "text": "Copy button"
+  },
   "hYPMUc": {
     "note": "Form button text",
     "text": "Fix view"


### PR DESCRIPTION
## Overview
Customers are facing issues with long propertyNames: 1) not being able to copy them over to rule expressions easily, and 2) not being able to read their rule expressions due to the long names taking up the entire text input field.

To resolve this, a copy button for propertyName has been added, and the rule expression input is now a textArea, providing customers with more space to type and view their rule expressions.

## Verifying Changes

Run scene composer in storybook, and click on a tag. Assign an entity, component, and property to the tag. Notice that the copy button appears when a property is selected in the dropdown menu.

Open the rules panel and notice that the rule expression is in an expandable text area.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
