### PR TITLE
fix(dashboard): text widget crashed dashboard when resource explorer …

### DIFF
--- a/packages/dashboard/src/components/queryEditor/useQuery.ts
+++ b/packages/dashboard/src/components/queryEditor/useQuery.ts
@@ -41,7 +41,10 @@ export function useQuery(): [Query | undefined, (cb: (currentQuery?: Query) => Q
   const selectedWidgets = useSelectedWidgets<QueryProperty>();
   const selectedWidget = isOneWidgetSelected(selectedWidgets) ? getFirstWidget(selectedWidgets) : undefined;
 
-  const query = isWidget(selectedWidget) ? getQueryFromWidget(selectedWidget) : undefined;
+  const query =
+    isWidget(selectedWidget) && 'queryConfig' in selectedWidget.properties
+      ? getQueryFromWidget(selectedWidget)
+      : undefined;
 
   function setQuery(cb: (currentQuery?: Query) => Query | undefined): void {
     // Only update the query if a widget is selected


### PR DESCRIPTION


## Overview

The text widget was crashing the dashboard since it had no query property. To fix, added a check in the useQuery hook to check if the selected widget has a queryConfig in its properties. If it does not exist, the query is set as undefined.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/c1787c35-c25b-4878-b7f3-4a544858e71b


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
