### PR TITLE
fix(tools-iottwinmaker): update dashboard role to include execute que…

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneRulesPanel.spec.tsx
+++ b/packages/scene-composer/src/components/panels/SceneRulesPanel.spec.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
-import { render, act, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 
-import { IRuleBasedMapInternal, IRuleStatementInternal } from '../../store/internalInterfaces';
-import { IRuleBasedMap } from '../../interfaces';
-
-import { SceneRuleMapExpandableInfoSection, SceneRulesPanel } from './SceneRulesPanel';
+import { SceneRulesPanel } from './SceneRulesPanel';
 
 jest.mock('../../logger/react-logger/log-provider', () => (props) => <div {...props} />);
 jest.mock('./CommonPanelComponents', () => ({

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/interface.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/interface.tsx
@@ -1,4 +1,4 @@
-import { IconDefinition, IconLookup } from '@fortawesome/fontawesome-svg-core';
+import { IconLookup } from '@fortawesome/fontawesome-svg-core';
 
 export interface TagStyle {
   colorPicker?: React.ReactNode;

--- a/packages/scene-composer/src/hooks/useBindingData.spec.ts
+++ b/packages/scene-composer/src/hooks/useBindingData.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 
 import { useStore } from '../store';
 

--- a/packages/scene-composer/src/utils/styleUtils.ts
+++ b/packages/scene-composer/src/utils/styleUtils.ts
@@ -5,7 +5,6 @@ import {
   colorTextNotificationDefault,
   colorBackgroundNotificationRed,
   colorBorderButtonNormalDefault,
-  colorChartsBlue1500,
 } from '@awsui/design-tokens';
 
 const designTokenRegex = /^var\(([0-9a-zA-Z-]+),\s*(#[0-9a-z]+)\)$/;

--- a/packages/tools-iottwinmaker/src/lib/policy/workspace-dashboard-role-policy.ts
+++ b/packages/tools-iottwinmaker/src/lib/policy/workspace-dashboard-role-policy.ts
@@ -8,7 +8,7 @@ export const workspaceDashboardRolePolicyTemplate = {
     },
     {
       Effect: 'Allow',
-      Action: ['iottwinmaker:Get*', 'iottwinmaker:List*'],
+      Action: ['iottwinmaker:Get*', 'iottwinmaker:List*', 'iottwinmaker:ExecuteQuery'],
       Resource: ['{workspaceArn}', '{workspaceArn}/*'],
     },
     {


### PR DESCRIPTION
## Overview
This change is to Update Dashboard Role to include ExecuteQuery API call.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
