### PR TITLE
fix(dashboard): fix styling for tile and config panel

### DIFF
--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -8,8 +8,9 @@ import {
   colorBorderDividerDefault,
   borderRadiusBadge,
   colorBackgroundContainerContent,
+  spaceScaledXxs,
   spaceScaledXs,
-  spaceScaledS,
+  spaceScaledM,
 } from '@cloudscape-design/design-tokens';
 import { CancelableEventHandler, ClickDetail } from '@cloudscape-design/components/internal/events';
 
@@ -67,7 +68,7 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
           style={{
             display: 'flex',
             justifyContent: 'space-between',
-            padding: `${spaceScaledXs} ${spaceScaledXs} 0 ${spaceScaledS}`,
+            padding: `${spaceScaledXs} ${spaceScaledXs} ${spaceScaledXxs} ${spaceScaledM}`,
             borderBottom: `2px solid ${colorBorderDividerDefault}`,
           }}
         >

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
@@ -58,6 +58,7 @@ const YAxisPropertyConfig = ({
             <SpaceBetween size='s' direction='horizontal'>
               <label htmlFor='y-axis-min'>Min</label>
               <Input
+                disabled={!property.yAxis?.visible}
                 placeholder='Auto'
                 controlId='y-axis-min'
                 value={`${property.yAxis?.yMin ?? ''}`}
@@ -68,6 +69,7 @@ const YAxisPropertyConfig = ({
             <SpaceBetween size='s' direction='horizontal'>
               <label htmlFor='y-axis-max'>Max</label>
               <Input
+                disabled={!property.yAxis?.visible}
                 placeholder='Auto'
                 controlId='y-axis-max'
                 value={`${property.yAxis?.yMax ?? ''}`}


### PR DESCRIPTION
## Overview
Make padding in widget tile consistent

Disable property level y-axis min/max controls when they are not applied to the property

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
