### PR TITLE
feat(dashboard): add widget tile

### DIFF
--- a/packages/dashboard/src/components/widgets/tile/index.ts
+++ b/packages/dashboard/src/components/widgets/tile/index.ts
@@ -1,0 +1,3 @@
+import TileWidget from './tile';
+
+export default TileWidget;

--- a/packages/dashboard/src/components/widgets/tile/tile.css
+++ b/packages/dashboard/src/components/widgets/tile/tile.css
@@ -1,0 +1,22 @@
+.widget-tile {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.widget-tile-body {
+  flex: 1;
+}
+
+.widget-tile-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 4px;
+}
+
+.horizontal-divider {
+  width: 100%;
+  height: 2px;
+}

--- a/packages/dashboard/src/components/widgets/tile/tile.spec.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.spec.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import wrapper from '@cloudscape-design/components/test-utils/dom';
+
+import { act, render } from '@testing-library/react';
+
+import { screen } from '@testing-library/dom';
+
+import WidgetTile from './tile';
+import { configureDashboardStore } from '~/store';
+import { MOCK_LINE_CHART_WIDGET } from '../../../../testing/mocks';
+
+describe('WidgetTile', () => {
+  it('should render widget content', function () {
+    render(
+      <Provider
+        store={configureDashboardStore({
+          dashboardConfiguration: {
+            widgets: [MOCK_LINE_CHART_WIDGET],
+            viewport: { duration: '5m' },
+          },
+        })}
+      >
+        <WidgetTile widget={MOCK_LINE_CHART_WIDGET}>
+          <div>test-content</div>
+        </WidgetTile>
+        ;
+      </Provider>
+    );
+
+    expect(screen.getByText('test-content')).toBeInTheDocument();
+  });
+
+  it('should render a title', function () {
+    render(
+      <Provider
+        store={configureDashboardStore({
+          dashboardConfiguration: {
+            widgets: [MOCK_LINE_CHART_WIDGET],
+            viewport: { duration: '5m' },
+          },
+        })}
+      >
+        <WidgetTile title='test-title' widget={MOCK_LINE_CHART_WIDGET}>
+          <div>test-content</div>
+        </WidgetTile>
+        ;
+      </Provider>
+    );
+
+    expect(screen.getByText('test-title')).toBeInTheDocument();
+  });
+
+  it('can remove a widget', function () {
+    const store = configureDashboardStore({
+      dashboardConfiguration: {
+        widgets: [MOCK_LINE_CHART_WIDGET],
+        viewport: { duration: '5m' },
+      },
+    });
+    const { container } = render(
+      <Provider store={store}>
+        <WidgetTile removeable widget={MOCK_LINE_CHART_WIDGET}>
+          <div>test-content</div>
+        </WidgetTile>
+        ;
+      </Provider>
+    );
+
+    const removeButton = wrapper(container).findButton();
+
+    act(() => {
+      removeButton?.click();
+    });
+
+    expect(store.getState().dashboardConfiguration.widgets).toEqual([]);
+  });
+
+  it('does not show delete in readonly mode', function () {
+    const { container } = render(
+      <Provider
+        store={configureDashboardStore({
+          dashboardConfiguration: {
+            widgets: [MOCK_LINE_CHART_WIDGET],
+            viewport: { duration: '5m' },
+          },
+          readOnly: true,
+        })}
+      >
+        <WidgetTile removeable widget={MOCK_LINE_CHART_WIDGET}>
+          <div>test-content</div>
+        </WidgetTile>
+        ;
+      </Provider>
+    );
+
+    expect(container.querySelector('[aria-label="delete widget"]')).not.toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -1,0 +1,94 @@
+import React, { PropsWithChildren } from 'react';
+import { useSelector } from 'react-redux';
+
+import Box from '@cloudscape-design/components/box';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Button from '@cloudscape-design/components/button';
+import Icon from '@cloudscape-design/components/icon';
+import {
+  colorBorderDividerDefault,
+  borderRadiusBadge,
+  colorBackgroundContainerContent,
+} from '@cloudscape-design/design-tokens';
+import { CancelableEventHandler, ClickDetail } from '@cloudscape-design/components/internal/events';
+
+import { DashboardWidget } from '~/types';
+import { DashboardState } from '~/store/state';
+import { useDeleteWidgets } from '~/hooks/useDeleteWidgets';
+
+import './tile.css';
+
+type DeletableTileActionProps = {
+  widget: DashboardWidget;
+};
+const DeletableTileAction = ({ widget }: DeletableTileActionProps) => {
+  const { onDelete } = useDeleteWidgets();
+
+  const handleDelete: CancelableEventHandler<ClickDetail> = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onDelete(widget);
+  };
+
+  return <Button onClick={handleDelete} ariaLabel='delete widget' variant='icon' iconName='close'></Button>;
+};
+
+const Divider = () => <div className='horizontal-divider' style={{ backgroundColor: colorBorderDividerDefault }} />;
+
+export type WidgetTileProps = PropsWithChildren<{
+  widget: DashboardWidget;
+  title?: string;
+  removeable?: boolean;
+}>;
+
+/**
+ *
+ * Component to add functionality to the widget container
+ * Allows a user to title a widget, add click remove
+ */
+const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, removeable }) => {
+  const isReadOnly = useSelector((state: DashboardState) => state.readOnly);
+
+  const isRemoveable = !isReadOnly && removeable;
+  const isResizable = !isReadOnly;
+  const headerVisible = !isReadOnly || title;
+
+  return (
+    <div
+      role='widget'
+      aria-description='widget tile'
+      className='widget-tile'
+      style={{
+        border: `2px solid ${colorBorderDividerDefault}`,
+        borderRadius: borderRadiusBadge,
+        backgroundColor: colorBackgroundContainerContent,
+      }}
+    >
+      {headerVisible && (
+        <>
+          <Box padding={{ left: 'xs', right: 'xxs', top: 'xxs' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <Box variant='h1' fontSize='body-m'>
+                {title}
+              </Box>
+              <SpaceBetween size='s' direction='horizontal'>
+                {isRemoveable && <DeletableTileAction widget={widget} />}
+              </SpaceBetween>
+            </div>
+          </Box>
+          <Divider />
+        </>
+      )}
+      <div className='widget-tile-body'>
+        {children}
+        {isResizable && (
+          <div className='widget-tile-resize-handle'>
+            <Icon variant='disabled' name='resize-area' />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WidgetTile;

--- a/packages/dashboard/src/components/widgets/widget.css
+++ b/packages/dashboard/src/components/widgets/widget.css
@@ -10,12 +10,11 @@
 
 .widget-editable {
   /* Keeps widget in line with widget when selected */
-  padding: var(--selection-border-width);
+  border: var(--selection-border-width) solid transparent;
 }
 
 .widget-editable:hover {
   border: var(--selection-border-width) solid var(--selection-color-secondary);
-  padding: 0; /* removes padding that was present to keep aligned when border is added on hover */
   cursor: all-scroll;
   border-radius: var(--selection-radius-small);
 }
@@ -39,5 +38,8 @@
   align-items: center;
   width: 100%;
   height: 100%;
-  box-sizing: border-box;
+
+  /* override the more specific dashboard selector
+  which is being used to reset amplify stylesheet */
+  box-sizing: border-box !important;
 }

--- a/packages/dashboard/src/customization/widgets/barChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/component.tsx
@@ -10,6 +10,7 @@ import { useQueries } from '~/components/dashboard/queryContext';
 import { getAggregation } from '../utils/widgetAggregationUtils';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
 import { useChartSize } from '~/hooks/useChartSize';
+import WidgetTile from '~/components/widgets/tile';
 
 const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
   const viewport = useSelector((state: DashboardState) => state.dashboardConfiguration.viewport);
@@ -33,19 +34,21 @@ const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
 
   return (
-    <BarChart
-      chartSize={chartSize}
-      key={key}
-      queries={queries}
-      viewport={viewport}
-      gestures={readOnly}
-      aggregationType={aggregateToString(aggregation)}
-      axis={axis}
-      styles={styleSettings}
-      thresholds={thresholds}
-      thresholdSettings={thresholdSettings}
-      significantDigits={significantDigits}
-    />
+    <WidgetTile widget={widget} removeable>
+      <BarChart
+        chartSize={chartSize}
+        key={key}
+        queries={queries}
+        viewport={viewport}
+        gestures={readOnly}
+        aggregationType={aggregateToString(aggregation)}
+        axis={axis}
+        styles={styleSettings}
+        thresholds={thresholds}
+        thresholdSettings={thresholdSettings}
+        significantDigits={significantDigits}
+      />
+    </WidgetTile>
   );
 };
 

--- a/packages/dashboard/src/customization/widgets/kpi/component.tsx
+++ b/packages/dashboard/src/customization/widgets/kpi/component.tsx
@@ -12,6 +12,7 @@ import { getAggregation } from '../utils/widgetAggregationUtils';
 
 import './component.css';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
+import WidgetTile from '~/components/widgets/tile';
 
 const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
   const viewport = useSelector((state: DashboardState) => state.dashboardConfiguration.viewport);
@@ -39,7 +40,11 @@ const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
   const shouldShowEmptyState = query == null || !iotSiteWiseQuery;
 
   if (shouldShowEmptyState) {
-    return <KPIWidgetEmptyStateComponent />;
+    return (
+      <WidgetTile widget={widget} removeable>
+        <KPIWidgetEmptyStateComponent />
+      </WidgetTile>
+    );
   }
 
   const settings = pickBy(
@@ -59,16 +64,18 @@ const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
 
   return (
-    <KPI
-      key={key}
-      query={query}
-      viewport={viewport}
-      styles={styleSettings}
-      settings={settings}
-      thresholds={thresholds}
-      aggregationType={aggregateToString(aggregation)}
-      significantDigits={significantDigits}
-    />
+    <WidgetTile widget={widget} removeable>
+      <KPI
+        key={key}
+        query={query}
+        viewport={viewport}
+        styles={styleSettings}
+        settings={settings}
+        thresholds={thresholds}
+        aggregationType={aggregateToString(aggregation)}
+        significantDigits={significantDigits}
+      />
+    </WidgetTile>
   );
 };
 

--- a/packages/dashboard/src/customization/widgets/lineChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineChart/component.tsx
@@ -10,6 +10,7 @@ import { useQueries } from '~/components/dashboard/queryContext';
 import { getAggregation } from '../utils/widgetAggregationUtils';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
 import { useChartSize } from '~/hooks/useChartSize';
+import WidgetTile from '~/components/widgets/tile';
 
 const LineChartWidgetComponent: React.FC<LineChartWidget> = (widget) => {
   const viewport = useSelector((state: DashboardState) => state.dashboardConfiguration.viewport);
@@ -38,35 +39,39 @@ const LineChartWidgetComponent: React.FC<LineChartWidget> = (widget) => {
 
   if (showEcharts) {
     return (
-      <Chart
+      <WidgetTile widget={widget} removeable>
+        <Chart
+          key={key}
+          queries={queries}
+          viewport={viewport}
+          gestures={readOnly}
+          axis={axis}
+          aggregationType={aggregateToString(aggregation)}
+          styleSettings={styleSettings}
+          thresholds={thresholds}
+          thresholdSettings={thresholdSettings}
+          significantDigits={significantDigits}
+          size={size}
+        />
+      </WidgetTile>
+    );
+  }
+  return (
+    <WidgetTile widget={widget} removeable>
+      <LineChart
+        chartSize={chartSize}
         key={key}
         queries={queries}
         viewport={viewport}
         gestures={readOnly}
         axis={axis}
         aggregationType={aggregateToString(aggregation)}
-        styleSettings={styleSettings}
+        styles={styleSettings}
         thresholds={thresholds}
         thresholdSettings={thresholdSettings}
         significantDigits={significantDigits}
-        size={size}
       />
-    );
-  }
-  return (
-    <LineChart
-      chartSize={chartSize}
-      key={key}
-      queries={queries}
-      viewport={viewport}
-      gestures={readOnly}
-      axis={axis}
-      aggregationType={aggregateToString(aggregation)}
-      styles={styleSettings}
-      thresholds={thresholds}
-      thresholdSettings={thresholdSettings}
-      significantDigits={significantDigits}
-    />
+    </WidgetTile>
   );
 };
 

--- a/packages/dashboard/src/customization/widgets/scatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/scatterChart/component.tsx
@@ -10,6 +10,7 @@ import { useQueries } from '~/components/dashboard/queryContext';
 import { getAggregation } from '../utils/widgetAggregationUtils';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
 import { useChartSize } from '~/hooks/useChartSize';
+import WidgetTile from '~/components/widgets/tile';
 
 const ScatterChartWidgetComponent: React.FC<ScatterChartWidget> = (widget) => {
   const viewport = useSelector((state: DashboardState) => state.dashboardConfiguration.viewport);
@@ -37,36 +38,40 @@ const ScatterChartWidgetComponent: React.FC<ScatterChartWidget> = (widget) => {
 
   if (showEcharts) {
     return (
-      <Chart
-        defaultVisualizationType='bar'
+      <WidgetTile widget={widget} removeable>
+        <Chart
+          defaultVisualizationType='bar'
+          key={key}
+          queries={queries}
+          viewport={viewport}
+          gestures={readOnly}
+          axis={axis}
+          aggregationType={aggregateToString(aggregation)}
+          styleSettings={styleSettings}
+          thresholds={thresholds}
+          thresholdSettings={thresholdSettings}
+          significantDigits={significantDigits}
+          size={size}
+        />
+      </WidgetTile>
+    );
+  }
+  return (
+    <WidgetTile widget={widget} removeable>
+      <ScatterChart
+        chartSize={chartSize}
         key={key}
         queries={queries}
         viewport={viewport}
         gestures={readOnly}
         axis={axis}
-        aggregationType={aggregateToString(aggregation)}
-        styleSettings={styleSettings}
-        thresholds={thresholds}
+        styles={styleSettings}
         thresholdSettings={thresholdSettings}
+        aggregationType={aggregateToString(aggregation)}
+        thresholds={thresholds}
         significantDigits={significantDigits}
-        size={size}
       />
-    );
-  }
-  return (
-    <ScatterChart
-      chartSize={chartSize}
-      key={key}
-      queries={queries}
-      viewport={viewport}
-      gestures={readOnly}
-      axis={axis}
-      styles={styleSettings}
-      thresholdSettings={thresholdSettings}
-      aggregationType={aggregateToString(aggregation)}
-      thresholds={thresholds}
-      significantDigits={significantDigits}
-    />
+    </WidgetTile>
   );
 };
 

--- a/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
+++ b/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
@@ -7,6 +7,7 @@ import { useQueries } from '~/components/dashboard/queryContext';
 import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
 import { getAggregation } from '../utils/widgetAggregationUtils';
+import WidgetTile from '~/components/widgets/tile';
 
 const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (widget) => {
   const viewport = useSelector((state: DashboardState) => state.dashboardConfiguration.viewport);
@@ -29,17 +30,19 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (widget) =
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
 
   return (
-    <StatusTimeline
-      key={key}
-      queries={queries}
-      viewport={viewport}
-      gestures={readOnly}
-      axis={axis}
-      styles={styleSettings}
-      thresholds={thresholds}
-      aggregationType={aggregateToString(aggregation)}
-      significantDigits={significantDigits}
-    />
+    <WidgetTile widget={widget} removeable>
+      <StatusTimeline
+        key={key}
+        queries={queries}
+        viewport={viewport}
+        gestures={readOnly}
+        axis={axis}
+        styles={styleSettings}
+        thresholds={thresholds}
+        aggregationType={aggregateToString(aggregation)}
+        significantDigits={significantDigits}
+      />
+    </WidgetTile>
   );
 };
 

--- a/packages/dashboard/src/customization/widgets/status/component.tsx
+++ b/packages/dashboard/src/customization/widgets/status/component.tsx
@@ -12,6 +12,7 @@ import { aggregateToString } from '~/customization/propertiesSections/aggregatio
 import { getAggregation } from '../utils/widgetAggregationUtils';
 
 import './component.css';
+import WidgetTile from '~/components/widgets/tile';
 
 const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
   const viewport = useSelector((state: DashboardState) => state.dashboardConfiguration.viewport);
@@ -38,7 +39,11 @@ const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
   const aggregation = getAggregation(queryConfig);
 
   if (shouldShowEmptyState) {
-    return <StatusWidgetEmptyStateComponent />;
+    return (
+      <WidgetTile widget={widget} removeable>
+        <StatusWidgetEmptyStateComponent />
+      </WidgetTile>
+    );
   }
 
   const settings = pickBy(
@@ -57,16 +62,18 @@ const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
 
   return (
-    <Status
-      key={key}
-      query={query}
-      viewport={viewport}
-      styles={styleSettings}
-      settings={settings}
-      thresholds={thresholds}
-      aggregationType={aggregateToString(aggregation)}
-      significantDigits={significantDigits}
-    />
+    <WidgetTile widget={widget} removeable>
+      <Status
+        key={key}
+        query={query}
+        viewport={viewport}
+        styles={styleSettings}
+        settings={settings}
+        thresholds={thresholds}
+        aggregationType={aggregateToString(aggregation)}
+        significantDigits={significantDigits}
+      />
+    </WidgetTile>
   );
 };
 

--- a/packages/dashboard/src/hooks/useDeleteWidgets.ts
+++ b/packages/dashboard/src/hooks/useDeleteWidgets.ts
@@ -1,0 +1,18 @@
+import { useDispatch } from 'react-redux';
+import { DashboardWidget } from '..';
+import { onDeleteWidgetsAction } from '~/store/actions';
+
+export const useDeleteWidgets = () => {
+  const dispatch = useDispatch();
+  const onDelete = (toDelete: DashboardWidget | DashboardWidget[]) => {
+    dispatch(
+      onDeleteWidgetsAction({
+        widgets: Array.isArray(toDelete) ? toDelete : [toDelete],
+      })
+    );
+  };
+
+  return {
+    onDelete,
+  };
+};


### PR DESCRIPTION
## Overview
Adds a tile overlay to line / scatter / bar / status / timeline widgets which displays a title and a remove button. The title overlay is used in the plugin so that it is configurable by any extensibility options.
![image (10)](https://github.com/awslabs/iot-app-kit/assets/107281089/6fe8485a-96e2-4f66-9a9f-662cafbc4f73)
![image (9)](https://github.com/awslabs/iot-app-kit/assets/107281089/494d9bf6-ee34-4fa7-b085-26bbdd602686)
![image (8)](https://github.com/awslabs/iot-app-kit/assets/107281089/abb99142-2ce9-4233-aef6-2fee55ab2d6d)



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
