### PR TITLE
Add fixed height and width for the table widget #1872

### DIFF
--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -3,6 +3,8 @@ import { useSelector } from 'react-redux';
 
 import { Table, TableColumnDefinition } from '@iot-app-kit/react-components';
 
+import EmptyTableState from './emptyTableState';
+
 import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { TableWidget } from '../types';
@@ -65,6 +67,7 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
         items={items}
         thresholds={thresholds}
         significantDigits={significantDigits}
+        empty={<EmptyTableState />}
       />
     </div>
   );

--- a/packages/dashboard/src/customization/widgets/table/emptyTableState.spec.tsx
+++ b/packages/dashboard/src/customization/widgets/table/emptyTableState.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import EmptyTableState from './emptyTableState';
+
+describe('empty state should display', () => {
+  it('empty state should display in document', () => {
+    render(<EmptyTableState />);
+
+    expect(screen.getByTestId('emptyStateTableDisplay')).toBeInTheDocument();
+  });
+
+  it('should display "No data to display" in document', async () => {
+    render(<EmptyTableState />);
+
+    expect(screen.getByTestId('default-msg')).toHaveTextContent('No data to display');
+  });
+
+  it('should display "Add asset properties" Button', async () => {
+    render(<EmptyTableState />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveTextContent('Add asset properties');
+  });
+});

--- a/packages/dashboard/src/customization/widgets/table/emptyTableState.tsx
+++ b/packages/dashboard/src/customization/widgets/table/emptyTableState.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Box, Button, SpaceBetween } from '@cloudscape-design/components';
+import type { FunctionComponent } from 'react';
+
+const EmptyTableState: FunctionComponent = () => {
+  return (
+    <Box data-testid='emptyStateTableDisplay' margin={{ vertical: 'xs' }} textAlign='center' color='inherit'>
+      <SpaceBetween size='m'>
+        <b data-testid='default-msg'>No data to display</b>
+        <Button>Add asset properties</Button>
+      </SpaceBetween>
+    </Box>
+  );
+};
+
+export default EmptyTableState;

--- a/packages/react-components/src/components/table/table.tsx
+++ b/packages/react-components/src/components/table/table.tsx
@@ -32,7 +32,8 @@ export const Table = ({
   viewport?: Viewport;
   styles?: StyleSettingsMap;
   significantDigits?: number;
-} & Pick<TableBaseProps, 'resizableColumns'>) => {
+} & Pick<TableBaseProps, 'resizableColumns'> &
+  Pick<TableBaseProps, 'empty'>) => {
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
     queries,

--- a/packages/react-components/src/components/table/tableBase.tsx
+++ b/packages/react-components/src/components/table/tableBase.tsx
@@ -24,6 +24,7 @@ export const TableBase: FunctionComponent<TableProps> = (props) => {
       items={items}
       columnDefinitions={columnDefinitions}
       filter={propertyFiltering && <PropertyFilter {...propertyFilterProps} i18nStrings={propertyFilter} />}
+      empty={props.empty}
     />
   );
 };


### PR DESCRIPTION
## Overview
Please note in this CR we have just added the empty state design whereas width & height fix will be taken care in another CR .

## Verifying Changes

![image](https://github.com/awslabs/iot-app-kit/assets/81667589/44bb642f-1e4f-4e10-b30c-9d50bcf612dd)
