### PR TITLE
fix(composer): add aria labels to icons

### DIFF
--- a/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.tsx
@@ -2,13 +2,19 @@ import { AttributeEditor, FormField, Grid, Input, Select, SpaceBetween, TextCont
 import { IconLookup, findIconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { debounce } from 'lodash';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { useIntl } from 'react-intl';
+import { defineMessages, useIntl } from 'react-intl';
 
 import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { SCENE_ICONS } from '../../../common/constants';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import useDynamicScene from '../../../hooks/useDynamicScene';
-import { COMPOSER_FEATURES, IValueDataBinding, KnownSceneProperty, SceneResourceType } from '../../../interfaces';
+import {
+  COMPOSER_FEATURES,
+  DefaultAnchorStatus,
+  IValueDataBinding,
+  KnownSceneProperty,
+  SceneResourceType,
+} from '../../../interfaces';
 import { IAnchorComponentInternal, ISceneComponentInternal, useSceneDocument, useStore } from '../../../store';
 import { shallowEqualsArray } from '../../../utils/objectUtils';
 import { i18nSceneIconsKeysStrings } from '../../../utils/polarisUtils';
@@ -26,6 +32,14 @@ export const convertParamsToKeyValuePairs = (params: Record<string, string>) => 
     return { key, value: params[key] };
   });
 };
+
+const i18nIconStrings = defineMessages({
+  [DefaultAnchorStatus.Info]: { defaultMessage: 'Info icon', description: 'Icon name label' },
+  [DefaultAnchorStatus.Warning]: { defaultMessage: 'Warning icon', description: 'Icon name label' },
+  [DefaultAnchorStatus.Error]: { defaultMessage: 'Error icon', description: 'Icon name label' },
+  [DefaultAnchorStatus.Video]: { defaultMessage: 'Video icon', description: 'Icon name label' },
+  [DefaultAnchorStatus.Custom]: { defaultMessage: 'Custom icon', description: 'Icon name label' },
+});
 
 export type IAnchorComponentEditorProps = IComponentEditorProps;
 
@@ -209,9 +223,15 @@ export const AnchorComponentEditor: React.FC<IAnchorComponentEditorProps> = ({
                 customIcon={findIconDefinition(customIcon)}
                 width='32px'
                 height='32px'
+                ariaLabel={intl.formatMessage(i18nIconStrings[iconOptions[iconSelectedOptionIndex]?.value])}
               />
             ) : (
-              <img width='32px' height='32px' src={`data:image/svg+xml;base64,${iconString}`} />
+              <img
+                aria-label={intl.formatMessage(i18nIconStrings[iconOptions[iconSelectedOptionIndex]?.value])}
+                width='32px'
+                height='32px'
+                src={`data:image/svg+xml;base64,${iconString}`}
+              />
             ))}
         </Grid>
       </FormField>

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
@@ -22,6 +22,7 @@ exports[`AnchorComponentEditor should render with no tag style 1`] = `
           selectedoption="{\\"label\\":\\"Info\\",\\"value\\":\\"Info\\"}"
         />
         <img
+          aria-label="Info icon"
           height="32px"
           src="data:image/svg+xml;base64,CiAgPHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA1MiA1Micgd2lkdGg9JzI1NicgaGVpZ2h0PScyNTYnPgogICAgPGcgZmlsbD0nbm9uZScgZmlsbFJ1bGU9J2V2ZW5vZGQnIHRyYW5zZm9ybT0ndHJhbnNsYXRlKDEgMSknPgogICAgICA8ZWxsaXBzZSBjeD0nMjUnIGN5PScyNScgcng9JzIxJyByeT0nMjEnIHN0cm9rZT0nIzAwMDAwMCcgc3Ryb2tlLXdpZHRoPScyJyAvPgogICAgICA8Y2lyY2xlIGN4PScyNScgY3k9JzI1JyByPScxNicgZmlsbD0nIzAwMDAwMCcgLz4KICAgIDwvZz4KICA8L3N2Zz4K"
           width="32px"
@@ -161,6 +162,7 @@ exports[`AnchorComponentEditor should render with tag style 1`] = `
           selectedoption="{\\"label\\":\\"Info\\",\\"value\\":\\"Info\\"}"
         />
         <img
+          aria-label="Info icon"
           height="32px"
           src="data:image/svg+xml;base64,CiAgPHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA1MiA1Micgd2lkdGg9JzI1NicgaGVpZ2h0PScyNTYnPgogICAgPGcgZmlsbD0nbm9uZScgZmlsbFJ1bGU9J2V2ZW5vZGQnIHRyYW5zZm9ybT0ndHJhbnNsYXRlKDEgMSknPgogICAgICA8ZWxsaXBzZSBjeD0nMjUnIGN5PScyNScgcng9JzIxJyByeT0nMjEnIHN0cm9rZT0nIzAwMDAwMCcgc3Ryb2tlLXdpZHRoPScyJyAvPgogICAgICA8Y2lyY2xlIGN4PScyNScgY3k9JzI1JyByPScxNicgZmlsbD0nIzAwMDAwMCcgLz4KICAgIDwvZz4KICA8L3N2Zz4K"
           width="32px"

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/DecodeSvgString.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorPicker/ColorPickerUtils/DecodeSvgString.tsx
@@ -9,6 +9,7 @@ interface IConvertComponentProps {
   customIcon?: IconDefinition;
   width?: string;
   height?: string;
+  ariaLabel?: string;
 }
 
 export const DecodeSvgString = ({
@@ -17,6 +18,7 @@ export const DecodeSvgString = ({
   customIcon,
   width,
   height,
+  ariaLabel,
 }: IConvertComponentProps): JSX.Element => {
   const iconWidth = customIcon?.icon[0];
   const iconHeight = customIcon?.icon[1];
@@ -25,5 +27,7 @@ export const DecodeSvgString = ({
   ) as string;
 
   const svgCode = useSvgParser({ selectedColor, iconString, decodeCustomIcon, iconWidth, iconHeight });
-  return <img src={`data:image/svg+xml;base64,${btoa(svgCode)}`} width={width} height={height} />;
+  return (
+    <img aria-label={ariaLabel} src={`data:image/svg+xml;base64,${btoa(svgCode)}`} width={width} height={height} />
+  );
 };

--- a/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetIconEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetIconEditor.tsx
@@ -1,6 +1,6 @@
 import { Grid, Select } from '@awsui/components-react';
 import React, { useMemo, useState } from 'react';
-import { useIntl } from 'react-intl';
+import { useIntl, defineMessages } from 'react-intl';
 
 import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { SCENE_ICONS } from '../../../common/constants';
@@ -38,6 +38,15 @@ export const SceneRuleTargetIconEditor: React.FC<ISceneRuleTargetIconEditorProps
   }, [selectedIcon]);
 
   const isCustomStyle = tagStyle && targetValue === 'Custom';
+
+  const i18nIconStrings = defineMessages({
+    [DefaultAnchorStatus.Info]: { defaultMessage: 'Info icon', description: 'Icon name label' },
+    [DefaultAnchorStatus.Warning]: { defaultMessage: 'Warning icon', description: 'Icon name label' },
+    [DefaultAnchorStatus.Error]: { defaultMessage: 'Error icon', description: 'Icon name label' },
+    [DefaultAnchorStatus.Video]: { defaultMessage: 'Video icon', description: 'Icon name label' },
+    [DefaultAnchorStatus.Custom]: { defaultMessage: 'Custom icon', description: 'Icon name label' },
+  });
+
   return (
     <Grid gridDefinition={[{ colspan: 9 }, { colspan: 2 }]}>
       <Select
@@ -66,9 +75,15 @@ export const SceneRuleTargetIconEditor: React.FC<ISceneRuleTargetIconEditorProps
           iconString={iconString}
           width='32px'
           height='32px'
+          ariaLabel={intl.formatMessage(i18nIconStrings[targetValue])}
         />
       ) : (
-        <img width='32px' height='32px' src={`data:image/svg+xml;base64,${iconString}`} />
+        <img
+          aria-label={intl.formatMessage(i18nIconStrings[targetValue])}
+          width='32px'
+          height='32px'
+          src={`data:image/svg+xml;base64,${iconString}`}
+        />
       )}
     </Grid>
   );

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -127,6 +127,10 @@
     "note": "Expandable Section title",
     "text": "Annotation"
   },
+  "5F/kwX": {
+    "note": "Icon name label",
+    "text": "Error icon"
+  },
   "5pV1+0": {
     "note": "Form field label",
     "text": "Ref"
@@ -238,6 +242,10 @@
   "AEkvpm": {
     "note": "Input error message",
     "text": "Invalid character in the name"
+  },
+  "AePRVy": {
+    "note": "Icon name label",
+    "text": "Custom icon"
   },
   "As6z+e": {
     "note": "ExpandableInfoSection Title",
@@ -687,6 +695,10 @@
     "note": "Placeholder",
     "text": "Choose a color value"
   },
+  "duq5aL": {
+    "note": "Icon name label",
+    "text": "Warning icon"
+  },
   "dw/mQp": {
     "note": "Light Type in a dropdown menu",
     "text": "Hemisphere"
@@ -754,6 +766,10 @@
   "gZDAVH": {
     "note": "Menu Item label",
     "text": "Add Animations"
+  },
+  "gc20C0": {
+    "note": "Icon name label",
+    "text": "Info icon"
   },
   "ggiL3k": {
     "note": "Form Field label",
@@ -882,6 +898,10 @@
   "nhcDIE": {
     "note": "select box option text value",
     "text": "Receive Shadow"
+  },
+  "nwQbTY": {
+    "note": "Icon name label",
+    "text": "Video icon"
   },
   "o3PtbU": {
     "note": "Sub-Section Description",


### PR DESCRIPTION
## Overview
Add aria labels to icon previews in the rule panel and the scene node inspector panel. 

Icons in both panels in this pic will now have appropriate aria labels:
<img width="1762" alt="Screenshot 2023-09-22 at 3 26 49 PM" src="https://github.com/awslabs/iot-app-kit/assets/143754227/4d61911c-a26b-4069-a737-471818fd9255">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
