### PR TITLE
build(deps-dev): Revert "build(deps-dev): bump @types/d3-array from 3.0.5 to 3.0.7"

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@iot-app-kit/jest-config": "7.3.1",
     "@iot-app-kit/ts-config": "7.3.1",
-    "@types/d3-array": "^3.0.7",
+    "@types/d3-array": "^3.0.5",
     "@types/jest": "^29.4.0",
     "@types/uuid": "^9.0.2",
     "eslint-config-iot-app-kit": "7.3.1",


### PR DESCRIPTION
## Overview
This reverts awslabs/iot-app-kit#1869 to fix the internal repo build issue.
 
## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
