### PR TITLE
fix(composer): add aria labels to buttons in hierarchy panel

### DIFF
--- a/packages/scene-composer/src/components/Tree/TreeItem.tsx
+++ b/packages/scene-composer/src/components/Tree/TreeItem.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@awsui/components-react';
 import React, { ComponentPropsWithRef, FC, ReactNode, useCallback } from 'react';
+import { useIntl } from 'react-intl';
 
 import RadioButton from '../RadioButton';
 import { useStore } from '../../store';
@@ -17,7 +18,8 @@ interface TreeItemInnerProps {
 }
 
 export interface TreeItemProps extends TreeItemInnerProps, ComponentPropsWithRef<'li'> {
-  labelText: ReactNode;
+  labelNode: ReactNode;
+  labelText: string;
   selectionMode?: SelectionMode;
 
   // Expandable
@@ -77,6 +79,7 @@ const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
   (
     {
       className = '',
+      labelNode,
       labelText,
       children,
       selected,
@@ -91,6 +94,7 @@ const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
     }: TreeItemProps,
     ref,
   ) => {
+    const { formatMessage } = useIntl();
     const expandHandler = useCallback(
       async (e) => {
         e.stopPropagation(); // Prevent bubbling that would result in triggering selected.
@@ -111,7 +115,7 @@ const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
           selectable={selectable}
           onActivated={onActivated}
           onSelected={onSelected}
-          label={(labelText as any)?.props?.labelText || ''}
+          label={labelText}
         >
           {expandable && (
             <Button
@@ -119,9 +123,21 @@ const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
               variant='inline-icon'
               onClick={expandHandler}
               iconName={`treeview-${expanded ? 'collapse' : 'expand'}`}
+              ariaExpanded={expanded}
+              ariaLabel={`${
+                expanded
+                  ? formatMessage({
+                      defaultMessage: 'Collapse',
+                      description: 'Label for button that triggers a collapsable section',
+                    })
+                  : formatMessage({
+                      defaultMessage: 'Expand',
+                      description: 'Label for button that triggers a expandable section',
+                    })
+              } ${labelText}`}
             />
           )}
-          {labelText}
+          {labelNode}
         </TreeItemInner>
         {!expandable || (expandable && expanded) ? children : null}
       </li>

--- a/packages/scene-composer/src/components/Tree/__tests__/TreeItem.spec.tsx
+++ b/packages/scene-composer/src/components/Tree/__tests__/TreeItem.spec.tsx
@@ -2,22 +2,28 @@ import { render, fireEvent } from '@testing-library/react';
 import React, { useRef, useState } from 'react';
 
 import TreeItem, { TreeItemProps } from '../TreeItem';
+import SceneNodeLabel from '../../panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneNodeLabel';
 
 jest.mock('react-dnd', () => ({
   useDrag: jest.fn(() => [1, useRef(2)]),
   useDrop: jest.fn(() => [1, useRef(2)]),
 }));
 
+jest.mock('../../panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneNodeLabel', () => (props) => (
+  <div data-mocked='SceneNodeLabel'>{JSON.stringify(props)}</div>
+));
+
+const mockSceneNodeLabel = ({ label }) => <SceneNodeLabel objectRef='' labelText={label} componentTypes={['']} />;
+
 describe('<TreeItem />', () => {
   (
     [
-      { labelText: '', selected: false, expandable: false },
-      { labelText: null, selected: false, expandable: false },
-      { labelText: 'Label 1', selected: false, expandable: false },
-      { labelText: <span>Label</span>, selected: false, expandable: false },
-      { labelText: 'Label', selected: true, expandable: false },
-      { labelText: 'Label', selected: false, expandable: true },
-      { labelText: 'Label', selected: true, expandable: true },
+      { labelNode: mockSceneNodeLabel({ label: '' }), labelText: '', selected: false, expandable: false },
+      { labelNode: mockSceneNodeLabel({ label: 'Label 1' }), labelText: 'Label 1', selected: false, expandable: false },
+      { labelNode: mockSceneNodeLabel({ label: 'Label' }), labelText: 'Label', selected: false, expandable: false },
+      { labelNode: mockSceneNodeLabel({ label: 'Label' }), labelText: 'Label', selected: true, expandable: false },
+      { labelNode: mockSceneNodeLabel({ label: 'Label' }), labelText: 'Label', selected: false, expandable: true },
+      { labelNode: mockSceneNodeLabel({ label: 'Label' }), labelText: 'Label', selected: true, expandable: true },
     ] as TreeItemProps[]
   ).forEach((props) => {
     it(`should render appropriate configuration "${JSON.stringify(props)}"`, () => {
@@ -29,7 +35,9 @@ describe('<TreeItem />', () => {
   it(`should activate on double click`, () => {
     const onActivated = jest.fn();
 
-    const { container } = render(<TreeItem labelText='Click me' onActivated={onActivated} />);
+    const { container } = render(
+      <TreeItem labelNode={mockSceneNodeLabel({ label: 'Click me' })} labelText='Click me' onActivated={onActivated} />,
+    );
     const target = container.querySelector('.tm-tree-item-inner') as Element;
 
     fireEvent.doubleClick(target);
@@ -39,7 +47,9 @@ describe('<TreeItem />', () => {
   it(`should select on click`, () => {
     const onSelected = jest.fn();
 
-    const { container } = render(<TreeItem labelText='Click me' onSelected={onSelected} />);
+    const { container } = render(
+      <TreeItem labelNode={mockSceneNodeLabel({ label: 'Click me' })} labelText='Click me' onSelected={onSelected} />,
+    );
     const target = container.querySelector('.tm-tree-item-inner') as Element;
 
     fireEvent.click(target);
@@ -51,7 +61,13 @@ describe('<TreeItem />', () => {
       const [expand, setExpand] = useState(false);
 
       return (
-        <TreeItem expandable onExpand={setExpand} expanded={expand} labelText='I am expandable'>
+        <TreeItem
+          expandable
+          onExpand={setExpand}
+          expanded={expand}
+          labelNode={mockSceneNodeLabel({ label: 'I am expandable' })}
+          labelText='I am expandable'
+        >
           <div data-testid='hidden-section'>I should only exist when expanded</div>
         </TreeItem>
       );
@@ -75,15 +91,20 @@ describe('<TreeItem />', () => {
           >
             <input
               type="radio"
-              value=""
+              value="I am expandable"
             />
             <div
+              arialabel="Collapse I am expandable"
               class="tm-tree-item-expand-btn"
               data-mocked="Button"
               iconname="treeview-collapse"
               variant="inline-icon"
             />
-            I am expandable
+            <div
+              data-mocked="SceneNodeLabel"
+            >
+              {"objectRef":"","labelText":"I am expandable","componentTypes":[""]}
+            </div>
           </label>
           <div
             data-testid="hidden-section"
@@ -104,6 +125,7 @@ describe('<TreeItem />', () => {
           expandable
           onSelected={() => setSelected(!selected)}
           selected={selected}
+          labelNode={mockSceneNodeLabel({ label: `${selected ? 'selected' : 'not selected'}` })}
           labelText={`${selected ? 'selected' : 'not selected'}`}
         />
       );
@@ -128,15 +150,20 @@ describe('<TreeItem />', () => {
           >
             <input
               type="radio"
-              value=""
+              value="selected"
             />
             <div
+              arialabel="Expand selected"
               class="tm-tree-item-expand-btn"
               data-mocked="Button"
               iconname="treeview-expand"
               variant="inline-icon"
             />
-            selected
+            <div
+              data-mocked="SceneNodeLabel"
+            >
+              {"objectRef":"","labelText":"selected","componentTypes":[""]}
+            </div>
           </label>
         </li>
       </div>
@@ -152,6 +179,7 @@ describe('<TreeItem />', () => {
           children={null}
           onSelected={() => setSelected(!selected)}
           selected={selected}
+          labelNode={mockSceneNodeLabel({ label: `${selected ? 'selected' : 'not selected'}` })}
           labelText={`${selected ? 'selected' : 'not selected'}`}
         />
       );
@@ -176,9 +204,13 @@ describe('<TreeItem />', () => {
           >
             <input
               type="radio"
-              value=""
+              value="selected"
             />
-            selected
+            <div
+              data-mocked="SceneNodeLabel"
+            >
+              {"objectRef":"","labelText":"selected","componentTypes":[""]}
+            </div>
           </label>
         </li>
       </div>

--- a/packages/scene-composer/src/components/Tree/__tests__/__snapshots__/TreeItem.spec.tsx.snap
+++ b/packages/scene-composer/src/components/Tree/__tests__/__snapshots__/TreeItem.spec.tsx.snap
@@ -1,50 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<TreeItem /> should render appropriate configuration "{"labelText":"","selected":false,"expandable":false}" 1`] = `
+exports[`<TreeItem /> should render appropriate configuration "{"labelNode":{"key":null,"ref":null,"props":{"objectRef":"","labelText":"","componentTypes":[""]},"_owner":null,"_store":{}},"labelText":"","selected":false,"expandable":false}" 1`] = `
 <div>
   <li
     class="tm-tree-item"
-    role="treeitem"
-  >
-    <label
-      aria-selected="false"
-      class="tm-tree-item-inner"
-    >
-      <input
-        type="radio"
-        value=""
-      />
-    </label>
-    Item
-  </li>
-</div>
-`;
-
-exports[`<TreeItem /> should render appropriate configuration "{"labelText":"Label 1","selected":false,"expandable":false}" 1`] = `
-<div>
-  <li
-    class="tm-tree-item"
-    role="treeitem"
-  >
-    <label
-      aria-selected="false"
-      class="tm-tree-item-inner"
-    >
-      <input
-        type="radio"
-        value=""
-      />
-      Label 1
-    </label>
-    Item
-  </li>
-</div>
-`;
-
-exports[`<TreeItem /> should render appropriate configuration "{"labelText":"Label","selected":false,"expandable":true}" 1`] = `
-<div>
-  <li
-    class="tm-tree-item expandable"
     role="treeitem"
   >
     <label
@@ -56,18 +15,98 @@ exports[`<TreeItem /> should render appropriate configuration "{"labelText":"Lab
         value=""
       />
       <div
+        data-mocked="SceneNodeLabel"
+      >
+        {"objectRef":"","labelText":"","componentTypes":[""]}
+      </div>
+    </label>
+    Item
+  </li>
+</div>
+`;
+
+exports[`<TreeItem /> should render appropriate configuration "{"labelNode":{"key":null,"ref":null,"props":{"objectRef":"","labelText":"Label 1","componentTypes":[""]},"_owner":null,"_store":{}},"labelText":"Label 1","selected":false,"expandable":false}" 1`] = `
+<div>
+  <li
+    class="tm-tree-item"
+    role="treeitem"
+  >
+    <label
+      aria-selected="false"
+      class="tm-tree-item-inner"
+    >
+      <input
+        type="radio"
+        value="Label 1"
+      />
+      <div
+        data-mocked="SceneNodeLabel"
+      >
+        {"objectRef":"","labelText":"Label 1","componentTypes":[""]}
+      </div>
+    </label>
+    Item
+  </li>
+</div>
+`;
+
+exports[`<TreeItem /> should render appropriate configuration "{"labelNode":{"key":null,"ref":null,"props":{"objectRef":"","labelText":"Label","componentTypes":[""]},"_owner":null,"_store":{}},"labelText":"Label","selected":false,"expandable":false}" 1`] = `
+<div>
+  <li
+    class="tm-tree-item"
+    role="treeitem"
+  >
+    <label
+      aria-selected="false"
+      class="tm-tree-item-inner"
+    >
+      <input
+        type="radio"
+        value="Label"
+      />
+      <div
+        data-mocked="SceneNodeLabel"
+      >
+        {"objectRef":"","labelText":"Label","componentTypes":[""]}
+      </div>
+    </label>
+    Item
+  </li>
+</div>
+`;
+
+exports[`<TreeItem /> should render appropriate configuration "{"labelNode":{"key":null,"ref":null,"props":{"objectRef":"","labelText":"Label","componentTypes":[""]},"_owner":null,"_store":{}},"labelText":"Label","selected":false,"expandable":true}" 1`] = `
+<div>
+  <li
+    class="tm-tree-item expandable"
+    role="treeitem"
+  >
+    <label
+      aria-selected="false"
+      class="tm-tree-item-inner"
+    >
+      <input
+        type="radio"
+        value="Label"
+      />
+      <div
+        arialabel="Expand Label"
         class="tm-tree-item-expand-btn"
         data-mocked="Button"
         iconname="treeview-expand"
         variant="inline-icon"
       />
-      Label
+      <div
+        data-mocked="SceneNodeLabel"
+      >
+        {"objectRef":"","labelText":"Label","componentTypes":[""]}
+      </div>
     </label>
   </li>
 </div>
 `;
 
-exports[`<TreeItem /> should render appropriate configuration "{"labelText":"Label","selected":true,"expandable":false}" 1`] = `
+exports[`<TreeItem /> should render appropriate configuration "{"labelNode":{"key":null,"ref":null,"props":{"objectRef":"","labelText":"Label","componentTypes":[""]},"_owner":null,"_store":{}},"labelText":"Label","selected":true,"expandable":false}" 1`] = `
 <div>
   <li
     class="tm-tree-item"
@@ -80,16 +119,20 @@ exports[`<TreeItem /> should render appropriate configuration "{"labelText":"Lab
       <input
         checked=""
         type="radio"
-        value=""
+        value="Label"
       />
-      Label
+      <div
+        data-mocked="SceneNodeLabel"
+      >
+        {"objectRef":"","labelText":"Label","componentTypes":[""]}
+      </div>
     </label>
     Item
   </li>
 </div>
 `;
 
-exports[`<TreeItem /> should render appropriate configuration "{"labelText":"Label","selected":true,"expandable":true}" 1`] = `
+exports[`<TreeItem /> should render appropriate configuration "{"labelNode":{"key":null,"ref":null,"props":{"objectRef":"","labelText":"Label","componentTypes":[""]},"_owner":null,"_store":{}},"labelText":"Label","selected":true,"expandable":true}" 1`] = `
 <div>
   <li
     class="tm-tree-item expandable"
@@ -102,59 +145,21 @@ exports[`<TreeItem /> should render appropriate configuration "{"labelText":"Lab
       <input
         checked=""
         type="radio"
-        value=""
+        value="Label"
       />
       <div
+        arialabel="Expand Label"
         class="tm-tree-item-expand-btn"
         data-mocked="Button"
         iconname="treeview-expand"
         variant="inline-icon"
       />
-      Label
+      <div
+        data-mocked="SceneNodeLabel"
+      >
+        {"objectRef":"","labelText":"Label","componentTypes":[""]}
+      </div>
     </label>
-  </li>
-</div>
-`;
-
-exports[`<TreeItem /> should render appropriate configuration "{"labelText":{"type":"span","key":null,"ref":null,"props":{"children":"Label"},"_owner":null,"_store":{}},"selected":false,"expandable":false}" 1`] = `
-<div>
-  <li
-    class="tm-tree-item"
-    role="treeitem"
-  >
-    <label
-      aria-selected="false"
-      class="tm-tree-item-inner"
-    >
-      <input
-        type="radio"
-        value=""
-      />
-      <span>
-        Label
-      </span>
-    </label>
-    Item
-  </li>
-</div>
-`;
-
-exports[`<TreeItem /> should render appropriate configuration "{"labelText":null,"selected":false,"expandable":false}" 1`] = `
-<div>
-  <li
-    class="tm-tree-item"
-    role="treeitem"
-  >
-    <label
-      aria-selected="false"
-      class="tm-tree-item-inner"
-    >
-      <input
-        type="radio"
-        value=""
-      />
-    </label>
-    Item
   </li>
 </div>
 `;

--- a/packages/scene-composer/src/components/Tree/__tests__/__snapshots__/tree.spec.tsx.snap
+++ b/packages/scene-composer/src/components/Tree/__tests__/__snapshots__/tree.spec.tsx.snap
@@ -16,9 +16,13 @@ exports[`<Tree /> should render appropriate structure 1`] = `
       >
         <input
           type="radio"
-          value=""
+          value="Level 1"
         />
-        Level 1
+        <div
+          data-mocked="SceneNodeLabel"
+        >
+          {"objectRef":"","labelText":"Level 1","componentTypes":[""]}
+        </div>
       </label>
       <ol
         class="tm-tree"
@@ -34,9 +38,13 @@ exports[`<Tree /> should render appropriate structure 1`] = `
           >
             <input
               type="radio"
-              value=""
+              value="Level 2"
             />
-            Level 2
+            <div
+              data-mocked="SceneNodeLabel"
+            >
+              {"objectRef":"","labelText":"Level 2","componentTypes":[""]}
+            </div>
           </label>
           <ol
             class="tm-tree"
@@ -52,9 +60,13 @@ exports[`<Tree /> should render appropriate structure 1`] = `
               >
                 <input
                   type="radio"
-                  value=""
+                  value="Level 3"
                 />
-                Level 1
+                <div
+                  data-mocked="SceneNodeLabel"
+                >
+                  {"objectRef":"","labelText":"Level 3","componentTypes":[""]}
+                </div>
               </label>
             </li>
           </ol>
@@ -71,9 +83,13 @@ exports[`<Tree /> should render appropriate structure 1`] = `
       >
         <input
           type="radio"
-          value=""
+          value="Level 1 Sibling"
         />
-        Level 1 Sibling
+        <div
+          data-mocked="SceneNodeLabel"
+        >
+          {"objectRef":"","labelText":"Level 1 Sibling","componentTypes":[""]}
+        </div>
       </label>
     </li>
   </ol>

--- a/packages/scene-composer/src/components/Tree/__tests__/tree.spec.tsx
+++ b/packages/scene-composer/src/components/Tree/__tests__/tree.spec.tsx
@@ -2,26 +2,33 @@ import React, { useRef } from 'react';
 import { render } from '@testing-library/react';
 
 import Tree, { TreeItem } from '..';
+import SceneNodeLabel from '../../panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneNodeLabel';
 
 jest.mock('react-dnd', () => ({
   useDrag: jest.fn(() => [1, useRef(2)]),
   useDrop: jest.fn(() => [1, useRef(2)]),
 }));
 
+jest.mock('../../panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneNodeLabel', () => (props) => (
+  <div data-mocked='SceneNodeLabel'>{JSON.stringify(props)}</div>
+));
+
+const mockSceneNodeLabel = ({ label }) => <SceneNodeLabel objectRef='' labelText={label} componentTypes={['']} />;
+
 describe('<Tree />', () => {
   it('should render appropriate structure', () => {
     const { container } = render(
       <Tree>
-        <TreeItem labelText='Level 1'>
+        <TreeItem labelNode={mockSceneNodeLabel({ label: 'Level 1' })} labelText='Level 1'>
           <Tree>
-            <TreeItem labelText='Level 2'>
+            <TreeItem labelNode={mockSceneNodeLabel({ label: 'Level 2' })} labelText='Level 2'>
               <Tree>
-                <TreeItem labelText='Level 1' />
+                <TreeItem labelNode={mockSceneNodeLabel({ label: 'Level 3' })} labelText='Level 3' />
               </Tree>
             </TreeItem>
           </Tree>
         </TreeItem>
-        <TreeItem labelText='Level 1 Sibling' />
+        <TreeItem labelNode={mockSceneNodeLabel({ label: 'Level 1 Sibling' })} labelText='Level 1 Sibling' />
       </Tree>,
     );
 

--- a/packages/scene-composer/src/components/VisibilityToggle/index.tsx
+++ b/packages/scene-composer/src/components/VisibilityToggle/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useCallback } from 'react';
 import { Button, ButtonProps } from '@awsui/components-react';
+import { useIntl } from 'react-intl';
 
 import { Show } from '../../assets/auto-gen/icons';
 
@@ -11,6 +12,8 @@ interface VisibilityToggleProps extends ButtonProps {
 }
 
 const VisibilityToggle: FC<VisibilityToggleProps> = ({ visible = true, onToggle = () => {}, ...props }) => {
+  const { formatMessage } = useIntl();
+
   const onToggleHandler = useCallback(
     (e) => {
       onToggle(!visible);
@@ -30,6 +33,10 @@ const VisibilityToggle: FC<VisibilityToggleProps> = ({ visible = true, onToggle 
           <Show />
         </span>
       }
+      ariaLabel={formatMessage({
+        defaultMessage: 'Toggle visibility',
+        description: 'Label for button that toggles visibility of nodes in the scene',
+      })}
     />
   );
 };

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
@@ -96,7 +96,8 @@ const SceneHierarchyTreeItem: FC<SceneHierarchyTreeItemProps> = ({
   return (
     <EnhancedTreeItem
       key={key}
-      labelText={<SceneNodeLabel objectRef={key} labelText={labelText} componentTypes={componentTypes} />}
+      labelNode={<SceneNodeLabel objectRef={key} labelText={labelText} componentTypes={componentTypes} />}
+      labelText={labelText}
       onExpand={onExpandNode}
       expanded={expanded}
       expandable={((node && node.childRefs.length > 0) || showSubModel) && !isSearching}

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/__snapshots__/SceneHierarchyTreeItem.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/__snapshots__/SceneHierarchyTreeItem.spec.tsx.snap
@@ -7,6 +7,7 @@ exports[`SceneHierarchyTreeItem should bubble up when expanded 1`] = `
     data="{\\"ref\\":\\"1\\"}"
     data-mocked="EnhancedTreeItem"
     datatype="modelRef"
+    labeltext="Label 1"
     selectionmode="single"
   >
     <div>
@@ -28,6 +29,7 @@ exports[`SceneHierarchyTreeItem should render SubModelTree when item has a model
     data="{\\"ref\\":\\"1\\"}"
     data-mocked="EnhancedTreeItem"
     datatype="ModelRef"
+    labeltext="Label 1"
     selectionmode="single"
   >
     <div>
@@ -49,6 +51,7 @@ exports[`SceneHierarchyTreeItem should render dynamic node with drag and drop di
     data="{\\"ref\\":\\"1\\"}"
     data-mocked="EnhancedTreeItem"
     datatype="Tag"
+    labeltext="Label 1"
     selectionmode="single"
   >
     <div>

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
@@ -51,6 +51,7 @@ exports[`SubModelTree should not render a SubModel Tree if isOriginal flag is fa
       class="tm-tree-item-inner"
     >
       <div
+        arialabel="Expand RootObject"
         class="tm-tree-item-expand-btn"
         data-mocked="Button"
         iconname="treeview-expand"
@@ -77,6 +78,7 @@ exports[`SubModelTree should not render a SubModel Tree if name is null 1`] = `
       class="tm-tree-item-inner"
     >
       <div
+        arialabel="Expand RootObject"
         class="tm-tree-item-expand-btn"
         data-mocked="Button"
         iconname="treeview-expand"
@@ -103,6 +105,7 @@ exports[`SubModelTree should render appropriately based on the object 1`] = `
       class="tm-tree-item-inner"
     >
       <div
+        arialabel="Expand RootObject"
         class="tm-tree-item-expand-btn"
         data-mocked="Button"
         iconname="treeview-expand"

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTreeItemLabel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTreeItemLabel.spec.tsx.snap
@@ -20,6 +20,7 @@ exports[`SubModelTreeItemLabel should render as appropriate 1`] = `
         variant="inline-icon"
       />
       <div
+        arialabel="Toggle visibility"
         class="tm-visibility-toggle visible tm-icon-button"
         data-mocked="Button"
         variant="inline-icon"

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/index.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/index.tsx
@@ -146,7 +146,7 @@ const SubModelTree: FC<SubModelTreeProps> = ({
   return (
     <TreeItem
       className='tm-sub-model'
-      labelText={
+      labelNode={
         <TreeItemLabel
           onMouseOver={onHover}
           onMouseLeave={onMouseLeave}
@@ -157,6 +157,7 @@ const SubModelTree: FC<SubModelTreeProps> = ({
           {name}
         </TreeItemLabel>
       }
+      labelText={name}
       expandable={namedChildren.length > 0}
       expanded={expanded}
       onExpand={setExpanded}

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -31,6 +31,10 @@
     "note": "Distance Units in a dropdown menu",
     "text": "Custom Scale"
   },
+  "/RFl5Q": {
+    "note": "Label for button that triggers a expandable section",
+    "text": "Expand"
+  },
   "/j+uhN": {
     "note": "Select an icon",
     "text": "Select an icon"
@@ -499,6 +503,10 @@
     "note": "Label clarifying the exact text a user is searching for.",
     "text": "Use: {value}"
   },
+  "PIF5h2": {
+    "note": "Label for button that triggers a collapsable section",
+    "text": "Collapse"
+  },
   "PLTmIg": {
     "note": "circle picker",
     "text": "circlePicker"
@@ -530,6 +538,10 @@
   "QU6P87": {
     "note": "Distance Units in a dropdown menu",
     "text": "millimeters"
+  },
+  "QVa0GF": {
+    "note": "Label for button that toggles visibility of nodes in the scene",
+    "text": "Toggle visibility"
   },
   "R+xDel": {
     "note": "Form Field label",


### PR DESCRIPTION
## Overview
To meet a11y guidelines, all icon buttons must have appropriate aria labels so screen readers users can decipher their purpose.

Changes (nothing visual):
- Add ariaExpanded and ariaLabels to expand/collapse buttons in hierarchy panel
- Add ariaLabel to visibility toggle button
- Add a prop to TreeItem so that `labelText` is not overworked. This fixes a bug that (while not caught by level access) would prevent users using a screen reader from determining the usage of a checkbox in the `SubModelTree`

Pics (no visual change)
Before:
<img width="448" alt="Screenshot 2023-10-03 at 1 01 08 PM" src="https://github.com/awslabs/iot-app-kit/assets/143754227/018da49a-4f6d-4fe8-89c0-7634a971d1a2">

After:

<img width="448" alt="After" src="https://github.com/awslabs/iot-app-kit/assets/143754227/f0c15202-1cf9-41a2-9359-d20cbc8bab7f">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
