### PR TITLE
fix(matterport): fix zoom to tag

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/EditorCamera.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EditorCamera.tsx
@@ -118,14 +118,20 @@ export const EditorMainCamera = forwardRef<Camera>((_, forwardedRef) => {
       });
     } else {
       log?.verbose('setting camera target by command', cameraCommand);
-      const object3d = cameraCommand?.target === 'string' ? getObject3DBySceneNodeRef(cameraCommand.target) : undefined;
-      setCameraTarget({
-        target: getCameraTargetByCommand(cameraCommand),
-        shouldTween: cameraCommand?.mode === 'transition',
-        object3d,
-      });
+      const object3d =
+        typeof cameraCommand?.target === 'string' ? getObject3DBySceneNodeRef(cameraCommand.target) : undefined;
+      if (matterportSdk && object3d) {
+        // Don't set target and instead let matterport internally calculate best viewing position based on the object3d
+        setCameraTarget({ object3d });
+      } else {
+        setCameraTarget({
+          target: getCameraTargetByCommand(cameraCommand),
+          shouldTween: cameraCommand?.mode === 'transition',
+          object3d,
+        });
+      }
     }
-  }, [cameraCommand, mounted]);
+  }, [cameraCommand, mounted, matterportSdk]);
 
   // execute camera command
   useEffect(() => {


### PR DESCRIPTION
## Overview
This address an known issue where a scene selection event sends an updated camera target to the Matterport Camera system and the camera moves to an unexpected location such as further away from tag selected.
To fix this we stop trying to send Matterport a desired camera location to look form and let Matterport calculate that internally instead. We only send Matterport's camera the target object location.

## Verifying Changes
Storybook to a matterport scene with known incorrect behavior.
position camera in scene in place that causes known issue
open scene hierarchy
select tag that causes known issue
observe that behavior is improved.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
