### PR TITLE
chore(deps): disable dependabot to not auto update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
-    open-pull-requests-limit: 5
+    # Disable auto version updates for npm dependencies temporarily 
+    open-pull-requests-limit: 0
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']


### PR DESCRIPTION


## Overview
Disable dependabot to not auto update dependencies due to inconsistencies caused in internal repo.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
