### PR TITLE
feat(dashboard): update collapsible side panels

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/collapsiblePanel.spec.tsx
+++ b/packages/dashboard/src/components/internalDashboard/collapsiblePanel.spec.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+
+import { CollapsiblePanel } from './collapsiblePanel';
+import { DEFAULT_SIDE_PANE_WIDTH } from '../resizablePanes/constants';
+
+const panelContent = `Temperature monitoring`;
+
+const panelWidth = DEFAULT_SIDE_PANE_WIDTH;
+
+const mockIcon = 'mockIcon';
+const headerText = 'Configuration';
+
+describe('CollapsiblePanel', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should open collapsed panel when icon is clicked', async () => {
+    const side = 'right';
+    let isPanelCollapsed = true;
+    const onCollapsedPanelClick = jest.fn().mockImplementation(() => (isPanelCollapsed = !isPanelCollapsed));
+    const collapsedElement = (
+      <CollapsiblePanel
+        isPanelCollapsed={isPanelCollapsed}
+        panelWidth={panelWidth}
+        onCollapsedPanelClick={onCollapsedPanelClick}
+        panelContent={panelContent}
+        icon={mockIcon}
+        side={side}
+        headerText={headerText}
+      />
+    );
+
+    render(collapsedElement);
+
+    // Assert collapsed panel content
+    const iconButton = screen.getByTestId(`collapsed-${side}-panel-icon`);
+    expect(iconButton).toHaveAttribute('src', mockIcon);
+
+    act(() => {
+      iconButton.click();
+    });
+
+    // Assert panel expanded
+    expect(isPanelCollapsed).toBe(false);
+  });
+
+  it('should close expanded panel when button is clicked', async () => {
+    const side = 'left';
+    let isPanelCollapsed = false;
+    const onCollapsedPanelClick = jest.fn().mockImplementation(() => (isPanelCollapsed = !isPanelCollapsed));
+    const collapsedElement = (
+      <CollapsiblePanel
+        isPanelCollapsed={isPanelCollapsed}
+        panelWidth={panelWidth}
+        onCollapsedPanelClick={onCollapsedPanelClick}
+        panelContent={panelContent}
+        icon={mockIcon}
+        side={side}
+        headerText={headerText}
+      />
+    );
+
+    render(collapsedElement);
+
+    // Assert expanded panel content
+    expect(screen.getByText(headerText)).toBeVisible();
+    const collapseButton = screen.getByTestId(`expanded-${side}-panel-button`);
+    expect(collapseButton).toBeVisible();
+
+    act(() => {
+      collapseButton.click();
+    });
+
+    // Assert panel collapsed
+    expect(isPanelCollapsed).toBe(true);
+  });
+});

--- a/packages/dashboard/src/components/internalDashboard/collapsiblePanel.tsx
+++ b/packages/dashboard/src/components/internalDashboard/collapsiblePanel.tsx
@@ -1,19 +1,95 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import './index.css';
-import { colorBackgroundButtonPrimaryDefault, spaceContainerHorizontal } from '@cloudscape-design/design-tokens';
+import {
+  colorBackgroundButtonPrimaryDefault,
+  colorBorderDividerDefault,
+  spaceContainerHorizontal,
+  spaceStaticXxxs,
+} from '@cloudscape-design/design-tokens';
+import Box, { BoxProps } from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import { IconProps } from '@cloudscape-design/components/icon';
+import { DEFAULT_COLLAPSED_SIDE_PANE_WIDTH } from '../resizablePanes/constants';
 
-export function CollapsiblePanel(props: { icon: string; dataCy: string }) {
-  return (
+type CollapsiblePanelProps = {
+  isPanelCollapsed: boolean;
+  panelWidth: number;
+  onCollapsedPanelClick: () => void;
+  panelContent: ReactNode;
+  icon: string;
+  side: 'right' | 'left';
+  headerText: string;
+};
+
+export function CollapsiblePanel(props: CollapsiblePanelProps) {
+  // Used to set the borderRight or borderLeft prop of the pane
+  const borderSide = props.side === 'right' ? 'Left' : 'Right';
+
+  // Used to set the side of the icon in the top level box
+  const iconSide = borderSide.toLowerCase() as BoxProps.Float;
+
+  // Used to set the iconName of the collapsible button
+  const iconName = `angle-${props.side}` as IconProps.Name;
+
+  const Divider = () => (
+    <div className='collapsible-panel-vertical-divider' style={{ backgroundColor: colorBorderDividerDefault }} />
+  );
+
+  const expandedPanel = (
+    <div className='collapsible-panel'>
+      <div className='collapsible-panel-header-container' style={{ borderColor: colorBorderDividerDefault }}>
+        <Box>
+          <Box float={iconSide} padding={{ [iconSide]: 'xs', vertical: 'xs' }}>
+            <Button
+              iconName={iconName}
+              variant='icon'
+              onClick={props.onCollapsedPanelClick}
+              data-testid={`expanded-${props.side}-panel-button`}
+            />
+          </Box>
+          <Box float={iconSide} padding={{ [iconSide]: 'xs', vertical: 'xs' }}>
+            <Divider />
+          </Box>
+          <Box float={props.side}>
+            <Box variant='h4' padding='m'>
+              {props.headerText}
+            </Box>
+          </Box>
+        </Box>
+      </div>
+      {props.panelContent}
+    </div>
+  );
+
+  const collapsedPanel = (
     <div
-      data-testid={props.dataCy}
       style={{
         backgroundColor: colorBackgroundButtonPrimaryDefault,
         margin: spaceContainerHorizontal,
       }}
       className='side_panels_collapsed_style'
     >
-      <img src={props.icon} alt={props.icon} />
+      <img
+        src={props.icon}
+        alt={props.icon}
+        onClick={props.onCollapsedPanelClick}
+        data-testid={`collapsed-${props.side}-panel-icon`}
+      />
+    </div>
+  );
+
+  return (
+    <div
+      className={`collapsible-panel collapsible-panel-${props.side}`}
+      style={{
+        width: props.isPanelCollapsed ? `${DEFAULT_COLLAPSED_SIDE_PANE_WIDTH}px` : `${props.panelWidth}px`,
+        ...(props.isPanelCollapsed && {
+          [`border${borderSide}`]: `${spaceStaticXxxs} solid ${colorBorderDividerDefault}`,
+        }),
+      }}
+    >
+      {props.isPanelCollapsed ? collapsedPanel : expandedPanel}
     </div>
   );
 }

--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -52,3 +52,35 @@
   width: 40px;
   height: 40px;
 }
+
+.collapsible-panel-vertical-divider {
+  width: 2px;
+  height: 26px;
+  margin-top: 3px;
+}
+
+.collapsible-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.collapsible-panel-header-container {
+  border-bottom: 2px solid;
+}
+
+.collapsible-panel {
+  overflow: hidden;
+  position: relative;
+}
+
+.collapsible-panel-left,
+.collapsible-panel-right {
+  width: 15%;
+  min-width: 0;
+  height: 100%;
+  max-height: calc(100vh - var(--toolbar-overlay-height));
+  z-index: var(--stack-order-grid-inputs);
+  background-color: var(--colors-white);
+  overflow-y: auto;
+}

--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -8,9 +8,6 @@ import InternalDashboard from './index';
 import { configureDashboardStore } from '~/store';
 import { DashboardWidgetsConfiguration } from '~/types';
 import { initialState } from '~/store/state';
-import { CollapsiblePanel } from './collapsiblePanel';
-import PropertiesPanelIcon from '../resizablePanes/assets/propertiesPane.svg';
-import ResourceExplorerPanelIcon from '../resizablePanes/assets/resourceExplorer.svg';
 
 const EMPTY_DASHBOARD: DashboardWidgetsConfiguration = {
   widgets: [],
@@ -133,18 +130,4 @@ it('toggles to preview mode and hides the component library', function () {
   expect(screen.queryByText(/time machine/i)).toBeInTheDocument();
   expect(screen.queryByText(/actions/i)).toBeInTheDocument();
   expect(screen.queryByText(/component library/i)).not.toBeInTheDocument();
-});
-
-it(`should render collapsed pane with icon when right pane collapsed`, () => {
-  render(<CollapsiblePanel icon={PropertiesPanelIcon} dataCy='collapsed-right-panel-icon' />);
-
-  expect(screen.queryByText('Select widgets to configure.')).not.toBeInTheDocument();
-  expect(screen.getByTestId('collapsed-right-panel-icon')).toBeInTheDocument();
-});
-
-it('should render collapsed pane with icon when left pane collapsed', () => {
-  render(<CollapsiblePanel icon={ResourceExplorerPanelIcon} dataCy='collapsed-left-panel-icon' />);
-
-  expect(screen.getByTestId('collapsed-left-panel-icon')).toBeInTheDocument();
-  expect(screen.queryByText('Asset has no properties or child assets.')).not.toBeInTheDocument();
 });

--- a/packages/dashboard/src/components/resizablePanes/index.css
+++ b/packages/dashboard/src/components/resizablePanes/index.css
@@ -10,17 +10,6 @@
   position: relative;
 }
 
-.iot-resizable-panes-pane-left,
-.iot-resizable-panes-pane-right {
-  width: 15%;
-  min-width: 0;
-  height: 100%;
-  max-height: calc(100vh - var(--toolbar-overlay-height));
-  z-index: var(--stack-order-grid-inputs);
-  background-color: var(--colors-white);
-  overflow-y: auto;
-}
-
 .iot-resizable-panes-handle {
   background-color: var(--colors-light-grey);
   cursor: ew-resize;

--- a/packages/dashboard/src/components/resizablePanes/index.tsx
+++ b/packages/dashboard/src/components/resizablePanes/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import type { MouseEvent, FC, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
-import { colorBorderDividerDefault, spaceStaticXs, spaceStaticXxxs } from '@cloudscape-design/design-tokens';
+import { spaceStaticXs } from '@cloudscape-design/design-tokens';
 import { DashboardState } from '~/store/state';
 import {
   LEFT_WIDTH_PERCENT,
@@ -18,7 +18,6 @@ import {
 
 import './index.css';
 import { CollapsiblePanel } from '../internalDashboard/collapsiblePanel';
-import { useSelection } from '~/customization/propertiesSection';
 import resourceExplorerPanelIcon from './assets/resourceExplorer.svg';
 import PropertiesPanelIcon from './assets/propertiesPane.svg';
 
@@ -58,7 +57,6 @@ export const ResizablePanes: FC<ResizablePanesProps> = ({ leftPane, centerPane, 
   const selectedWidget = useSelector((state: DashboardState) => state.selectedWidgets);
   const [isRightPaneCollapsed, setRightPaneCollapsed] = useState(selectedWidget?.length === 0);
   const [isLeftPaneCollapsed, setLeftPaneCollapsed] = useState(selectedWidget?.length === 0);
-  const selection = useSelection();
 
   useEffect(() => {
     // On initial load, attempt to get stored widths from sessionStorage.
@@ -92,12 +90,6 @@ export const ResizablePanes: FC<ResizablePanesProps> = ({ leftPane, centerPane, 
       setRightPaneWidth(computedRightPaneWidthWithMinimums);
     }
   }, []);
-
-  // Collapse left and right panes when no widgets are selected
-  useEffect(() => {
-    setRightPaneCollapsed(selectedWidget?.length === 0);
-    setLeftPaneCollapsed(selectedWidget?.length === 0);
-  }, [selection == null]);
 
   /**
    * Drag handlers
@@ -218,19 +210,25 @@ export const ResizablePanes: FC<ResizablePanesProps> = ({ leftPane, centerPane, 
     setRightPaneWidth(nextRightPaneWidth);
   };
 
-  // expand right resourceexplorer pane when screen clicked collapsed left panel
+  // expand and collapse left pane
   const onLeftCollapsedPaneClick = () => {
     if (isLeftPaneCollapsed) {
       setLeftPaneWidth(DEFAULT_SIDE_PANE_WIDTH);
       setLeftPaneCollapsed(false);
+    } else {
+      setLeftPaneWidth(DEFAULT_COLLAPSED_SIDE_PANE_WIDTH);
+      setLeftPaneCollapsed(true);
     }
   };
 
-  // expand left properties pane when screen clicked collapsed right panel
+  // expand and collapse right pane
   const onRightCollapsedPaneClick = () => {
     if (isRightPaneCollapsed) {
       setRightPaneWidth(DEFAULT_SIDE_PANE_WIDTH);
       setRightPaneCollapsed(false);
+    } else {
+      setRightPaneWidth(DEFAULT_COLLAPSED_SIDE_PANE_WIDTH);
+      setRightPaneCollapsed(true);
     }
   };
 
@@ -252,20 +250,15 @@ export const ResizablePanes: FC<ResizablePanesProps> = ({ leftPane, centerPane, 
         } max-content`,
       }}
     >
-      <div
-        className='iot-resizable-panes-pane iot-resizable-panes-pane-left'
-        style={{
-          width: isLeftPaneCollapsed ? `${DEFAULT_COLLAPSED_SIDE_PANE_WIDTH}px` : `${leftPaneWidth}px`,
-          ...(isLeftPaneCollapsed && { borderRight: `${spaceStaticXxxs} solid ${colorBorderDividerDefault}` }),
-        }}
-        onClick={onLeftCollapsedPaneClick}
-      >
-        {isLeftPaneCollapsed ? (
-          <CollapsiblePanel icon={resourceExplorerPanelIcon} dataCy='collapsed-left-panel-icon' />
-        ) : (
-          leftPane
-        )}
-      </div>
+      <CollapsiblePanel
+        isPanelCollapsed={isLeftPaneCollapsed}
+        panelWidth={leftPaneWidth}
+        onCollapsedPanelClick={onLeftCollapsedPaneClick}
+        panelContent={leftPane}
+        icon={resourceExplorerPanelIcon}
+        side='left'
+        headerText='Resource explorer'
+      />
 
       <div
         className={!isLeftPaneCollapsed ? 'iot-resizable-panes-handle iot-resizable-panes-handle-left' : ''}
@@ -281,20 +274,15 @@ export const ResizablePanes: FC<ResizablePanesProps> = ({ leftPane, centerPane, 
         tabIndex={0}
       />
 
-      <div
-        className='iot-resizable-panes-pane iot-resizable-panes-pane-right'
-        style={{
-          width: isRightPaneCollapsed ? `${DEFAULT_COLLAPSED_SIDE_PANE_WIDTH}px` : `${rightPaneWidth}px`,
-          ...(isRightPaneCollapsed && { borderLeft: `${spaceStaticXxxs} solid ${colorBorderDividerDefault}` }),
-        }}
-        onClick={onRightCollapsedPaneClick}
-      >
-        {isRightPaneCollapsed ? (
-          <CollapsiblePanel icon={PropertiesPanelIcon} dataCy='collapsed-right-panel-icon' />
-        ) : (
-          rightPane
-        )}
-      </div>
+      <CollapsiblePanel
+        isPanelCollapsed={isRightPaneCollapsed}
+        panelWidth={rightPaneWidth}
+        onCollapsedPanelClick={onRightCollapsedPaneClick}
+        panelContent={rightPane}
+        icon={PropertiesPanelIcon}
+        side='right'
+        headerText='Configuration'
+      />
     </div>
   );
 };

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.css
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.css
@@ -1,9 +1,0 @@
-.properties-panel {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-.properties-panel-header-container {
-  border-bottom: 2px solid;
-}

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
@@ -117,7 +117,6 @@ describe(`${PropertiesPanel.name}`, () => {
   it('should render tabs', async () => {
     await renderTestComponentAsync();
 
-    expect(screen.getByText('Configuration')).toBeVisible();
     expect(screen.getByText('Style')).toBeVisible();
     expect(screen.getByText('Properties & Alarms')).toBeVisible();
     expect(screen.getByText('Thresholds')).toBeVisible();
@@ -126,7 +125,6 @@ describe(`${PropertiesPanel.name}`, () => {
   it('should render an empty selection when nothing is selected', async () => {
     await renderTestComponentAsync({ selectedWidgets: [] });
 
-    expect(screen.getByText('Configuration')).toBeVisible();
     expect(screen.getByText('Select widgets to configure.')).toBeVisible();
   });
 

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { colorBorderDividerDefault } from '@cloudscape-design/design-tokens';
-import Header from '@cloudscape-design/components/header';
 import Box from '@cloudscape-design/components/box';
 import Tabs from '@cloudscape-design/components/tabs';
 
@@ -10,7 +8,6 @@ import { useSelection } from '../../propertiesSection';
 import { PropertiesPanelEmpty } from './emptyPanel';
 import { StylesSection } from './styleTab';
 
-import './panel.css';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import { PropertiesAndAlarmsSettingsConfiguration } from '../propertiesAndAlarmsSettings';
 import { ThresholdSettingsConfiguration } from '../thresholdSettings';
@@ -19,47 +16,37 @@ import { ThresholdSettingsConfiguration } from '../thresholdSettings';
 export const PropertiesPanel = () => {
   const selection = useSelection();
 
-  return (
-    <div className='properties-panel'>
-      <div className='properties-panel-header-container' style={{ borderColor: colorBorderDividerDefault }}>
-        <Box padding='m'>
-          <Header variant='h3'>Configuration</Header>
-        </Box>
-      </div>
-
-      {selection ? (
-        <Box padding={{ horizontal: 'm', bottom: 'l' }}>
-          <Tabs
-            tabs={[
-              {
-                label: 'Style',
-                id: 'style',
-                content: <StylesSection />,
-              },
-              {
-                label: 'Properties & Alarms',
-                id: 'propertiesAndAlarms',
-                content: (
-                  <SpaceBetween size='xs' direction='vertical'>
-                    <PropertiesAndAlarmsSettingsConfiguration />
-                  </SpaceBetween>
-                ),
-              },
-              {
-                label: 'Thresholds',
-                id: 'thresholds',
-                content: (
-                  <SpaceBetween size='xs' direction='vertical'>
-                    <ThresholdSettingsConfiguration />
-                  </SpaceBetween>
-                ),
-              },
-            ]}
-          />
-        </Box>
-      ) : (
-        <PropertiesPanelEmpty />
-      )}
-    </div>
+  return selection ? (
+    <Box padding={{ horizontal: 'm', bottom: 'l' }}>
+      <Tabs
+        tabs={[
+          {
+            label: 'Style',
+            id: 'style',
+            content: <StylesSection />,
+          },
+          {
+            label: 'Properties & Alarms',
+            id: 'propertiesAndAlarms',
+            content: (
+              <SpaceBetween size='xs' direction='vertical'>
+                <PropertiesAndAlarmsSettingsConfiguration />
+              </SpaceBetween>
+            ),
+          },
+          {
+            label: 'Thresholds',
+            id: 'thresholds',
+            content: (
+              <SpaceBetween size='xs' direction='vertical'>
+                <ThresholdSettingsConfiguration />
+              </SpaceBetween>
+            ),
+          },
+        ]}
+      />
+    </Box>
+  ) : (
+    <PropertiesPanelEmpty />
   );
 };


### PR DESCRIPTION
## Overview
Updated the side panels to expand only when clicking the panel icon and collapse when clicking the arrow button. 

Stories:
* As a user, I can collapse the resource explorer and configuration panel by clicking the collapse arrow at the top of the panel.
* As a user, I don't want the panels to collapse and expand based on the selection state.

## Verifying Changes
Tested with storybook, see the video below.

https://github.com/awslabs/iot-app-kit/assets/87385528/416b4d21-64a7-47bd-b503-3c28001a90a8


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
