### PR TITLE
feat(TM-source): add entity APIs to SceneMetadataModule

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -129,6 +129,7 @@
     "webpack": "^5.88.2"
   },
   "dependencies": {
+    "@aws-sdk/client-iottwinmaker": "3.335.0",
     "@awsui/collection-hooks": "^1.0.51",
     "@awsui/components-react": "^3.0.0",
     "@awsui/design-tokens": "^3.0.41",

--- a/packages/source-iottwinmaker/src/__mocks__/iottwinmakerSDK.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/iottwinmakerSDK.ts
@@ -1,4 +1,8 @@
 import {
+  CreateEntityCommandInput,
+  CreateEntityCommandOutput,
+  DeleteEntityCommandInput,
+  DeleteEntityCommandOutput,
   ExecuteQueryCommandInput,
   ExecuteQueryCommandOutput,
   GetEntityCommandInput,
@@ -12,6 +16,8 @@ import {
   IoTTwinMakerClient,
   ListEntitiesCommandInput,
   ListEntitiesCommandOutput,
+  UpdateEntityCommandInput,
+  UpdateEntityCommandOutput,
   UpdateSceneCommandInput,
   UpdateSceneCommandOutput,
 } from '@aws-sdk/client-iottwinmaker';
@@ -20,6 +26,9 @@ const nonOverriddenMock = () => Promise.reject(new Error('Mock method not overri
 
 export const createMockTwinMakerSDK = ({
   getEntity = nonOverriddenMock,
+  createEntity = nonOverriddenMock,
+  updateEntity = nonOverriddenMock,
+  deleteEntity = nonOverriddenMock,
   getPropertyValueHistory = nonOverriddenMock,
   getPropertyValue = nonOverriddenMock,
   getScene = nonOverriddenMock,
@@ -28,6 +37,9 @@ export const createMockTwinMakerSDK = ({
   executeQuery = nonOverriddenMock,
 }: {
   getEntity?: (input: GetEntityCommandInput) => Promise<GetEntityCommandOutput>;
+  createEntity?: (input: CreateEntityCommandInput) => Promise<CreateEntityCommandOutput>;
+  updateEntity?: (input: UpdateEntityCommandInput) => Promise<UpdateEntityCommandOutput>;
+  deleteEntity?: (input: DeleteEntityCommandInput) => Promise<DeleteEntityCommandOutput>;
   getPropertyValueHistory?: (
     input: GetPropertyValueHistoryCommandInput
   ) => Promise<GetPropertyValueHistoryCommandOutput>;
@@ -48,6 +60,12 @@ export const createMockTwinMakerSDK = ({
       switch (commandName) {
         case 'GetEntityCommand':
           return getEntity(command.input);
+        case 'UpdateEntityCommand':
+          return updateEntity(command.input);
+        case 'DeleteEntityCommand':
+          return deleteEntity(command.input);
+        case 'CreateEntityCommand':
+          return createEntity(command.input);
         case 'GetPropertyValueHistoryCommand':
           return getPropertyValueHistory(command.input);
         case 'GetPropertyValueCommand':

--- a/packages/source-iottwinmaker/src/data-binding-provider/EntityPropertyBindingProviderStore.spec.ts
+++ b/packages/source-iottwinmaker/src/data-binding-provider/EntityPropertyBindingProviderStore.spec.ts
@@ -17,9 +17,9 @@ describe('EntityPropertyBindingProviderStore', () => {
   const mapToKV = (key: string): IDataFieldOption => ({ label: key + '-name', value: key + '-id' });
 
   const mockEntityDataFieldOptions = [
+    { label: 'e3-name', value: 'e3' },
     mapToKV('entity-option-1'),
     mapToKV('entity-option-2'),
-    mapToKV('entity-option-3'),
   ];
 
   const mockDataBindingInput = {
@@ -41,8 +41,8 @@ describe('EntityPropertyBindingProviderStore', () => {
         entityId: 'entity-option-2-id',
       },
       {
-        entityName: 'entity-option-3-name',
-        entityId: 'entity-option-3-id',
+        entityName: 'e3-name',
+        entityId: 'e3',
       },
     ],
   };
@@ -189,6 +189,15 @@ describe('EntityPropertyBindingProviderStore', () => {
     const state = await providerStore.updateSelection('entityId', { value: 'wrong', label: 'wrong' });
 
     expect(state.errors?.invalidEntityId).toBeTruthy();
+  });
+
+  it('should update selectedOptions when entity selection is in options', async () => {
+    const mockOnChange = jest.fn();
+    providerStore.setOnStateChangedListener(mockOnChange);
+
+    await providerStore.updateSelection('entityId', { value: 'e3', label: 'e3-name' });
+
+    expect(mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0].selectedOptions[0].value).toBe('e3');
   });
 
   it('should update selectedOptions when entity selection is changed', async () => {

--- a/packages/source-iottwinmaker/src/data-binding-provider/EntityPropertyBindingProviderStore.ts
+++ b/packages/source-iottwinmaker/src/data-binding-provider/EntityPropertyBindingProviderStore.ts
@@ -157,12 +157,13 @@ export class EntityPropertyBindingProviderStore implements IValueDataBindingStor
       }
       if (store.state.selectedOptions[DataField.ENTITY_ID]?.value !== selected.value) {
         if (
-          this.dataBindingConfig?.fieldMapping?.[DATA_BINDING_CONTEXT_KEYS?.entityId]?.find(
+          (this.dataBindingConfig?.fieldMapping?.[DATA_BINDING_CONTEXT_KEYS?.entityId]?.find(
             (val) => this.dataBindingConfig?.template?.[val]
           ) &&
-          this.dataBindingConfig?.fieldMapping?.[DATA_BINDING_CONTEXT_KEYS?.entityId].find(
-            (val) => decorateDataBindingTemplate(val) === selected.value
-          )
+            this.dataBindingConfig?.fieldMapping?.[DATA_BINDING_CONTEXT_KEYS?.entityId].find(
+              (val) => decorateDataBindingTemplate(val) === selected.value
+            )) ||
+          store.state.definitions[DataField.ENTITY_ID].options.find((val) => val.value === selected.value)
         ) {
           validEntity = true;
         } else if (selected.value && selected.value.length > MIN_ENTITY_VALIDATION_COUNT) {

--- a/packages/source-iottwinmaker/src/metadata-module/TwinMakerMetadataModule.ts
+++ b/packages/source-iottwinmaker/src/metadata-module/TwinMakerMetadataModule.ts
@@ -26,7 +26,7 @@ export class TwinMakerMetadataModule {
     this.cachedQueryClient = cachedQueryClient;
   }
 
-  async fetchEntity({ entityId }: { entityId: string }): Promise<GetEntityResponse> {
+  fetchEntity = async ({ entityId }: { entityId: string }): Promise<GetEntityResponse> => {
     const request = new GetEntityCommand({ workspaceId: this.workspaceId, entityId });
 
     try {
@@ -41,13 +41,13 @@ export class TwinMakerMetadataModule {
 
       throw errorDetail;
     }
-  }
+  };
 
-  async fetchEntitiesByComponentTypeId({
+  fetchEntitiesByComponentTypeId = async ({
     componentTypeId,
   }: {
     componentTypeId: string | undefined;
-  }): Promise<GetEntityResponse[]> {
+  }): Promise<GetEntityResponse[]> => {
     return this.cachedQueryClient.fetchQuery({
       queryKey: ['list-entities-by-component-type-id', this.workspaceId, componentTypeId],
       queryFn: async () => {
@@ -62,9 +62,9 @@ export class TwinMakerMetadataModule {
         return (await Promise.all(requests)).filter(isDefined);
       },
     });
-  }
+  };
 
-  async fetchEntitiesSummaries(): Promise<EntitySummary[]> {
+  fetchEntitiesSummaries = async (): Promise<EntitySummary[]> => {
     return this.cachedQueryClient.fetchQuery({
       queryKey: ['list-entities', this.workspaceId],
       queryFn: () =>
@@ -72,13 +72,13 @@ export class TwinMakerMetadataModule {
           componentTypeId: undefined,
         }),
     });
-  }
+  };
 
-  private async _requestEntitiesByComponentTypeId({
+  private _requestEntitiesByComponentTypeId = async ({
     componentTypeId,
   }: {
     componentTypeId: string | undefined;
-  }): Promise<EntitySummary[]> {
+  }): Promise<EntitySummary[]> => {
     try {
       const summaries = [];
 
@@ -101,5 +101,5 @@ export class TwinMakerMetadataModule {
 
       throw errorDetail;
     }
-  }
+  };
 }

--- a/packages/source-iottwinmaker/src/scene-module/SceneMetadataModule.spec.ts
+++ b/packages/source-iottwinmaker/src/scene-module/SceneMetadataModule.spec.ts
@@ -4,9 +4,17 @@ import { createMockTwinMakerSDK } from '../__mocks__/iottwinmakerSDK';
 
 const getScene = jest.fn();
 const updateScene = jest.fn();
+const getEntity = jest.fn();
+const createEntity = jest.fn();
+const updateEntity = jest.fn();
+const deleteEntity = jest.fn();
 const twinMakerClientMock = createMockTwinMakerSDK({
   getScene,
   updateScene,
+  getEntity,
+  createEntity,
+  updateEntity,
+  deleteEntity,
 });
 
 const listSecrets = jest.fn();
@@ -110,6 +118,116 @@ describe('get3pConnectionList', () => {
     } catch (err) {
       expect(err).toEqual('Secrets Manager  API failed');
       expect(listSecrets).toBeCalledTimes(1);
+    }
+  });
+});
+
+describe('getSceneId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should get correct sceneId', async () => {
+    const result = await sceneMetadataModule.getSceneId();
+
+    expect(result).toEqual('scene-id');
+  });
+});
+
+describe('getSceneEntity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should get correct entity', async () => {
+    getEntity.mockResolvedValue({ entityId: 'eid' });
+
+    const result = await sceneMetadataModule.getSceneEntity({ entityId: 'eid' });
+
+    expect(result).toEqual({ entityId: 'eid' });
+    expect(getEntity).toBeCalledTimes(1);
+  });
+
+  it('should get error when API failed', async () => {
+    getEntity.mockRejectedValue('TwinMaker API failed');
+
+    try {
+      await sceneMetadataModule.getSceneEntity({ entityId: 'eid' });
+    } catch (err) {
+      expect(err).toEqual('TwinMaker API failed');
+      expect(getEntity).toBeCalledTimes(1);
+    }
+  });
+});
+
+describe('createSceneEntity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call API to create entity successfully', async () => {
+    await sceneMetadataModule.createSceneEntity({ entityId: 'eid', entityName: 'ename' });
+
+    expect(createEntity).toBeCalledTimes(1);
+    expect(createEntity).toBeCalledWith({ entityId: 'eid', entityName: 'ename', workspaceId: 'ws-id' });
+  });
+
+  it('should get error when API failed', async () => {
+    getEntity.mockRejectedValue('TwinMaker API failed');
+
+    try {
+      await sceneMetadataModule.createSceneEntity({ entityId: 'eid', entityName: 'ename' });
+    } catch (err) {
+      expect(err).toEqual('TwinMaker API failed');
+      expect(createEntity).toBeCalledTimes(1);
+    }
+  });
+});
+
+describe('updateSceneEntity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call API to update entity successfully', async () => {
+    await sceneMetadataModule.updateSceneEntity({ entityId: 'eid', componentUpdates: { test: {} } });
+
+    expect(updateEntity).toBeCalledTimes(1);
+    expect(updateEntity).toBeCalledWith({ entityId: 'eid', componentUpdates: { test: {} }, workspaceId: 'ws-id' });
+  });
+
+  it('should get error when API failed', async () => {
+    getEntity.mockRejectedValue('TwinMaker API failed');
+
+    try {
+      await sceneMetadataModule.updateSceneEntity({ entityId: 'eid' });
+    } catch (err) {
+      expect(err).toEqual('TwinMaker API failed');
+      expect(updateEntity).toBeCalledTimes(1);
+    }
+  });
+});
+
+describe('deleteSceneEntity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call API to delete entity successfully', async () => {
+    await sceneMetadataModule.deleteSceneEntity({ entityId: 'eid' });
+
+    expect(deleteEntity).toBeCalledTimes(1);
+    expect(deleteEntity).toBeCalledWith({ entityId: 'eid', workspaceId: 'ws-id' });
+  });
+
+  it('should get error when API failed', async () => {
+    getEntity.mockRejectedValue('TwinMaker API failed');
+
+    try {
+      await sceneMetadataModule.deleteSceneEntity({ entityId: 'eid' });
+    } catch (err) {
+      expect(err).toEqual('TwinMaker API failed');
+      expect(deleteEntity).toBeCalledTimes(1);
     }
   });
 });

--- a/packages/source-iottwinmaker/src/scene-module/SceneMetadataModule.ts
+++ b/packages/source-iottwinmaker/src/scene-module/SceneMetadataModule.ts
@@ -1,7 +1,15 @@
 import {
+  CreateEntityCommand,
+  CreateEntityCommandInput,
+  DeleteEntityCommand,
+  DeleteEntityCommandInput,
+  GetEntityCommand,
+  GetEntityCommandInput,
   GetSceneCommand,
   GetSceneCommandOutput,
   IoTTwinMakerClient,
+  UpdateEntityCommand,
+  UpdateEntityCommandInput,
   UpdateSceneCommand,
 } from '@aws-sdk/client-iottwinmaker';
 import { ListSecretsCommand, SecretListEntry, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
@@ -24,6 +32,10 @@ export class SceneMetadataModule implements TwinMakerSceneMetadataModule {
     this.twinMakerClient = input.twinMakerClient;
     this.secretsManagerClient = input.secretsManagerClient;
   }
+
+  getSceneId = (): string => {
+    return this.sceneId;
+  };
 
   getSceneInfo = async (): Promise<GetSceneCommandOutput> => {
     const sceneInfo: GetSceneCommandOutput = await this.twinMakerClient.send(
@@ -57,5 +69,21 @@ export class SceneMetadataModule implements TwinMakerSceneMetadataModule {
           reject(error);
         });
     });
+  };
+
+  getSceneEntity = (input: Omit<GetEntityCommandInput, 'workspaceId'>) => {
+    return this.twinMakerClient.send(new GetEntityCommand({ ...input, workspaceId: this.workspaceId }));
+  };
+
+  createSceneEntity = (input: Omit<CreateEntityCommandInput, 'workspaceId'>) => {
+    return this.twinMakerClient.send(new CreateEntityCommand({ ...input, workspaceId: this.workspaceId }));
+  };
+
+  updateSceneEntity = (input: Omit<UpdateEntityCommandInput, 'workspaceId'>) => {
+    return this.twinMakerClient.send(new UpdateEntityCommand({ ...input, workspaceId: this.workspaceId }));
+  };
+
+  deleteSceneEntity = (input: Omit<DeleteEntityCommandInput, 'workspaceId'>) => {
+    return this.twinMakerClient.send(new DeleteEntityCommand({ ...input, workspaceId: this.workspaceId }));
   };
 }

--- a/packages/source-iottwinmaker/src/types.ts
+++ b/packages/source-iottwinmaker/src/types.ts
@@ -1,4 +1,15 @@
-import { GetSceneCommandOutput, ExecuteQueryCommandOutput } from '@aws-sdk/client-iottwinmaker';
+import {
+  GetSceneCommandOutput,
+  ExecuteQueryCommandOutput,
+  CreateEntityCommandInput,
+  UpdateEntityCommandInput,
+  DeleteEntityCommandInput,
+  CreateEntityCommandOutput,
+  UpdateEntityCommandOutput,
+  DeleteEntityCommandOutput,
+  GetEntityCommandInput,
+  GetEntityCommandOutput,
+} from '@aws-sdk/client-iottwinmaker';
 import { SecretListEntry } from '@aws-sdk/client-secrets-manager';
 
 import type { VideoPlaybackMode } from './video-data/types';
@@ -13,9 +24,15 @@ export interface SceneLoader {
 export type SceneInfo = { capabilities?: string[]; sceneMetadata?: Record<string, string> };
 
 export interface TwinMakerSceneMetadataModule {
+  getSceneId: () => string;
   getSceneInfo: () => Promise<GetSceneCommandOutput>;
   updateSceneInfo: (sceneInfo: SceneInfo) => Promise<void>;
   get3pConnectionList: (connectionTag: string) => Promise<SecretListEntry[] | undefined> | null;
+
+  getSceneEntity: (input: Omit<GetEntityCommandInput, 'workspaceId'>) => Promise<GetEntityCommandOutput>;
+  createSceneEntity: (input: Omit<CreateEntityCommandInput, 'workspaceId'>) => Promise<CreateEntityCommandOutput>;
+  updateSceneEntity: (input: Omit<UpdateEntityCommandInput, 'workspaceId'>) => Promise<UpdateEntityCommandOutput>;
+  deleteSceneEntity: (input: Omit<DeleteEntityCommandInput, 'workspaceId'>) => Promise<DeleteEntityCommandOutput>;
 }
 
 export interface VideoData {


### PR DESCRIPTION
## Overview
add entity APIs to SceneMetadataModule so scene composer has access to those APIs

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
