### PR TITLE
feat: remove drag icon in chat widget

### DIFF
--- a/packages/dashboard/src/components/widgets/tile/tile.css
+++ b/packages/dashboard/src/components/widgets/tile/tile.css
@@ -10,12 +10,6 @@
   flex: 1;
 }
 
-.widget-tile-resize-handle {
-  position: absolute;
-  bottom: 0;
-  right: 4px;
-}
-
 .horizontal-divider {
   width: 100%;
   height: 2px;

--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import Box from '@cloudscape-design/components/box';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import Button from '@cloudscape-design/components/button';
-import Icon from '@cloudscape-design/components/icon';
 import {
   colorBorderDividerDefault,
   borderRadiusBadge,
@@ -50,7 +49,6 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
   const isReadOnly = useSelector((state: DashboardState) => state.readOnly);
 
   const isRemoveable = !isReadOnly && removeable;
-  const isResizable = !isReadOnly;
   const headerVisible = !isReadOnly || title;
 
   return (
@@ -81,14 +79,7 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
           </SpaceBetween>
         </div>
       )}
-      <div className='widget-tile-body'>
-        {children}
-        {isResizable && (
-          <div className='widget-tile-resize-handle'>
-            <Icon variant='disabled' name='resize-area' />
-          </div>
-        )}
-      </div>
+      <div className='widget-tile-body'>{children}</div>
     </div>
   );
 };


### PR DESCRIPTION
## Overview
This CR is for the below ticket
https://github.com/awslabs/iot-app-kit/issues/1923

Removed the resize-area icon and related styles

![image](https://github.com/awslabs/iot-app-kit/assets/139960352/3d62b23b-f27e-4f0f-b621-bedcbcd4014c)
 
