### PR TITLE
fix: use one timesync for all of dashboard

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactNode, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { TimeSync, WebglContext, TrendCursorSync } from '@iot-app-kit/react-components';
+import { WebglContext, TrendCursorSync, TimeSync } from '@iot-app-kit/react-components';
 import Box from '@cloudscape-design/components/box';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 
@@ -187,58 +187,53 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({ onSave, edit
     hasSelectedWidgets: selectedWidgets.length > 0,
   };
 
-  if (readOnly) {
-    return (
-      <TimeSync group='default-dashboard-edit'>
-        <TrendCursorSync>
-          <div className='dashboard'>
-            <div className='dashboard-toolbar-read-only'>
-              <Box float='right' padding='s'>
-                <SpaceBetween size='s' direction='horizontal'>
-                  <ViewportSelection key='1' messageOverrides={DefaultDashboardMessages} />
-                  {editable && (
-                    <>
-                      <Divider key='2' />
-                      <Actions
-                        key='3'
-                        readOnly={readOnly}
-                        onSave={onSave}
-                        dashboardConfiguration={dashboardConfiguration}
-                        grid={grid}
-                        significantDigits={significantDigits}
-                        editable={editable}
-                      />
-                    </>
-                  )}
-                </SpaceBetween>
-              </Box>
-            </div>
-            <div className='display-area' ref={(el) => setViewFrameElement(el || undefined)}>
-              <ReadOnlyGrid {...grid}>
-                <Widgets {...widgetsProps} />
-              </ReadOnlyGrid>
-              <WebglContext viewFrame={viewFrame} />
-            </div>
+  const EditComponent = (
+    <div className='dashboard' style={userSelect}>
+      <CustomDragLayer onDrag={(isDragging) => setUserSelect(isDragging ? disabledUserSelect : defaultUserSelect)} />
+      <div className='dashboard-toolbar'>
+        <Box float='left' padding='xs'>
+          <ComponentPalette />
+        </Box>
+        <Box float='right' padding='xs'>
+          <SpaceBetween size='s' direction='horizontal'>
+            <ViewportSelection key='1' messageOverrides={DefaultDashboardMessages} />
+            <Divider key='2' />
+            <Actions
+              key='3'
+              readOnly={readOnly}
+              onSave={onSave}
+              dashboardConfiguration={dashboardConfiguration}
+              grid={grid}
+              significantDigits={significantDigits}
+              editable={editable}
+            />
+          </SpaceBetween>
+        </Box>
+      </div>
+      <ResizablePanes
+        leftPane={<ResourceExplorer />}
+        centerPane={
+          <div className='display-area' ref={(el) => setViewFrameElement(el || undefined)}>
+            <GestureableGrid {...gridProps}>
+              <ContextMenu {...contextMenuProps} />
+              <Widgets {...widgetsProps} />
+              {activeGesture === 'select' && <UserSelection {...selectionProps} />}
+            </GestureableGrid>
+            <WebglContext viewFrame={viewFrame} />
           </div>
-        </TrendCursorSync>
-      </TimeSync>
-    );
-  }
-
-  return (
-    <TimeSync group='default-dashboard-view'>
-      <TrendCursorSync>
-        <div className='dashboard' style={userSelect}>
-          <CustomDragLayer
-            onDrag={(isDragging) => setUserSelect(isDragging ? disabledUserSelect : defaultUserSelect)}
-          />
-          <div className='dashboard-toolbar'>
-            <Box float='left' padding='xs'>
-              <ComponentPalette />
-            </Box>
-            <Box float='right' padding='xs'>
-              <SpaceBetween size='s' direction='horizontal'>
-                <ViewportSelection key='1' messageOverrides={DefaultDashboardMessages} />
+        }
+        rightPane={propertiesPanel}
+      />
+    </div>
+  );
+  const ReadOnlyComponent = (
+    <div className='dashboard'>
+      <div className='dashboard-toolbar-read-only'>
+        <Box float='right' padding='s'>
+          <SpaceBetween size='s' direction='horizontal'>
+            <ViewportSelection key='1' messageOverrides={DefaultDashboardMessages} />
+            {editable && (
+              <>
                 <Divider key='2' />
                 <Actions
                   key='3'
@@ -249,26 +244,24 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({ onSave, edit
                   significantDigits={significantDigits}
                   editable={editable}
                 />
-              </SpaceBetween>
-            </Box>
-          </div>
-          <ResizablePanes
-            leftPane={<ResourceExplorer />}
-            centerPane={
-              <div className='display-area' ref={(el) => setViewFrameElement(el || undefined)}>
-                <GestureableGrid {...gridProps}>
-                  <ContextMenu {...contextMenuProps} />
-                  <Widgets {...widgetsProps} />
-                  {activeGesture === 'select' && <UserSelection {...selectionProps} />}
-                </GestureableGrid>
-                <WebglContext viewFrame={viewFrame} />
-              </div>
-            }
-            rightPane={propertiesPanel}
-          />
-        </div>
-      </TrendCursorSync>
-    </TimeSync>
+              </>
+            )}
+          </SpaceBetween>
+        </Box>
+      </div>
+      <div className='display-area' ref={(el) => setViewFrameElement(el || undefined)}>
+        <ReadOnlyGrid {...grid}>
+          <Widgets {...widgetsProps} />
+        </ReadOnlyGrid>
+        <WebglContext viewFrame={viewFrame} />
+      </div>
+    </div>
+  );
+
+  return (
+    <TrendCursorSync>
+      <TimeSync group='dashboard-timesync'>{readOnly ? ReadOnlyComponent : EditComponent}</TimeSync>
+    </TrendCursorSync>
   );
 };
 


### PR DESCRIPTION
## Overview
we were using two different timeSync components for edit/view mode, so the viewport would reset if you changed dashboard mode

## Verifying Changes

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
