### PR TITLE
fix(react-components): echarts resize drag fix

### DIFF
--- a/packages/react-components/src/hooks/useECharts/useResizeableEChart.ts
+++ b/packages/react-components/src/hooks/useECharts/useResizeableEChart.ts
@@ -34,6 +34,7 @@ export const useResizeableEChart = (
   const [chartWidth, setWidth] = useState(getChartWidth(width - leftLegendWidth));
 
   const onResize = (_event: SyntheticEvent, data: ResizeCallbackData) => {
+    _event.stopPropagation();
     setWidth(data.size.width);
   };
 


### PR DESCRIPTION
## Overview
This is to fix the drag issue of resize handle of the echarts in dashboard

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
