### PR TITLE
fix(composer): add aria labels to rules panel

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
@@ -80,9 +80,24 @@ export const SceneRuleMapExpandableInfoSection: React.FC<
   if (newRule) {
     items.push(newRule);
   }
+  //TODO: When we migrate from polaris to cloudscape, just pass these as normal props to AttributeEditor
+  const a11yProps = {
+    i18nStrings: {
+      itemRemovedAriaLive: intl.formatMessage({
+        defaultMessage: 'Removed statement',
+        description: 'Aria live announcement for when a statement is removed',
+      }),
+    },
+    removeButtonAriaLabel: (statement: IRuleStatementInternal) =>
+      `${intl.formatMessage({
+        defaultMessage: 'Remove statement',
+        description: 'Aria label for remove statement button',
+      })} ${statement.expression}`,
+  };
   return (
     <ExpandableInfoSection title={ruleBasedMapId} defaultExpanded={false}>
       <AttributeEditor
+        {...a11yProps}
         onAddButtonClick={() => setNewRule({ expression: '', target: '' })}
         onRemoveButtonClick={({ detail: { itemIndex } }) => onRemoveRule(itemIndex)}
         items={items}

--- a/packages/scene-composer/src/components/panels/__snapshots__/SceneRulesPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__snapshots__/SceneRulesPanel.spec.tsx.snap
@@ -14,6 +14,7 @@ exports[`SceneRulesPanel returns expected elements. SceneRulesPanel returns expe
         data-mocked="AttributeEditor"
         definition="[{\\"label\\":\\"Expression\\"},{\\"label\\":\\"Target\\"}]"
         empty="No statements"
+        i18nstrings="{\\"itemRemovedAriaLive\\":\\"Removed statement\\"}"
         items="[{\\"expression\\":\\"exp1\\",\\"target\\":\\"target1\\"},\\"mapId\\"]"
         removebuttontext="Remove statement"
       />

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -375,6 +375,10 @@
     "note": "Menu Item",
     "text": "Pointer Lock"
   },
+  "J+haL1": {
+    "note": "Aria live announcement for when a statement is removed",
+    "text": "Removed statement"
+  },
   "JTUN+G": {
     "note": "Form field label",
     "text": "Focal length"
@@ -526,6 +530,10 @@
   "RNZ9kW": {
     "note": "Expandable Section title",
     "text": "Tag"
+  },
+  "RZeAOs": {
+    "note": "Aria label for remove statement button",
+    "text": "Remove statement"
   },
   "SYAG+q": {
     "note": "Form Field label",


### PR DESCRIPTION
## Overview
Remediation for a11y violation. This is a bit of a hack to pass the necessary i18n strings to polaris, and should be updated once the scene-composer migrates from polaris to cloudscape. 

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
