### PR TITLE
feat: updated chart initial widget size

### DIFF
--- a/packages/dashboard/src/customization/widgets/barChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/plugin.tsx
@@ -6,6 +6,7 @@ import type { DashboardPlugin } from '~/customization/api';
 import type { BarChartWidget } from '../types';
 import { PropertyDataType } from '@aws-sdk/client-iotsitewise';
 import { queryWidgetOnDrop } from '../queryWidget/multiQueryWidgetDrop';
+import { WIDGET_INITIAL_HEIGHT, WIDGET_INITIAL_WIDTH } from '../constants';
 
 export const barChartPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
@@ -34,8 +35,8 @@ export const barChartPlugin: DashboardPlugin = {
         },
       }),
       initialSize: {
-        height: 250,
-        width: 270,
+        height: WIDGET_INITIAL_HEIGHT,
+        width: WIDGET_INITIAL_WIDTH,
       },
     });
   },

--- a/packages/dashboard/src/customization/widgets/constants.ts
+++ b/packages/dashboard/src/customization/widgets/constants.ts
@@ -1,3 +1,15 @@
 export const SVG_STROKE_SOLID = '1,0';
 export const SVG_STROKE_DASHED = '10,5';
 export const SVG_STROKE_DOTTED = '3,3';
+
+export const WIDGET_INITIAL_HEIGHT = 400;
+export const WIDGET_INITIAL_WIDTH = 650;
+
+export const KPI_WIDGET_INITIAL_HEIGHT = 200;
+export const KPI_WIDGET_INITIAL_WIDTH = 350;
+
+export const TABLE_WIDGET_INITIAL_HEIGHT = 300;
+export const TABLE_WIDGET_INITIAL_WIDTH = 850;
+
+export const TABLE_WIDGET_MAX_HEIGHT = 520;
+export const TABLE_OVERFLOW_HEIGHT = 200;

--- a/packages/dashboard/src/customization/widgets/kpi/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/kpi/plugin.tsx
@@ -4,6 +4,7 @@ import KPIWidgetComponent from './component';
 import KPIIcon from './icon';
 import type { DashboardPlugin } from '~/customization/api';
 import type { KPIWidget } from '../types';
+import { KPI_WIDGET_INITIAL_HEIGHT, KPI_WIDGET_INITIAL_WIDTH } from '../constants';
 
 export const kpiPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
@@ -26,8 +27,8 @@ export const kpiPlugin: DashboardPlugin = {
         secondaryFont: {},
       }),
       initialSize: {
-        height: 120,
-        width: 270,
+        height: KPI_WIDGET_INITIAL_HEIGHT,
+        width: KPI_WIDGET_INITIAL_WIDTH,
       },
     });
   },

--- a/packages/dashboard/src/customization/widgets/lineChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/lineChart/plugin.tsx
@@ -6,6 +6,7 @@ import type { DashboardPlugin } from '~/customization/api';
 import type { LineChartWidget } from '../types';
 import { PropertyDataType } from '@aws-sdk/client-iotsitewise';
 import { queryWidgetOnDrop } from '../queryWidget/multiQueryWidgetDrop';
+import { WIDGET_INITIAL_HEIGHT, WIDGET_INITIAL_WIDTH } from '../constants';
 
 export const lineChartPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
@@ -34,8 +35,8 @@ export const lineChartPlugin: DashboardPlugin = {
         },
       }),
       initialSize: {
-        height: 250,
-        width: 270,
+        height: WIDGET_INITIAL_HEIGHT,
+        width: WIDGET_INITIAL_WIDTH,
       },
     });
   },

--- a/packages/dashboard/src/customization/widgets/scatterChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/scatterChart/plugin.tsx
@@ -6,6 +6,7 @@ import type { DashboardPlugin } from '~/customization/api';
 import type { ScatterChartWidget } from '../types';
 import { PropertyDataType } from '@aws-sdk/client-iotsitewise';
 import { queryWidgetOnDrop } from '../queryWidget/multiQueryWidgetDrop';
+import { WIDGET_INITIAL_HEIGHT, WIDGET_INITIAL_WIDTH } from '../constants';
 
 export const scatterChartPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
@@ -34,8 +35,8 @@ export const scatterChartPlugin: DashboardPlugin = {
         },
       }),
       initialSize: {
-        height: 250,
-        width: 270,
+        height: WIDGET_INITIAL_HEIGHT,
+        width: WIDGET_INITIAL_WIDTH,
       },
     });
   },

--- a/packages/dashboard/src/customization/widgets/status-timeline/statusTimelinePlugin.tsx
+++ b/packages/dashboard/src/customization/widgets/status-timeline/statusTimelinePlugin.tsx
@@ -5,6 +5,7 @@ import { StatusTimelineWidget } from '../types';
 import StatusTimelineWidgetComponent from './statusTimeline';
 import StatusTimelineIcon from './statusTimelineIcon';
 import { queryWidgetOnDrop } from '../queryWidget/multiQueryWidgetDrop';
+import { WIDGET_INITIAL_HEIGHT, WIDGET_INITIAL_WIDTH } from '../constants';
 
 export const statusTimelineChartPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
@@ -29,8 +30,8 @@ export const statusTimelineChartPlugin: DashboardPlugin = {
         },
       }),
       initialSize: {
-        height: 250,
-        width: 270,
+        height: WIDGET_INITIAL_HEIGHT,
+        width: WIDGET_INITIAL_WIDTH,
       },
     });
   },

--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -11,7 +11,7 @@ import type { TableWidget } from '../types';
 import { useQueries } from '~/components/dashboard/queryContext';
 import { useChartSize } from '~/hooks/useChartSize';
 import { DEFAULT_PREFERENCES } from './table-config';
-import { TABLE_OVERFLOW_HEIGHT, TABLE_WIDGET_MAX_HEIGHT } from './constants';
+import { TABLE_OVERFLOW_HEIGHT, TABLE_WIDGET_MAX_HEIGHT } from '../constants';
 
 export const DEFAULT_TABLE_COLUMN_DEFINITIONS: TableColumnDefinition[] = [
   {

--- a/packages/dashboard/src/customization/widgets/table/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/table/plugin.tsx
@@ -5,10 +5,10 @@ import TableIcon from './icon';
 import { toId } from '@iot-app-kit/source-iotsitewise';
 import type { DashboardPlugin } from '~/customization/api';
 import type { TableWidget } from '../types';
-import { TABLE_WIDGET_INITIAL_HEIGHT, TABLE_WIDGET_INITIAL_WIDTH } from './constants';
 import { queryWidgetOnDrop } from '../queryWidget/multiQueryWidgetDrop';
 import { ResourcePanelItem } from '~/components/resourceExplorer/components/panel';
 import { DashboardWidget } from '~/types';
+import { TABLE_WIDGET_INITIAL_HEIGHT, TABLE_WIDGET_INITIAL_WIDTH } from '../constants';
 
 const tableOnDropAsset = (item: ResourcePanelItem, widget: DashboardWidget) => {
   const tableWidget = widget as TableWidget;


### PR DESCRIPTION
## Overview
This PR is for the chart initial widget size updates. new changes include
Line, scatter, bar, timeline charts will have default size: height- 400, width- 650 and for KPI default size is set to: height-200 and width- 350

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
