### PR TITLE
fix(composer): debounce component update to reduce UpdateEntity error

### DIFF
--- a/packages/scene-composer/src/common/entityModelConstants.ts
+++ b/packages/scene-composer/src/common/entityModelConstants.ts
@@ -1,7 +1,7 @@
 import { KnownComponentType } from '../interfaces';
 
 // Scene Nodes
-const SCENE_COMPONENT_TYPE_ID_PREFIX = 'com.example.3d';
+const SCENE_COMPONENT_TYPE_ID_PREFIX = 'com.amazon.iottwinmaker.3d';
 export const NODE_COMPONENT_TYPE_ID = `${SCENE_COMPONENT_TYPE_ID_PREFIX}.node`;
 export const LAYER_COMPONENT_TYPE_ID = `${SCENE_COMPONENT_TYPE_ID_PREFIX}.layer`;
 export const componentTypeToId: Record<KnownComponentType, string> = {

--- a/packages/scene-composer/src/components/panels/CommonPanelComponents.tsx
+++ b/packages/scene-composer/src/components/panels/CommonPanelComponents.tsx
@@ -4,9 +4,9 @@ import {
   AttributeEditor,
   Box,
   ExpandableSection,
-  FormField,
   Grid,
   Input,
+  InputProps,
   Select,
   SelectProps,
   SpaceBetween,
@@ -54,7 +54,7 @@ export function NumericInput(props: {
 export type TextInputProps = {
   value: string;
   setValue: (val: string | null) => void;
-};
+} & InputProps;
 
 export const TextInput = (props: TextInputProps): React.ReactElement => {
   const { value, setValue } = props;
@@ -66,6 +66,7 @@ export const TextInput = (props: TextInputProps): React.ReactElement => {
 
   return (
     <Input
+      {...props}
       value={inputValue}
       onChange={(event) => {
         setInputValue(event.detail.value);

--- a/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { act, render } from '@testing-library/react';
-import wrapper from '@awsui/components-react/test-utils/dom';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 
 import { KnownComponentType } from '../../../interfaces';
 import { IDataOverlayComponentInternal, ISceneNodeInternal, useStore } from '../../../store';
@@ -53,22 +52,23 @@ describe('DataOverlayComponentEditor', () => {
   it('should add new binding by clicking add button', async () => {
     useStore('default').setState(baseState);
 
-    const { container } = render(<DataOverlayComponentEditor node={node} component={component} />);
-    const polarisWrapper = wrapper(container);
+    const { getByDisplayValue } = render(<DataOverlayComponentEditor node={node} component={component} />);
 
-    const textarea = polarisWrapper.findTextarea();
+    const textarea = getByDisplayValue(component.dataRows[0].content);
     expect(textarea).not.toBeNull();
 
     const newContent = 'new content';
     act(() => {
-      textarea!.setTextareaValue(newContent);
+      fireEvent.change(textarea, { target: { value: newContent } });
     });
 
-    expect(updateComponentInternalMock).toBeCalledTimes(1);
-    expect(updateComponentInternalMock).toBeCalledWith(
-      node.ref,
-      { ref: component.ref, dataRows: [{ ...component.dataRows[0], content: newContent }] },
-      undefined,
+    waitFor(() => expect(updateComponentInternalMock).toBeCalledTimes(1));
+    waitFor(() =>
+      expect(updateComponentInternalMock).toBeCalledWith(
+        node.ref,
+        { ref: component.ref, dataRows: [{ ...component.dataRows[0], content: newContent }] },
+        undefined,
+      ),
     );
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.tsx
@@ -1,11 +1,13 @@
 import { FormField, SpaceBetween, Textarea } from '@awsui/components-react';
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
+import { debounce } from 'lodash';
 
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { Component } from '../../../models/SceneModels';
 import { IDataOverlayComponentInternal, ISceneComponentInternal, useStore } from '../../../store';
 import { IComponentEditorProps } from '../ComponentEditor';
+import useDynamicScene from '../../../hooks/useDynamicScene';
 
 import { ComponentWithDataBindings, DataBindingMapEditor } from './common/DataBindingMapEditor';
 
@@ -22,20 +24,30 @@ export const DataOverlayComponentEditor: React.FC<IDataOverlayComponentEditorPro
   const valueDataBindingProvider = useStore(sceneComposerId)(
     (state) => state.getEditorConfig().valueDataBindingProvider,
   );
+  const [newRows, setNewRows] = useState<Component.DataOverlayMarkdownRow[]>(component.dataRows);
+
+  const dynamicSceneEnabled = useDynamicScene();
 
   const { formatMessage } = useIntl();
   const onUpdateCallback = useCallback(
-    (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean) => {
-      const componentPartialWithRef = { ref: component.ref, ...componentPartial };
-      updateComponentInternal(node.ref, componentPartialWithRef as ISceneComponentInternal, replace);
-    },
+    debounce(
+      (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean) => {
+        const componentPartialWithRef = { ref: component.ref, ...componentPartial };
+        updateComponentInternal(node.ref, componentPartialWithRef as ISceneComponentInternal, replace);
+      },
+      dynamicSceneEnabled ? 1000 : 100,
+    ), // TODO: Temporary solution for the error when updating entity too frequent. Will implement a better solution for GA.
     [node.ref, component.ref],
   );
 
+  useEffect(() => {
+    setNewRows(component.dataRows);
+  }, [component.dataRows]);
+
   return (
     <SpaceBetween size='s'>
-      {component.dataRows.length > 0 &&
-        component.dataRows.map(
+      {newRows.length > 0 &&
+        newRows.map(
           (row, index) =>
             row.rowType === Component.DataOverlayRowType.Markdown && (
               <FormField
@@ -53,9 +65,10 @@ export const DataOverlayComponentEditor: React.FC<IDataOverlayComponentEditorPro
                     { variable: '${temperature-binding-name}' },
                   )}
                   onChange={(e) => {
-                    const newRows = [...component.dataRows];
-                    newRows[index] = { ...newRows[index], content: e.detail.value };
-                    onUpdateCallback({ dataRows: newRows });
+                    const changedRows = [...newRows];
+                    changedRows[index] = { ...changedRows[index], content: e.detail.value };
+                    setNewRows(changedRows);
+                    onUpdateCallback({ dataRows: changedRows });
                   }}
                 />
               </FormField>

--- a/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/common/DataBindingMapEditor.tsx
@@ -63,6 +63,22 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
     [component.valueDataBindings, onUpdateCallback],
   );
 
+  const onBindingNameChange = useCallback(
+    (bindingName: string, index) => {
+      // we don't want to merge the dataBindingContext, so we'll need to manually replace it
+      const updatedComponent = {
+        ...component,
+        valueDataBindings: [...component.valueDataBindings],
+      };
+      updatedComponent.valueDataBindings[index] = {
+        ...updatedComponent.valueDataBindings[index],
+        bindingName,
+      };
+      onUpdateCallback(updatedComponent, true);
+    },
+    [component, onUpdateCallback],
+  );
+
   const onRemoveBinding = useCallback(
     (index) => {
       const newBindings = component.valueDataBindings.filter((_, i) => i !== index);
@@ -99,9 +115,8 @@ export const DataBindingMapEditor: React.FC<IDataBindingMapEditorProps> = ({
                 {hasBindingName && (
                   <DataBindingMapNameEditor
                     bindingName={(binding as Component.ValueDataBindingNamedMap).bindingName}
-                    index={index}
                     valueDataBindings={component.valueDataBindings as Component.ValueDataBindingNamedMap[]}
-                    onUpdateCallback={onUpdateCallback}
+                    onBindingNameChange={(name) => onBindingNameChange(name, index)}
                   />
                 )}
 

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditor.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { act, render } from '@testing-library/react';
-import wrapper from '@awsui/components-react/test-utils/dom';
+import { act, fireEvent, render } from '@testing-library/react';
 
 import { DataBindingMapNameEditor } from './DataBindingMapNameEditor';
 
@@ -13,7 +12,7 @@ describe('DataBindingMapNameEditor', () => {
     {
       bindingName: 'binding-1',
       valueDataBinding: {
-        dataBindingContext: 'random-1',
+        dataBindingContext: { entityId: 'random-1' },
       },
     },
   ];
@@ -24,26 +23,23 @@ describe('DataBindingMapNameEditor', () => {
   });
 
   it('should update binding name', async () => {
-    const { container } = render(
+    const { getByDisplayValue } = render(
       <DataBindingMapNameEditor
         bindingName='binding-1'
-        index={0}
         valueDataBindings={valueDataBindings}
-        onUpdateCallback={onUpdateCallbackMock}
+        onBindingNameChange={onUpdateCallbackMock}
       />,
     );
-    const polarisWrapper = wrapper(container);
 
-    const nameInput = polarisWrapper.findInput('[data-testid="binding-name-input"]');
+    const nameInput = getByDisplayValue('binding-1');
     expect(nameInput).not.toBeNull();
 
     act(() => {
-      nameInput!.setInputValue('new-name');
+      fireEvent.change(nameInput, { target: { value: 'new-name' } });
+      fireEvent.blur(nameInput);
     });
 
     expect(onUpdateCallbackMock).toBeCalledTimes(1);
-    expect(onUpdateCallbackMock).toBeCalledWith({
-      valueDataBindings: [{ ...valueDataBindings[0], bindingName: 'new-name' }],
-    });
+    expect(onUpdateCallbackMock).toBeCalledWith('new-name');
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/data-overlay/DataBindingMapNameEditor.tsx
@@ -1,16 +1,15 @@
 import React, { useCallback } from 'react';
-import { FormField, Input } from '@awsui/components-react';
+import { FormField } from '@awsui/components-react';
 import { useIntl } from 'react-intl';
 import { isEmpty } from 'lodash';
 
-import { IDataOverlayComponentInternal } from '../../../../store';
 import { Component } from '../../../../models/SceneModels';
+import { TextInput } from '../../CommonPanelComponents';
 
 interface IDataBindingMapNameEditorProps {
   bindingName: string;
-  index: number;
   valueDataBindings: Component.ValueDataBindingNamedMap[];
-  onUpdateCallback: (componentPartial: Partial<IDataOverlayComponentInternal>, replace?: boolean | undefined) => void;
+  onBindingNameChange: (bindingName: string) => void;
 }
 
 // eslint-disable-next-line no-useless-escape
@@ -18,21 +17,20 @@ const INVALID_BINDING_NAME_CHARACTERS = /[\$\{\}\.\[\]]/g;
 
 export const DataBindingMapNameEditor: React.FC<IDataBindingMapNameEditorProps> = ({
   bindingName,
-  index,
   valueDataBindings,
-  onUpdateCallback,
+  onBindingNameChange,
 }) => {
   const { formatMessage } = useIntl();
 
   const bindingNameError = useCallback(
-    (bindingName: string) => {
-      if (isEmpty(bindingName)) {
+    (name: string) => {
+      if (isEmpty(name)) {
         return formatMessage({ defaultMessage: 'Invalid name', description: 'Input error message' });
       }
-      if (valueDataBindings.filter((v) => v.bindingName === bindingName).length > 1) {
+      if (valueDataBindings.filter((v) => v.bindingName === name).length > 1) {
         return formatMessage({ defaultMessage: 'Duplicate name', description: 'Input error message' });
       }
-      if (bindingName.search(INVALID_BINDING_NAME_CHARACTERS) >= 0) {
+      if (name.search(INVALID_BINDING_NAME_CHARACTERS) >= 0) {
         return formatMessage({ defaultMessage: 'Invalid character in the name', description: 'Input error message' });
       }
       return null;
@@ -40,13 +38,11 @@ export const DataBindingMapNameEditor: React.FC<IDataBindingMapNameEditorProps> 
     [valueDataBindings, formatMessage],
   );
 
-  const onBindingNameChange = useCallback(
-    (e, index) => {
-      const newBindings = [...valueDataBindings];
-      newBindings[index] = { ...newBindings[index], bindingName: e.detail.value };
-      onUpdateCallback({ valueDataBindings: newBindings });
+  const onNameChange = useCallback(
+    (e: string | null) => {
+      onBindingNameChange(e || '');
     },
-    [valueDataBindings, onUpdateCallback],
+    [onBindingNameChange],
   );
 
   return (
@@ -54,7 +50,7 @@ export const DataBindingMapNameEditor: React.FC<IDataBindingMapNameEditorProps> 
       errorText={bindingNameError(bindingName)}
       label={formatMessage({ defaultMessage: 'Binding Name', description: 'FormField label' })}
     >
-      <Input data-testid='binding-name-input' value={bindingName} onChange={(e) => onBindingNameChange(e, index)} />
+      <TextInput data-testid='binding-name-input' value={bindingName} setValue={onNameChange} />
     </FormField>
   );
 };

--- a/packages/scene-composer/src/utils/entityModelUtils/dataBindingUtils.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/dataBindingUtils.spec.ts
@@ -13,9 +13,6 @@ describe('createDataBindingMap', () => {
   it('should return map with only entityId', () => {
     expect(createDataBindingMap({ dataBindingContext: { entityId: 'eid' } })).toEqual({
       entityId: { stringValue: 'eid' },
-      componentName: { stringValue: undefined },
-      propertyName: { stringValue: undefined },
-      isStaticData: { stringValue: 'false' },
     });
   });
 

--- a/packages/scene-composer/src/utils/entityModelUtils/dataBindingUtils.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/dataBindingUtils.ts
@@ -14,25 +14,40 @@ enum DataBindingPropertyKey {
 
 export const createDataBindingMap = (
   binding: ValueDataBinding | undefined,
-): Record<DataBindingPropertyKey, DataValue> | {} => {
+): Partial<Record<DataBindingPropertyKey, DataValue>> => {
+  const result: Partial<Record<DataBindingPropertyKey, DataValue>> = {};
+
   if (!binding || isEmpty(binding.dataBindingContext)) {
-    return {};
+    return result;
   }
 
-  return {
-    [DataBindingPropertyKey.EntityId]: {
+  const context = binding.dataBindingContext as ITwinMakerEntityDataBindingContext;
+
+  if (context.entityId) {
+    result[DataBindingPropertyKey.EntityId] = {
       stringValue: binding.dataBindingContext.entityId,
-    },
-    [DataBindingPropertyKey.ComponentName]: {
-      stringValue: (binding.dataBindingContext as ITwinMakerEntityDataBindingContext).componentName,
-    },
-    [DataBindingPropertyKey.PropertyName]: {
-      stringValue: (binding.dataBindingContext as ITwinMakerEntityDataBindingContext).propertyName,
-    },
-    [DataBindingPropertyKey.IsStaticData]: {
+    };
+  }
+
+  if (context.componentName) {
+    result[DataBindingPropertyKey.ComponentName] = {
+      stringValue: context.componentName,
+    };
+  }
+
+  if (context.propertyName) {
+    result[DataBindingPropertyKey.PropertyName] = {
+      stringValue: context.propertyName,
+    };
+  }
+
+  if (binding.isStaticData !== undefined) {
+    result[DataBindingPropertyKey.IsStaticData] = {
       stringValue: String(!!binding.isStaticData),
-    },
-  };
+    };
+  }
+
+  return result;
 };
 
 export const parseDataBinding = (bindingMap: DocumentType): ValueDataBinding | undefined => {

--- a/packages/scene-composer/src/utils/entityModelUtils/tagComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/tagComponent.spec.ts
@@ -126,9 +126,6 @@ describe('createTagEntityComponent', () => {
             propertyName: {
               stringValue: 'pname',
             },
-            isStaticData: {
-              stringValue: 'false',
-            },
           },
         },
       },

--- a/packages/scene-composer/src/utils/entityModelUtils/tagComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/tagComponent.ts
@@ -40,7 +40,9 @@ export const createTagEntityComponent = (tag: IAnchorComponent): ComponentReques
   if (tag.navLink?.params) {
     const params = {};
     Object.keys(tag.navLink.params).forEach((k) => {
-      params[k] = { stringValue: encodeURI(tag.navLink?.params![k]) };
+      if (k) {
+        params[k] = { stringValue: encodeURI(tag.navLink?.params![k]) };
+      }
     });
     comp.properties![TagComponentProperty.NavLinkParams] = {
       value: {


### PR DESCRIPTION
## Overview
- update comppnent type id to be 1P version
- debounce component update to reduce UpdateEntity error

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
