### PR TITLE
fix(dashboard): removing all props wont crash chart

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
@@ -118,7 +118,7 @@ describe(`${PropertiesPanel.name}`, () => {
     await renderTestComponentAsync();
 
     expect(screen.getByText('Style')).toBeVisible();
-    expect(screen.getByText('Properties & Alarms')).toBeVisible();
+    expect(screen.getByText('Properties')).toBeVisible();
     expect(screen.getByText('Thresholds')).toBeVisible();
   });
 
@@ -152,7 +152,7 @@ describe(`${PropertiesPanel.name}`, () => {
     const element = await renderTestComponentAsync();
     const trigger = createWrapper(element.baseElement);
 
-    expect(screen.getByText('Properties & Alarms')).toBeVisible();
+    expect(screen.getByText('Properties')).toBeVisible();
 
     await act(() => {
       trigger.findTabs()?.findTabLinkByIndex(2)?.click();

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.tsx
@@ -27,8 +27,8 @@ export const PropertiesPanel = () => {
             content: <StylesSection />,
           },
           {
-            label: 'Properties & Alarms',
-            id: 'propertiesAndAlarms',
+            label: 'Properties',
+            id: 'properties',
             content: (
               <SpaceBetween size='xs' direction='vertical'>
                 <PropertiesAndAlarmsSettingsConfiguration />

--- a/packages/dashboard/src/customization/widgets/utils/widgetAggregationUtils.ts
+++ b/packages/dashboard/src/customization/widgets/utils/widgetAggregationUtils.ts
@@ -47,6 +47,8 @@ export const getAggregation = (widget: QueryWidget | LineScatterChartWidget) => 
     return widget.properties.aggregationType;
   }
 
+  if (widget.properties.queryConfig.query?.assets.length === 0) return undefined;
+
   const firstAssetProperty = widget.properties.queryConfig.query?.assets[0].properties[0];
   return firstAssetProperty?.aggregationType;
 };


### PR DESCRIPTION
## Overview
Removing all properties from a chart wont crash the chart anymore :) 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
