### PR TITLE
feat: added empty state for line and scatter chart widgets

### DIFF
--- a/packages/dashboard/src/customization/widgets/components/no-chart-data.css
+++ b/packages/dashboard/src/customization/widgets/components/no-chart-data.css
@@ -1,0 +1,7 @@
+.no-chart-data-empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}

--- a/packages/dashboard/src/customization/widgets/components/no-chart-data.spec.tsx
+++ b/packages/dashboard/src/customization/widgets/components/no-chart-data.spec.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import NoChartData from './no-chart-data';
+
+describe('NoChartData', () => {
+  it('renders the component with the correct icon and empty state text', () => {
+    const icon = 'path/to/icon.png';
+    const emptyStateText = 'No chart data available';
+
+    const { getByAltText, getByText } = render(<NoChartData icon={icon} emptyStateText={emptyStateText} />);
+
+    expect(getByAltText('empty widget icon')).toBeInTheDocument();
+    expect(getByText('No chart data available')).toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/customization/widgets/components/no-chart-data.tsx
+++ b/packages/dashboard/src/customization/widgets/components/no-chart-data.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { Box, SpaceBetween } from '@cloudscape-design/components';
+import {
+  borderRadiusContainer,
+  colorBorderDividerDefault,
+  colorTextLayoutToggle,
+  spaceStaticXxxs,
+} from '@cloudscape-design/design-tokens';
+
+import './no-chart-data.css';
+
+interface NoChartDataProps {
+  icon: string;
+  emptyStateText: string;
+}
+
+const NoChartData = ({ icon, emptyStateText }: NoChartDataProps) => {
+  return (
+    <div
+      role='empty widget'
+      aria-description='empty widget tile'
+      className='no-chart-data-empty-state'
+      style={{
+        backgroundColor: colorTextLayoutToggle,
+        border: `${spaceStaticXxxs} solid ${colorBorderDividerDefault}`,
+        borderRadius: borderRadiusContainer,
+      }}
+    >
+      <Box textAlign='center'>
+        <SpaceBetween size='xxs'>
+          <img height={50} width={50} src={icon} alt='empty widget icon' />
+          <Box color='text-label' variant='p' fontWeight='bold'>
+            {emptyStateText}
+          </Box>
+        </SpaceBetween>
+      </Box>
+    </div>
+  );
+};
+
+export default NoChartData;

--- a/packages/dashboard/src/customization/widgets/lineChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineChart/component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { LineChart } from '@iot-app-kit/react-components';
+import { SiteWiseAssetQuery } from '@iot-app-kit/source-iotsitewise';
 
 import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
@@ -11,7 +12,6 @@ import { getAggregation } from '../utils/widgetAggregationUtils';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
 import { useChartSize } from '~/hooks/useChartSize';
 import WidgetTile from '~/components/widgets/tile';
-import { SiteWiseAssetQuery } from '@iot-app-kit/source-iotsitewise';
 
 const LineChartWidgetComponent: React.FC<LineChartWidget> = (widget) => {
   const viewport = useSelector((state: DashboardState) => state.dashboardConfiguration.viewport);

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -22,6 +22,8 @@ import { ChartOptions, ChartStyleSettingsOptions } from '@iot-app-kit/react-comp
 // import { applyAggregationToQuery } from '../utils/assetQuery/applyAggregationToQuery';
 // import { applyResolutionToQuery } from '../utils/assetQuery/applyResolutionToQuery';
 import WidgetTile from '~/components/widgets/tile/tile';
+import NoChartData from '../components/no-chart-data';
+import { default as lineSvgDark } from './line-dark.svg';
 
 const mapConnectionStyleToVisualizationType = (
   connectionStyle: LineStyles['connectionStyle']
@@ -135,6 +137,17 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (widge
   // so not entirely sure if we can have a mechanism where the container auto adjusts the height
   // the 44 is from the widget tile header's height
   const size = { width: chartSize.width, height: chartSize.height - 44 };
+
+  const isEmptyWidget = !queryConfig.query || queryConfig.query.assets.length === 0;
+
+  if (isEmptyWidget) {
+    return (
+      <NoChartData
+        icon={lineSvgDark}
+        emptyStateText='Browse and select to add your asset properties in your line widget.'
+      />
+    );
+  }
 
   return (
     <WidgetTile widget={widget} removeable title={title}>

--- a/packages/dashboard/src/customization/widgets/scatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/scatterChart/component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { ScatterChart } from '@iot-app-kit/react-components';
+import { SiteWiseAssetQuery } from '@iot-app-kit/source-iotsitewise';
 
 import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
@@ -11,7 +12,6 @@ import { getAggregation } from '../utils/widgetAggregationUtils';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
 import { useChartSize } from '~/hooks/useChartSize';
 import WidgetTile from '~/components/widgets/tile';
-import { SiteWiseAssetQuery } from '@iot-app-kit/source-iotsitewise';
 
 const ScatterChartWidgetComponent: React.FC<ScatterChartWidget> = (widget) => {
   const viewport = useSelector((state: DashboardState) => state.dashboardConfiguration.viewport);


### PR DESCRIPTION
## Overview

This change is related to https://github.com/awslabs/iot-app-kit/issues/1919

Added empty state for line, and scatter widgets when there are no assets added to the respective widgets.





