### PR TITLE
fix(composer): matterport tag sync tag style under flag

### DIFF
--- a/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
+++ b/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
@@ -4,11 +4,11 @@ import flushPromises from 'flush-promises';
 import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 
 import { generateUUID } from '../utils/mathUtils';
-import { IAnchorComponent, ISceneNode, KnownComponentType } from '../interfaces';
+import { COMPOSER_FEATURES, IAnchorComponent, ISceneNode, KnownComponentType } from '../interfaces';
 import { IDataOverlayComponentInternal, ISceneNodeInternal, useStore } from '../store';
 import { MattertagItem, TagItem } from '../utils/matterportTagUtils';
 import { Component } from '../models/SceneModels';
-import { setTwinMakerSceneMetadataModule } from '../common/GlobalSettings';
+import { setFeatureConfig, setTwinMakerSceneMetadataModule } from '../common/GlobalSettings';
 
 import useMatterportTags from './useMatterportTags';
 import useDynamicScene from './useDynamicScene';
@@ -116,6 +116,7 @@ ${mattertagItem.description}`,
       removeSceneNode,
     });
     jest.clearAllMocks();
+    setFeatureConfig({ [COMPOSER_FEATURES.TagStyle]: true });
   });
 
   it('should add matterport mattertag', () => {

--- a/packages/scene-composer/src/hooks/useMatterportTags.ts
+++ b/packages/scene-composer/src/hooks/useMatterportTags.ts
@@ -4,6 +4,7 @@ import { Color } from 'three';
 
 import { useSceneComposerId } from '../common/sceneComposerIdContext';
 import {
+  COMPOSER_FEATURES,
   DefaultAnchorStatus,
   IAnchorComponent,
   IDataOverlayComponent,
@@ -54,11 +55,17 @@ const addTag = async (
   id: string,
   item: MattertagItem | TagItem,
 ) => {
+  const tagStyleEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagStyle];
+
   const anchorComponent: IAnchorComponent = {
     type: KnownComponentType.Tag,
     offset: [item.stemVector.x, item.stemVector.y, item.stemVector.z],
-    icon: convertToIotTwinMakerNamespace(SceneResourceType.Icon, DefaultAnchorStatus.Custom),
-    chosenColor: '#' + new Color(item.color.r, item.color.g, item.color.b).getHexString('srgb'),
+    icon: tagStyleEnabled
+      ? convertToIotTwinMakerNamespace(SceneResourceType.Icon, DefaultAnchorStatus.Custom)
+      : undefined,
+    chosenColor: tagStyleEnabled
+      ? '#' + new Color(item.color.r, item.color.g, item.color.b).getHexString('srgb')
+      : undefined,
   };
   const dataoverlayComponent = getNewDataOverlayComponent(item);
   const nodeRef = generateUUID();
@@ -115,6 +122,8 @@ const updateTag = async (
   node: ISceneNodeInternal,
   item: MattertagItem | TagItem,
 ) => {
+  const tagStyleEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagStyle];
+
   // assume only one tag per node which is same assumption as findComponentByType
   const components = [...node.components];
   const tagIndex = node.components.findIndex((elem) => elem.type === KnownComponentType.Tag);
@@ -122,8 +131,12 @@ const updateTag = async (
     components[tagIndex] = {
       ...components[tagIndex],
       offset: [item.stemVector.x, item.stemVector.y, item.stemVector.z],
-      icon: convertToIotTwinMakerNamespace(SceneResourceType.Icon, DefaultAnchorStatus.Custom),
-      chosenColor: '#' + new Color(item.color.r, item.color.g, item.color.b).getHexString('srgb'),
+      icon: tagStyleEnabled
+        ? convertToIotTwinMakerNamespace(SceneResourceType.Icon, DefaultAnchorStatus.Custom)
+        : undefined,
+      chosenColor: tagStyleEnabled
+        ? '#' + new Color(item.color.r, item.color.g, item.color.b).getHexString('srgb')
+        : undefined,
     } as IAnchorComponentInternal;
   }
   const dataOverlayIndex = node.components.findIndex((elem) => elem.type === KnownComponentType.DataOverlay);


### PR DESCRIPTION
## Overview
sync tag style from matterport tag only when flag is on

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
