### PR TITLE
feat(composer): support sync matterport tag as entities

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -46,7 +46,7 @@
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --index-template tools/index-template.js -- src/assets/icons/",
     "release": "run-s compile copy-assets",
     "copy-assets": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" dist/",
-    "lint": "eslint . --max-warnings=643",
+    "lint": "eslint . --max-warnings=636",
     "fix": "eslint --fix .",
     "test": "jest --config jest.config.ts --coverage --silent",
     "test:dev": "jest --config jest.config.ts --coverage",

--- a/packages/scene-composer/src/common/entityModelConstants.ts
+++ b/packages/scene-composer/src/common/entityModelConstants.ts
@@ -1,0 +1,38 @@
+import { KnownComponentType } from '../interfaces';
+
+// Scene Nodes
+const SCENE_COMPONENT_TYPE_ID_PREFIX = 'com.example.3d';
+export const NODE_COMPONENT_TYPE_ID = `${SCENE_COMPONENT_TYPE_ID_PREFIX}.node`;
+export const LAYER_COMPONENT_TYPE_ID = `${SCENE_COMPONENT_TYPE_ID_PREFIX}.layer`;
+export const componentTypeToId: Record<KnownComponentType, string> = {
+  Tag: `${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.tag`,
+  DataOverlay: `${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.dataoverlay`,
+  ModelRef: `${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.modelref`,
+  ModelShader: `${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.modelshader`,
+  SubModelRef: `${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.submodelref`,
+  Animation: `${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.animation`,
+  MotionIndicator: `${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.motionindicator`,
+  Light: `${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.light`,
+  Camera: `${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.camera`,
+  EntityBinding: NODE_COMPONENT_TYPE_ID, // EntityBinding is saved at node component
+};
+export const DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME = 'isVisualOf';
+export const DEFAULT_NODE_COMPONENT_NAME = 'Node';
+export const SCENE_ROOT_ENTITY_ID = 'SCENES_EntityId';
+
+// Matterport
+export const MATTERPORT_TAG_LAYER_PREFIX = 'Matterport_Tag_';
+
+// Layer
+export const DEFAULT_LAYER_RELATIONSHIP_NAME = 'inLayerOf';
+export const DEFAULT_LAYER_COMPONENT_NAME = 'Layer';
+export const LAYER_ROOT_ENTITY_ID = 'LAYERS_EntityId';
+export enum LayerType {
+  Relationship = 'Relationship',
+  Query = 'Query',
+}
+export const layerPropertyNames = {
+  type: 'type',
+  queryString: 'queryString',
+  relationshipName: 'relationshipName',
+};

--- a/packages/scene-composer/src/components/panels/ComponentEditMenu.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditMenu.tsx
@@ -21,9 +21,7 @@ interface ComponentEditMenuProps {
 enum ObjectTypes {
   EditComponent = 'edit-component',
   AddDataBinding = 'add-data-binding',
-  AddEntityBinding = 'add-entity-binding',
   RemoveEntityBinding = 'remove-entity-binding',
-  RemoveAllDataBinding = 'remove-all-data-binding',
   RemoveOverlay = 'remove-overlay',
 }
 
@@ -34,15 +32,12 @@ type ComponentEditMenuItem = ToolbarItemOptions & {
 const labelStrings: { [key in ObjectTypes]: MessageDescriptor } = defineMessages({
   [ObjectTypes.EditComponent]: { defaultMessage: 'Edit component', description: 'Menu Item label' },
   [ObjectTypes.AddDataBinding]: { defaultMessage: 'Add data binding', description: 'Menu Item label' },
-  [ObjectTypes.AddEntityBinding]: { defaultMessage: 'Add entity binding', description: 'Menu Item label' },
   [ObjectTypes.RemoveEntityBinding]: { defaultMessage: 'Remove entity binding', description: 'Menu Item label' },
-  [ObjectTypes.RemoveAllDataBinding]: { defaultMessage: 'Remove all data binding', description: 'Menu Item label' },
   [ObjectTypes.RemoveOverlay]: { defaultMessage: 'Remove overlay', description: 'Menu Item label' },
 });
 
 const textStrings = defineMessages({
   [ObjectTypes.AddDataBinding]: { defaultMessage: 'Add data binding', description: 'Menu Item' },
-  [ObjectTypes.RemoveAllDataBinding]: { defaultMessage: 'Remove all data binding', description: 'Menu Item' },
   [ObjectTypes.RemoveEntityBinding]: { defaultMessage: 'Remove entity binding', description: 'Menu Item' },
   [ObjectTypes.RemoveOverlay]: { defaultMessage: 'Remove overlay', description: 'Menu Item' },
 });

--- a/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.spec.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { MpSdk } from '@matterport/r3f/dist';
 
 import { ISceneNodeInternal, useStore } from '../../../store';
 import { MattertagItem, TagItem } from '../../../utils/matterportTagUtils';
+import useDynamicScene from '../../../hooks/useDynamicScene';
+import { KnownSceneProperty } from '../../../interfaces';
+import { createLayer } from '../../../utils/entityModelUtils/sceneLayerUtils';
+import { LayerType, MATTERPORT_TAG_LAYER_PREFIX } from '../../../common/entityModelConstants';
+import { createSceneRootEntity } from '../../../utils/entityModelUtils/sceneUtils';
+
+import { MatterportTagSync } from './MatterportTagSync';
 
 const getMatterTagsMock = jest.fn();
 const getTagsMock = jest.fn();
@@ -18,9 +25,9 @@ jest.mock('../../../hooks/useMatterportObserver', () => {
   }));
 });
 
-const handleAddMatterportTagMock = jest.fn();
-const handleUpdateMatterportTagMock = jest.fn();
-const handleRemoveMatterportTagMock = jest.fn();
+const handleAddMatterportTagMock = jest.fn().mockResolvedValue(undefined);
+const handleUpdateMatterportTagMock = jest.fn().mockResolvedValue(undefined);
+const handleRemoveMatterportTagMock = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../../hooks/useMatterportTags', () => {
   return jest.fn(() => ({
     handleAddMatterportTag: handleAddMatterportTagMock,
@@ -29,15 +36,25 @@ jest.mock('../../../hooks/useMatterportTags', () => {
   }));
 });
 
-import { MatterportTagSync } from './MatterportTagSync';
+jest.mock('../../../hooks/useDynamicScene', () => jest.fn());
+jest.mock('../../../utils/entityModelUtils/sceneLayerUtils', () => ({
+  createLayer: jest.fn(),
+}));
+jest.mock('../../../utils/entityModelUtils/sceneUtils', () => ({
+  createSceneRootEntity: jest.fn(),
+}));
 
-describe('MatterportIntegration', () => {
+describe('MatterportTagSync', () => {
   const getComponentRefByTypeMock = jest.fn();
   const getSceneNodeByRefMock = jest.fn();
+  const setScenePropertyMock = jest.fn();
+  const getScenePropertyMock = jest.fn();
 
   const baseState = {
     getComponentRefByType: getComponentRefByTypeMock,
     getSceneNodeByRef: getSceneNodeByRefMock,
+    setSceneProperty: setScenePropertyMock,
+    getSceneProperty: getScenePropertyMock,
   };
 
   const testInternalNode: ISceneNodeInternal = {
@@ -146,11 +163,13 @@ describe('MatterportIntegration', () => {
     getTagsMock.mockImplementation(() => undefined);
     const rendered = render(<MatterportTagSync />);
 
-    fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+    await act(async () => {
+      fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+    });
 
     expect(getComponentRefByTypeMock).toBeCalled();
-    expect(handleAddMatterportTagMock).toBeCalledWith('id3', matterTag3);
-    expect(handleUpdateMatterportTagMock).toBeCalledWith('ref2', node2, matterTag2);
+    expect(handleAddMatterportTagMock).toBeCalledWith(undefined, undefined, 'id3', matterTag3);
+    expect(handleUpdateMatterportTagMock).toBeCalledWith(undefined, 'ref2', node2, matterTag2);
     expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
   });
 
@@ -193,11 +212,183 @@ describe('MatterportIntegration', () => {
     });
     const rendered = render(<MatterportTagSync />);
 
-    fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+    await act(async () => {
+      fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+    });
 
     expect(getComponentRefByTypeMock).toBeCalled();
-    expect(handleAddMatterportTagMock).toBeCalledWith('id3', tag2);
-    expect(handleUpdateMatterportTagMock).toBeCalledWith('ref2', node2, tag3);
+    expect(handleAddMatterportTagMock).toBeCalledWith(undefined, undefined, 'id3', tag2);
+    expect(handleUpdateMatterportTagMock).toBeCalledWith(undefined, 'ref2', node2, tag3);
     expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
+  });
+
+  describe('when dynamic scene is enabled', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (useDynamicScene as jest.Mock).mockReturnValue(true);
+      (createLayer as jest.Mock).mockImplementation((name, _) => {
+        return Promise.resolve({ entityId: name });
+      });
+      (createSceneRootEntity as jest.Mock).mockImplementation(() => {
+        return Promise.resolve({ entityId: 'scene-root-id' });
+      });
+
+      getScenePropertyMock.mockImplementation((p) => {
+        if (p == KnownSceneProperty.MatterportModelId) {
+          return 'matterportModelId';
+        } else if (p == KnownSceneProperty.LayerIds) {
+          return ['layer-id'];
+        } else if (p == KnownSceneProperty.SceneRootEntityId) {
+          return 'scene-root-id';
+        } else {
+          return undefined;
+        }
+      });
+    });
+
+    it('should create a default layer and root entity when none available', async () => {
+      getScenePropertyMock.mockImplementation((p) => {
+        if (p == KnownSceneProperty.MatterportModelId) {
+          return 'matterportModelId';
+        } else {
+          return undefined;
+        }
+      });
+      useStore('default').setState(baseState);
+      const rendered = render(<MatterportTagSync />);
+
+      await act(async () => {
+        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+      });
+
+      expect(createLayer as jest.Mock).toBeCalledTimes(1);
+      expect(createLayer as jest.Mock).toBeCalledWith(
+        MATTERPORT_TAG_LAYER_PREFIX + 'matterportModelId',
+        LayerType.Relationship,
+      );
+      expect(createSceneRootEntity as jest.Mock).toBeCalledTimes(1);
+      expect(setScenePropertyMock).toBeCalledTimes(2);
+      expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.LayerIds, [
+        MATTERPORT_TAG_LAYER_PREFIX + 'matterportModelId',
+      ]);
+      expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneRootEntityId, 'scene-root-id');
+    });
+
+    it('should not create the default layer and root entity when available', async () => {
+      useStore('default').setState(baseState);
+      const rendered = render(<MatterportTagSync />);
+
+      await act(async () => {
+        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+      });
+
+      expect(createLayer as jest.Mock).not.toBeCalled();
+      expect(createSceneRootEntity as jest.Mock).not.toBeCalled();
+      expect(setScenePropertyMock).not.toBeCalled();
+    });
+
+    it('should sync mattertags by deleting id1, updating id2, and adding id3', async () => {
+      useStore('default').setState(baseState);
+
+      getComponentRefByTypeMock.mockImplementation(() => {
+        const deletableTag: Record<string, string[]> = {
+          ref1: [],
+          ref2: [],
+          'ref3:': [],
+        };
+        return deletableTag;
+      });
+
+      const node1: ISceneNodeInternal = { ...testInternalNode };
+      const node2: ISceneNodeInternal = {
+        ...testInternalNode,
+        properties: {
+          matterportId: 'id2',
+        },
+      };
+      const node3: ISceneNodeInternal = {
+        ...testInternalNode,
+        properties: {},
+      };
+
+      getSceneNodeByRefMock.mockImplementation((ref: string) => {
+        const nodeLookup = {
+          ref1: node1,
+          ref2: node2,
+          ref3: node3,
+        };
+        return nodeLookup[ref];
+      });
+
+      const matterTag2 = { ...testMattertagItem, sid: 'id2' };
+      const matterTag3 = { ...testMattertagItem, sid: 'id2' };
+      getMatterTagsMock.mockImplementation(() => {
+        const mattertags: Array<[string, MpSdk.Mattertag.ObservableMattertagData]> = [
+          ['id2', matterTag2],
+          ['id3', matterTag3],
+        ];
+        return mattertags;
+      });
+      getTagsMock.mockImplementation(() => undefined);
+      const rendered = render(<MatterportTagSync />);
+
+      await act(async () => {
+        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+      });
+
+      expect(getComponentRefByTypeMock).toBeCalled();
+      expect(handleAddMatterportTagMock).toBeCalledWith('layer-id', 'scene-root-id', 'id3', matterTag3);
+      expect(handleUpdateMatterportTagMock).toBeCalledWith('layer-id', 'ref2', node2, matterTag2);
+      expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
+    });
+
+    it('should sync matterport tags by deleting id1, updating id2, and adding id3', async () => {
+      useStore('default').setState(baseState);
+
+      getComponentRefByTypeMock.mockImplementation(() => {
+        const deletableTag: Record<string, string[]> = {
+          ref1: [],
+          ref2: [],
+        };
+        return deletableTag;
+      });
+
+      const node1: ISceneNodeInternal = { ...testInternalNode };
+      const node2: ISceneNodeInternal = {
+        ...testInternalNode,
+        properties: {
+          matterportId: 'id2',
+        },
+      };
+
+      getSceneNodeByRefMock.mockImplementation((ref: string) => {
+        const nodeLookup = {
+          ref1: node1,
+          ref2: node2,
+        };
+        return nodeLookup[ref];
+      });
+
+      const tag2 = { ...testTagItem, sid: 'id2' };
+      const tag3 = { ...testTagItem, sid: 'id2' };
+      getMatterTagsMock.mockImplementation(() => undefined);
+      getTagsMock.mockImplementation(() => {
+        const tags: Array<[string, MpSdk.Tag.TagData]> = [
+          ['id2', tag2],
+          ['id3', tag3],
+        ];
+        return tags;
+      });
+      const rendered = render(<MatterportTagSync />);
+
+      await act(async () => {
+        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+      });
+
+      expect(getComponentRefByTypeMock).toBeCalled();
+      expect(handleAddMatterportTagMock).toBeCalledWith('layer-id', 'scene-root-id', 'id3', tag2);
+      expect(handleUpdateMatterportTagMock).toBeCalledWith('layer-id', 'ref2', node2, tag3);
+      expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
+    });
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/MatterportTagSync.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/MatterportTagSync.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MatterportIntegration should render correctly 1`] = `
+exports[`MatterportTagSync should render correctly 1`] = `
 <div>
   <div
     data-mocked="Popover"

--- a/packages/scene-composer/src/hooks/useDynamicScene.spec.tsx
+++ b/packages/scene-composer/src/hooks/useDynamicScene.spec.tsx
@@ -1,0 +1,20 @@
+import { renderHook } from '@testing-library/react';
+
+import { setFeatureConfig } from '../common/GlobalSettings';
+import { COMPOSER_FEATURES } from '../interfaces';
+
+import useDynamicScene from './useDynamicScene';
+
+describe('useDynamicScene', () => {
+  [true, false].forEach((state) => {
+    it(`should render correctly when state is ${state}`, () => {
+      setFeatureConfig({
+        [COMPOSER_FEATURES[COMPOSER_FEATURES.DynamicScene]]: state,
+      });
+
+      const { result } = renderHook(() => useDynamicScene());
+
+      expect(result.current).toEqual(state);
+    });
+  });
+});

--- a/packages/scene-composer/src/hooks/useDynamicScene.ts
+++ b/packages/scene-composer/src/hooks/useDynamicScene.ts
@@ -1,0 +1,11 @@
+import { COMPOSER_FEATURES } from '../interfaces';
+
+import useFeature from './useFeature';
+
+const useDynamicScene = () => {
+  const enabled = useFeature(COMPOSER_FEATURES.DynamicScene).at(0)?.variation === 'T1';
+
+  return !!enabled;
+};
+
+export default useDynamicScene;

--- a/packages/scene-composer/src/hooks/useMatterportTags.ts
+++ b/packages/scene-composer/src/hooks/useMatterportTags.ts
@@ -1,12 +1,28 @@
 import { useCallback } from 'react';
+import { CreateEntityCommandInput, UpdateEntityCommandInput } from '@aws-sdk/client-iottwinmaker';
+import { Color } from 'three';
 
 import { useSceneComposerId } from '../common/sceneComposerIdContext';
-import { IAnchorComponent, ISceneNode, KnownComponentType } from '../interfaces';
+import {
+  DefaultAnchorStatus,
+  IAnchorComponent,
+  IDataOverlayComponent,
+  ISceneNode,
+  KnownComponentType,
+  SceneResourceType,
+} from '../interfaces';
 import { IAnchorComponentInternal, IDataOverlayComponentInternal, ISceneNodeInternal, useStore } from '../store';
 import { MattertagItem, TagItem } from '../utils/matterportTagUtils';
 import { RecursivePartial } from '../utils/typeUtils';
 import { Component } from '../models/SceneModels';
 import { generateUUID } from '../utils/mathUtils';
+import { getGlobalSettings } from '../common/GlobalSettings';
+import { createTagEntityComponent, updateTagEntityComponent } from '../utils/entityModelUtils/tagComponent';
+import { createOverlayEntityComponent, updateOverlayEntityComponent } from '../utils/entityModelUtils/overlayComponent';
+import { createNodeEntityComponent, updateNodeEntityComponent } from '../utils/entityModelUtils/nodeComponent';
+import { convertToIotTwinMakerNamespace } from '../utils/sceneResourceUtils';
+
+import useDynamicScene from './useDynamicScene';
 
 const getContentForOverlayComponent = (label: string, description: string): string => {
   // Do not change indentation as it affects rendering
@@ -30,7 +46,10 @@ const getNewDataOverlayComponent = (item: MattertagItem | TagItem): IDataOverlay
   return dataoverlayComponent;
 };
 
-const addTag = (
+const addTag = async (
+  dynamicSceneEnabled: boolean,
+  layerId: string | undefined,
+  sceneRootId: string | undefined,
   addSceneNode: (node: ISceneNode, parentRef?: string) => Readonly<ISceneNode>,
   id: string,
   item: MattertagItem | TagItem,
@@ -38,9 +57,13 @@ const addTag = (
   const anchorComponent: IAnchorComponent = {
     type: KnownComponentType.Tag,
     offset: [item.stemVector.x, item.stemVector.y, item.stemVector.z],
+    icon: convertToIotTwinMakerNamespace(SceneResourceType.Icon, DefaultAnchorStatus.Custom),
+    chosenColor: '#' + new Color(item.color.r, item.color.g, item.color.b).getHexString('srgb'),
   };
   const dataoverlayComponent = getNewDataOverlayComponent(item);
+  const nodeRef = generateUUID();
   const node = {
+    ref: nodeRef,
     name: item.label,
     components: [anchorComponent, dataoverlayComponent],
     transform: {
@@ -53,10 +76,40 @@ const addTag = (
     },
   } as ISceneNode;
 
+  const sceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
+
+  if (dynamicSceneEnabled && sceneMetadataModule) {
+    if (!layerId || !sceneRootId) {
+      return;
+    }
+
+    const tagComp = createTagEntityComponent(anchorComponent);
+    const overlayComp = createOverlayEntityComponent(dataoverlayComponent);
+    const nodeComp = createNodeEntityComponent(node, layerId);
+
+    const creatEntity: CreateEntityCommandInput = {
+      workspaceId: undefined,
+      entityId: nodeRef,
+      entityName: item.label + '_' + nodeRef,
+      parentEntityId: sceneRootId,
+      components: {
+        [KnownComponentType.Tag]: tagComp,
+        [KnownComponentType.DataOverlay]: overlayComp,
+        Node: nodeComp,
+      },
+    };
+    try {
+      await sceneMetadataModule.createSceneEntity(creatEntity);
+    } catch (e) {
+      console.error('Create scene node entity failed', e);
+    }
+  }
   addSceneNode(node);
 };
 
-const updateTag = (
+const updateTag = async (
+  dynamicSceneEnabled: boolean,
+  layerId: string | undefined,
   updateSceneNode: (ref: string, partial: RecursivePartial<ISceneNodeInternal>, isTransient?: boolean) => void,
   ref: string,
   node: ISceneNodeInternal,
@@ -69,6 +122,8 @@ const updateTag = (
     components[tagIndex] = {
       ...components[tagIndex],
       offset: [item.stemVector.x, item.stemVector.y, item.stemVector.z],
+      icon: convertToIotTwinMakerNamespace(SceneResourceType.Icon, DefaultAnchorStatus.Custom),
+      chosenColor: '#' + new Color(item.color.r, item.color.g, item.color.b).getHexString('srgb'),
     } as IAnchorComponentInternal;
   }
   const dataOverlayIndex = node.components.findIndex((elem) => elem.type === KnownComponentType.DataOverlay);
@@ -86,6 +141,42 @@ const updateTag = (
     const dataoverlayComponent = getNewDataOverlayComponent(item);
     components.push(dataoverlayComponent);
   }
+
+  const sceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
+
+  if (dynamicSceneEnabled && sceneMetadataModule) {
+    if (!layerId) {
+      return;
+    }
+
+    const tagComp = tagIndex !== -1 ? updateTagEntityComponent(components[tagIndex]) : undefined;
+    const overlayComp =
+      dataOverlayIndex !== -1
+        ? updateOverlayEntityComponent(components[dataOverlayIndex] as IDataOverlayComponent)
+        : undefined;
+    const nodeComp = updateNodeEntityComponent(node, layerId);
+
+    const updateEntity: UpdateEntityCommandInput = {
+      workspaceId: undefined,
+      entityId: ref,
+      entityName: item.label + '_' + ref,
+      componentUpdates: {
+        Node: nodeComp,
+      },
+    };
+    if (tagComp) {
+      updateEntity.componentUpdates![KnownComponentType.Tag] = tagComp;
+    }
+    if (overlayComp) {
+      updateEntity.componentUpdates![KnownComponentType.DataOverlay] = overlayComp;
+    }
+    try {
+      await sceneMetadataModule.updateSceneEntity(updateEntity);
+    } catch (e) {
+      console.error('Update scene node entity failed', e);
+    }
+  }
+
   updateSceneNode(ref, {
     name: item.label,
     transform: {
@@ -96,32 +187,55 @@ const updateTag = (
 };
 
 const useMatterportTags = (): {
-  handleAddMatterportTag: (id: string, item: MattertagItem | TagItem) => void;
-  handleUpdateMatterportTag: (ref: string, node: ISceneNodeInternal, item: MattertagItem | TagItem) => void;
+  handleAddMatterportTag: (
+    layerId: string | undefined,
+    sceneRootId: string | undefined,
+    id: string,
+    item: MattertagItem | TagItem,
+  ) => Promise<void>;
+  handleUpdateMatterportTag: (
+    layerId: string | undefined,
+    ref: string,
+    node: ISceneNodeInternal,
+    item: MattertagItem | TagItem,
+  ) => Promise<void>;
   handleRemoveMatterportTag: (nodeRef: string) => void;
 } => {
   const sceneComposerId = useSceneComposerId();
   const appendSceneNode = useStore(sceneComposerId)((state) => state.appendSceneNode);
   const updateSceneNodeInternal = useStore(sceneComposerId)((state) => state.updateSceneNodeInternal);
   const removeSceneNode = useStore(sceneComposerId)((state) => state.removeSceneNode);
+  const dynamicSceneEnabled = useDynamicScene();
 
   const handleAddMatterportTag = useCallback(
-    (id: string, item: MattertagItem | TagItem) => {
-      addTag(appendSceneNode, id, item);
+    async (layerId: string | undefined, sceneRootId: string | undefined, id: string, item: MattertagItem | TagItem) => {
+      await addTag(dynamicSceneEnabled, layerId, sceneRootId, appendSceneNode, id, item);
     },
     [appendSceneNode],
   );
 
   const handleUpdateMatterportTag = useCallback(
-    (ref: string, node: ISceneNodeInternal, item: MattertagItem | TagItem) => {
-      updateTag(updateSceneNodeInternal, ref, node, item);
+    async (layerId: string | undefined, ref: string, node: ISceneNodeInternal, item: MattertagItem | TagItem) => {
+      await updateTag(dynamicSceneEnabled, layerId, updateSceneNodeInternal, ref, node, item);
     },
     [updateSceneNodeInternal],
   );
 
   const handleRemoveMatterportTag = useCallback(
     (nodeRef: string) => {
-      removeSceneNode(nodeRef);
+      const sceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
+      if (dynamicSceneEnabled && sceneMetadataModule) {
+        sceneMetadataModule
+          .deleteSceneEntity({ entityId: nodeRef })
+          .then((_) => {
+            removeSceneNode(nodeRef);
+          })
+          .catch((e) => {
+            console.error('Delete scene node entity failed', e);
+          });
+      } else {
+        removeSceneNode(nodeRef);
+      }
     },
     [removeSceneNode],
   );

--- a/packages/scene-composer/src/interfaces/feature.ts
+++ b/packages/scene-composer/src/interfaces/feature.ts
@@ -17,6 +17,7 @@ export enum COMPOSER_FEATURES {
   TagStyle = 'TagStyle',
   AutoQuery = 'AutoQuery',
   Animations = 'Animations',
+  DynamicScene = 'DynamicScene',
 
   // Deprecated features (to be removed)
   EnvironmentModel = 'EnvironmentModel',

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -61,7 +61,7 @@ export interface ISceneNode {
   components?: ISceneComponent[];
   parentRef?: string;
   childRefs?: string[];
-  properties?: Record<string, any>;
+  properties?: Partial<Record<'alwaysVisible' | 'matterportId' | 'hiddenWhileImmersive', boolean | string>>;
 }
 
 export enum KnownSceneProperty {
@@ -70,6 +70,8 @@ export enum KnownSceneProperty {
   DataBindingConfig = 'dataBindingConfig',
   ComponentSettings = 'componentSettings',
   MatterportModelId = 'matterportModelId',
+  LayerIds = 'layerIds',
+  SceneRootEntityId = 'sceneRootEntityId',
 }
 
 /************************************************

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -97,7 +97,7 @@ export interface Node {
   transformConstraint?: TransformConstraint;
   components?: Array<Component.IComponent>;
   children?: Array<number>;
-  properties?: Record<string, any>;
+  properties?: Partial<Record<'alwaysVisible' | 'matterportId' | 'hiddenWhileImmersive', boolean | string>>;
 }
 
 export enum ModelType {

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -387,7 +387,7 @@ function createSceneNodeInternal(deserializedNode: Node) {
     ref: uuid,
     name: deserializedNode.name || uuid,
     transform: {
-      position: deserializedNode.transform.position,
+      position: deserializedNode.transform.position ?? [0, 0, 0],
       rotation: deserializedNode.transform.rotation ?? [0, 0, 0],
       scale: deserializedNode.transform.scale ?? [1, 1, 1],
     },

--- a/packages/scene-composer/src/store/internalInterfaces.ts
+++ b/packages/scene-composer/src/store/internalInterfaces.ts
@@ -81,7 +81,7 @@ export interface ISceneNodeInternal extends ISceneNode {
   transformConstraint: ITransformConstraint;
   components: ISceneComponentInternal[];
   childRefs: string[];
-  properties: Record<string, any>;
+  properties: Partial<Record<'alwaysVisible' | 'matterportId' | 'hiddenWhileImmersive', boolean | string>>;
 }
 
 export interface ISceneDocumentInternal extends ISceneDocument {

--- a/packages/scene-composer/src/utils/entityModelUtils/dataBindingUtils.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/dataBindingUtils.spec.ts
@@ -1,0 +1,35 @@
+import { ValueDataBinding } from '../../models/SceneModels';
+
+import { createDataBindingMap } from './dataBindingUtils';
+
+describe('createDataBindingMap', () => {
+  it('should return empty map when no data binding is provided', () => {
+    expect(createDataBindingMap(undefined)).toEqual({});
+    expect(createDataBindingMap({})).toEqual({});
+    expect(createDataBindingMap({ dataBindingContext: undefined })).toEqual({});
+    expect(createDataBindingMap({ dataBindingContext: {} } as ValueDataBinding)).toEqual({});
+  });
+
+  it('should return map with only entityId', () => {
+    expect(createDataBindingMap({ dataBindingContext: { entityId: 'eid' } })).toEqual({
+      entityId: { stringValue: 'eid' },
+      componentName: { stringValue: undefined },
+      propertyName: { stringValue: undefined },
+      isStaticData: { stringValue: 'false' },
+    });
+  });
+
+  it('should return map with all data', () => {
+    expect(
+      createDataBindingMap({
+        dataBindingContext: { entityId: 'eid', componentName: 'cname', propertyName: 'pname' },
+        isStaticData: true,
+      }),
+    ).toEqual({
+      entityId: { stringValue: 'eid' },
+      componentName: { stringValue: 'cname' },
+      propertyName: { stringValue: 'pname' },
+      isStaticData: { stringValue: 'true' },
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/dataBindingUtils.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/dataBindingUtils.ts
@@ -1,0 +1,26 @@
+import { DataValue } from '@aws-sdk/client-iottwinmaker';
+import { ITwinMakerEntityDataBindingContext } from '@iot-app-kit/source-iottwinmaker';
+import { isEmpty } from 'lodash';
+
+import { ValueDataBinding } from '../../models/SceneModels';
+
+export const createDataBindingMap = (binding: ValueDataBinding | undefined): Record<string, DataValue> => {
+  if (!binding || isEmpty(binding.dataBindingContext)) {
+    return {};
+  }
+
+  return {
+    entityId: {
+      stringValue: binding.dataBindingContext.entityId,
+    },
+    componentName: {
+      stringValue: (binding.dataBindingContext as ITwinMakerEntityDataBindingContext).componentName,
+    },
+    propertyName: {
+      stringValue: (binding.dataBindingContext as ITwinMakerEntityDataBindingContext).propertyName,
+    },
+    isStaticData: {
+      stringValue: String(!!binding.isStaticData),
+    },
+  };
+};

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
@@ -1,0 +1,124 @@
+import {
+  DEFAULT_LAYER_COMPONENT_NAME,
+  DEFAULT_LAYER_RELATIONSHIP_NAME,
+  NODE_COMPONENT_TYPE_ID,
+} from '../../common/entityModelConstants';
+
+import { createNodeEntityComponent, updateNodeEntityComponent } from './nodeComponent';
+
+describe('createNodeEntityComponent', () => {
+  it('should return expected empty node component', () => {
+    expect(createNodeEntityComponent({ name: 'Test' })).toEqual({
+      componentTypeId: NODE_COMPONENT_TYPE_ID,
+      properties: {
+        name: {
+          value: {
+            stringValue: 'Test',
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected node component with transform', () => {
+    const result = createNodeEntityComponent({
+      transform: { position: [1, 2, 3], rotation: [4, 5, 6], scale: [7, 8, 9] },
+    });
+
+    expect(result.properties).toEqual({
+      name: {
+        value: {
+          stringValue: 'Node',
+        },
+      },
+      transform_position: {
+        value: {
+          listValue: [{ doubleValue: 1 }, { doubleValue: 2 }, { doubleValue: 3 }],
+        },
+      },
+      transform_rotation: {
+        value: {
+          listValue: [{ doubleValue: 4 }, { doubleValue: 5 }, { doubleValue: 6 }],
+        },
+      },
+      transform_scale: {
+        value: {
+          listValue: [{ doubleValue: 7 }, { doubleValue: 8 }, { doubleValue: 9 }],
+        },
+      },
+    });
+  });
+
+  it('should return expected node component with transform constraint.snapToFloor', () => {
+    const result = createNodeEntityComponent({ transformConstraint: { snapToFloor: true } });
+
+    expect(result.properties).toEqual({
+      name: {
+        value: {
+          stringValue: 'Node',
+        },
+      },
+      transformConstraint_snapToFloor: {
+        value: {
+          booleanValue: true,
+        },
+      },
+    });
+  });
+
+  it('should return expected node component with layer', () => {
+    const result = createNodeEntityComponent({}, 'layer-1');
+
+    expect(result.properties).toEqual({
+      name: {
+        value: {
+          stringValue: 'Node',
+        },
+      },
+      [DEFAULT_LAYER_RELATIONSHIP_NAME]: {
+        value: {
+          relationshipValue: {
+            targetEntityId: 'layer-1',
+            targetComponentName: DEFAULT_LAYER_COMPONENT_NAME,
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected node component with properties', () => {
+    const result = createNodeEntityComponent({ properties: { matterportId: 'abc def' } });
+
+    expect(result.properties).toEqual({
+      name: {
+        value: {
+          stringValue: 'Node',
+        },
+      },
+      properties: {
+        value: {
+          mapValue: {
+            matterportId: {
+              stringValue: 'abc%20def',
+            },
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('updateNodeEntityComponent', () => {
+  it('should return expected empty node component', () => {
+    expect(updateNodeEntityComponent({ name: 'Test' })).toEqual({
+      componentTypeId: NODE_COMPONENT_TYPE_ID,
+      propertyUpdates: {
+        name: {
+          value: {
+            stringValue: 'Test',
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
@@ -1,0 +1,72 @@
+import { ComponentRequest, ComponentUpdateRequest } from '@aws-sdk/client-iottwinmaker';
+import { isEmpty } from 'lodash';
+
+import { ISceneNode } from '../../interfaces';
+import { NODE_COMPONENT_TYPE_ID } from '../../common/entityModelConstants';
+
+import { attachToLayerRequest } from './sceneLayerUtils';
+
+export const createNodeEntityComponent = (node: ISceneNode, layerId?: string): ComponentRequest => {
+  const comp: ComponentRequest = {
+    componentTypeId: NODE_COMPONENT_TYPE_ID,
+    properties: {
+      name: {
+        value: {
+          stringValue: node.name ?? 'Node',
+        },
+      },
+    },
+  };
+  if (node.transform?.position) {
+    comp.properties!['transform_position'] = {
+      value: {
+        listValue: node.transform.position.map((v) => ({ doubleValue: v })),
+      },
+    };
+  }
+  if (node.transform?.rotation) {
+    comp.properties!['transform_rotation'] = {
+      value: {
+        listValue: node.transform.rotation.map((v) => ({ doubleValue: v })),
+      },
+    };
+  }
+  if (node.transform?.scale) {
+    comp.properties!['transform_scale'] = {
+      value: {
+        listValue: node.transform.scale.map((v) => ({ doubleValue: v })),
+      },
+    };
+  }
+  if (node.transformConstraint?.snapToFloor !== undefined) {
+    comp.properties!['transformConstraint_snapToFloor'] = {
+      value: {
+        booleanValue: node.transformConstraint.snapToFloor,
+      },
+    };
+  }
+  if (layerId) {
+    comp.properties = Object.assign(comp.properties!, attachToLayerRequest(layerId));
+  }
+  if (!isEmpty(node.properties)) {
+    const params = {};
+    Object.keys(node.properties).forEach((k) => {
+      params[k] = { stringValue: encodeURI(node.properties![k]) };
+    });
+    comp.properties!['properties'] = {
+      value: {
+        mapValue: params,
+      },
+    };
+  }
+
+  return comp;
+};
+
+export const updateNodeEntityComponent = (node: ISceneNode, layerId?: string): ComponentUpdateRequest => {
+  const request = createNodeEntityComponent(node, layerId);
+  return {
+    componentTypeId: request.componentTypeId,
+    propertyUpdates: request.properties,
+  };
+};

--- a/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.spec.ts
@@ -1,0 +1,148 @@
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { KnownComponentType } from '../../interfaces';
+import { Component } from '../../models/SceneModels';
+
+import { createOverlayEntityComponent, updateOverlayEntityComponent } from './overlayComponent';
+
+describe('createOverlayEntityComponent', () => {
+  it('should return expected default overlay component', () => {
+    expect(
+      createOverlayEntityComponent({
+        type: KnownComponentType.DataOverlay,
+        subType: Component.DataOverlaySubType.OverlayPanel,
+        dataRows: [],
+        valueDataBindings: [],
+      }),
+    ).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.DataOverlay],
+      properties: {
+        subType: {
+          value: { stringValue: Component.DataOverlaySubType.OverlayPanel },
+        },
+        dataRows: {
+          value: {
+            listValue: [],
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected overlay component with data rows', () => {
+    const result = createOverlayEntityComponent({
+      type: KnownComponentType.DataOverlay,
+      subType: Component.DataOverlaySubType.TextAnnotation,
+      dataRows: [
+        {
+          rowType: Component.DataOverlayRowType.Markdown,
+          content: '${abc} def',
+        },
+      ],
+      valueDataBindings: [],
+    });
+
+    expect(result.properties).toEqual({
+      subType: {
+        value: { stringValue: Component.DataOverlaySubType.TextAnnotation },
+      },
+      dataRows: {
+        value: {
+          listValue: [
+            {
+              mapValue: {
+                rowType: {
+                  stringValue: Component.DataOverlayRowType.Markdown,
+                },
+                content: {
+                  stringValue: '$%7Babc%7D%20def',
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('should return expected tag component with rowBindings', () => {
+    const result = createOverlayEntityComponent({
+      type: KnownComponentType.DataOverlay,
+      subType: Component.DataOverlaySubType.TextAnnotation,
+      dataRows: [],
+      valueDataBindings: [
+        {
+          valueDataBinding: {
+            dataBindingContext: {
+              entityId: 'eid',
+              componentName: 'cname',
+              propertyName: 'pname',
+            },
+            isStaticData: true,
+          },
+          bindingName: 'binding-a',
+        },
+      ],
+    });
+
+    expect(result.properties).toEqual({
+      subType: {
+        value: { stringValue: Component.DataOverlaySubType.TextAnnotation },
+      },
+      dataRows: {
+        value: {
+          listValue: [],
+        },
+      },
+      rowBindings: {
+        value: {
+          listValue: [
+            {
+              mapValue: {
+                bindingName: {
+                  stringValue: 'binding-a',
+                },
+                entityId: {
+                  stringValue: 'eid',
+                },
+                componentName: {
+                  stringValue: 'cname',
+                },
+                propertyName: {
+                  stringValue: 'pname',
+                },
+                isStaticData: {
+                  stringValue: 'true',
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+});
+
+describe('updateOverlayEntityComponent', () => {
+  it('should return expected empty overlay component', () => {
+    expect(
+      updateOverlayEntityComponent({
+        type: KnownComponentType.DataOverlay,
+        subType: Component.DataOverlaySubType.OverlayPanel,
+        dataRows: [],
+        valueDataBindings: [],
+      }),
+    ).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.DataOverlay],
+      propertyUpdates: {
+        subType: {
+          value: { stringValue: Component.DataOverlaySubType.OverlayPanel },
+        },
+        dataRows: {
+          value: {
+            listValue: [],
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.ts
@@ -1,0 +1,61 @@
+import { ComponentRequest, ComponentUpdateRequest } from '@aws-sdk/client-iottwinmaker';
+import { isEmpty } from 'lodash';
+
+import { IDataOverlayComponent, KnownComponentType } from '../../interfaces';
+import { componentTypeToId } from '../../common/entityModelConstants';
+
+import { createDataBindingMap } from './dataBindingUtils';
+
+export const createOverlayEntityComponent = (overlay: IDataOverlayComponent): ComponentRequest => {
+  const comp: ComponentRequest = {
+    componentTypeId: componentTypeToId[KnownComponentType.DataOverlay],
+    properties: {
+      subType: {
+        value: {
+          stringValue: overlay.subType,
+        },
+      },
+      dataRows: {
+        value: {
+          listValue: overlay.dataRows.map((r) => {
+            return {
+              mapValue: {
+                rowType: {
+                  stringValue: r.rowType,
+                },
+                content: {
+                  stringValue: encodeURI(r.content),
+                },
+              },
+            };
+          }),
+        },
+      },
+    },
+  };
+  if (!isEmpty(overlay.valueDataBindings)) {
+    comp.properties!['rowBindings'] = {
+      value: {
+        listValue: overlay.valueDataBindings.map((v) => {
+          const bindings = createDataBindingMap(v.valueDataBinding);
+          bindings['bindingName'] = {
+            stringValue: v.bindingName,
+          };
+          return {
+            mapValue: bindings,
+          };
+        }),
+      },
+    };
+  }
+
+  return comp;
+};
+
+export const updateOverlayEntityComponent = (overlay: IDataOverlayComponent): ComponentUpdateRequest => {
+  const request = createOverlayEntityComponent(overlay);
+  return {
+    componentTypeId: request.componentTypeId,
+    propertyUpdates: request.properties,
+  };
+};

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneLayerUtils.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneLayerUtils.spec.ts
@@ -1,0 +1,108 @@
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
+
+import { setTwinMakerSceneMetadataModule } from '../../common/GlobalSettings';
+import {
+  LayerType,
+  LAYER_ROOT_ENTITY_ID,
+  DEFAULT_LAYER_COMPONENT_NAME,
+  LAYER_COMPONENT_TYPE_ID,
+  layerPropertyNames,
+  DEFAULT_LAYER_RELATIONSHIP_NAME,
+  DEFAULT_NODE_COMPONENT_NAME,
+} from '../../common/entityModelConstants';
+
+import { attachToLayer, attachToLayerRequest, createLayer, createLayerId } from './sceneLayerUtils';
+
+jest.mock('../mathUtils', () => ({
+  generateUUID: jest.fn(() => 'random-uuid'),
+}));
+
+describe('createLayerId', () => {
+  it('should return expected scene layer entityId', () => {
+    expect(createLayerId('test')).toEqual('LAYER_test_random-uuid');
+  });
+});
+
+describe('createLayer', () => {
+  const createSceneEntity = jest.fn();
+  const mockMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
+    createSceneEntity,
+  };
+
+  it('should call createSceneEntity with expected input', () => {
+    setTwinMakerSceneMetadataModule(mockMetadataModule as unknown as TwinMakerSceneMetadataModule);
+
+    createLayer('test', LayerType.Relationship);
+
+    expect(createSceneEntity).toBeCalledWith({
+      workspaceId: undefined,
+      entityId: createLayerId('test'),
+      parentEntityId: LAYER_ROOT_ENTITY_ID,
+      entityName: createLayerId('test'),
+      components: {
+        [DEFAULT_LAYER_COMPONENT_NAME]: {
+          componentTypeId: LAYER_COMPONENT_TYPE_ID,
+          properties: {
+            [layerPropertyNames.type]: {
+              value: {
+                stringValue: LayerType.Relationship,
+              },
+            },
+            [layerPropertyNames.relationshipName]: {
+              value: {
+                stringValue: DEFAULT_LAYER_RELATIONSHIP_NAME,
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('attachToLayerRequest', () => {
+  it('should return expected request', () => {
+    expect(attachToLayerRequest('test')).toEqual({
+      [DEFAULT_LAYER_RELATIONSHIP_NAME]: {
+        value: {
+          relationshipValue: {
+            targetEntityId: 'test',
+            targetComponentName: DEFAULT_LAYER_COMPONENT_NAME,
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('attachToLayer', () => {
+  const updateSceneEntity = jest.fn();
+  const mockMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
+    updateSceneEntity,
+  };
+
+  it('should return expected request', () => {
+    setTwinMakerSceneMetadataModule(mockMetadataModule as unknown as TwinMakerSceneMetadataModule);
+
+    attachToLayer('layer', 'entity');
+
+    expect(updateSceneEntity).toBeCalledWith({
+      workspaceId: undefined,
+      entityId: 'entity',
+      componentUpdates: {
+        [DEFAULT_NODE_COMPONENT_NAME]: {
+          propertyUpdates: {
+            [DEFAULT_LAYER_RELATIONSHIP_NAME]: {
+              value: {
+                relationshipValue: {
+                  targetEntityId: 'layer',
+                  targetComponentName: DEFAULT_LAYER_COMPONENT_NAME,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneLayerUtils.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneLayerUtils.ts
@@ -1,0 +1,77 @@
+import { CreateEntityCommandInput, PropertyRequest, UpdateEntityCommandInput } from '@aws-sdk/client-iottwinmaker';
+
+import {
+  DEFAULT_LAYER_COMPONENT_NAME,
+  DEFAULT_LAYER_RELATIONSHIP_NAME,
+  DEFAULT_NODE_COMPONENT_NAME,
+  LAYER_COMPONENT_TYPE_ID,
+  LAYER_ROOT_ENTITY_ID,
+  LayerType,
+  layerPropertyNames,
+} from '../../common/entityModelConstants';
+import { getGlobalSettings } from '../../common/GlobalSettings';
+import { generateUUID } from '../mathUtils';
+
+export const createLayerId = (layerName: string) => {
+  return `LAYER_${layerName}_${generateUUID()}`;
+};
+
+export const createLayer = (layerName: string, type: LayerType) => {
+  const layerId = createLayerId(layerName);
+  const input: CreateEntityCommandInput = {
+    workspaceId: undefined,
+    entityId: layerId,
+    parentEntityId: LAYER_ROOT_ENTITY_ID,
+    entityName: layerId,
+    components: {
+      [DEFAULT_LAYER_COMPONENT_NAME]: {
+        componentTypeId: LAYER_COMPONENT_TYPE_ID,
+        properties: {
+          [layerPropertyNames.type]: {
+            value: {
+              stringValue: type,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  if (type === LayerType.Relationship) {
+    input.components![DEFAULT_LAYER_COMPONENT_NAME].properties![layerPropertyNames.relationshipName] = {
+      value: {
+        stringValue: DEFAULT_LAYER_RELATIONSHIP_NAME,
+      },
+    };
+  }
+  // TODO: handle create query type layer
+
+  return getGlobalSettings().twinMakerSceneMetadataModule?.createSceneEntity(input);
+};
+
+export const attachToLayerRequest = (layerId: string): Record<string, PropertyRequest> => {
+  return {
+    [DEFAULT_LAYER_RELATIONSHIP_NAME]: {
+      value: {
+        relationshipValue: {
+          targetEntityId: layerId,
+          targetComponentName: DEFAULT_LAYER_COMPONENT_NAME,
+        },
+      },
+    },
+  };
+};
+
+export const attachToLayer = (layerId: string, sceneEntityId: string) => {
+  const updateSceneEntity: UpdateEntityCommandInput = {
+    workspaceId: undefined,
+    entityId: sceneEntityId,
+    componentUpdates: {
+      [DEFAULT_NODE_COMPONENT_NAME]: {
+        propertyUpdates: attachToLayerRequest(layerId),
+      },
+    },
+  };
+
+  return getGlobalSettings().twinMakerSceneMetadataModule?.updateSceneEntity(updateSceneEntity);
+};

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.spec.ts
@@ -1,0 +1,37 @@
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
+
+import { setTwinMakerSceneMetadataModule } from '../../common/GlobalSettings';
+import { SCENE_ROOT_ENTITY_ID } from '../../common/entityModelConstants';
+
+import { createSceneEntityId, createSceneRootEntity } from './sceneUtils';
+
+jest.mock('../mathUtils', () => ({
+  generateUUID: jest.fn(() => 'random-uuid'),
+}));
+
+describe('createSceneEntityId', () => {
+  it('should return expected scene entityId', () => {
+    expect(createSceneEntityId('test')).toEqual('SCENE_test_random-uuid');
+  });
+});
+
+describe('createSceneRootEntity', () => {
+  const createSceneEntity = jest.fn();
+  const mockMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
+    createSceneEntity,
+    getSceneId: jest.fn().mockReturnValue('test'),
+  };
+
+  it('should call createSceneEntity with expected input', () => {
+    setTwinMakerSceneMetadataModule(mockMetadataModule as unknown as TwinMakerSceneMetadataModule);
+
+    createSceneRootEntity();
+
+    expect(createSceneEntity).toBeCalledWith({
+      workspaceId: undefined,
+      entityId: createSceneEntityId('test'),
+      parentEntityId: SCENE_ROOT_ENTITY_ID,
+      entityName: createSceneEntityId('test'),
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
@@ -1,0 +1,26 @@
+import { CreateEntityCommandInput } from '@aws-sdk/client-iottwinmaker';
+
+import { SCENE_ROOT_ENTITY_ID } from '../../common/entityModelConstants';
+import { getGlobalSettings } from '../../common/GlobalSettings';
+import { generateUUID } from '../mathUtils';
+
+export const createSceneEntityId = (sceneName: string) => {
+  return `SCENE_${sceneName}_${generateUUID()}`;
+};
+
+export const createSceneRootEntity = () => {
+  if (!getGlobalSettings().twinMakerSceneMetadataModule) {
+    return;
+  }
+
+  const sceneName = getGlobalSettings().twinMakerSceneMetadataModule!.getSceneId();
+  const sceneEntityId = createSceneEntityId(sceneName);
+  const input: CreateEntityCommandInput = {
+    workspaceId: undefined,
+    entityId: sceneEntityId,
+    parentEntityId: SCENE_ROOT_ENTITY_ID,
+    entityName: sceneEntityId,
+  };
+
+  return getGlobalSettings().twinMakerSceneMetadataModule!.createSceneEntity(input);
+};

--- a/packages/scene-composer/src/utils/entityModelUtils/tagComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/tagComponent.spec.ts
@@ -1,0 +1,149 @@
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { KnownComponentType } from '../../interfaces';
+
+import { createTagEntityComponent, updateTagEntityComponent } from './tagComponent';
+
+describe('createTagEntityComponent', () => {
+  it('should return expected empty tag component', () => {
+    expect(createTagEntityComponent({ type: KnownComponentType.Tag })).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.Tag],
+      properties: {},
+    });
+  });
+
+  it('should return expected tag component with icon', () => {
+    const result = createTagEntityComponent({ type: KnownComponentType.Tag, icon: 'info' });
+
+    expect(result.properties).toEqual({
+      icon: {
+        value: { stringValue: 'info' },
+      },
+    });
+  });
+
+  it('should return expected tag component with navLink destination', () => {
+    const result = createTagEntityComponent({
+      type: KnownComponentType.Tag,
+      navLink: {
+        destination: 'destination',
+      },
+    });
+
+    expect(result.properties).toEqual({
+      navLink_destination: {
+        value: { stringValue: 'destination' },
+      },
+    });
+  });
+
+  it('should return expected tag component with navLink params', () => {
+    const result = createTagEntityComponent({
+      type: KnownComponentType.Tag,
+      navLink: {
+        params: {
+          param1: 'value 1',
+          param2: 'value 2',
+        },
+      },
+    });
+
+    expect(result.properties).toEqual({
+      navLink_params: {
+        value: {
+          mapValue: {
+            param1: {
+              stringValue: 'value%201',
+            },
+            param2: {
+              stringValue: 'value%202',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected tag component with offset', () => {
+    const result = createTagEntityComponent({ type: KnownComponentType.Tag, offset: [1, 2, 3] });
+
+    expect(result.properties).toEqual({
+      offset: {
+        value: {
+          listValue: [{ doubleValue: 1 }, { doubleValue: 2 }, { doubleValue: 3 }],
+        },
+      },
+    });
+  });
+
+  it('should return expected tag component with chosenColor', () => {
+    const result = createTagEntityComponent({ type: KnownComponentType.Tag, chosenColor: 'red' });
+
+    expect(result.properties).toEqual({
+      chosenColor: {
+        value: { stringValue: 'red' },
+      },
+    });
+  });
+
+  it('should return expected tag component with styleBinding with rule id', () => {
+    const result = createTagEntityComponent({ type: KnownComponentType.Tag, ruleBasedMapId: 'rule-id' });
+
+    expect(result.properties).toEqual({
+      styleBinding: {
+        value: {
+          mapValue: {
+            ruleBasedMapId: {
+              stringValue: 'rule-id',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected tag component with styleBinding with data binding context', () => {
+    const result = createTagEntityComponent({
+      type: KnownComponentType.Tag,
+      valueDataBinding: {
+        dataBindingContext: {
+          entityId: 'eid',
+          componentName: 'cname',
+          propertyName: 'pname',
+        },
+      },
+    });
+
+    expect(result.properties).toEqual({
+      styleBinding: {
+        value: {
+          mapValue: {
+            ruleBasedMapId: {
+              stringValue: undefined,
+            },
+            entityId: {
+              stringValue: 'eid',
+            },
+            componentName: {
+              stringValue: 'cname',
+            },
+            propertyName: {
+              stringValue: 'pname',
+            },
+            isStaticData: {
+              stringValue: 'false',
+            },
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('updateTagEntityComponent', () => {
+  it('should return expected empty tag component', () => {
+    expect(updateTagEntityComponent({ type: KnownComponentType.Tag })).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.Tag],
+      propertyUpdates: {},
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/tagComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/tagComponent.ts
@@ -1,0 +1,72 @@
+import { ComponentRequest, ComponentUpdateRequest } from '@aws-sdk/client-iottwinmaker';
+
+import { IAnchorComponent, KnownComponentType } from '../../interfaces';
+import { componentTypeToId } from '../../common/entityModelConstants';
+
+import { createDataBindingMap } from './dataBindingUtils';
+
+export const createTagEntityComponent = (tag: IAnchorComponent): ComponentRequest => {
+  const comp: ComponentRequest = {
+    componentTypeId: componentTypeToId[KnownComponentType.Tag],
+    properties: {},
+  };
+  if (tag.icon) {
+    comp.properties!['icon'] = {
+      value: {
+        stringValue: tag.icon,
+      },
+    };
+  }
+  if (tag.navLink?.destination) {
+    comp.properties!['navLink_destination'] = {
+      value: {
+        stringValue: tag.navLink.destination,
+      },
+    };
+  }
+  if (tag.navLink?.params) {
+    const params = {};
+    Object.keys(tag.navLink.params).forEach((k) => {
+      params[k] = { stringValue: encodeURI(tag.navLink?.params![k]) };
+    });
+    comp.properties!['navLink_params'] = {
+      value: {
+        mapValue: params,
+      },
+    };
+  }
+  if (tag.offset) {
+    comp.properties!['offset'] = {
+      value: {
+        listValue: tag.offset.map((v) => ({ doubleValue: v })),
+      },
+    };
+  }
+  if (tag.chosenColor) {
+    comp.properties!['chosenColor'] = {
+      value: {
+        stringValue: tag.chosenColor,
+      },
+    };
+  }
+  if (tag.ruleBasedMapId || tag.valueDataBinding?.dataBindingContext) {
+    const map = createDataBindingMap(tag.valueDataBinding);
+    map['ruleBasedMapId'] = { stringValue: tag.ruleBasedMapId };
+
+    comp.properties!['styleBinding'] = {
+      value: {
+        mapValue: map,
+      },
+    };
+  }
+
+  return comp;
+};
+
+export const updateTagEntityComponent = (tag: IAnchorComponent): ComponentUpdateRequest => {
+  const request = createTagEntityComponent(tag);
+  return {
+    componentTypeId: request.componentTypeId,
+    propertyUpdates: request.properties,
+  };
+};

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -535,10 +535,6 @@
     "note": "label for when the user searches for a nonexistent animation",
     "text": "No matches found"
   },
-  "TaxKIJ": {
-    "note": "Menu Item label",
-    "text": "Remove all data binding"
-  },
   "TicaWZ": {
     "note": "Progress Bar label",
     "text": "Loading assets"
@@ -822,10 +818,6 @@
   "kYpWHA": {
     "note": "placeholder",
     "text": "Select an option"
-  },
-  "kdEHiD": {
-    "note": "Menu Item",
-    "text": "Remove all data binding"
   },
   "ksfSZA": {
     "note": "Distance Units in a dropdown menu",


### PR DESCRIPTION
## Overview
support sync matterport tag as entities

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
