### PR TITLE
feat(dashboard): change dashboard viewport default from 5m to 10m

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -14,7 +14,7 @@ import ResourceExplorerPanelIcon from '../resizablePanes/assets/resourceExplorer
 
 const EMPTY_DASHBOARD: DashboardWidgetsConfiguration = {
   widgets: [],
-  viewport: { duration: '5m' },
+  viewport: { duration: '10m' },
 };
 
 it('saves when the save button is pressed with default grid settings provided', function () {

--- a/packages/dashboard/src/store/state.ts
+++ b/packages/dashboard/src/store/state.ts
@@ -39,7 +39,7 @@ export const initialState: DashboardState = deepFreeze({
   copiedWidgets: [],
   pasteCounter: 0,
   dashboardConfiguration: {
-    viewport: { duration: '5m' },
+    viewport: { duration: '10m' },
     widgets: [],
   },
   significantDigits: 4,

--- a/packages/dashboard/stories/dashboard/sitewise-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/sitewise-dashboard.stories.tsx
@@ -42,7 +42,7 @@ const args: DashboardProperties = {
       numRows: 55,
     },
     widgets: [],
-    viewport: { duration: '5m' },
+    viewport: { duration: '10m' },
   },
   onSave: async (dashboard) => {
     console.log(dashboard);


### PR DESCRIPTION
## Overview
Updating the initial dashboard viewport default to be 10 minutes instead of 5.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
