### PR TITLE
feat: add fixed height and width for the table widget

### DIFF
--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -3,6 +3,8 @@ import { useSelector } from 'react-redux';
 
 import { Table, TableColumnDefinition } from '@iot-app-kit/react-components';
 
+import EmptyTableComponent from './emptyTableComponent';
+
 import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { TableWidget } from '../types';
@@ -80,6 +82,7 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
         stickyHeader
         pageSize={preferences.pageSize}
         paginationEnabled
+        empty={<EmptyTableComponent />}
       />
     </div>
   );

--- a/packages/dashboard/src/customization/widgets/table/emptyTableComponent.spec.tsx
+++ b/packages/dashboard/src/customization/widgets/table/emptyTableComponent.spec.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import EmptyTableComponent from './emptyTableComponent';
+
+describe('empty state should display', () => {
+  it('empty state should display in document', () => {
+    render(<EmptyTableComponent />);
+
+    expect(screen.getByTestId('emptyStateTableDisplay')).toBeInTheDocument();
+  });
+
+  it('should display "No data to display" in document', async () => {
+    render(<EmptyTableComponent />);
+
+    expect(screen.getByTestId('default-msg')).toHaveTextContent('No data to display');
+  });
+});

--- a/packages/dashboard/src/customization/widgets/table/emptyTableComponent.tsx
+++ b/packages/dashboard/src/customization/widgets/table/emptyTableComponent.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Box, SpaceBetween } from '@cloudscape-design/components';
+import type { FunctionComponent } from 'react';
+
+const EmptyTableComponent: FunctionComponent = () => {
+  return (
+    <Box data-testid='emptyStateTableDisplay' margin={{ vertical: 'xs' }} textAlign='center' color='inherit'>
+      <SpaceBetween size='m'>
+        <b data-testid='default-msg'>No data to display</b>
+      </SpaceBetween>
+    </Box>
+  );
+};
+
+export default EmptyTableComponent;

--- a/packages/react-components/src/components/table/table.tsx
+++ b/packages/react-components/src/components/table/table.tsx
@@ -36,7 +36,7 @@ export const Table = ({
   significantDigits?: number;
   paginationEnabled?: boolean;
   pageSize?: number;
-} & Pick<TableBaseProps, 'resizableColumns' | 'sortingDisabled' | 'stickyHeader'>) => {
+} & Pick<TableBaseProps, 'resizableColumns' | 'sortingDisabled' | 'stickyHeader' | 'empty'>) => {
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
     queries,

--- a/packages/react-components/src/components/table/tableBase.tsx
+++ b/packages/react-components/src/components/table/tableBase.tsx
@@ -16,6 +16,7 @@ export const TableBase: FunctionComponent<TableProps> = (props) => {
     precision,
     paginationEnabled,
     pageSize,
+    empty,
   } = props;
   const { items, collectionProps, propertyFilterProps, paginationProps } = useCollection(userItems, {
     sorting,
@@ -33,6 +34,7 @@ export const TableBase: FunctionComponent<TableProps> = (props) => {
       items={items}
       columnDefinitions={columnDefinitions}
       filter={propertyFiltering && <PropertyFilter {...propertyFilterProps} i18nStrings={propertyFilter} />}
+      empty={empty}
     />
   );
 };


### PR DESCRIPTION
Added empty table state design with "No data to display" content.

![image](https://github.com/awslabs/iot-app-kit/assets/81667589/4948f226-59d3-4ba1-9487-80f487766cab)

Please note we have just added empty state design for the table whereas width & height will be taken care in another CR.