### PR TITLE
fix(composer): create existing matterport tag as entities

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -77,11 +77,9 @@ jobs:
         with:
           package: './packages/scene-composer/package.json'
           token: ${{ secrets.NPM_TOKEN }}
-          tag: 'alpha'
 
       - name: Publish @iot-app-kit/tools-iottwinmaker
         uses: JS-DevTools/npm-publish@v2
         with:
           package: './packages/tools-iottwinmaker/package.json'
           token: ${{ secrets.NPM_TOKEN }}
-          tag: 'alpha'

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -46,7 +46,7 @@
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --index-template tools/index-template.js -- src/assets/icons/",
     "release": "run-s compile copy-assets",
     "copy-assets": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" dist/",
-    "lint": "eslint . --max-warnings=625",
+    "lint": "eslint . --max-warnings=585",
     "fix": "eslint --fix .",
     "test": "jest --config jest.config.ts --coverage --silent",
     "test:dev": "jest --config jest.config.ts --coverage",

--- a/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.spec.tsx
@@ -168,8 +168,8 @@ describe('MatterportTagSync', () => {
     });
 
     expect(getComponentRefByTypeMock).toBeCalled();
-    expect(handleAddMatterportTagMock).toBeCalledWith(undefined, undefined, 'id3', matterTag3);
-    expect(handleUpdateMatterportTagMock).toBeCalledWith(undefined, 'ref2', node2, matterTag2);
+    expect(handleAddMatterportTagMock).toBeCalledWith({ id: 'id3', item: matterTag3 });
+    expect(handleUpdateMatterportTagMock).toBeCalledWith({ ref: 'ref2', node: node2, item: matterTag2 });
     expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
   });
 
@@ -217,8 +217,8 @@ describe('MatterportTagSync', () => {
     });
 
     expect(getComponentRefByTypeMock).toBeCalled();
-    expect(handleAddMatterportTagMock).toBeCalledWith(undefined, undefined, 'id3', tag2);
-    expect(handleUpdateMatterportTagMock).toBeCalledWith(undefined, 'ref2', node2, tag3);
+    expect(handleAddMatterportTagMock).toBeCalledWith({ id: 'id3', item: tag2 });
+    expect(handleUpdateMatterportTagMock).toBeCalledWith({ ref: 'ref2', node: node2, item: tag3 });
     expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
   });
 
@@ -337,8 +337,19 @@ describe('MatterportTagSync', () => {
       });
 
       expect(getComponentRefByTypeMock).toBeCalled();
-      expect(handleAddMatterportTagMock).toBeCalledWith('layer-id', 'scene-root-id', 'id3', matterTag3);
-      expect(handleUpdateMatterportTagMock).toBeCalledWith('layer-id', 'ref2', node2, matterTag2);
+      expect(handleAddMatterportTagMock).toBeCalledWith({
+        layerId: 'layer-id',
+        sceneRootId: 'scene-root-id',
+        id: 'id3',
+        item: matterTag3,
+      });
+      expect(handleUpdateMatterportTagMock).toBeCalledWith({
+        layerId: 'layer-id',
+        sceneRootId: 'scene-root-id',
+        ref: 'ref2',
+        node: node2,
+        item: matterTag2,
+      });
       expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
     });
 
@@ -386,8 +397,19 @@ describe('MatterportTagSync', () => {
       });
 
       expect(getComponentRefByTypeMock).toBeCalled();
-      expect(handleAddMatterportTagMock).toBeCalledWith('layer-id', 'scene-root-id', 'id3', tag2);
-      expect(handleUpdateMatterportTagMock).toBeCalledWith('layer-id', 'ref2', node2, tag3);
+      expect(handleAddMatterportTagMock).toBeCalledWith({
+        layerId: 'layer-id',
+        sceneRootId: 'scene-root-id',
+        id: 'id3',
+        item: tag2,
+      });
+      expect(handleUpdateMatterportTagMock).toBeCalledWith({
+        layerId: 'layer-id',
+        sceneRootId: 'scene-root-id',
+        ref: 'ref2',
+        node: node2,
+        item: tag3,
+      });
       expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
     });
   });

--- a/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.tsx
@@ -83,9 +83,15 @@ export const MatterportTagSync: React.FC = () => {
     if (tags) {
       for (const [key, value] of tags) {
         if (oldTagMap[key]) {
-          await handleUpdateMatterportTag(layerId, oldTagMap[key].nodeRef, oldTagMap[key].node, value);
+          await handleUpdateMatterportTag({
+            layerId,
+            sceneRootId: rootId,
+            ref: oldTagMap[key].nodeRef,
+            node: oldTagMap[key].node,
+            item: value,
+          });
         } else {
-          await handleAddMatterportTag(layerId, rootId, key, value);
+          await handleAddMatterportTag({ layerId, sceneRootId: rootId, id: key, item: value });
         }
         delete oldTagMap[key];
       }
@@ -102,9 +108,15 @@ export const MatterportTagSync: React.FC = () => {
         }
 
         if (oldTagMap[key]) {
-          await handleUpdateMatterportTag(layerId, oldTagMap[key].nodeRef, oldTagMap[key].node, value);
+          await handleUpdateMatterportTag({
+            layerId,
+            sceneRootId: rootId,
+            ref: oldTagMap[key].nodeRef,
+            node: oldTagMap[key].node,
+            item: value,
+          });
         } else {
-          await handleAddMatterportTag(layerId, rootId, key, value);
+          await handleAddMatterportTag({ layerId, sceneRootId: rootId, id: key, item: value });
         }
         delete oldTagMap[key];
       }

--- a/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
+++ b/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
@@ -123,21 +123,21 @@ ${mattertagItem.description}`,
   it('should add matterport mattertag', () => {
     const { handleAddMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
-    handleAddMatterportTag('', '', id, mattertagItem);
+    handleAddMatterportTag({ id, item: mattertagItem });
     expect(appendSceneNode).toBeCalledWith(testNode);
   });
 
   it('should add matterport tag', () => {
     const { handleAddMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
-    handleAddMatterportTag('', '', id, tagItem);
+    handleAddMatterportTag({ id, item: tagItem });
     expect(appendSceneNode).toBeCalledWith(testNode);
   });
 
   it('should update matterport mattertag', () => {
     const { handleUpdateMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
-    handleUpdateMatterportTag('', '', testInternalNode, mattertagItem);
+    handleUpdateMatterportTag({ ref: '', node: testInternalNode, item: mattertagItem });
     expect(updateSceneNodeInternal).toBeCalledWith('', {
       name: mattertagItem.label,
       transform: {
@@ -160,13 +160,14 @@ ${mattertagItem.description}`,
           ],
         },
       ],
+      properties: { [SceneNodeRuntimeProperty.LayerIds]: undefined },
     });
   });
 
   it('should update matterport tag', () => {
     const { handleUpdateMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
-    handleUpdateMatterportTag('', '', testInternalNode, tagItem);
+    handleUpdateMatterportTag({ ref: '', node: testInternalNode, item: tagItem });
     expect(updateSceneNodeInternal).toBeCalledWith('', {
       name: tagItem.label,
       transform: {
@@ -189,6 +190,7 @@ ${mattertagItem.description}`,
           ],
         },
       ],
+      properties: { [SceneNodeRuntimeProperty.LayerIds]: undefined },
     });
   });
 
@@ -209,6 +211,14 @@ ${mattertagItem.description}`,
       deleteSceneEntity,
     };
 
+    const testInternalNodeWithLayerId: ISceneNodeInternal = {
+      ...testInternalNode,
+      properties: {
+        ...testInternalNode.properties,
+        [SceneNodeRuntimeProperty.LayerIds]: ['layer-id'],
+      },
+    };
+
     beforeEach(() => {
       jest.clearAllMocks();
 
@@ -225,7 +235,7 @@ ${mattertagItem.description}`,
     it('should add matterport mattertag', async () => {
       const { handleAddMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
-      await handleAddMatterportTag('layer-id', 'scene-root-id', id, mattertagItem);
+      await handleAddMatterportTag({ layerId: 'layer-id', sceneRootId: 'scene-root-id', id, item: mattertagItem });
       expect(appendSceneNode).toBeCalledTimes(1);
       expect(appendSceneNode).toBeCalledWith({
         ...testNode,
@@ -251,7 +261,7 @@ ${mattertagItem.description}`,
     it('should add matterport tag', async () => {
       const { handleAddMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
-      await handleAddMatterportTag('layer-id', 'scene-root-id', id, tagItem);
+      await handleAddMatterportTag({ layerId: 'layer-id', sceneRootId: 'scene-root-id', id, item: tagItem });
       expect(appendSceneNode).toBeCalledTimes(1);
       expect(createSceneEntity).toBeCalledTimes(1);
       expect(createSceneEntity).toBeCalledWith({
@@ -270,7 +280,13 @@ ${mattertagItem.description}`,
     it('should update matterport mattertag', async () => {
       const { handleUpdateMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
-      await handleUpdateMatterportTag('layer-id', generateUUID(), testInternalNode, mattertagItem);
+      await handleUpdateMatterportTag({
+        layerId: 'layer-id',
+        sceneRootId: 'scene-root',
+        ref: generateUUID(),
+        node: testInternalNodeWithLayerId,
+        item: mattertagItem,
+      });
       expect(updateSceneNodeInternal).toBeCalledTimes(1);
       expect(updateSceneEntity).toBeCalledTimes(1);
       expect(updateSceneEntity).toBeCalledWith({
@@ -287,7 +303,13 @@ ${mattertagItem.description}`,
     it('should update matterport tag', async () => {
       const { handleUpdateMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
-      await handleUpdateMatterportTag('layer-id', generateUUID(), testInternalNode, tagItem);
+      await handleUpdateMatterportTag({
+        layerId: 'layer-id',
+        sceneRootId: 'scene-root',
+        ref: generateUUID(),
+        node: testInternalNodeWithLayerId,
+        item: tagItem,
+      });
       expect(updateSceneNodeInternal).toBeCalledTimes(1);
       expect(updateSceneEntity).toBeCalledTimes(1);
       expect(updateSceneEntity).toBeCalledWith({
@@ -297,6 +319,31 @@ ${mattertagItem.description}`,
         componentUpdates: {
           Node: expect.anything(),
           [KnownComponentType.Tag]: expect.anything(),
+        },
+      });
+    });
+
+    it('should create matterport tag when existing tag is not linked to a layer', async () => {
+      const { handleUpdateMatterportTag } = renderHook(() => useMatterportTags()).result.current;
+
+      await handleUpdateMatterportTag({
+        layerId: 'layer-id',
+        sceneRootId: 'scene-root',
+        ref: generateUUID(),
+        node: testInternalNode,
+        item: tagItem,
+      });
+      expect(updateSceneNodeInternal).toBeCalledTimes(1);
+      expect(updateSceneEntity).not.toBeCalled();
+      expect(createSceneEntity).toBeCalledTimes(1);
+      expect(createSceneEntity).toBeCalledWith({
+        workspaceId: undefined,
+        entityId: generateUUID(),
+        entityName: tagItem.label + '_' + generateUUID(),
+        parentEntityId: 'scene-root',
+        components: {
+          [KnownComponentType.Tag]: expect.anything(),
+          Node: expect.anything(),
         },
       });
     });


### PR DESCRIPTION
## Overview
For existing matterport scenes that has already synced tags into scene json file, create them as entities when dynamic scene is enabled and the sync button is clicked 

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
