### PR TITLE
fix(composer): autofocus on error, rules panel

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
@@ -1,5 +1,14 @@
-import React, { useCallback, useContext, useState } from 'react';
-import { AttributeEditor, Box, Button, FormField, Input, SpaceBetween, Textarea } from '@awsui/components-react';
+import React, { useCallback, useContext, useRef, useState } from 'react';
+import {
+  AttributeEditor,
+  Box,
+  Button,
+  FormField,
+  Input,
+  InputProps,
+  SpaceBetween,
+  Textarea,
+} from '@awsui/components-react';
 import { useIntl } from 'react-intl';
 
 import { useSceneDocument } from '../../store';
@@ -119,6 +128,7 @@ export const SceneRulesPanel: React.FC = () => {
   const { getSceneRuleMapById, listSceneRuleMapIds, updateSceneRuleMapById } = useSceneDocument(sceneComposerId);
   const [newRuleBasedMapId, setNewRuleBasedMapId] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
+  const inputRef = useRef<InputProps.Ref | null>(null);
   const intl = useIntl();
 
   const onAddRuleClick = useCallback(() => {
@@ -134,6 +144,7 @@ export const SceneRulesPanel: React.FC = () => {
           description: 'Error message wrong input',
         }),
       );
+      inputRef.current?.focus();
     }
   }, [newRuleBasedMapId]);
 
@@ -157,6 +168,7 @@ export const SceneRulesPanel: React.FC = () => {
               onChange={(event) => {
                 setNewRuleBasedMapId(event.detail.value);
               }}
+              ref={inputRef}
             />
           </FormField>
           <Button data-testid='addNewRuleButton' onClick={onAddRuleClick}>


### PR DESCRIPTION
## Overview
To meet a11y guidelines, focus should move to the first form field in error upon form submission. This PR fixes this issue for the rules panel.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
