### PR TITLE
feat: make session token optional for local development

### DIFF
--- a/packages/dashboard/testing/getEnvCredentials.ts
+++ b/packages/dashboard/testing/getEnvCredentials.ts
@@ -1,17 +1,27 @@
-export const getEnvCredentials = () => {
-  if (
-    process.env.AWS_ACCESS_KEY_ID == null ||
-    process.env.AWS_SECRET_ACCESS_KEY == null ||
-    process.env.AWS_SESSION_TOKEN == null
-  ) {
-    throw new Error(
-      'Missing credentials: must provide the following env variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN within .env'
-    );
+interface Credentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string | undefined;
+}
+
+/** Call to return AWS SDK credentials defined in `.env`.  */
+export function getEnvCredentials(): Credentials | never {
+  const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  const sessionToken = process.env.AWS_SESSION_TOKEN;
+
+  if (!accessKeyId) {
+    throw new Error('Missing credentials: AWS_ACCESS_KEY_ID. Update AWS_ACCESS_KEY_ID in root `.env` file.');
   }
+
+  if (!secretAccessKey) {
+    throw new Error('Missing credentials: AWS_SECRET_ACCESS_KEY. Update AWS_SECRET_ACCESS_KEY in root `.env` file.');
+  }
+
   return {
     // Provided by `.env` environment variable file
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-    sessionToken: process.env.AWS_SESSION_TOKEN,
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
   };
-};
+}


### PR DESCRIPTION
## Overview
This change removes the requirement to set a session token when developing the dashboard locally, allowing usage of non-emphemeral AWS credentials.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
