### PR TITLE
fix(composer): resize/reposition overlaps on small screens

### DIFF
--- a/packages/scene-composer/src/components/toolbars/common/__snapshots__/ItemContainer.spec.tsx.snap
+++ b/packages/scene-composer/src/components/toolbars/common/__snapshots__/ItemContainer.spec.tsx.snap
@@ -20,6 +20,7 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
+  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -70,6 +71,7 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
+  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -104,6 +106,7 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
+  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
@@ -335,6 +338,7 @@ exports[`ItemContainer should render selected item properly with custom menuHeig
   justify-content: flex-start;
   min-width: 40px;
   height: 100px;
+  max-height: 100px;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
@@ -376,6 +380,7 @@ exports[`ItemContainer should render when feature is enabled 1`] = `
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
+  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;

--- a/packages/scene-composer/src/components/toolbars/common/styledComponents.ts
+++ b/packages/scene-composer/src/components/toolbars/common/styledComponents.ts
@@ -49,6 +49,7 @@ export const ToolbarItemContainer = styled.div<
   justify-content: flex-start;
   min-width: 40px;
   height: ${({ height }) => height || '40px'};
+  max-height: ${({ height }) => height || '10vh'};
   text-decoration: none;
   cursor: ${({ isDisabled, isSelected }) => (isDisabled || isSelected ? 'default' : 'pointer')};
   pointer-events: ${({ isDisabled, isSelected }) => (isDisabled || isSelected ? 'none' : 'initial')};

--- a/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
+++ b/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
@@ -1331,6 +1331,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
+  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -1365,6 +1366,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
+  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
@@ -1863,6 +1865,7 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
+  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -1897,6 +1900,7 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
+  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;


### PR DESCRIPTION
## Overview
Fix a11y issue where the floating toolbar and the 'Scene Statistics' overlap badly when using a viewport of 360px wide and 256px tall. In addition, the bottom few items of the floating toolbar were completely inaccessible. A11y guidelines dictate all content should reflow or resize to be accessible at these viewport dimensions.

Changes:
- Add max-height to items in the floating toolbar, which is automatically overridden by any height passed in.
- For scenes less than 600px wide, adjust the position of the 'Scene Statistics.' Details of positioning are in code comments

Before, small viewport:
<img width="447" alt="Screenshot 2023-09-21 at 11 38 56 AM" src="https://github.com/awslabs/iot-app-kit/assets/143754227/50e57c9d-2d6c-4d8c-9de1-c6ed7f50294e">


After, small viewport:
<img width="447" alt="Screenshot 2023-09-21 at 4 19 57 PM" src="https://github.com/awslabs/iot-app-kit/assets/143754227/a3dc28bb-5f3b-40dc-a145-ef690b326168">


After, medium viewport:
<img width="528" alt="Screenshot 2023-09-21 at 4 20 29 PM" src="https://github.com/awslabs/iot-app-kit/assets/143754227/f0f88b64-4b41-4026-9de6-0bdb454d82ca">

After, large viewport (no change to current):
<img width="1762" alt="Screenshot 2023-09-21 at 5 52 50 PM" src="https://github.com/awslabs/iot-app-kit/assets/143754227/57e95b41-f371-40c9-bba0-d19fb46dc7a4">



## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
