### PR TITLE
feat: chart fit and finish - match cloudscape colors for axis and lab…

### DIFF
--- a/packages/react-components/src/components/chart/converters/convertAxis.ts
+++ b/packages/react-components/src/components/chart/converters/convertAxis.ts
@@ -8,4 +8,8 @@ export const convertYAxis = (axis: ChartAxisOptions | undefined): YAXisComponent
   show: axis?.showY ?? DEFAULT_Y_AXIS.show,
   min: axis?.yMin ?? undefined,
   max: axis?.yMax ?? undefined,
+  axisLabel: {
+    hideOverlap: true,
+    color: '#5f6b7a',
+  },
 });

--- a/packages/react-components/src/components/chart/hooks/useXAxis.ts
+++ b/packages/react-components/src/components/chart/hooks/useXAxis.ts
@@ -11,6 +11,13 @@ export const useXAxis = (viewportInMs: ViewportInMs, axis?: ChartAxisOptions): X
       type: 'time' as const,
       axisLabel: {
         hideOverlap: true,
+        color: '#5f6b7a',
+      },
+      axisLine: {
+        lineStyle: {
+          color: '#e9ebed',
+          width: 2,
+        },
       },
       splitNumber: 6,
       min: 0,


### PR DESCRIPTION
![image](https://github.com/awslabs/iot-app-kit/assets/81667589/8e6d35fd-fa31-41b9-b960-9b300a9615ad)

Issue : https://github.com/awslabs/iot-app-kit/issues/1929

Changes in the CR:
axis label for E-chart - grey-550
axis line - grey-200, 2px