### PR TITLE
fix: resolved table widget column resize issue

### DIFF
--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { Table, TableColumnDefinition } from '@iot-app-kit/react-components';
 
 import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
-
 import type { DashboardState } from '~/store/state';
 import type { TableWidget } from '../types';
 import { useQueries } from '~/components/dashboard/queryContext';
@@ -45,17 +44,29 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
 
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
 
+  const handleMouseDown = (e: MouseEvent) => {
+    const target = e.target as HTMLElement;
+
+    /* Condition to check table column resizer className to stop onMouseDouwn event 
+      propagation to fix widget dragging issue while column resizing */
+    if (target.className.includes('resizer')) {
+      e.stopPropagation();
+    }
+  };
+
   return (
-    <Table
-      resizableColumns
-      key={key}
-      queries={queries}
-      viewport={viewport}
-      columnDefinitions={columnDefinitions}
-      items={items}
-      thresholds={thresholds}
-      significantDigits={significantDigits}
-    />
+    <div onMouseDown={handleMouseDown}>
+      <Table
+        resizableColumns
+        key={key}
+        queries={queries}
+        viewport={viewport}
+        columnDefinitions={columnDefinitions}
+        items={items}
+        thresholds={thresholds}
+        significantDigits={significantDigits}
+      />
+    </div>
   );
 };
 

--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -44,8 +44,8 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
 
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
 
-  const handleMouseDown = (e: MouseEvent) => {
-    const target = e.target as HTMLElement;
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLDivElement;
 
     /* Condition to check table column resizer className to stop onMouseDouwn event 
       propagation to fix widget dragging issue while column resizing */


### PR DESCRIPTION
## Overview
Wrapped table component into div and stopped onMouseDown event propagation to the parent to stop dragging the table widget while resizing the columns
