### PR TITLE
fix: fixed step after chart type #1978

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/typeSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/typeSection.tsx
@@ -10,7 +10,7 @@ const typeOptions = [
   defaultTypeOption,
   { label: 'Step before', value: 'step-start', description: 'Step points rendered at the end of the step.' },
   { label: 'Step middle', value: 'step-middle', description: 'Step points rendered in the middle of the step.' },
-  { label: 'Step after', value: 'step-after', description: 'Step points rendered at the beginning of the step.' },
+  { label: 'Step after', value: 'step-end', description: 'Step points rendered at the beginning of the step.' },
 ] as const;
 
 type TypeSectionOptions = {


### PR DESCRIPTION
## Overview
This change is made for the bug #1978
 
Renamed the **step-after** to **step-end** to work as expected 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
