### PR TITLE
build(deps-dev): Revert "build(deps-dev): bump @babel/preset-env from 7.22.5 to 7.22.15"

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@aws-sdk/credential-providers": "3.395.0",
     "@awsui/jest-preset": "^2.0.20",
-    "@babel/preset-env": "^7.22.15",
+    "@babel/preset-env": "^7.22.5",
     "@babel/preset-react": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@formatjs/cli": "6.1.3",


### PR DESCRIPTION
## Overview
This reverts commit 7465ddb51685d2f3cbfb88f665802cfd4b19ae3c to fix the internal repo build issue.
 
## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
