### PR TITLE
feat: added delete widget confirm modal #1921

### DIFF
--- a/packages/dashboard/e2e/tests/dashboard/dashboard.spec.ts
+++ b/packages/dashboard/e2e/tests/dashboard/dashboard.spec.ts
@@ -114,6 +114,10 @@ test('dashboard add and remove multiple widgets', async ({ page }) => {
 
   await page.keyboard.down('Delete');
 
+  const deleteBtn = await page.getByRole('button', { name: 'Delete', exact: true });
+
+  await deleteBtn.click();
+
   const deletedWidgets = await grid.widgets();
   expect(deletedWidgets).toHaveLength(0);
 });

--- a/packages/dashboard/src/components/confirmDeleteModal/index.spec.tsx
+++ b/packages/dashboard/src/components/confirmDeleteModal/index.spec.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import ConfirmDeleteModal from './index';
+
+describe('Confirm Delete Modal', () => {
+  test('renders correctly', () => {
+    const props = {
+      headerTitle: 'Confirmation',
+      submitTitle: 'Submit',
+      description: 'Are you sure you want to submit?',
+      visible: true,
+      handleDismiss: jest.fn(),
+      handleCancel: jest.fn(),
+      handleSubmit: jest.fn(),
+    };
+    const { getByText, getByTestId } = render(<ConfirmDeleteModal {...props} />);
+
+    // Assert that the header, description, cancel button, and submit button are rendered correctly
+    expect(getByText('Confirmation')).toBeInTheDocument();
+    expect(getByText('Are you sure you want to submit?')).toBeInTheDocument();
+    expect(getByText('Cancel')).toBeInTheDocument();
+    expect(getByTestId('custom-orange-button')).toBeInTheDocument();
+  });
+
+  test('calls handleCancel when cancel button is clicked', () => {
+    const handleCancel = jest.fn();
+    const props = {
+      headerTitle: 'Confirmation',
+      submitTitle: 'Submit',
+      description: 'Are you sure you want to submit?',
+      visible: true,
+      handleDismiss: jest.fn(),
+      handleCancel,
+      handleSubmit: jest.fn(),
+    };
+    const { getByText } = render(<ConfirmDeleteModal {...props} />);
+    const cancelButton = getByText('Cancel');
+
+    fireEvent.click(cancelButton); // Simulate clicking the cancel button
+
+    // Assert that handleCancel is called
+    expect(handleCancel).toHaveBeenCalled();
+  });
+
+  test('calls handleSubmit when submit button is clicked', () => {
+    const handleSubmit = jest.fn();
+    const props = {
+      headerTitle: 'Confirmation',
+      submitTitle: 'Submit',
+      description: 'Are you sure you want to submit?',
+      visible: true,
+      handleDismiss: jest.fn(),
+      handleCancel: jest.fn(),
+      handleSubmit,
+    };
+    const { getByTestId } = render(<ConfirmDeleteModal {...props} />);
+    const submitButton = getByTestId('custom-orange-button');
+
+    fireEvent.click(submitButton); // Simulate clicking the submit button
+
+    // Assert that handleSubmit is called
+    expect(handleSubmit).toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/components/confirmDeleteModal/index.tsx
+++ b/packages/dashboard/src/components/confirmDeleteModal/index.tsx
@@ -1,0 +1,52 @@
+import React, { ReactElement } from 'react';
+
+import { Box, Button, Modal, SpaceBetween } from '@cloudscape-design/components';
+
+import CustomOrangeButton from '../customOrangeButton';
+
+interface ConfirmDeleteModalProps {
+  headerTitle: string;
+  cancelTitle?: string;
+  submitTitle: string;
+  description: ReactElement | string;
+  visible: boolean;
+  handleDismiss: () => void;
+  handleCancel: () => void;
+  handleSubmit: () => void;
+}
+
+const ConfirmDeleteModal = ({
+  headerTitle,
+  cancelTitle = 'Cancel',
+  submitTitle,
+  description,
+  visible,
+  handleDismiss,
+  handleCancel,
+  handleSubmit,
+}: ConfirmDeleteModalProps) => {
+  return (
+    <Modal
+      visible={visible}
+      onDismiss={handleDismiss}
+      header={headerTitle}
+      data-testid='confirm-modal'
+      footer={
+        <Box float='right'>
+          <SpaceBetween direction='horizontal' size='xs'>
+            {cancelTitle && (
+              <Button variant='link' onClick={handleCancel}>
+                {cancelTitle}
+              </Button>
+            )}
+            <CustomOrangeButton title={submitTitle} handleClick={handleSubmit} />
+          </SpaceBetween>
+        </Box>
+      }
+    >
+      {description}
+    </Modal>
+  );
+};
+
+export default ConfirmDeleteModal;

--- a/packages/dashboard/src/components/customOrangeButton/index.css
+++ b/packages/dashboard/src/components/customOrangeButton/index.css
@@ -1,0 +1,9 @@
+.btn-custom-primary {
+  border-color: var(--colors-background-button) !important;
+  background-color: var(--colors-background-button) !important;
+}
+
+.btn-custom-primary:hover {
+  border-color: var(--colors-button-hover) !important;
+  background-color: var(--colors-button-hover) !important;
+}

--- a/packages/dashboard/src/components/customOrangeButton/index.spec.tsx
+++ b/packages/dashboard/src/components/customOrangeButton/index.spec.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import CustomOrangeButton from './index';
+
+describe('CustomOrangeButton', () => {
+  const title = 'Test Button';
+  const handleClick = jest.fn();
+
+  test('renders button with correct title', () => {
+    const { getByText } = render(<CustomOrangeButton title={title} handleClick={handleClick} />);
+    expect(getByText(title)).toBeInTheDocument();
+  });
+  test('calls handleClick when button is clicked', () => {
+    const { getByRole } = render(<CustomOrangeButton title={title} handleClick={handleClick} />);
+    const button = getByRole('button');
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dashboard/src/components/customOrangeButton/index.tsx
+++ b/packages/dashboard/src/components/customOrangeButton/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { colorBackgroundHomeHeader } from '@cloudscape-design/design-tokens';
+import { Button, ButtonProps } from '@cloudscape-design/components';
+
+import './index.css';
+
+const CustomOrangeButton = ({
+  title,
+  handleClick,
+  ...rest
+}: { title: string; handleClick: () => void } & ButtonProps) => {
+  return (
+    <Button className='btn-custom-primary' onClick={handleClick} data-testid='custom-orange-button' {...rest}>
+      <span style={{ color: colorBackgroundHomeHeader }}>{title}</span>
+    </Button>
+  );
+};
+
+export default CustomOrangeButton;

--- a/packages/dashboard/src/components/grid/gestures/usePointerTracker.ts
+++ b/packages/dashboard/src/components/grid/gestures/usePointerTracker.ts
@@ -40,7 +40,6 @@ export const usePointerTracker = ({ readOnly, enabled, union, click }: PointerTr
 
   const onPointerUp: PointerEventHandler = (e) => {
     if (cancelClick || !enabled || readOnly) return;
-
     if (e.button === MouseClick.Left) {
       click({
         position: getDashboardPosition(e),

--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -14,6 +14,16 @@ const EMPTY_DASHBOARD: DashboardWidgetsConfiguration = {
   viewport: { duration: '10m' },
 };
 
+jest.mock('../../store/actions', () => {
+  const originalModule = jest.requireActual('../../store/actions');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    onDeleteWidgetsAction: jest.fn(),
+  };
+});
+
 // TODO: fix these tests (likely need to mock TwinMaker client)
 it.skip('saves when the save button is pressed with default grid settings provided', function () {
   const onSave = jest.fn().mockImplementation(() => Promise.resolve());

--- a/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.test.tsx
@@ -9,12 +9,7 @@ import { act } from '@testing-library/react';
 import InternalDashboard from './index';
 import { configureDashboardStore } from '../../store';
 
-import {
-  onBringWidgetsToFrontAction,
-  onDeleteWidgetsAction,
-  onSelectWidgetsAction,
-  onSendWidgetsToBackAction,
-} from '../../store/actions';
+import { onBringWidgetsToFrontAction, onSelectWidgetsAction, onSendWidgetsToBackAction } from '../../store/actions';
 
 jest.mock('../../store/actions', () => {
   const originalModule = jest.requireActual('../../store/actions');
@@ -85,18 +80,6 @@ it.skip('can clear the selection', () => {
   });
 });
 
-// TODO: fix these tests (likely need to mock TwinMaker client)
-it.skip('can delete the selection', () => {
-  (onDeleteWidgetsAction as jest.Mock).mockImplementation(() => ({ type: '', payload: {} }));
-
-  renderDashboardAndPressKey({ key: 'Backspace', meta: false });
-
-  expect(onDeleteWidgetsAction).toBeCalledWith({
-    widgets: [],
-  });
-});
-
-// TODO: fix these tests (likely need to mock TwinMaker client)
 it.skip('can send the selection to the back', () => {
   (onSendWidgetsToBackAction as jest.Mock).mockImplementation(() => ({ type: '', payload: {} }));
 

--- a/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.ts
+++ b/packages/dashboard/src/components/internalDashboard/keyboardShortcuts.ts
@@ -11,8 +11,13 @@ import {
 } from '../../store/actions';
 import { DASHBOARD_CONTAINER_ID } from '../grid/getDashboardPosition';
 import { useSelectedWidgets } from '~/hooks/useSelectedWidgets';
+import { isFunction } from 'lodash';
 
-export const useKeyboardShortcuts = () => {
+type useKeyboardShortcutsProps = {
+  deleteWidgets?: () => void;
+};
+
+export const useKeyboardShortcuts = ({ deleteWidgets: handleDeleteWidgetModal }: useKeyboardShortcutsProps) => {
   const dispatch = useDispatch();
   const selectedWidgets = useSelectedWidgets();
 
@@ -46,11 +51,15 @@ export const useKeyboardShortcuts = () => {
   };
 
   const deleteWidgets = useCallback(() => {
-    dispatch(
-      onDeleteWidgetsAction({
-        widgets: selectedWidgets,
-      })
-    );
+    if (isFunction(handleDeleteWidgetModal)) {
+      handleDeleteWidgetModal();
+    } else {
+      dispatch(
+        onDeleteWidgetsAction({
+          widgets: selectedWidgets,
+        })
+      );
+    }
   }, [selectedWidgets]);
 
   /**
@@ -59,10 +68,12 @@ export const useKeyboardShortcuts = () => {
    * other areas where we might use keyboard interactions such as
    * the settings pane or a text area in a widget
    */
+
   const keyPressFilter = (e: KeyboardEvent) =>
     e.target !== null &&
     e.target instanceof Element &&
     (e.target.id === DASHBOARD_CONTAINER_ID || e.target === document.body);
+
   useKeyPress('esc', { filter: keyPressFilter, callback: onClearSelection });
   useKeyPress('backspace, del', { filter: keyPressFilter, callback: deleteWidgets });
   useKeyPress('mod+c', { filter: keyPressFilter, callback: copyWidgets });

--- a/packages/dashboard/src/components/widgets/tile/tile.spec.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.spec.tsx
@@ -71,6 +71,11 @@ describe('WidgetTile', () => {
       removeButton?.click();
     });
 
+    const deleteBtn = screen.getByText('Delete');
+    expect(deleteBtn).toBeInTheDocument();
+    act(() => {
+      deleteBtn?.click();
+    });
     expect(store.getState().dashboardConfiguration.widgets).toEqual([]);
   });
 

--- a/packages/dashboard/src/styles/variables.css
+++ b/packages/dashboard/src/styles/variables.css
@@ -40,4 +40,6 @@
   --radius-component-palette-icon: 8px;
   --toolbar-overlay-height: 116px;
   --button-action-gap: 0.5rem;
+  --colors-background-button: #f90;
+  --colors-button-hover: #ec7211;
 }


### PR DESCRIPTION
## Overview

Added confirm modal for delete widget when we click on (X) button on widget tile and click on the 'delete' button in the context menu and when we press 'backspace' or 'delete' buttons in the keyboard. Also, fixed widget dragging when we drag in X icon.


