### PR TITLE
feat(first Person): proof of using pointer lock for a first person view

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.spec.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/common/SvgIconToWidgetSprite.spec.tsx
@@ -1,4 +1,4 @@
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 
 import { DefaultAnchorStatus, SelectedAnchor } from '../../../..';
 import {
@@ -27,7 +27,7 @@ describe('svgIconToWidgetSprite', () => {
     it(`it should render the ${value[0]} correctly`, () => {
       jest.spyOn(window.Math, 'random').mockReturnValue(0.1);
       const { key, icon } = value[1] as Icons;
-      const container = renderer.create(svgIconToWidgetSprite(icon, key, key, false, true));
+      const container = create(svgIconToWidgetSprite(icon, key, key, false, true));
 
       expect(container).toMatchSnapshot();
     });
@@ -37,7 +37,7 @@ describe('svgIconToWidgetSprite', () => {
     it(`it should render the always visible ${value[0]} correctly`, () => {
       jest.spyOn(window.Math, 'random').mockReturnValue(0.1);
       const { key, icon } = value[1] as Icons;
-      const container = renderer.create(svgIconToWidgetSprite(icon, key, key, true, true));
+      const container = create(svgIconToWidgetSprite(icon, key, key, true, true));
 
       expect(container).toMatchSnapshot();
     });
@@ -47,7 +47,7 @@ describe('svgIconToWidgetSprite', () => {
     it(`it should render the constant sized ${value[0]} correctly`, () => {
       jest.spyOn(window.Math, 'random').mockReturnValue(0.1);
       const { key, icon } = value[1] as Icons;
-      const container = renderer.create(svgIconToWidgetSprite(icon, key, key, false, false));
+      const container = create(svgIconToWidgetSprite(icon, key, key, false, false));
 
       expect(container).toMatchSnapshot();
     });

--- a/packages/scene-composer/src/common/constants.ts
+++ b/packages/scene-composer/src/common/constants.ts
@@ -16,7 +16,7 @@ import {
   ITagSettings,
   IOverlaySettings,
 } from '../interfaces';
-import { CameraControlImpl } from '../store/internalInterfaces';
+import { MapControls as MapControlsImpl, OrbitControls as OrbitControlsImpl } from '../three/OrbitControls';
 
 /******************************************************************************
  * Document Constants
@@ -140,12 +140,14 @@ export const DEFAULT_OVERLAY_GLOBAL_SETTINGS: IOverlaySettings = {
 /******************************************************************************
  * Camera Constants
  ******************************************************************************/
-export const DEFAULT_CAMERA_CONTROLS_OPTIONS: Pick<CameraControlImpl, 'dampingFactor' | 'maxDistance' | 'minDistance'> =
-  {
-    dampingFactor: 0.2,
-    maxDistance: Infinity,
-    minDistance: 0,
-  };
+export const DEFAULT_ORBIT_CAMERA_CONTROLS_OPTIONS: Pick<
+  OrbitControlsImpl | MapControlsImpl,
+  'dampingFactor' | 'maxDistance' | 'minDistance'
+> = {
+  dampingFactor: 0.2,
+  maxDistance: Infinity,
+  minDistance: 0,
+};
 export const DEFAULT_CAMERA_POSITION: Vector3 = [5, 5, 5];
 export const DEFAULT_CAMERA_OPTIONS: Pick<THREE.PerspectiveCamera, 'far' | 'fov' | 'near'> = {
   far: 1000,

--- a/packages/scene-composer/src/components/DefaultErrorFallback/__tests__/DefaultErrorFallback.spec.tsx
+++ b/packages/scene-composer/src/components/DefaultErrorFallback/__tests__/DefaultErrorFallback.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 
 import { ErrorCode, ErrorLevel, SceneComposerRuntimeError } from '../../..';
 import DefaultErrorFallback from '..';
@@ -27,7 +27,7 @@ describe('DefaultErrorFallback', () => {
     ['Unknown', other],
   ].forEach((value) => {
     it(`should render correctly with a ${value[0]} type`, () => {
-      const container = renderer.create(<DefaultErrorFallback error={value[1] as any} />);
+      const container = create(<DefaultErrorFallback error={value[1] as any} />);
 
       expect(container).toMatchSnapshot();
     });

--- a/packages/scene-composer/src/components/SceneComposerInternal.spec.tsx
+++ b/packages/scene-composer/src/components/SceneComposerInternal.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import renderer, { act } from 'react-test-renderer';
+import { act, create } from 'react-test-renderer';
 import { cleanup, renderHook } from '@testing-library/react-hooks';
 import str2ab from 'string-to-arraybuffer';
 import flushPromises from 'flush-promises';
@@ -64,7 +64,7 @@ describe('SceneComposerInternal', () => {
           );
         };
 
-        renderer.create(<TestComponent />);
+        create(<TestComponent />);
 
         await flushPromises();
       });
@@ -84,7 +84,7 @@ describe('SceneComposerInternal', () => {
       };
 
       await act(async () => {
-        renderer.create(<TestComponent />);
+        create(<TestComponent />);
 
         await flushPromises();
       });

--- a/packages/scene-composer/src/components/SceneComposerInternalSnap.spec.tsx
+++ b/packages/scene-composer/src/components/SceneComposerInternalSnap.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import renderer, { act } from 'react-test-renderer';
+import { create, act } from 'react-test-renderer';
 import str2ab from 'string-to-arraybuffer';
 import flushPromises from 'flush-promises';
 
@@ -39,7 +39,7 @@ describe('SceneComposerInternal', () => {
   it('should render correctly with an empty scene in editing mode', async () => {
     let container;
     await act(async () => {
-      container = renderer.create(
+      container = create(
         <SceneComposerInternal config={{ mode: 'Editing' }} sceneLoader={createSceneLoaderMock('')} />,
       );
 
@@ -53,7 +53,7 @@ describe('SceneComposerInternal', () => {
   it('should render correctly with an empty scene in viewing mode', async () => {
     let container;
     await act(async () => {
-      container = renderer.create(
+      container = create(
         <SceneComposerInternal config={{ mode: 'Viewing' }} sceneLoader={createSceneLoaderMock('')} />,
       );
 
@@ -67,7 +67,7 @@ describe('SceneComposerInternal', () => {
   it('should render correctly with a valid scene in editing mode', async () => {
     let container;
     await act(async () => {
-      container = renderer.create(
+      container = create(
         <SceneComposerInternal config={{ mode: 'Editing' }} sceneLoader={createSceneLoaderMock(testScenes.scene1)} />,
       );
 
@@ -81,7 +81,7 @@ describe('SceneComposerInternal', () => {
   it('should render warning when minor version is newer', async () => {
     let container;
     await act(async () => {
-      container = renderer.create(
+      container = create(
         <SceneComposerInternal
           config={{ mode: 'Editing' }}
           sceneLoader={createSceneLoaderMock(invalidTestScenes.unsupportedMinorVersionScene)}
@@ -97,7 +97,7 @@ describe('SceneComposerInternal', () => {
   it('should render error when major version is newer', async () => {
     let container;
     await act(async () => {
-      container = renderer.create(
+      container = create(
         <SceneComposerInternal
           config={{ mode: 'Editing' }}
           sceneLoader={createSceneLoaderMock(invalidTestScenes.unsupportedMajorVersion)}
@@ -113,7 +113,7 @@ describe('SceneComposerInternal', () => {
   it('should render error when specVersion is invalid', async () => {
     let container;
     await act(async () => {
-      container = renderer.create(
+      container = create(
         <SceneComposerInternal
           config={{ mode: 'Editing' }}
           sceneLoader={createSceneLoaderMock(invalidTestScenes.invalidSpecVersionScene)}
@@ -129,7 +129,7 @@ describe('SceneComposerInternal', () => {
   it('should support rendering multiple valid scenes', async () => {
     let container;
     await act(async () => {
-      container = renderer.create(
+      container = create(
         <div>
           <SceneComposerInternal config={{ mode: 'Editing' }} sceneLoader={createSceneLoaderMock(testScenes.scene1)} />
           <SceneComposerInternal config={{ mode: 'Editing' }} sceneLoader={createSceneLoaderMock(testScenes.scene2)} />
@@ -146,7 +146,7 @@ describe('SceneComposerInternal', () => {
   it('should render both valid and invalid scene correctly', async () => {
     let container;
     await act(async () => {
-      container = renderer.create(
+      container = create(
         <div>
           <SceneComposerInternal
             config={{ mode: 'Editing' }}
@@ -165,7 +165,7 @@ describe('SceneComposerInternal', () => {
   it('should render a default error view when loading a bad scene content', async () => {
     let container;
     await act(async () => {
-      container = renderer.create(
+      container = create(
         <SceneComposerInternal
           config={{ mode: 'Editing' }}
           sceneLoader={createSceneLoaderMock(invalidTestScenes.invalidJson)}
@@ -183,7 +183,7 @@ describe('SceneComposerInternal', () => {
       throw new Error('failed to render');
     });
 
-    const container = renderer.create(
+    const container = create(
       <SceneComposerInternal config={{ mode: 'Editing' }} sceneLoader={createSceneLoaderMock('')} />,
     );
 

--- a/packages/scene-composer/src/components/WebGLCanvasManager.spec.tsx
+++ b/packages/scene-composer/src/components/WebGLCanvasManager.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Canvas, useThree } from '@react-three/fiber';
 import { BoxGeometry, Mesh, MeshBasicMaterial, Group } from 'three';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 
 import { useStore } from '../store';
 import { setFeatureConfig } from '../common/GlobalSettings';
@@ -129,7 +129,7 @@ describe('WebGLCanvasManagerSnap', () => {
     baseState.isEditing.mockReturnValue(true);
     baseState.getSceneNodeByRef.mockReturnValue('childNode');
 
-    const container = renderer.create(<Layout />);
+    const container = create(<Layout />);
     expect(container).toMatchSnapshot();
   });
 
@@ -138,7 +138,7 @@ describe('WebGLCanvasManagerSnap', () => {
     baseState.isEditing.mockReturnValue(false);
     baseState.getSceneNodeByRef.mockReturnValue('childNode');
 
-    const container = renderer.create(<Layout />);
+    const container = create(<Layout />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/ComponentTypeIcon.spec.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/ComponentTypeIcon.spec.tsx
@@ -1,4 +1,4 @@
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import React from 'react';
 
 import { Camera, Light, Modelref, Tag } from '../../../../../assets/auto-gen/icons';
@@ -16,7 +16,7 @@ describe('ComponentTypeIcon', () => {
   ].forEach((value) => {
     it(`it should render the ${value[0]} svg`, () => {
       const { key } = value[1] as any;
-      const container = renderer.create(ComponentTypeIcon({ type: key }));
+      const container = create(ComponentTypeIcon({ type: key }));
 
       expect(container).toMatchSnapshot();
     });

--- a/packages/scene-composer/src/components/three-fiber/AnchorComponent/__tests__/AnchorComponent.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/AnchorComponent/__tests__/AnchorComponent.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 
 import AnchorComponent from '..';
 import { IAnchorComponentInternal, ISceneNodeInternal } from '../../../../store';
@@ -26,7 +26,7 @@ describe('AnchorComponent', () => {
   } as unknown as IAnchorComponentInternal;
 
   it('should render correctly with default icon', () => {
-    const container = renderer.create(<AnchorComponent node={node} component={component} />);
+    const container = create(<AnchorComponent node={node} component={component} />);
     expect(container).toMatchSnapshot();
   });
 
@@ -37,7 +37,7 @@ describe('AnchorComponent', () => {
       navLink: 'https://test.url',
       valueDataBinding: { test: 'test' },
     } as unknown as IAnchorComponentInternal;
-    const container = renderer.create(<AnchorComponent node={node} component={component} />);
+    const container = create(<AnchorComponent node={node} component={component} />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/src/components/three-fiber/CameraPreview/__tests__/CameraPreview.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/CameraPreview/__tests__/CameraPreview.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 
 import { CameraPreview } from '../index';
 import { useStore } from '../../../../store';
@@ -42,7 +42,7 @@ describe('CameraPreview', () => {
       return <CameraPreview track={div} />;
     };
 
-    const container = renderer.create(<TestComponent />);
+    const container = create(<TestComponent />);
 
     expect(container).toMatchSnapshot();
   });

--- a/packages/scene-composer/src/components/three-fiber/EditorCamera.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EditorCamera.tsx
@@ -9,7 +9,7 @@ import useLogger from '../../logger/react-logger/hooks/useLogger';
 import {
   Layers,
   ROOT_OBJECT_3D_NAME,
-  DEFAULT_CAMERA_CONTROLS_OPTIONS,
+  DEFAULT_ORBIT_CAMERA_CONTROLS_OPTIONS,
   DEFAULT_CAMERA_POSITION,
   DEFAULT_CAMERA_TARGET,
   DEFAULT_TWEEN_DURATION,
@@ -22,8 +22,11 @@ import { CameraControlImpl, TweenValueObject } from '../../store/internalInterfa
 import useActiveCamera from '../../hooks/useActiveCamera';
 import { getSafeBoundingBox } from '../../utils/objectThreeUtils';
 import { getMatterportSdk } from '../../common/GlobalSettings';
+import { MapControls as MapControlsImpl, OrbitControls as OrbitControlsImpl } from '../../three/OrbitControls';
+import { PointerLockControls as PointerLockControlsImpl } from '../../three/PointerLockControls';
+import { isOrbitOrPanControl } from '../../utils/controlUtils';
 
-import { MapControls, OrbitControls } from './controls';
+import { MapControls, OrbitControls, PointerLockControls } from './controls';
 
 export const EditorMainCamera = forwardRef<Camera>((_, forwardedRef) => {
   const log = useLogger('EditorMainCamera');
@@ -34,7 +37,8 @@ export const EditorMainCamera = forwardRef<Camera>((_, forwardedRef) => {
   const matterportSdk = getMatterportSdk(sceneComposerId);
   const scene = useThree((state) => state.scene);
   const setThree = useThree((state) => state.set);
-  const makeDefault = cameraControlsType === 'orbit' || cameraControlsType === 'pan';
+  const makeDefault =
+    cameraControlsType === 'orbit' || cameraControlsType === 'pan' || cameraControlsType === 'pointerLock';
 
   const cameraControlsImplRef = useRef<CameraControlImpl>();
   const cameraRef = useRef<Camera>();
@@ -55,7 +59,13 @@ export const EditorMainCamera = forwardRef<Camera>((_, forwardedRef) => {
       return;
     }
     // Otherwise, return CameraControls for the current cameraControlsType. Do nothing for Immersive
-    return cameraControlsType === 'orbit' ? OrbitControls : cameraControlsType === 'pan' ? MapControls : undefined;
+    return cameraControlsType === 'orbit'
+      ? OrbitControls
+      : cameraControlsType === 'pan'
+      ? MapControls
+      : cameraControlsType === 'pointerLock'
+      ? PointerLockControls
+      : undefined;
   }, [cameraControlsType, controlsRemove]);
 
   const handleTransformEvent = useCallback(({ type }) => {
@@ -79,7 +89,9 @@ export const EditorMainCamera = forwardRef<Camera>((_, forwardedRef) => {
   const controlsRef = useCallback((ref) => {
     if (ref) {
       const controls = ref as CameraControlImpl;
-      controls.listenToWindowKeyEvents(window);
+      if (controls instanceof OrbitControlsImpl || controls instanceof MapControlsImpl) {
+        controls.listenToWindowKeyEvents(window);
+      }
       cameraControlsImplRef.current = controls;
       setThree({ controls });
       log?.verbose('setting camera controls', controls);
@@ -126,12 +138,9 @@ export const EditorMainCamera = forwardRef<Camera>((_, forwardedRef) => {
       }
 
       const currentPosition = getTweenValueFromVector3(cameraRef.current.position);
-      const currentTarget = getTweenValueFromVector3(cameraControlsImplRef.current?.target ?? DEFAULT_CAMERA_TARGET);
       const duration = cameraTarget?.shouldTween ? DEFAULT_TWEEN_DURATION : 0;
 
-      log?.verbose('moving camera to target', position, target);
-
-      setTween(
+      const tweenConfigs = [
         {
           from: currentPosition,
           to: getTweenValueFromVector3(position),
@@ -141,17 +150,26 @@ export const EditorMainCamera = forwardRef<Camera>((_, forwardedRef) => {
           },
           duration,
         },
-        {
+      ];
+
+      if (isOrbitOrPanControl(cameraControlsType)) {
+        const controlRef = cameraControlsImplRef.current as OrbitControlsImpl | MapControlsImpl | undefined;
+        const currentTarget = getTweenValueFromVector3(controlRef?.target ?? DEFAULT_CAMERA_TARGET);
+        tweenConfigs.push({
           from: currentTarget,
           to: getTweenValueFromVector3(target),
           onUpdate: () => {
-            cameraControlsImplRef.current?.target.set(currentTarget.x, currentTarget.y, currentTarget.z);
+            controlRef?.target.set(currentTarget.x, currentTarget.y, currentTarget.z);
           },
           duration,
-        },
-      );
+        });
+      }
+
+      log?.verbose('moving camera to target', position, target);
+
+      setTween(...tweenConfigs);
     }
-  }, [cameraTarget]);
+  }, [cameraTarget, cameraControlsType]);
 
   // handle mouse events
   useEffect(() => {
@@ -174,6 +192,8 @@ export const EditorMainCamera = forwardRef<Camera>((_, forwardedRef) => {
     setMainCameraObject(cameraRef.current);
   }, [cameraRef.current]);
 
+  // TODO: change to useKeyMap hook to get keySettings
+  // note current interface uses keyboardevent.code but useKeyMap is using keyboardevent.key
   const keysSetting = useMemo(() => {
     return { LEFT: 'KeyA', UP: 'KeyW', RIGHT: 'KeyD', BOTTOM: 'KeyS' };
   }, []);
@@ -207,16 +227,24 @@ export const EditorMainCamera = forwardRef<Camera>((_, forwardedRef) => {
         makeDefault={makeDefault}
         ref={mergeRefs([forwardedRef, cameraRef])}
       />
-      {makeDefault && CameraControls && (
-        <CameraControls
-          {...DEFAULT_CAMERA_CONTROLS_OPTIONS}
-          camera={cameraRef.current}
-          target={cameraControlsImplRef.current?.target}
-          makeDefault
-          ref={controlsRef}
-          keys={keysSetting}
-        />
-      )}
+      {makeDefault &&
+        CameraControls &&
+        (cameraControlsType === 'orbit' || cameraControlsType === 'pan' ? (
+          <CameraControls
+            {...DEFAULT_ORBIT_CAMERA_CONTROLS_OPTIONS}
+            camera={cameraRef.current}
+            target={(cameraControlsImplRef.current as OrbitControlsImpl)?.target}
+            makeDefault
+            ref={controlsRef}
+            keys={keysSetting}
+          />
+        ) : (
+          <CameraControls // as PointerLockControls
+            camera={cameraRef.current}
+            makeDefault
+            ref={controlsRef}
+          />
+        ))}
     </Fragment>
   );
 });
@@ -243,11 +271,12 @@ export function findBestViewingPosition(
     Number.isFinite(objectBoundingBox.max.z)
   ) {
     // normal case
-    const camera = controls.object as THREE.PerspectiveCamera;
+    const camera =
+      controls instanceof OrbitControlsImpl || controls instanceof MapControlsImpl ? controls.object : controls.camera;
     const currentCameraPosition: THREE.Vector3 = initial ? objectBoundingBox.max : camera.position;
     const distanceToTarget = currentCameraPosition.distanceTo(target);
 
-    const minimumDistance = minimumDistanceByGeometry(size, camera);
+    const minimumDistance = minimumDistanceByGeometry(size, camera as THREE.PerspectiveCamera);
 
     if (distanceToTarget >= minimumDistance) {
       position.copy(currentCameraPosition);

--- a/packages/scene-composer/src/components/three-fiber/LightComponent/__tests__/LightComponent.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/LightComponent/__tests__/LightComponent.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/first */
 /* eslint-disable import/order */
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 
 import LightComponent from '..';
 import { LightType } from '../../../../models/SceneModels';
@@ -33,7 +33,7 @@ describe('LightComponent', () => {
     ['Unknown', 'Unknown'],
   ].forEach((value) => {
     it(`should render correctly for ${value[0]} light`, () => {
-      const container = renderer.create(
+      const container = create(
         <LightComponent
           node={{ name: 'Light' } as any}
           component={{ ref: 'light-ref', lightType: value[1] as any, lightSettings } as any}

--- a/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/__tests__/CircularCylinderMotionIndicator.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/__tests__/CircularCylinderMotionIndicator.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import * as THREE from 'three';
 
 import * as helpers from '../helpers';
@@ -23,7 +23,7 @@ describe('CircularCylinderMotionIndicator', () => {
     };
     jest.spyOn(helpers, 'useArrowTexture').mockReturnValue(mockTextureRef);
 
-    const container = renderer.create(<CircularCylinderMotionIndicator {...baseProps} />);
+    const container = create(<CircularCylinderMotionIndicator {...baseProps} />);
     container.update(<CircularCylinderMotionIndicator {...baseProps} />);
 
     expect(container).toMatchSnapshot();

--- a/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/__tests__/LinearCylinderMotionIndicator.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/__tests__/LinearCylinderMotionIndicator.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import * as THREE from 'three';
 
 import * as helpers from '../helpers';
@@ -23,7 +23,7 @@ describe('LinearCylinderMotionIndicator', () => {
     };
     jest.spyOn(helpers, 'useArrowTexture').mockReturnValue(mockTextureRef);
 
-    const container = renderer.create(<LinearCylinderMotionIndicator {...baseProps} />);
+    const container = create(<LinearCylinderMotionIndicator {...baseProps} />);
     container.update(<LinearCylinderMotionIndicator {...baseProps} />);
 
     expect(container).toMatchSnapshot();

--- a/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/__tests__/LinearPlaneMotionIndicator.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/__tests__/LinearPlaneMotionIndicator.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import * as THREE from 'three';
 
 import * as helpers from '../helpers';
@@ -23,7 +23,7 @@ describe('LinearPlaneMotionIndicator', () => {
     };
     jest.spyOn(helpers, 'useArrowTexture').mockReturnValue(mockTextureRef);
 
-    const container = renderer.create(<LinearPlaneMotionIndicator {...baseProps} />);
+    const container = create(<LinearPlaneMotionIndicator {...baseProps} />);
 
     expect(container).toMatchSnapshot();
   });

--- a/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/__tests__/MotionIndicatorMeshMaterial.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/__tests__/MotionIndicatorMeshMaterial.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import * as THREE from 'three';
 
 import { MotionIndicatorMeshMaterial, onBeforeCompile } from '../MotionIndicatorMeshMaterial';
@@ -20,7 +20,7 @@ describe('MotionIndicatorMeshMaterial', () => {
 
   it('should render correctly', async () => {
     // transparent background
-    const container = renderer.create(createComponent());
+    const container = create(createComponent());
     expect(container).toMatchSnapshot();
 
     // colored background with opacity

--- a/packages/scene-composer/src/components/three-fiber/controls/PointerLockControls.tsx
+++ b/packages/scene-composer/src/components/three-fiber/controls/PointerLockControls.tsx
@@ -1,0 +1,210 @@
+/* istanbul ignore file */
+import { EventManager, ReactThreeFiber, RootState, useThree, useFrame } from '@react-three/fiber';
+import { DomEvent } from '@react-three/fiber/dist/declarations/src/core/events';
+import * as React from 'react';
+import { forwardRef, useMemo, useEffect, useCallback, useRef } from 'react';
+import * as THREE from 'three';
+
+import useKeyPress from '../../../hooks/useKeyPress';
+import { defaultKeyMap } from '../../../hooks/useKeyMap';
+import { PointerLockControls as PointerLockControlsImpl } from '../../../three/PointerLockControls';
+
+export type PointerLockControlsProps = ReactThreeFiber.Object3DNode<
+  PointerLockControlsImpl,
+  typeof PointerLockControlsImpl
+> & {
+  domElement?: HTMLElement;
+  selector?: string;
+  enabled?: boolean;
+  camera?: THREE.Camera;
+  onChange?: (e?: THREE.Event) => void;
+  onLock?: (e?: THREE.Event) => void;
+  onUnlock?: (e?: THREE.Event) => void;
+  makeDefault?: boolean;
+};
+
+export const PointerLockControls = forwardRef<PointerLockControlsImpl, PointerLockControlsProps>(
+  ({ domElement, selector, onChange, onLock, onUnlock, enabled = true, makeDefault, ...props }, ref) => {
+    const { camera, ...rest } = props;
+    const setEvents = useThree((state) => state.setEvents);
+    const gl = useThree((state) => state.gl);
+    const defaultCamera = useThree((state) => state.camera);
+    const invalidate = useThree((state) => state.invalidate);
+    const events = useThree((state) => state.events) as EventManager<HTMLElement>;
+    const get = useThree((state) => state.get);
+    const set = useThree((state) => state.set);
+    const explCamera = camera || defaultCamera;
+    const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement;
+
+    const controls = useMemo(() => new PointerLockControlsImpl(explCamera), [explCamera]);
+
+    const moveForward = useRef(false);
+    const moveBackward = useRef(false);
+    const moveLeft = useRef(false);
+    const moveRight = useRef(false);
+    const moveUp = useRef(false);
+    const moveDown = useRef(false);
+
+    const velocity = useRef(new THREE.Vector3());
+
+    useFrame((state, delta) => {
+      if (enabled && controls.isLocked) {
+        const newVelocity = velocity.current;
+        newVelocity.x -= velocity.current.x * 10.0 * delta;
+        newVelocity.y -= velocity.current.y * 10.0 * delta; //fly not fall
+        newVelocity.z -= velocity.current.z * 10.0 * delta;
+
+        const direction = new THREE.Vector3();
+        direction.x = Number(moveRight.current) - Number(moveLeft.current);
+        direction.y = Number(moveUp.current) - Number(moveDown.current);
+        direction.z = Number(moveForward.current) - Number(moveBackward.current);
+        direction.normalize(); // this ensures consistent movements in all directions
+
+        if (moveLeft.current || moveRight.current) newVelocity.x -= direction.x * 400.0 * delta;
+        if (moveUp.current || moveDown.current) newVelocity.y -= direction.y * 400.0 * delta;
+        if (moveForward.current || moveBackward.current) newVelocity.z -= direction.z * 400.0 * delta;
+
+        controls.moveRight(-newVelocity.x * delta);
+        controls.moveForward(-newVelocity.z * delta);
+        controls.moveUp(-newVelocity.y * delta);
+
+        velocity.current = newVelocity;
+      }
+    });
+
+    const setMoveForward = useCallback((active: boolean) => {
+      moveForward.current = active;
+    }, []);
+    const setMoveBackwards = useCallback((active: boolean) => {
+      moveBackward.current = active;
+    }, []);
+    const setMoveLeft = useCallback((active: boolean) => {
+      moveLeft.current = active;
+    }, []);
+    const setMoveRight = useCallback((active: boolean) => {
+      moveRight.current = active;
+    }, []);
+    const setMoveUp = useCallback((active: boolean) => {
+      moveUp.current = active;
+    }, []);
+    const setMoveDown = useCallback((active: boolean) => {
+      moveDown.current = active;
+    }, []);
+
+    // These should use useKeyMap once we have a way for users to reset back to default
+    // const { key, keymap } = useKeyMap();
+    // example of use would be
+    // useKeyPress(key('movement', 'forward1'), {enabled, onKeyDown: () => setMoveForward(true), onKeyUp: () => setMoveForward(false)});
+
+    useKeyPress(defaultKeyMap['movement']['forward'], {
+      enabled,
+      onKeyDown: () => setMoveForward(true),
+      onKeyUp: () => setMoveForward(false),
+    });
+    useKeyPress(defaultKeyMap['movement']['forward1'], {
+      enabled,
+      onKeyDown: () => setMoveForward(true),
+      onKeyUp: () => setMoveForward(false),
+    });
+
+    useKeyPress(defaultKeyMap['movement']['left'], {
+      enabled,
+      onKeyDown: () => setMoveLeft(true),
+      onKeyUp: () => setMoveLeft(false),
+    });
+    useKeyPress(defaultKeyMap['movement']['left1'], {
+      enabled,
+      onKeyDown: () => setMoveLeft(true),
+      onKeyUp: () => setMoveLeft(false),
+    });
+
+    useKeyPress(defaultKeyMap['movement']['backward'], {
+      enabled,
+      onKeyDown: () => setMoveBackwards(true),
+      onKeyUp: () => setMoveBackwards(false),
+    });
+    useKeyPress(defaultKeyMap['movement']['backward1'], {
+      enabled,
+      onKeyDown: () => setMoveBackwards(true),
+      onKeyUp: () => setMoveBackwards(false),
+    });
+
+    useKeyPress(defaultKeyMap['movement']['right'], {
+      enabled,
+      onKeyDown: () => setMoveRight(true),
+      onKeyUp: () => setMoveRight(false),
+    });
+    useKeyPress(defaultKeyMap['movement']['right1'], {
+      enabled,
+      onKeyDown: () => setMoveRight(true),
+      onKeyUp: () => setMoveRight(false),
+    });
+
+    useKeyPress(defaultKeyMap['movement']['up'], {
+      enabled,
+      onKeyDown: () => setMoveUp(true),
+      onKeyUp: () => setMoveUp(false),
+    });
+
+    useKeyPress(defaultKeyMap['movement']['down'], {
+      enabled,
+      onKeyDown: () => setMoveDown(true),
+      onKeyUp: () => setMoveDown(false),
+    });
+
+    useEffect(() => {
+      if (enabled) {
+        controls.connect(explDomElement);
+
+        // Force events to be centered while PLC is active
+        const oldComputeOffsets = get().events.compute;
+        setEvents({
+          compute(event: DomEvent, state: RootState) {
+            const offsetX = state.size.width / 2;
+            const offsetY = state.size.height / 2;
+            state.pointer.set((offsetX / state.size.width) * 2 - 1, -(offsetY / state.size.height) * 2 + 1);
+            state.raycaster.setFromCamera(state.pointer, state.camera);
+          },
+        });
+        return () => {
+          controls.disconnect();
+          setEvents({ compute: oldComputeOffsets });
+        };
+      }
+    }, [enabled, controls]);
+
+    useEffect(() => {
+      const callback = (e: THREE.Event) => {
+        invalidate();
+        if (onChange) onChange(e);
+      };
+
+      controls.addEventListener('change', callback);
+
+      if (onLock) controls.addEventListener('lock', onLock);
+      if (onUnlock) controls.addEventListener('unlock', onUnlock);
+
+      // Enforce previous interaction
+      const handler = () => controls.lock();
+      const elements = selector ? Array.from(document.querySelectorAll(selector)) : [document];
+      elements.forEach((element) => element && element.addEventListener('click', handler));
+
+      return () => {
+        controls.removeEventListener('change', callback);
+        if (onLock) controls.addEventListener('lock', onLock);
+        if (onUnlock) controls.addEventListener('unlock', onUnlock);
+        elements.forEach((element) => (element ? element.removeEventListener('click', handler) : undefined));
+      };
+    }, [onChange, onLock, onUnlock, selector, controls, invalidate]);
+
+    useEffect(() => {
+      if (makeDefault) {
+        const old = get().controls;
+        set({ controls });
+        return () => set({ controls: old });
+      }
+    }, [makeDefault, controls]);
+
+    return <primitive ref={ref} object={controls} {...rest} />;
+  },
+);

--- a/packages/scene-composer/src/components/three-fiber/controls/index.ts
+++ b/packages/scene-composer/src/components/three-fiber/controls/index.ts
@@ -1,3 +1,4 @@
 export * from './OrbitControls';
 export * from './MapControls';
 export * from './TripodControls';
+export * from './PointerLockControls';

--- a/packages/scene-composer/src/hooks/useKeyMap.ts
+++ b/packages/scene-composer/src/hooks/useKeyMap.ts
@@ -1,0 +1,25 @@
+/* istanbul ignore file */
+export type ModifierKey = 'shift' | 'alt' | 'ctrl';
+export type Key = { key: string | number; modifier?: ModifierKey };
+
+export interface KeyMap {
+  [category: string]: {
+    [feature: string]: string | number | Key;
+  };
+}
+
+export const defaultKeyMap: KeyMap = {
+  movement: {
+    forward: 'w',
+    forward1: 'ArrowUp',
+    backward: 's',
+    backward1: 'ArrowDown',
+    left: 'a',
+    left1: 'ArrowLeft',
+    right: 'd',
+    right1: 'ArrowRight',
+    up: ' ',
+    down: 'v',
+    doubleUp: 'e',
+  },
+};

--- a/packages/scene-composer/src/hooks/useKeyPress.ts
+++ b/packages/scene-composer/src/hooks/useKeyPress.ts
@@ -1,0 +1,92 @@
+/* istanbul ignore file */
+// Credit original Source: https://codesandbox.io/s/rob7b8?file=/src/hooks/useKeyPress.tsx:0-2069
+
+import { useCallback, useEffect, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+
+import { Key } from './useKeyMap';
+
+function isKey(key: string | number | Key): key is Key {
+  return !!(key as Key).key;
+}
+
+interface KeyPressArgs {
+  enabled?: boolean;
+  onKeyPressed?: (delta?: number) => void;
+  onKeyDown?: (e: globalThis.KeyboardEvent) => void;
+  onKeyUp?: (e: globalThis.KeyboardEvent) => void;
+}
+
+const useKeyPress = (
+  targetKey: string | number | Key,
+  { enabled = true, onKeyPressed: pressMethod, onKeyDown: downMethod, onKeyUp: upMethod }: KeyPressArgs,
+): boolean => {
+  const target = isKey(targetKey) ? targetKey : ({ key: targetKey } as Key);
+
+  const [keyPressed, setKeyPressed] = useState(false);
+
+  const { modifier } = target;
+  const modifierPressed = useCallback(
+    ({ altKey, ctrlKey, shiftKey }: Partial<globalThis.KeyboardEvent>) => {
+      if (!modifier) return true;
+
+      switch (modifier) {
+        case 'ctrl':
+          return ctrlKey;
+        case 'alt':
+          return altKey;
+        case 'shift':
+          return shiftKey;
+        default:
+          return false;
+      }
+    },
+    [modifier],
+  );
+
+  const downHandler = useCallback(
+    (e: globalThis.KeyboardEvent) => {
+      if (e.key === target.key && modifierPressed(e)) {
+        setKeyPressed(true);
+        downMethod?.(e);
+      }
+    },
+    [downMethod, modifierPressed, target.key],
+  );
+
+  const upHandler = useCallback(
+    (e: globalThis.KeyboardEvent) => {
+      if (e.key === target.key) {
+        setKeyPressed(false);
+        upMethod?.(e);
+      }
+    },
+    [target.key, upMethod],
+  );
+
+  useFrame((_s, dt) => {
+    if (keyPressed && pressMethod) {
+      pressMethod(dt);
+    }
+  });
+
+  // Add event listeners for keypress
+  useEffect(() => {
+    if (enabled) {
+      window.addEventListener('keydown', downHandler);
+      window.addEventListener('keyup', upHandler);
+    } else {
+      window.removeEventListener('keydown', downHandler);
+      window.removeEventListener('keyup', upHandler);
+    }
+    // Remove event listeners on cleanup
+    return () => {
+      window.removeEventListener('keydown', downHandler);
+      window.removeEventListener('keyup', upHandler);
+    };
+  }, [enabled]); // We don't pass more than enabled here, because it adds unnecessary event listeners. This ensures we only bind once, and we unbind when disabled.
+
+  return keyPressed;
+};
+
+export default useKeyPress;

--- a/packages/scene-composer/src/interfaces/feature.ts
+++ b/packages/scene-composer/src/interfaces/feature.ts
@@ -18,6 +18,7 @@ export enum COMPOSER_FEATURES {
   AutoQuery = 'AutoQuery',
   Animations = 'Animations',
   DynamicScene = 'DynamicScene',
+  FirstPerson = 'FirstPerson',
 
   // Deprecated features (to be removed)
   EnvironmentModel = 'EnvironmentModel',

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -79,7 +79,7 @@ export enum KnownSceneProperty {
  ************************************************/
 
 export type CameraControlMode = 'transition' | 'teleport';
-export type CameraControlsType = 'orbit' | 'pan' | 'immersive';
+export type CameraControlsType = 'orbit' | 'pan' | 'immersive' | 'pointerLock';
 export type TransformControlMode = 'translate' | 'rotate' | 'scale';
 export enum CameraViewAxisValues {
   Front = 'front',

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.spec.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/first */
 /* eslint-disable import/order */
 import * as React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 
 import { SceneLayout } from '.';
 import { useStore } from '../../store';
@@ -67,7 +67,7 @@ describe('SceneLayout', () => {
     ['Viewing mode with modal', { isViewing: true, showMessageModal: true }],
   ].forEach((value) => {
     it(`should render correctly in ${value[0]}`, () => {
-      const container = renderer.create(
+      const container = create(
         <SceneLayout
           onPointerMissed={() => {}}
           LoadingView={<div data-test-id='Loading view' />}
@@ -92,7 +92,7 @@ describe('SceneLayout', () => {
       },
     });
 
-    const container = renderer.create(
+    const container = create(
       <SceneLayout
         onPointerMissed={() => {}}
         LoadingView={<div data-test-id='Loading view' />}
@@ -105,7 +105,7 @@ describe('SceneLayout', () => {
   });
 
   it('should not render camera preview if editing and non-camera component is on selectedNode', () => {
-    const container = renderer.create(
+    const container = create(
       <SceneLayout
         onPointerMissed={() => {}}
         LoadingView={<div data-test-id='Loading view' />}

--- a/packages/scene-composer/src/layouts/SceneLayout/components/CameraPreviewTrack.spec.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/components/CameraPreviewTrack.spec.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 
 import CameraPreviewTrack from './CameraPreviewTrack';
 
 describe('CameraPreviewTrack', () => {
   it('should render correctly', () => {
-    const container = renderer.create(<CameraPreviewTrack title='Test Title' />);
+    const container = create(<CameraPreviewTrack title='Test Title' />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/src/layouts/SceneLayout/components/TabbedPanelContainer.spec.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/components/TabbedPanelContainer.spec.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable import/first */
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import React from 'react';
 
 import TabbedPanelContainer from './TabbedPanelContainer';
 
 describe('TabbedPanelContainerSnap', () => {
   it('should render correctly', () => {
-    const container = renderer.create(
+    const container = create(
       <TabbedPanelContainer panels={{ test1: <div> Panel 1 </div>, test2: <div> Panel 2 </div> }} />,
     );
     expect(container).toMatchSnapshot();

--- a/packages/scene-composer/src/layouts/StaticLayout/__tests__/StaticLayout.spec.tsx
+++ b/packages/scene-composer/src/layouts/StaticLayout/__tests__/StaticLayout.spec.tsx
@@ -1,11 +1,11 @@
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import React from 'react';
 
 import { StaticLayout } from '..';
 
 describe('StaticLayoutSnap', () => {
   it('should render correctly without modal', () => {
-    const container = renderer.create(
+    const container = create(
       <StaticLayout
         header='header'
         footer='footer'
@@ -20,7 +20,7 @@ describe('StaticLayoutSnap', () => {
   });
 
   it('should render correctly with modal', () => {
-    const container = renderer.create(
+    const container = create(
       <StaticLayout
         header='header'
         footer='footer'
@@ -35,7 +35,7 @@ describe('StaticLayoutSnap', () => {
   });
 
   it('should render correctly with topBar', () => {
-    const container = renderer.create(
+    const container = create(
       <StaticLayout
         header='header'
         footer='footer'

--- a/packages/scene-composer/src/store/internalInterfaces.ts
+++ b/packages/scene-composer/src/store/internalInterfaces.ts
@@ -27,6 +27,7 @@ import {
   IEntityBindingComponent,
 } from '../interfaces';
 import { MapControls as MapControlsImpl, OrbitControls as OrbitControlsImpl } from '../three/OrbitControls';
+import { PointerLockControls as PointerLockControlsImpl } from '../three/PointerLockControls';
 
 export type ISerializationErrorDetails = IErrorDetails;
 
@@ -45,7 +46,7 @@ export enum DisplayMessageCategory {
   Info = 'Info',
 }
 
-export type CameraControlImpl = MapControlsImpl | OrbitControlsImpl;
+export type CameraControlImpl = OrbitControlsImpl | MapControlsImpl | PointerLockControlsImpl;
 export type TweenValueObject = { x: number; y: number; z: number };
 
 export type CursorStyle = 'move' | 'edit';

--- a/packages/scene-composer/src/three/PointerLockControls.ts
+++ b/packages/scene-composer/src/three/PointerLockControls.ts
@@ -1,0 +1,121 @@
+/* istanbul ignore file */
+/**
+ * This file is copied from https://github.com/pmndrs/three-stdlib with some modifications.
+ */
+import { Euler, Camera, EventDispatcher, Vector3 } from 'three';
+
+const _euler = /* @__PURE__ */ new Euler(0, 0, 0, 'YXZ');
+const _vector = /* @__PURE__ */ new Vector3();
+const _changeEvent = { type: 'change' };
+const _lockEvent = { type: 'lock' };
+const _unlockEvent = { type: 'unlock' };
+const _PI_2 = Math.PI / 2;
+
+class PointerLockControls extends EventDispatcher {
+  public camera: Camera;
+  public domElement?: HTMLElement;
+  public isLocked: boolean;
+  public minPolarAngle: number;
+  public maxPolarAngle: number;
+  public pointerSpeed: number;
+
+  constructor(camera: Camera, domElement?: HTMLElement) {
+    super();
+
+    this.camera = camera;
+    this.domElement = domElement;
+    this.isLocked = false;
+
+    // Set to constrain the pitch of the camera
+    // Range is 0 to Math.PI radians
+    this.minPolarAngle = 0; // radians
+    this.maxPolarAngle = Math.PI; // radians
+
+    this.pointerSpeed = 1.0;
+    if (domElement) this.connect(domElement);
+  }
+
+  private onMouseMove = (event: MouseEvent): void => {
+    if (!this.domElement || this.isLocked === false) return;
+    const movementX = event.movementX || 0;
+    const movementY = event.movementY || 0;
+    _euler.setFromQuaternion(this.camera.quaternion);
+    _euler.y -= movementX * 0.002 * this.pointerSpeed;
+    _euler.x -= movementY * 0.002 * this.pointerSpeed;
+    _euler.x = Math.max(_PI_2 - this.maxPolarAngle, Math.min(_PI_2 - this.minPolarAngle, _euler.x));
+    this.camera.quaternion.setFromEuler(_euler);
+    this.dispatchEvent(_changeEvent);
+  };
+
+  private onPointerlockChange = (): void => {
+    if (!this.domElement) return;
+    if (this.domElement.ownerDocument.pointerLockElement === this.domElement) {
+      this.dispatchEvent(_lockEvent);
+      this.isLocked = true;
+    } else {
+      this.dispatchEvent(_unlockEvent);
+      this.isLocked = false;
+    }
+  };
+
+  private onPointerlockError = (): void => {
+    console.error('THREE.PointerLockControls: Unable to use Pointer Lock API');
+  };
+
+  public connect = (domElement: HTMLElement): void => {
+    this.domElement = domElement || this.domElement;
+    if (!this.domElement) return;
+    this.domElement.ownerDocument.addEventListener('mousemove', this.onMouseMove);
+    this.domElement.ownerDocument.addEventListener('pointerlockchange', this.onPointerlockChange);
+    this.domElement.ownerDocument.addEventListener('pointerlockerror', this.onPointerlockError);
+  };
+
+  public disconnect = (): void => {
+    if (!this.domElement) return;
+    this.domElement.ownerDocument.removeEventListener('mousemove', this.onMouseMove);
+    this.domElement.ownerDocument.removeEventListener('pointerlockchange', this.onPointerlockChange);
+    this.domElement.ownerDocument.removeEventListener('pointerlockerror', this.onPointerlockError);
+  };
+
+  public dispose = (): void => {
+    this.disconnect();
+  };
+
+  public getObject = (): Camera => {
+    // retaining this method for backward compatibility
+    return this.camera;
+  };
+
+  private direction = new Vector3(0, 0, -1);
+  public getDirection = (v: Vector3): Vector3 => {
+    return v.copy(this.direction).applyQuaternion(this.camera.quaternion);
+  };
+
+  public moveForward = (distance: number): void => {
+    // move forward parallel to the xz-plane
+    // assumes camera.up is y-up
+    _vector.setFromMatrixColumn(this.camera.matrix, 0);
+    _vector.crossVectors(this.camera.up, _vector);
+    this.camera.position.addScaledVector(_vector, distance);
+  };
+
+  public moveRight = (distance: number): void => {
+    _vector.setFromMatrixColumn(this.camera.matrix, 0);
+    this.camera.position.addScaledVector(_vector, distance);
+  };
+
+  public moveUp = (distance: number): void => {
+    //_vector.setFromMatrixColumn(this.camera.matrix, 0)
+    this.camera.position.addScaledVector(this.camera.up, distance);
+  };
+
+  public lock = (): void => {
+    if (this.domElement) this.domElement.requestPointerLock();
+  };
+
+  public unlock = (): void => {
+    if (this.domElement) this.domElement.ownerDocument.exitPointerLock();
+  };
+}
+
+export { PointerLockControls };

--- a/packages/scene-composer/src/utils/controlUtils.spec.ts
+++ b/packages/scene-composer/src/utils/controlUtils.spec.ts
@@ -1,0 +1,39 @@
+import {
+  isImmersiveControl,
+  isPanControl,
+  isPointerLockControl,
+  isOrbitControl,
+  isOrbitOrPanControl,
+} from './controlUtils';
+describe('control utils', () => {
+  it('should detect immersive correctly', () => {
+    expect(isImmersiveControl('immersive')).toBeTruthy();
+    expect(isImmersiveControl('orbit')).toBeFalsy();
+    expect(isImmersiveControl('pan')).toBeFalsy();
+    expect(isImmersiveControl('pointerLock')).toBeFalsy();
+  });
+  it('should detect orbit correctly', () => {
+    expect(isOrbitControl('immersive')).toBeFalsy();
+    expect(isOrbitControl('orbit')).toBeTruthy();
+    expect(isOrbitControl('pan')).toBeFalsy();
+    expect(isOrbitControl('pointerLock')).toBeFalsy();
+  });
+  it('should detect pan correctly', () => {
+    expect(isPanControl('immersive')).toBeFalsy();
+    expect(isPanControl('orbit')).toBeFalsy();
+    expect(isPanControl('pan')).toBeTruthy();
+    expect(isPanControl('pointerLock')).toBeFalsy();
+  });
+  it('should detect pointer lock correctly', () => {
+    expect(isPointerLockControl('immersive')).toBeFalsy();
+    expect(isPointerLockControl('orbit')).toBeFalsy();
+    expect(isPointerLockControl('pan')).toBeFalsy();
+    expect(isPointerLockControl('pointerLock')).toBeTruthy();
+  });
+  it('should detect pan or orbit correctly', () => {
+    expect(isOrbitOrPanControl('immersive')).toBeFalsy();
+    expect(isOrbitOrPanControl('orbit')).toBeTruthy();
+    expect(isOrbitOrPanControl('pan')).toBeTruthy();
+    expect(isOrbitOrPanControl('pointerLock')).toBeFalsy();
+  });
+});

--- a/packages/scene-composer/src/utils/controlUtils.ts
+++ b/packages/scene-composer/src/utils/controlUtils.ts
@@ -1,0 +1,21 @@
+import { CameraControlsType } from '../interfaces';
+
+export const isPointerLockControl = (controlType: CameraControlsType): boolean => {
+  return controlType === 'pointerLock' ? true : false;
+};
+
+export const isOrbitControl = (controlType: CameraControlsType): boolean => {
+  return controlType === 'orbit' ? true : false;
+};
+
+export const isPanControl = (controlType: CameraControlsType): boolean => {
+  return controlType === 'pan' ? true : false;
+};
+
+export const isImmersiveControl = (controlType: CameraControlsType): boolean => {
+  return controlType === 'immersive' ? true : false;
+};
+
+export const isOrbitOrPanControl = (controlType: CameraControlsType): boolean => {
+  return isOrbitControl(controlType) || isPanControl(controlType) ? true : false;
+};

--- a/packages/scene-composer/stories/FirstPerson.stories.mdx
+++ b/packages/scene-composer/stories/FirstPerson.stories.mdx
@@ -1,0 +1,50 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+
+import SceneComposer, { argTypes, args } from './components/scene-composer';
+import { testScenes } from '../tests/testData';
+import { COMPOSER_FEATURES } from '../src/interfaces/feature';
+
+<Meta title="Tests/FirstPerson" component={SceneComposer} argTypes={argTypes} />
+
+export const defaultArgs = {
+  source: 'local',
+  scene: 'scene1',
+  theme: 'dark',
+  mode: 'Viewing',
+  density: 'comfortable',
+  features: [
+    COMPOSER_FEATURES.SceneHierarchyReorder,
+    COMPOSER_FEATURES.SceneHierarchySearch,
+    COMPOSER_FEATURES.SubModelSelection,
+    COMPOSER_FEATURES.ENHANCED_EDITING,
+    COMPOSER_FEATURES.CameraView,
+    COMPOSER_FEATURES.OpacityRule,
+    COMPOSER_FEATURES.FirstPerson,
+    COMPOSER_FEATURES.Overlay
+  ]
+}
+
+export const Template = (args) => {
+  return <SceneComposer {...defaultArgs} {...args} />
+}
+
+# Local Viewing
+
+<Canvas>
+  <Story name='Local Viewer'
+    height='500px'
+    parameters={{ controls: { include: ['onSelectionChanged', 'onWidgetClick'], hideNoControlsWarning: true }}}
+    args={{ ...defaultArgs, scene: 'CookieFactoryWaterTank' }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+# AWS Viewing
+
+<Canvas>
+  <Story name='AWS Viewer'
+    height='500px'
+    args={{ ...defaultArgs, source: 'aws', }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/packages/scene-composer/tests/components/DividerSnap.spec.tsx
+++ b/packages/scene-composer/tests/components/DividerSnap.spec.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 
 import { Divider } from '../../src/components/Divider';
 
 describe('Divider', () => {
   it('should render correctly', () => {
-    const container = renderer.create(<Divider />);
+    const container = create(<Divider />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/tests/components/three-fiber/EditorCamera.spec.tsx
+++ b/packages/scene-composer/tests/components/three-fiber/EditorCamera.spec.tsx
@@ -37,6 +37,15 @@ jest.doMock('../../../src/components/three-fiber/controls/OrbitControls', () => 
   };
 });
 
+const mockPointerLockControls = jest.fn();
+jest.doMock('../../../src/components/three-fiber/controls/PointerLockControls', () => {
+  const originalModule = jest.requireActual('../../../src/components/three-fiber/controls/PointerLockControls');
+  return {
+    ...originalModule,
+    PointerLockControls: mockPointerLockControls,
+  };
+});
+
 const mockPerspectiveCamera = jest.fn();
 jest.doMock('@react-three/drei/core/PerspectiveCamera', () => {
   const originalModule = jest.requireActual('@react-three/drei/core/PerspectiveCamera');
@@ -70,6 +79,9 @@ import { EditorMainCamera, findBestViewingPosition } from '../../../src/componen
 import { useStore } from '../../../src/store';
 
 import { useThree } from '@react-three/fiber';
+
+import { OrbitControls } from '../../../src/three/OrbitControls';
+
 /* eslint-enable */
 
 describe('EditorMainCamera', () => {
@@ -87,6 +99,7 @@ describe('EditorMainCamera', () => {
 
     mockMapControls.mockReturnValue(<div data-testid='map-control' />);
     mockOrbitControls.mockReturnValue(<div data-testid='orbit-control' />);
+    mockPointerLockControls.mockReturnValue(<div data-testid='pointer-lock-control' />);
     mockPerspectiveCamera.mockReturnValue(<div data-testid='perspective-camera' />);
     const useThreeMock = useThree as Mock;
     useThreeMock.mockImplementation((s) => {
@@ -111,6 +124,7 @@ describe('EditorMainCamera', () => {
       expect(rendered.queryByTestId('perspective-camera')).toBeTruthy();
       expect(rendered.queryByTestId('orbit-control')).toBeTruthy();
       expect(rendered.queryByTestId('map-control')).toBeFalsy();
+      expect(rendered.queryByTestId('pointer-lock-control')).toBeFalsy();
     });
 
     it('should render MapControl', async () => {
@@ -121,6 +135,18 @@ describe('EditorMainCamera', () => {
       expect(rendered.queryByTestId('perspective-camera')).toBeTruthy();
       expect(rendered.queryByTestId('orbit-control')).toBeFalsy();
       expect(rendered.queryByTestId('map-control')).toBeTruthy();
+      expect(rendered.queryByTestId('pointer-lock-control')).toBeFalsy();
+    });
+
+    it('should render PointerLockControl', async () => {
+      useStore('default').setState({ ...baseState, cameraControlsType: 'pointerLock' });
+
+      const rendered = render(<EditorMainCamera />);
+
+      expect(rendered.queryByTestId('perspective-camera')).toBeTruthy();
+      expect(rendered.queryByTestId('orbit-control')).toBeFalsy();
+      expect(rendered.queryByTestId('map-control')).toBeFalsy();
+      expect(rendered.queryByTestId('pointer-lock-control')).toBeTruthy();
     });
 
     it('should not render if ImmersiveViewControl', async () => {
@@ -131,6 +157,7 @@ describe('EditorMainCamera', () => {
       expect(rendered.queryByTestId('perspective-camera')).toBeTruthy();
       expect(rendered.queryByTestId('orbit-control')).toBeFalsy();
       expect(rendered.queryByTestId('map-control')).toBeFalsy();
+      expect(rendered.queryByTestId('pointer-lock-control')).toBeFalsy();
     });
 
     it('should not render control on mouseDown and render control on mouseUp', async () => {
@@ -146,6 +173,7 @@ describe('EditorMainCamera', () => {
       expect(rendered.queryByTestId('perspective-camera')).toBeTruthy();
       expect(rendered.queryByTestId('orbit-control')).toBeTruthy();
       expect(rendered.queryByTestId('map-control')).toBeFalsy();
+      expect(rendered.queryByTestId('pointer-lock-control')).toBeFalsy();
 
       // mouseDown
       await act(async () => {
@@ -156,6 +184,7 @@ describe('EditorMainCamera', () => {
       expect(rendered.queryByTestId('perspective-camera')).toBeTruthy();
       expect(rendered.queryByTestId('orbit-control')).toBeFalsy();
       expect(rendered.queryByTestId('map-control')).toBeFalsy();
+      expect(rendered.queryByTestId('pointer-lock-control')).toBeFalsy();
 
       // mouseUp
       await act(async () => {
@@ -166,6 +195,7 @@ describe('EditorMainCamera', () => {
       expect(rendered.queryByTestId('perspective-camera')).toBeTruthy();
       expect(rendered.queryByTestId('orbit-control')).toBeTruthy();
       expect(rendered.queryByTestId('map-control')).toBeFalsy();
+      expect(rendered.queryByTestId('pointer-lock-control')).toBeFalsy();
 
       // unmount remove listener
       rendered.unmount();
@@ -303,9 +333,7 @@ describe('EditorMainCamera', () => {
 
     const mockCamera = new THREE.PerspectiveCamera(60, 0.75);
     mockCamera.position.copy(new THREE.Vector3(-1, -1, -1));
-    const mockControls: any = {
-      object: mockCamera,
-    };
+    const mockControls: OrbitControls = new OrbitControls(mockCamera);
 
     // half length of unit vector divide by sin of half our smallest FOV axis for our box of size 1,1,1
     const minimumDistance = Math.sqrt(3) / 2 / Math.sin(0.5 * (Math.PI / 180) * 45);
@@ -376,9 +404,7 @@ describe('EditorMainCamera', () => {
       );
       const mockCamera = new THREE.PerspectiveCamera(60, 0.75);
       mockCamera.position.copy(new THREE.Vector3(0.1, 0.1, 0.1));
-      const mockControls: any = {
-        object: mockCamera,
-      };
+      const mockControls: OrbitControls = new OrbitControls(mockCamera);
       const result = findBestViewingPosition(mockObject, false, mockControls);
 
       expect(result.position[0]).toBeCloseTo(expectedVectorLength, 5);

--- a/packages/scene-composer/tests/components/toolbars/floatingToolbar/FloatingToolbar.spec.tsx
+++ b/packages/scene-composer/tests/components/toolbars/floatingToolbar/FloatingToolbar.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/first,import/order */
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 
 import { AddObjectMenu } from '../../../../src/components/toolbars/floatingToolbar/items/AddObjectMenu';
 
@@ -26,14 +26,12 @@ describe('FloatingToolbar', () => {
   });
 
   it('should render correctly', () => {
-    const container = renderer.create(
-      <FloatingToolbar enableDefaultItems={true} additionalMenuItems={<AddObjectMenu />} />,
-    );
+    const container = create(<FloatingToolbar enableDefaultItems={true} additionalMenuItems={<AddObjectMenu />} />);
     expect(container).toMatchSnapshot();
   });
 
   it('should render correctly in view mode', () => {
-    const container = renderer.create(
+    const container = create(
       <FloatingToolbar isViewing={true} enableDefaultItems={true} additionalMenuItems={<AddObjectMenu />} />,
     );
     expect(container).toMatchSnapshot();
@@ -43,7 +41,7 @@ describe('FloatingToolbar', () => {
     useStore('default').setState({
       addingWidget: {},
     } as any);
-    const container = renderer.create(<FloatingToolbar enableDefaultItems={true} />);
+    const container = create(<FloatingToolbar enableDefaultItems={true} />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -187,6 +187,10 @@
     "note": "Status indicator label",
     "text": "Tags sync successful"
   },
+  "81kEJb": {
+    "note": "Menu Item",
+    "text": "3D Pointer Lock"
+  },
   "89bwEi": {
     "note": "Environment presets drop down menu options",
     "text": "Chromatic"
@@ -358,6 +362,10 @@
   "IRTrH8": {
     "note": "Menu Item",
     "text": "Add camera from current view"
+  },
+  "IsC9Hg": {
+    "note": "Menu Item",
+    "text": "Pointer Lock"
   },
   "JTUN+G": {
     "note": "Form field label",


### PR DESCRIPTION
## Overview
Add an option for a first person camera view and navigation mode using a pointer lock model.

## Verifying Changes
Storybook
select the First Person story.  This should auto set the First Person feature flag.
Your camera controls should have a third option added to them of 'Pointer Lock' that's in addition to the existing orbit and pan modes.

Selecting this button and then using the mouse to click the canvas will put you into pointer lock mode.  to leave the mode click Esc like the pop-up message in Chrome mentions.

Once in pointer lock mode navigation works as:
Rotation camera view: left mouse click and drag mouse
move forward: W key or Up arrow key
move backward: S key or down arrow key
move left: A key or left arrow key
move right: D key or right arrow key
move down: V key
move up: space bar

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
