### PR TITLE
fix: x-axis toggle will toggle both x and y axis

### DIFF
--- a/packages/react-components/src/components/chart/converters/convertAxis.ts
+++ b/packages/react-components/src/components/chart/converters/convertAxis.ts
@@ -5,7 +5,7 @@ import { DEFAULT_Y_AXIS } from '../eChartsConstants';
 export const convertYAxis = (axis: ChartAxisOptions | undefined): YAXisComponentOption => ({
   ...DEFAULT_Y_AXIS,
   name: axis?.yAxisLabel,
-  show: axis?.showX ?? DEFAULT_Y_AXIS.show,
+  show: axis?.showY ?? DEFAULT_Y_AXIS.show,
   min: axis?.yMin ?? undefined,
   max: axis?.yMax ?? undefined,
 });

--- a/packages/react-components/src/components/chart/converters/converters.spec.ts
+++ b/packages/react-components/src/components/chart/converters/converters.spec.ts
@@ -40,11 +40,42 @@ const QUERIES = mockTimeSeriesDataQuery([
 
 describe('testing converters', () => {
   it('converts axis to eCharts axis', async () => {
-    const convertedYAxis = convertYAxis(MOCK_AXIS);
+    [
+      {
+        yAxisLabel: 'Y Value',
+        yMin: 0,
+        yMax: 100,
+        showY: true,
+        showX: true,
+      },
+      {
+        yAxisLabel: 'Y Value',
+        yMin: 0,
+        yMax: 100,
+        showY: false,
+        showX: false,
+      },
+      {
+        yAxisLabel: 'Y Value',
+        yMin: 0,
+        yMax: 100,
+        showY: true,
+        showX: false,
+      },
+      {
+        yAxisLabel: 'Y Value',
+        yMin: 0,
+        yMax: 100,
+        showY: false,
+        showX: true,
+      },
+    ].forEach((axis_values) => {
+      const convertedYAxis = convertYAxis(axis_values);
 
-    expect(convertedYAxis).toHaveProperty('type', 'value');
-    expect(convertedYAxis).toHaveProperty('name', MOCK_AXIS.yAxisLabel);
-    expect(convertedYAxis).toHaveProperty('show', true);
+      expect(convertedYAxis).toHaveProperty('type', 'value');
+      expect(convertedYAxis).toHaveProperty('name', axis_values.yAxisLabel);
+      expect(convertedYAxis).toHaveProperty('show', axis_values.showY);
+    });
   });
 
   it('converts data points to echarts data points', async () => {


### PR DESCRIPTION
## Overview
This fix fixes the x-axis toggle issue, now x-axis toggle will only toggle the visibility of the x-axis


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
