### PR TITLE
fix(dashboard): disable dashboard drag when shift key is pressed

### DIFF
--- a/packages/dashboard/src/components/grid/gestures/useGridDragAndDrop.ts
+++ b/packages/dashboard/src/components/grid/gestures/useGridDragAndDrop.ts
@@ -38,7 +38,7 @@ export const useGridDragAndDrop = ({
   });
   const { dragRef } = useDragMonitor({
     readOnly,
-    enabled,
+    enabled: enabled && !union,
     union,
     target,
     dashboardGrid,


### PR DESCRIPTION
## Overview
While panning in edit mode, dashboard elements were being selected. Panning on the bar chart is performed by holding shift and dragging.

This PR disables dragging on the dashboard when the shift key is pressed down.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/87385528/2e7587f2-7223-4af5-a9f7-b4a394d128af

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
