### PR TITLE
fix(composer): associate inputs to labels

### DIFF
--- a/packages/scene-composer/src/components/panels/CommonPanelComponents.tsx
+++ b/packages/scene-composer/src/components/panels/CommonPanelComponents.tsx
@@ -168,13 +168,16 @@ export function Matrix3XInputGrid<T>({
   }, [values, dirty, focus]);
 
   return (
-    <FormField label={name}>
+    <Box>
+      <Box margin={{ bottom: 'xxs' }}>
+        <label id={`${name}_label`}>{name}</label>
+      </Box>{' '}
       <Grid gridDefinition={[{ colspan: 4 }, { colspan: 4 }, { colspan: 4 }]}>
         {values.map((value, index) => (
           <MatrixCell key={index}>
             <MatrixLabel>
               <TextContent>
-                <p>{labels[index]}</p>
+                <label htmlFor={`${name}_input_${labels[index]}`}>{labels[index]}</label>{' '}
               </TextContent>
             </MatrixLabel>
             <MatrixCellInputWrapper>
@@ -192,13 +195,14 @@ export function Matrix3XInputGrid<T>({
                     setDirty(true);
                   }}
                   disabled={disabled && disabled[index]}
+                  ariaLabelledby={`${name}_input_${labels[index]} ${name}_label`}
                 ></Input>
               )}
             </MatrixCellInputWrapper>
           </MatrixCell>
         ))}
       </Grid>
-    </FormField>
+    </Box>
   );
 }
 

--- a/packages/scene-composer/src/components/panels/__tests__/__snapshots__/CommonPanelComponents.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__tests__/__snapshots__/CommonPanelComponents.spec.tsx.snap
@@ -219,9 +219,19 @@ exports[`render correct panels. render Matrix3XInputGrid correctly. 1`] = `
 
 <div>
   <div
-    data-mocked="FormField"
-    label="gridName"
+    data-mocked="Box"
   >
+    <div
+      data-mocked="Box"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+    >
+      <label
+        id="gridName_label"
+      >
+        gridName
+      </label>
+    </div>
+     
     <div
       data-mocked="Grid"
       griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -235,15 +245,19 @@ exports[`render correct panels. render Matrix3XInputGrid correctly. 1`] = `
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l1"
+            >
               l1
-            </p>
+            </label>
+             
           </div>
         </div>
         <div
           class="c2"
         >
           <div
+            arialabelledby="gridName_input_l1 gridName_label"
             controlid="gridName_input_l1"
             data-mocked="Input"
             value="1"
@@ -259,15 +273,19 @@ exports[`render correct panels. render Matrix3XInputGrid correctly. 1`] = `
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l2"
+            >
               l2
-            </p>
+            </label>
+             
           </div>
         </div>
         <div
           class="c2"
         >
           <div
+            arialabelledby="gridName_input_l2 gridName_label"
             controlid="gridName_input_l2"
             data-mocked="Input"
             value="2"
@@ -283,15 +301,19 @@ exports[`render correct panels. render Matrix3XInputGrid correctly. 1`] = `
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l3"
+            >
               l3
-            </p>
+            </label>
+             
           </div>
         </div>
         <div
           class="c2"
         >
           <div
+            arialabelledby="gridName_input_l3 gridName_label"
             controlid="gridName_input_l3"
             data-mocked="Input"
             value="3"
@@ -333,9 +355,19 @@ exports[`render correct panels. render Matrix3XInputGrid readonly correctly. 1`]
 
 <div>
   <div
-    data-mocked="FormField"
-    label="gridName"
+    data-mocked="Box"
   >
+    <div
+      data-mocked="Box"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+    >
+      <label
+        id="gridName_label"
+      >
+        gridName
+      </label>
+    </div>
+     
     <div
       data-mocked="Grid"
       griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -349,9 +381,12 @@ exports[`render correct panels. render Matrix3XInputGrid readonly correctly. 1`]
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l1"
+            >
               l1
-            </p>
+            </label>
+             
           </div>
         </div>
         <div
@@ -375,9 +410,12 @@ exports[`render correct panels. render Matrix3XInputGrid readonly correctly. 1`]
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l2"
+            >
               l2
-            </p>
+            </label>
+             
           </div>
         </div>
         <div
@@ -401,9 +439,12 @@ exports[`render correct panels. render Matrix3XInputGrid readonly correctly. 1`]
           <div
             data-mocked="TextContent"
           >
-            <p>
+            <label
+              for="gridName_input_l3"
+            >
               l3
-            </p>
+            </label>
+             
           </div>
         </div>
         <div

--- a/packages/scene-composer/src/components/panels/__tests__/__snapshots__/SceneNodeInspectorPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__tests__/__snapshots__/SceneNodeInspectorPanel.spec.tsx.snap
@@ -301,9 +301,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
           data-mocked="SpaceBetween"
         >
           <div
-            data-mocked="FormField"
-            label="Position"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Position_label"
+              >
+                Position
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -317,15 +327,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_X Position_label"
                     controlid="Position_input_X"
                     data-mocked="Input"
                     value="1.000"
@@ -341,15 +355,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Y Position_label"
                     controlid="Position_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -366,15 +384,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Z Position_label"
                     controlid="Position_input_Z"
                     data-mocked="Input"
                     value="1.000"
@@ -384,9 +406,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Rotation"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Rotation_label"
+              >
+                Rotation
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -400,15 +432,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_X Rotation_label"
                     controlid="Rotation_input_X"
                     data-mocked="Input"
                     value="0.000"
@@ -424,15 +460,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Y Rotation_label"
                     controlid="Rotation_input_Y"
                     data-mocked="Input"
                     value="0.000"
@@ -448,15 +488,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Z Rotation_label"
                     controlid="Rotation_input_Z"
                     data-mocked="Input"
                     value="0.000"
@@ -466,9 +510,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Scale"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Scale_label"
+              >
+                Scale
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -482,15 +536,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_X Scale_label"
                     controlid="Scale_input_X"
                     data-mocked="Input"
                     value="2.000"
@@ -506,15 +564,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Y Scale_label"
                     controlid="Scale_input_Y"
                     data-mocked="Input"
                     value="2.000"
@@ -530,15 +592,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. SceneNode panel cont
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Z Scale_label"
                     controlid="Scale_input_Z"
                     data-mocked="Input"
                     value="2.000"
@@ -722,9 +788,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
           data-mocked="SpaceBetween"
         >
           <div
-            data-mocked="FormField"
-            label="Position"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Position_label"
+              >
+                Position
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -738,15 +814,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_X Position_label"
                     controlid="Position_input_X"
                     data-mocked="Input"
                     value="1.000"
@@ -762,15 +842,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Y Position_label"
                     controlid="Position_input_Y"
                     data-mocked="Input"
                     value="1.000"
@@ -786,15 +870,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Z Position_label"
                     controlid="Position_input_Z"
                     data-mocked="Input"
                     value="1.000"
@@ -804,9 +892,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Rotation"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Rotation_label"
+              >
+                Rotation
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -820,15 +918,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_X Rotation_label"
                     controlid="Rotation_input_X"
                     data-mocked="Input"
                     disabled=""
@@ -845,15 +947,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Y Rotation_label"
                     controlid="Rotation_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -870,15 +976,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Z Rotation_label"
                     controlid="Rotation_input_Z"
                     data-mocked="Input"
                     disabled=""
@@ -1086,9 +1196,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
           data-mocked="SpaceBetween"
         >
           <div
-            data-mocked="FormField"
-            label="Position"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Position_label"
+              >
+                Position
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1102,15 +1222,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_X Position_label"
                     controlid="Position_input_X"
                     data-mocked="Input"
                     value="1.000"
@@ -1126,15 +1250,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Y Position_label"
                     controlid="Position_input_Y"
                     data-mocked="Input"
                     value="1.000"
@@ -1150,15 +1278,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Z Position_label"
                     controlid="Position_input_Z"
                     data-mocked="Input"
                     value="1.000"
@@ -1168,9 +1300,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Rotation"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Rotation_label"
+              >
+                Rotation
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1184,15 +1326,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_X Rotation_label"
                     controlid="Rotation_input_X"
                     data-mocked="Input"
                     disabled=""
@@ -1209,15 +1355,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Y Rotation_label"
                     controlid="Rotation_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -1234,15 +1384,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable rotation, hi
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Z Rotation_label"
                     controlid="Rotation_input_Z"
                     data-mocked="Input"
                     disabled=""
@@ -1417,9 +1571,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
           data-mocked="SpaceBetween"
         >
           <div
-            data-mocked="FormField"
-            label="Position"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Position_label"
+              >
+                Position
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1433,15 +1597,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_X Position_label"
                     controlid="Position_input_X"
                     data-mocked="Input"
                     value="1.000"
@@ -1457,15 +1625,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Y Position_label"
                     controlid="Position_input_Y"
                     data-mocked="Input"
                     value="1.000"
@@ -1481,15 +1653,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Z Position_label"
                     controlid="Position_input_Z"
                     data-mocked="Input"
                     value="1.000"
@@ -1499,9 +1675,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Rotation"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Rotation_label"
+              >
+                Rotation
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1515,15 +1701,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_X Rotation_label"
                     controlid="Rotation_input_X"
                     data-mocked="Input"
                     disabled=""
@@ -1540,15 +1730,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Y Rotation_label"
                     controlid="Rotation_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -1565,15 +1759,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Z Rotation_label"
                     controlid="Rotation_input_Z"
                     data-mocked="Input"
                     disabled=""
@@ -1584,9 +1782,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Scale"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Scale_label"
+              >
+                Scale
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1600,15 +1808,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_X Scale_label"
                     controlid="Scale_input_X"
                     data-mocked="Input"
                     disabled=""
@@ -1625,15 +1837,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Y Scale_label"
                     controlid="Scale_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -1650,15 +1866,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable scale and ro
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Z Scale_label"
                     controlid="Scale_input_Z"
                     data-mocked="Input"
                     disabled=""
@@ -1833,9 +2053,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
           data-mocked="SpaceBetween"
         >
           <div
-            data-mocked="FormField"
-            label="Position"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Position_label"
+              >
+                Position
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1849,15 +2079,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_X Position_label"
                     controlid="Position_input_X"
                     data-mocked="Input"
                     value="1.000"
@@ -1873,15 +2107,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Y Position_label"
                     controlid="Position_input_Y"
                     data-mocked="Input"
                     value="1.000"
@@ -1897,15 +2135,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Position_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Position_input_Z Position_label"
                     controlid="Position_input_Z"
                     data-mocked="Input"
                     value="1.000"
@@ -1915,9 +2157,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Rotation"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Rotation_label"
+              >
+                Rotation
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -1931,15 +2183,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_X Rotation_label"
                     controlid="Rotation_input_X"
                     data-mocked="Input"
                     value="0.000"
@@ -1955,15 +2211,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Y Rotation_label"
                     controlid="Rotation_input_Y"
                     data-mocked="Input"
                     value="0.000"
@@ -1979,15 +2239,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Rotation_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Rotation_input_Z Rotation_label"
                     controlid="Rotation_input_Z"
                     data-mocked="Input"
                     value="0.000"
@@ -1997,9 +2261,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
             </div>
           </div>
           <div
-            data-mocked="FormField"
-            label="Scale"
+            data-mocked="Box"
           >
+            <div
+              data-mocked="Box"
+              margin="{\\"bottom\\":\\"xxs\\"}"
+            >
+              <label
+                id="Scale_label"
+              >
+                Scale
+              </label>
+            </div>
+             
             <div
               data-mocked="Grid"
               griddefinition="[{\\"colspan\\":4},{\\"colspan\\":4},{\\"colspan\\":4}]"
@@ -2013,15 +2287,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_X"
+                    >
                       X
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_X Scale_label"
                     controlid="Scale_input_X"
                     data-mocked="Input"
                     value="2.000"
@@ -2037,15 +2315,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Y"
+                    >
                       Y
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Y Scale_label"
                     controlid="Scale_input_Y"
                     data-mocked="Input"
                     disabled=""
@@ -2062,15 +2344,19 @@ exports[`SceneNodeInspectorPanel returns expected elements. disable y scale when
                   <div
                     data-mocked="TextContent"
                   >
-                    <p>
+                    <label
+                      for="Scale_input_Z"
+                    >
                       Z
-                    </p>
+                    </label>
+                     
                   </div>
                 </div>
                 <div
                   class="c4"
                 >
                   <div
+                    arialabelledby="Scale_input_Z Scale_label"
                     controlid="Scale_input_Z"
                     data-mocked="Input"
                     value="2.000"


### PR DESCRIPTION
## Overview
The 3x3 matrix grid in the scene node inspector panel was not organized semantically correct. This made navigating it with a screen reader an impossible task.

Changes:
- Removed the FormField that wrapped around each row, Polaris recommends only one Input per FormField
- Programmatically associate each Input with a both appropriate labels ie. 'Position X' or 'Rotation Z'

Visual Changes:
Should be none
Pic 1: Before changes
<img width="416" alt="Before labeling" src="https://github.com/awslabs/iot-app-kit/assets/143754227/24437883-bc16-4592-bd38-a8d838009cba">

Pic 2: After changes
<img width="416" alt="After labeling" src="https://github.com/awslabs/iot-app-kit/assets/143754227/78d49525-02aa-4a4a-b625-efc1ecb72dcc">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
