### PR TITLE
feat: preferences for pagination in table widget

### DIFF
--- a/packages/dashboard/src/customization/widgets/table/table-config.tsx
+++ b/packages/dashboard/src/customization/widgets/table/table-config.tsx
@@ -1,3 +1,19 @@
 export const DEFAULT_PREFERENCES = {
   pageSize: 20,
 };
+
+export const pageSizePreference = {
+  title: 'Select page size',
+  options: [
+    { value: 10, label: '10 resources' },
+    { value: 20, label: '20 resources' },
+    { value: 30, label: '30 resources' },
+  ],
+};
+
+export const collectionPreferencesProps = {
+  pageSizePreference,
+  cancelLabel: 'Cancel',
+  confirmLabel: 'Confirm',
+  title: 'Preferences',
+};

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -159,6 +159,7 @@ export type TableProperties = QueryProperties & {
   items?: TableItem[];
   columnDefinitions?: TableColumnDefinition[];
   significantDigits?: number;
+  pageSize?: number;
 };
 export type TablePropertiesKeys = keyof TableProperties;
 

--- a/packages/react-components/src/components/table/table.tsx
+++ b/packages/react-components/src/components/table/table.tsx
@@ -36,7 +36,7 @@ export const Table = ({
   significantDigits?: number;
   paginationEnabled?: boolean;
   pageSize?: number;
-} & Pick<TableBaseProps, 'resizableColumns' | 'sortingDisabled' | 'stickyHeader' | 'empty'>) => {
+} & Pick<TableBaseProps, 'resizableColumns' | 'sortingDisabled' | 'stickyHeader' | 'empty' | 'preferences'>) => {
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
     queries,


### PR DESCRIPTION
## Overview
adding the preferences for pagination to the table widget ( #1890 ) and it includes

1. preferences is available only in edit mode and not visible in preview mode
2. preferences will persist in preview mode which are applied in edit mode
3. preferences have 3 options (10, 20, 30)


## Verifying Changes
refer to the screen capture
![image](https://github.com/awslabs/iot-app-kit/assets/142866907/526460bd-a430-4007-b3b3-382da66bd2c8)



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
