### PR TITLE
fix(composer): create default entity roots

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -46,7 +46,7 @@
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --index-template tools/index-template.js -- src/assets/icons/",
     "release": "run-s compile copy-assets",
     "copy-assets": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" dist/",
-    "lint": "eslint . --max-warnings=585",
+    "lint": "eslint . --max-warnings=575",
     "fix": "eslint --fix .",
     "test": "jest --config jest.config.ts --coverage --silent",
     "test:dev": "jest --config jest.config.ts --coverage",

--- a/packages/scene-composer/src/common/entityModelConstants.ts
+++ b/packages/scene-composer/src/common/entityModelConstants.ts
@@ -20,6 +20,7 @@ export const DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME = 'isVisualOf';
 export const DEFAULT_PARENT_RELATIONSHIP_NAME = 'isChildOf';
 export const DEFAULT_NODE_COMPONENT_NAME = 'Node';
 export const SCENE_ROOT_ENTITY_ID = 'SCENES_EntityId';
+export const SCENE_ROOT_ENTITY_NAME = '$SCENES';
 
 // Matterport
 export const MATTERPORT_TAG_LAYER_PREFIX = 'Matterport_Tag_';
@@ -28,6 +29,7 @@ export const MATTERPORT_TAG_LAYER_PREFIX = 'Matterport_Tag_';
 export const DEFAULT_LAYER_RELATIONSHIP_NAME = 'inLayerOf';
 export const DEFAULT_LAYER_COMPONENT_NAME = 'Layer';
 export const LAYER_ROOT_ENTITY_ID = 'LAYERS_EntityId';
+export const LAYER_ROOT_ENTITY_NAME = '$LAYERS';
 export enum LayerType {
   Relationship = 'Relationship',
   Query = 'Query',

--- a/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import { MpSdk } from '@matterport/r3f/dist';
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 
 import { ISceneNodeInternal, useStore } from '../../../store';
 import { MattertagItem, TagItem } from '../../../utils/matterportTagUtils';
@@ -8,7 +9,12 @@ import useDynamicScene from '../../../hooks/useDynamicScene';
 import { KnownSceneProperty } from '../../../interfaces';
 import { createLayer } from '../../../utils/entityModelUtils/sceneLayerUtils';
 import { LayerType, MATTERPORT_TAG_LAYER_PREFIX } from '../../../common/entityModelConstants';
-import { createSceneRootEntity } from '../../../utils/entityModelUtils/sceneUtils';
+import {
+  checkIfEntityAvailable,
+  createSceneRootEntity,
+  prepareWorkspace,
+} from '../../../utils/entityModelUtils/sceneUtils';
+import { setTwinMakerSceneMetadataModule } from '../../../common/GlobalSettings';
 
 import { MatterportTagSync } from './MatterportTagSync';
 
@@ -42,6 +48,8 @@ jest.mock('../../../utils/entityModelUtils/sceneLayerUtils', () => ({
 }));
 jest.mock('../../../utils/entityModelUtils/sceneUtils', () => ({
   createSceneRootEntity: jest.fn(),
+  prepareWorkspace: jest.fn(),
+  checkIfEntityAvailable: jest.fn(),
 }));
 
 describe('MatterportTagSync', () => {
@@ -244,6 +252,21 @@ describe('MatterportTagSync', () => {
           return undefined;
         }
       });
+
+      (checkIfEntityAvailable as jest.Mock).mockReturnValue(true);
+
+      setTwinMakerSceneMetadataModule({} as TwinMakerSceneMetadataModule);
+    });
+
+    it('should call prepareWorkspace', async () => {
+      useStore('default').setState(baseState);
+      const rendered = render(<MatterportTagSync />);
+
+      await act(async () => {
+        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+      });
+
+      expect(prepareWorkspace as jest.Mock).toBeCalledTimes(1);
     });
 
     it('should create a default layer and root entity when none available', async () => {
@@ -271,6 +294,54 @@ describe('MatterportTagSync', () => {
       expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.LayerIds, [
         MATTERPORT_TAG_LAYER_PREFIX + 'matterportModelId',
       ]);
+      expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneRootEntityId, 'scene-root-id');
+    });
+
+    it('should create a default layer entity when it does not exist', async () => {
+      (checkIfEntityAvailable as jest.Mock).mockImplementation((entityId) => {
+        if (entityId == 'layer-id') {
+          return Promise.resolve(false);
+        }
+        return Promise.resolve(true);
+      });
+
+      useStore('default').setState(baseState);
+      const rendered = render(<MatterportTagSync />);
+
+      await act(async () => {
+        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+      });
+
+      expect(createLayer as jest.Mock).toBeCalledTimes(1);
+      expect(createLayer as jest.Mock).toBeCalledWith(
+        MATTERPORT_TAG_LAYER_PREFIX + 'matterportModelId',
+        LayerType.Relationship,
+      );
+      expect(createSceneRootEntity as jest.Mock).not.toBeCalled();
+      expect(setScenePropertyMock).toBeCalledTimes(1);
+      expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.LayerIds, [
+        MATTERPORT_TAG_LAYER_PREFIX + 'matterportModelId',
+      ]);
+    });
+
+    it('should create a default scene entity when it does not exist', async () => {
+      (checkIfEntityAvailable as jest.Mock).mockImplementation((entityId) => {
+        if (entityId == 'scene-root-id') {
+          return Promise.resolve(false);
+        }
+        return Promise.resolve(true);
+      });
+
+      useStore('default').setState(baseState);
+      const rendered = render(<MatterportTagSync />);
+
+      await act(async () => {
+        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
+      });
+
+      expect(createLayer as jest.Mock).not.toBeCalled();
+      expect(createSceneRootEntity as jest.Mock).toBeCalledTimes(1);
+      expect(setScenePropertyMock).toBeCalledTimes(1);
       expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneRootEntityId, 'scene-root-id');
     });
 

--- a/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
+++ b/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
@@ -124,14 +124,14 @@ ${mattertagItem.description}`,
     const { handleAddMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
     handleAddMatterportTag({ id, item: mattertagItem });
-    expect(appendSceneNode).toBeCalledWith(testNode);
+    expect(appendSceneNode).toBeCalledWith(testNode, true);
   });
 
   it('should add matterport tag', () => {
     const { handleAddMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
     handleAddMatterportTag({ id, item: tagItem });
-    expect(appendSceneNode).toBeCalledWith(testNode);
+    expect(appendSceneNode).toBeCalledWith(testNode, true);
   });
 
   it('should update matterport mattertag', () => {
@@ -237,13 +237,16 @@ ${mattertagItem.description}`,
 
       await handleAddMatterportTag({ layerId: 'layer-id', sceneRootId: 'scene-root-id', id, item: mattertagItem });
       expect(appendSceneNode).toBeCalledTimes(1);
-      expect(appendSceneNode).toBeCalledWith({
-        ...testNode,
-        properties: {
-          ...testNode.properties,
-          [SceneNodeRuntimeProperty.LayerIds]: ['layer-id'],
+      expect(appendSceneNode).toBeCalledWith(
+        {
+          ...testNode,
+          properties: {
+            ...testNode.properties,
+            [SceneNodeRuntimeProperty.LayerIds]: ['layer-id'],
+          },
         },
-      });
+        true,
+      );
       expect(createSceneEntity).toBeCalledTimes(1);
       expect(createSceneEntity).toBeCalledWith({
         workspaceId: undefined,

--- a/packages/scene-composer/src/hooks/useMatterportTags.ts
+++ b/packages/scene-composer/src/hooks/useMatterportTags.ts
@@ -50,7 +50,7 @@ const getNewDataOverlayComponent = (item: MattertagItem | TagItem): IDataOverlay
 
 const addTag = async (
   dynamicSceneEnabled: boolean,
-  addSceneNode: (node: ISceneNode, parentRef?: string) => Readonly<ISceneNode>,
+  addSceneNode: (node: ISceneNode, disableAutoSelect?: boolean) => Readonly<ISceneNode>,
   { layerId, sceneRootId, id, item }: AddTagInputs,
 ) => {
   const tagStyleEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagStyle];
@@ -110,7 +110,7 @@ const addTag = async (
       console.error('Create scene node entity failed', e);
     }
   }
-  addSceneNode(node);
+  addSceneNode(node, true);
 };
 
 const updateTag = async (

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.spec.ts
@@ -1,9 +1,14 @@
 import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 
 import { setTwinMakerSceneMetadataModule } from '../../common/GlobalSettings';
-import { SCENE_ROOT_ENTITY_ID } from '../../common/entityModelConstants';
+import {
+  LAYER_ROOT_ENTITY_ID,
+  LAYER_ROOT_ENTITY_NAME,
+  SCENE_ROOT_ENTITY_ID,
+  SCENE_ROOT_ENTITY_NAME,
+} from '../../common/entityModelConstants';
 
-import { createSceneEntityId, createSceneRootEntity } from './sceneUtils';
+import { checkIfEntityAvailable, createSceneEntityId, createSceneRootEntity, prepareWorkspace } from './sceneUtils';
 
 jest.mock('../mathUtils', () => ({
   generateUUID: jest.fn(() => 'random-uuid'),
@@ -33,5 +38,103 @@ describe('createSceneRootEntity', () => {
       parentEntityId: SCENE_ROOT_ENTITY_ID,
       entityName: createSceneEntityId('test'),
     });
+  });
+});
+
+describe('checkIfEntityAvailable', () => {
+  const getSceneEntity = jest.fn();
+  const mockMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
+    getSceneEntity,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return true when entity exist', async () => {
+    getSceneEntity.mockResolvedValue(undefined);
+
+    const result = await checkIfEntityAvailable('eid', mockMetadataModule as TwinMakerSceneMetadataModule);
+
+    expect(result).toEqual(true);
+  });
+
+  it('should return false when entity does not exist', async () => {
+    getSceneEntity.mockRejectedValue(() => new Error('entity does not exist'));
+
+    const result = await checkIfEntityAvailable('eid', mockMetadataModule as TwinMakerSceneMetadataModule);
+
+    expect(result).toEqual(false);
+  });
+});
+
+describe('prepareWorkspace', () => {
+  const createSceneEntity = jest.fn();
+  const getSceneEntity = jest.fn();
+  const mockMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
+    createSceneEntity,
+    getSceneEntity,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call createSceneEntity to create scenes root entity', async () => {
+    getSceneEntity.mockImplementation(({ entityId }) => {
+      if (entityId === SCENE_ROOT_ENTITY_ID) {
+        throw new Error('entity does not exist');
+      }
+      return;
+    });
+
+    await prepareWorkspace(mockMetadataModule as TwinMakerSceneMetadataModule);
+
+    expect(createSceneEntity).toBeCalledTimes(1);
+    expect(createSceneEntity).toBeCalledWith({
+      entityId: SCENE_ROOT_ENTITY_ID,
+      entityName: SCENE_ROOT_ENTITY_NAME,
+    });
+  });
+
+  it('should call createSceneEntity to create layers root entity', async () => {
+    getSceneEntity.mockImplementation(({ entityId }) => {
+      if (entityId === LAYER_ROOT_ENTITY_ID) {
+        throw new Error('entity does not exist');
+      }
+      return;
+    });
+
+    await prepareWorkspace(mockMetadataModule as TwinMakerSceneMetadataModule);
+
+    expect(createSceneEntity).toBeCalledTimes(1);
+    expect(createSceneEntity).toBeCalledWith({
+      entityId: LAYER_ROOT_ENTITY_ID,
+      entityName: LAYER_ROOT_ENTITY_NAME,
+    });
+  });
+
+  it('should call createSceneEntity to create both layers and scenes root entities', async () => {
+    getSceneEntity.mockRejectedValue(() => new Error('entity does not exist'));
+
+    await prepareWorkspace(mockMetadataModule as TwinMakerSceneMetadataModule);
+
+    expect(createSceneEntity).toBeCalledTimes(2);
+    expect(createSceneEntity).toBeCalledWith({
+      entityId: LAYER_ROOT_ENTITY_ID,
+      entityName: LAYER_ROOT_ENTITY_NAME,
+    });
+    expect(createSceneEntity).toBeCalledWith({
+      entityId: SCENE_ROOT_ENTITY_ID,
+      entityName: SCENE_ROOT_ENTITY_NAME,
+    });
+  });
+
+  it('should not call createSceneEntity when root entities exist', async () => {
+    getSceneEntity.mockResolvedValue(undefined);
+
+    await prepareWorkspace(mockMetadataModule as TwinMakerSceneMetadataModule);
+
+    expect(createSceneEntity).not.toBeCalled();
   });
 });

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
@@ -1,6 +1,12 @@
 import { CreateEntityCommandInput, CreateEntityCommandOutput } from '@aws-sdk/client-iottwinmaker';
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 
-import { SCENE_ROOT_ENTITY_ID } from '../../common/entityModelConstants';
+import {
+  LAYER_ROOT_ENTITY_ID,
+  LAYER_ROOT_ENTITY_NAME,
+  SCENE_ROOT_ENTITY_ID,
+  SCENE_ROOT_ENTITY_NAME,
+} from '../../common/entityModelConstants';
 import { getGlobalSettings } from '../../common/GlobalSettings';
 import { generateUUID } from '../mathUtils';
 
@@ -23,4 +29,38 @@ export const createSceneRootEntity = (): Promise<CreateEntityCommandOutput> | un
   };
 
   return getGlobalSettings().twinMakerSceneMetadataModule!.createSceneEntity(input);
+};
+
+export const checkIfEntityAvailable = async (
+  entityId: string,
+  sceneMetadataModule: TwinMakerSceneMetadataModule,
+): Promise<boolean> => {
+  try {
+    await sceneMetadataModule.getSceneEntity({ entityId });
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+export const prepareWorkspace = async (sceneMetadataModule: TwinMakerSceneMetadataModule): Promise<void> => {
+  // Check if root entities exist
+  const checkRoots = await Promise.all([
+    checkIfEntityAvailable(SCENE_ROOT_ENTITY_ID, sceneMetadataModule),
+    checkIfEntityAvailable(LAYER_ROOT_ENTITY_ID, sceneMetadataModule),
+  ]);
+
+  // Create root entities that do not exist
+  const createRootRequests: Promise<CreateEntityCommandOutput>[] = [];
+  if (!checkRoots[0]) {
+    createRootRequests.push(
+      sceneMetadataModule.createSceneEntity({ entityId: SCENE_ROOT_ENTITY_ID, entityName: SCENE_ROOT_ENTITY_NAME }),
+    );
+  }
+  if (!checkRoots[1]) {
+    createRootRequests.push(
+      sceneMetadataModule.createSceneEntity({ entityId: LAYER_ROOT_ENTITY_ID, entityName: LAYER_ROOT_ENTITY_NAME }),
+    );
+  }
+  await Promise.all(createRootRequests);
 };


### PR DESCRIPTION
## Overview
- create default $SCENES and $LAYERS entity roots for private beta. they will be created from backend for GA
- do not set selected node ref when adding matterport tag from sync button, so overlays will not all be opened during sync

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
