### PR TITLE
fix(composer): associate labels to input fields

### DIFF
--- a/packages/scene-composer/src/components/panels/CommonPanelComponents.tsx
+++ b/packages/scene-composer/src/components/panels/CommonPanelComponents.tsx
@@ -168,13 +168,16 @@ export function Matrix3XInputGrid<T>({
   }, [values, dirty, focus]);
 
   return (
-    <FormField label={name}>
+    <Box>
+      <Box margin={{ bottom: 'xxs' }}>
+        <label id={`${name}_label`}>{name}</label>
+      </Box>
       <Grid gridDefinition={[{ colspan: 4 }, { colspan: 4 }, { colspan: 4 }]}>
         {values.map((value, index) => (
           <MatrixCell key={index}>
             <MatrixLabel>
               <TextContent>
-                <p>{labels[index]}</p>
+                <label htmlFor={`${name}_input_${labels[index]}`}>{labels[index]}</label>
               </TextContent>
             </MatrixLabel>
             <MatrixCellInputWrapper>
@@ -192,13 +195,14 @@ export function Matrix3XInputGrid<T>({
                     setDirty(true);
                   }}
                   disabled={disabled && disabled[index]}
+                  ariaLabelledby={`${name}_input_${labels[index]} ${name}_label`}
                 ></Input>
               )}
             </MatrixCellInputWrapper>
           </MatrixCell>
         ))}
       </Grid>
-    </FormField>
+    </Box>
   );
 }
 

--- a/packages/scene-composer/src/components/panels/__tests__/__snapshots__/CommonPanelComponents.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__tests__/__snapshots__/CommonPanelComponents.spec.tsx.snap
@@ -219,9 +219,18 @@ exports[`render correct panels. render Matrix3XInputGrid correctly. 1`] = `
 
 <div>
   <div
-    data-mocked="FormField"
-    label="gridName"
+    data-mocked="Box"
   >
+    <div
+      data-mocked="Box"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+    >
+      <label
+        id="gridName_label"
+      >
+        gridName
+      </label>
+    </div>
     <div
       data-mocked="Grid"
       griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -235,15 +244,18 @@ exports[`render correct panels. render Matrix3XInputGrid correctly. 1`] = `
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l1"
+            >
               l1
-            </p>
+            </label>
           </div>
         </div>
         <div
           class="c2"
         >
           <div
+            arialabelledby="gridName_input_l1 gridName_label"
             controlid="gridName_input_l1"
             data-mocked="Input"
             value="1"
@@ -259,15 +271,18 @@ exports[`render correct panels. render Matrix3XInputGrid correctly. 1`] = `
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l2"
+            >
               l2
-            </p>
+            </label>
           </div>
         </div>
         <div
           class="c2"
         >
           <div
+            arialabelledby="gridName_input_l2 gridName_label"
             controlid="gridName_input_l2"
             data-mocked="Input"
             value="2"
@@ -283,15 +298,18 @@ exports[`render correct panels. render Matrix3XInputGrid correctly. 1`] = `
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l3"
+            >
               l3
-            </p>
+            </label>
           </div>
         </div>
         <div
           class="c2"
         >
           <div
+            arialabelledby="gridName_input_l3 gridName_label"
             controlid="gridName_input_l3"
             data-mocked="Input"
             value="3"
@@ -333,9 +351,18 @@ exports[`render correct panels. render Matrix3XInputGrid readonly correctly. 1`]
 
 <div>
   <div
-    data-mocked="FormField"
-    label="gridName"
+    data-mocked="Box"
   >
+    <div
+      data-mocked="Box"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+    >
+      <label
+        id="gridName_label"
+      >
+        gridName
+      </label>
+    </div>
     <div
       data-mocked="Grid"
       griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -349,9 +376,11 @@ exports[`render correct panels. render Matrix3XInputGrid readonly correctly. 1`]
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l1"
+            >
               l1
-            </p>
+            </label>
           </div>
         </div>
         <div
@@ -375,9 +404,11 @@ exports[`render correct panels. render Matrix3XInputGrid readonly correctly. 1`]
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l2"
+            >
               l2
-            </p>
+            </label>
           </div>
         </div>
         <div
@@ -401,9 +432,11 @@ exports[`render correct panels. render Matrix3XInputGrid readonly correctly. 1`]
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l3"
+            >
               l3
-            </p>
+            </label>
           </div>
         </div>
         <div

--- a/packages/scene-composer/src/components/panels/__tests__/__snapshots__/SceneNodeInspectorPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__tests__/__snapshots__/SceneNodeInspectorPanel.spec.tsx.snap
@@ -301,9 +301,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
           data-mocked="SpaceBetween"
         >
           <div
-            data-mocked="FormField"
-            label="Position"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Position_label"
+              >
+                Position
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -317,15 +326,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_X Position_label"
                     controlid="Position_input_X"
                     data-mocked="Input"
                     value="1.000"
@@ -341,15 +353,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Y Position_label"
                     controlid="Position_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -366,15 +381,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Z Position_label"
                     controlid="Position_input_Z"
                     data-mocked="Input"
                     value="1.000"
@@ -384,9 +402,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Rotation"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Rotation_label"
+              >
+                Rotation
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -400,15 +427,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_X Rotation_label"
                     controlid="Rotation_input_X"
                     data-mocked="Input"
                     value="0.000"
@@ -424,15 +454,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Y Rotation_label"
                     controlid="Rotation_input_Y"
                     data-mocked="Input"
                     value="0.000"
@@ -448,15 +481,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Z Rotation_label"
                     controlid="Rotation_input_Z"
                     data-mocked="Input"
                     value="0.000"
@@ -466,9 +502,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Scale"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Scale_label"
+              >
+                Scale
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -482,15 +527,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_X Scale_label"
                     controlid="Scale_input_X"
                     data-mocked="Input"
                     value="2.000"
@@ -506,15 +554,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Y Scale_label"
                     controlid="Scale_input_Y"
                     data-mocked="Input"
                     value="2.000"
@@ -530,15 +581,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Z Scale_label"
                     controlid="Scale_input_Z"
                     data-mocked="Input"
                     value="2.000"
@@ -722,9 +776,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
           data-mocked="SpaceBetween"
         >
           <div
-            data-mocked="FormField"
-            label="Position"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Position_label"
+              >
+                Position
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -738,15 +801,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_X Position_label"
                     controlid="Position_input_X"
                     data-mocked="Input"
                     value="1.000"
@@ -762,15 +828,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Y Position_label"
                     controlid="Position_input_Y"
                     data-mocked="Input"
                     value="1.000"
@@ -786,15 +855,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Z Position_label"
                     controlid="Position_input_Z"
                     data-mocked="Input"
                     value="1.000"
@@ -804,9 +876,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Rotation"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Rotation_label"
+              >
+                Rotation
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -820,15 +901,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_X Rotation_label"
                     controlid="Rotation_input_X"
                     data-mocked="Input"
                     disabled=""
@@ -845,15 +929,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Y Rotation_label"
                     controlid="Rotation_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -870,15 +957,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Z Rotation_label"
                     controlid="Rotation_input_Z"
                     data-mocked="Input"
                     disabled=""
@@ -1086,9 +1176,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
           data-mocked="SpaceBetween"
         >
           <div
-            data-mocked="FormField"
-            label="Position"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Position_label"
+              >
+                Position
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1102,15 +1201,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_X Position_label"
                     controlid="Position_input_X"
                     data-mocked="Input"
                     value="1.000"
@@ -1126,15 +1228,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Y Position_label"
                     controlid="Position_input_Y"
                     data-mocked="Input"
                     value="1.000"
@@ -1150,15 +1255,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Z Position_label"
                     controlid="Position_input_Z"
                     data-mocked="Input"
                     value="1.000"
@@ -1168,9 +1276,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Rotation"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Rotation_label"
+              >
+                Rotation
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1184,15 +1301,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_X Rotation_label"
                     controlid="Rotation_input_X"
                     data-mocked="Input"
                     disabled=""
@@ -1209,15 +1329,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Y Rotation_label"
                     controlid="Rotation_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -1234,15 +1357,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Z Rotation_label"
                     controlid="Rotation_input_Z"
                     data-mocked="Input"
                     disabled=""
@@ -1417,9 +1543,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
           data-mocked="SpaceBetween"
         >
           <div
-            data-mocked="FormField"
-            label="Position"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Position_label"
+              >
+                Position
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1433,15 +1568,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_X Position_label"
                     controlid="Position_input_X"
                     data-mocked="Input"
                     value="1.000"
@@ -1457,15 +1595,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Y Position_label"
                     controlid="Position_input_Y"
                     data-mocked="Input"
                     value="1.000"
@@ -1481,15 +1622,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Z Position_label"
                     controlid="Position_input_Z"
                     data-mocked="Input"
                     value="1.000"
@@ -1499,9 +1643,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Rotation"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Rotation_label"
+              >
+                Rotation
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1515,15 +1668,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_X Rotation_label"
                     controlid="Rotation_input_X"
                     data-mocked="Input"
                     disabled=""
@@ -1540,15 +1696,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Y Rotation_label"
                     controlid="Rotation_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -1565,15 +1724,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Z Rotation_label"
                     controlid="Rotation_input_Z"
                     data-mocked="Input"
                     disabled=""
@@ -1584,9 +1746,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Scale"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Scale_label"
+              >
+                Scale
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1600,15 +1771,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_X Scale_label"
                     controlid="Scale_input_X"
                     data-mocked="Input"
                     disabled=""
@@ -1625,15 +1799,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Y Scale_label"
                     controlid="Scale_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -1650,15 +1827,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Z Scale_label"
                     controlid="Scale_input_Z"
                     data-mocked="Input"
                     disabled=""
@@ -1833,9 +2013,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
           data-mocked="SpaceBetween"
         >
           <div
-            data-mocked="FormField"
-            label="Position"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Position_label"
+              >
+                Position
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1849,15 +2038,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_X Position_label"
                     controlid="Position_input_X"
                     data-mocked="Input"
                     value="1.000"
@@ -1873,15 +2065,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Y Position_label"
                     controlid="Position_input_Y"
                     data-mocked="Input"
                     value="1.000"
@@ -1897,15 +2092,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Z Position_label"
                     controlid="Position_input_Z"
                     data-mocked="Input"
                     value="1.000"
@@ -1915,9 +2113,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Rotation"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Rotation_label"
+              >
+                Rotation
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1931,15 +2138,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_X Rotation_label"
                     controlid="Rotation_input_X"
                     data-mocked="Input"
                     value="0.000"
@@ -1955,15 +2165,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Y Rotation_label"
                     controlid="Rotation_input_Y"
                     data-mocked="Input"
                     value="0.000"
@@ -1979,15 +2192,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Z Rotation_label"
                     controlid="Rotation_input_Z"
                     data-mocked="Input"
                     value="0.000"
@@ -1997,9 +2213,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Scale"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Scale_label"
+              >
+                Scale
+              </label>
+            </div>
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -2013,15 +2238,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_X"
+                    >
                       X
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_X Scale_label"
                     controlid="Scale_input_X"
                     data-mocked="Input"
                     value="2.000"
@@ -2037,15 +2265,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Y Scale_label"
                     controlid="Scale_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -2062,15 +2293,18 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Z Scale_label"
                     controlid="Scale_input_Z"
                     data-mocked="Input"
                     value="2.000"


### PR DESCRIPTION
## Overview
From AMP:
[Issue]
The text fields to enter co-ordinates for the following groups, do not have appropriate accessible labels. For example, when screen reader user is on the X coordinate field under 'Position', screen reader announces 'position' but not 'X'. 

[User Impact]
Screen reader users will have difficulty determining the purpose of these controls. Speech input users will have difficulty navigating to them.

Changes
- Removed FormField (Polaris team does not recommend multiple Inputs per FormField) and replaced it with a semantic label.
- Associated each Input with both the section label (ie. 'position') and its column label (ie. 'X')
- No visual changes, only semantic

## Revisions

SIM: https://sim.amazon.com/issues/IOT-CXT-6267

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
