### PR TITLE
feat(dashboard): empty widget configuration panel

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -53,6 +53,12 @@
   height: 40px;
 }
 
+.collapsible-panel-content {
+  min-height: 0;
+  overflow-y: scroll;
+  height: 100%;
+}
+
 .collapsible-panel-vertical-divider {
   width: 2px;
   height: 26px;

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/assets/emptyPanel.svg
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/assets/emptyPanel.svg
@@ -1,0 +1,16 @@
+<svg width="155" height="124" viewBox="0 0 155 124" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1" y="1.46582" width="130.763" height="32.2769" rx="2" fill="white" stroke="#000716" stroke-width="2"/>
+<circle cx="111.069" cy="18.0183" r="7.27614" fill="#F4F4F4" stroke="#000716" stroke-width="2"/>
+<line x1="16.7227" y1="17.0176" x2="78.7937" y2="17.0176" stroke="#000716" stroke-width="2"/>
+<rect x="1" y="1" width="152.281" height="37.6519" rx="2" fill="white" stroke="#000716" stroke-width="2"/>
+<line x1="35.7617" y1="19.4941" x2="93.3052" y2="19.4941" stroke="#000716" stroke-width="2"/>
+<path d="M25.7031 18.8161C26.3698 19.201 26.3698 20.1632 25.7031 20.5481L13.7845 27.4294C13.1178 27.8143 12.2845 27.3332 12.2845 26.5634L12.2845 12.8009C12.2845 12.0311 13.1178 11.5499 13.7845 11.9348L25.7031 18.8161Z" fill="#000716" stroke="#000716" stroke-width="2"/>
+<circle cx="129.435" cy="20.6622" r="8.62215" fill="#89BDEE" stroke="#000716" stroke-width="2"/>
+<path d="M125.1 20.6286L128.054 23.7944L133.964 17.4629" stroke="#000716" stroke-width="2"/>
+<rect x="1" y="48.2773" width="130.763" height="32.2769" rx="2" fill="white" stroke="#000716" stroke-width="2"/>
+<circle cx="111.069" cy="64.8298" r="7.27614" fill="#F4F4F4" stroke="#000716" stroke-width="2"/>
+<line x1="16.7227" y1="63.8291" x2="78.7937" y2="63.8291" stroke="#000716" stroke-width="2"/>
+<rect x="1" y="90.1787" width="130.763" height="32.2769" rx="2" fill="white" stroke="#000716" stroke-width="2"/>
+<circle cx="111.069" cy="106.731" r="7.27614" fill="#F4F4F4" stroke="#000716" stroke-width="2"/>
+<line x1="16.7227" y1="105.73" x2="78.7937" y2="105.73" stroke="#000716" stroke-width="2"/>
+</svg>

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/emptyPanel.css
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/emptyPanel.css
@@ -1,0 +1,7 @@
+.empty-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  top: 30%;
+}

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/emptyPanel.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/emptyPanel.tsx
@@ -1,20 +1,21 @@
 import Box from '@cloudscape-design/components/box';
 import React from 'react';
-
-const PROPERTIES_PANEL_EMPTY_STYLE = {
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  height: '100%',
-};
+import EmptyPanelSvg from './assets/emptyPanel.svg';
+import { SpaceBetween } from '@cloudscape-design/components';
+import './emptyPanel.css';
 
 /** Empty state for the properties panel. */
 export function PropertiesPanelEmpty() {
   return (
-    <div style={PROPERTIES_PANEL_EMPTY_STYLE}>
-      <Box margin='m' variant='p' color='text-status-inactive'>
-        Select widgets to configure.
-      </Box>
+    <div className='empty-panel'>
+      <SpaceBetween direction='vertical' size='xl'>
+        <Box textAlign='center' variant='p' fontWeight='bold'>
+          Select a widget to configure.
+        </Box>
+        <Box textAlign='center'>
+          <img src={EmptyPanelSvg} alt={EmptyPanelSvg} />
+        </Box>
+      </SpaceBetween>
     </div>
   );
 }

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
@@ -125,7 +125,7 @@ describe(`${PropertiesPanel.name}`, () => {
   it('should render an empty selection when nothing is selected', async () => {
     await renderTestComponentAsync({ selectedWidgets: [] });
 
-    expect(screen.getByText('Select widgets to configure.')).toBeVisible();
+    expect(screen.getByText('Select a widget to configure.')).toBeVisible();
   });
 
   it('should render the style section', async () => {


### PR DESCRIPTION
## Overview
Added a centered icon for the empty state of the widget config panel.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/87385528/0bdcf3eb-be43-4452-b6dc-7ef859f3854f


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
