### PR TITLE
fix(composer): bug fixes for dynamic scene

### DIFF
--- a/packages/scene-composer/src/SceneViewer.tsx
+++ b/packages/scene-composer/src/SceneViewer.tsx
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { isEqual } from 'lodash';
 import styled from 'styled-components';
 
-import { COMPOSER_FEATURES, KnownComponentType, SceneViewerProps } from './interfaces';
+import { COMPOSER_FEATURES, ISelectedDataBinding, KnownComponentType, SceneViewerProps } from './interfaces';
 import { SceneComposerInternal, useSceneComposerApi } from './components/SceneComposerInternal';
 
 const SceneComposerContainer = styled.div`
@@ -24,7 +24,7 @@ export const SceneViewer: React.FC<SceneViewerProps> = ({ sceneComposerId, confi
     return sceneComposerId || uuid();
   }, [sceneComposerId]);
   const composerApis = useSceneComposerApi(composerId);
-  const prevSelectedRef: any = useRef();
+  const prevSelectedRef = useRef<ISelectedDataBinding | undefined>();
   const [sceneLoaded, setSceneLoaded] = useState(false);
 
   useEffect(() => {
@@ -68,6 +68,9 @@ export const SceneViewer: React.FC<SceneViewerProps> = ({ sceneComposerId, confi
           ...(config || {}),
           mode: 'Viewing',
           featureConfig: {
+            // Allow beta users to override feature config
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...((config as any)?.featureConfig || {}),
             [COMPOSER_FEATURES.SceneHierarchySearch]: true,
             [COMPOSER_FEATURES.SceneHierarchyReorder]: true,
             [COMPOSER_FEATURES.SubModelSelection]: true,

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
@@ -11,6 +11,7 @@ import { ModelType } from '../../../../../models/SceneModels';
 import useFeature from '../../../../../hooks/useFeature';
 import { findComponentByType } from '../../../../../utils/nodeUtils';
 import { sceneComposerIdContext } from '../../../../../common/sceneComposerIdContext';
+import { isDynamicNode } from '../../../../../utils/entityModelUtils/sceneUtils';
 
 import SceneNodeLabel from './SceneNodeLabel';
 import { AcceptableDropTypes, EnhancedTree, EnhancedTreeItem } from './constants';
@@ -52,6 +53,7 @@ const SceneHierarchyTreeItem: FC<SceneHierarchyTreeItemProps> = ({
   const [{ variation: subModelSelectionEnabled }] = useFeature(COMPOSER_FEATURES[COMPOSER_FEATURES.SubModelSelection]);
   const showSubModel = subModelSelectionEnabled === 'T1' && isValidModelRef && !!model && !isViewing();
   const isSubModel = !!findComponentByType(node, KnownComponentType.SubModelRef);
+  const isDynamic = isDynamicNode(node);
 
   const { searchTerms } = useSceneHierarchyData();
   const isSearching = searchTerms !== '';
@@ -102,9 +104,9 @@ const SceneHierarchyTreeItem: FC<SceneHierarchyTreeItemProps> = ({
       selectionMode={selectionMode}
       onSelected={isViewing() ? onActivated : onToggle}
       onActivated={onActivated}
-      acceptDrop={AcceptableDropTypes}
+      acceptDrop={isDynamic ? [] : AcceptableDropTypes} // TODO: dynamic scene doesn't support hierarchy yet, disable drag for dynamic node
       onDropped={dropHandler}
-      draggable={enableDragAndDrop && !isViewing() && !isSubModel}
+      draggable={enableDragAndDrop && !isViewing() && !isSubModel && !isDynamic} // TODO: dynamic scene doesn't support hierarchy yet, disable drag for dynamic node
       dataType={componentTypes && componentTypes.length > 0 ? componentTypes[0] : /* istanbul ignore next */ 'default'} // TODO: This is somewhat based on the current assumption that items will currently only really have one componentType
       data={{ ref: key }}
     >

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/SceneHierarchyTreeItem.spec.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/SceneHierarchyTreeItem.spec.tsx
@@ -1,24 +1,32 @@
 import React, { useCallback } from 'react';
 import { render } from '@testing-library/react';
 
+// eslint-disable-next-line import/order
+import mockComponent from '../../../../../../../__mocks__/mockComponent';
+
+jest.doMock('../constants', () => ({
+  EnhancedTree: mockComponent('EnhancedTree'),
+  EnhancedTreeItem: mockComponent('EnhancedTreeItem'),
+  AcceptableDropTypes: 'AcceptableDropTypes',
+}));
+jest.doMock('../../SubModelTree', () => mockComponent('SubModelTree'));
+jest.doMock('../SceneNodeLabel', () => mockComponent('SceneNodeLabel'));
+
 import { useSceneHierarchyData, useChildNodes } from '../../../SceneHierarchyDataProvider';
 import SceneHierarchyTreeItem from '../SceneHierarchyTreeItem';
 import { KnownComponentType } from '../../../../../../interfaces';
+import { isDynamicNode } from '../../../../../../utils/entityModelUtils/sceneUtils';
 
 jest.mock('../../../../../../enhancers/draggable', () => (item: any) => item);
 jest.mock('../../../../../../enhancers/droppable', () => (item: any) => item);
 jest.mock('../../../SceneHierarchyDataProvider');
-jest.mock('../../SubModelTree', () => (props) => <div data-mocked='SubModelTree' {...props} />);
-jest.mock('../constants', () => ({
-  EnhancedTree: 'EnhancedTree',
-  EnhancedTreeItem: 'EnhancedTreeItem',
-  AcceptableDropTypes: 'AcceptableDropTypes',
-}));
 
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
   useCallback: jest.fn(),
 }));
+
+jest.mock('../../../../../../utils/entityModelUtils/sceneUtils');
 
 describe('SceneHierarchyTreeItem', () => {
   const select = jest.fn();
@@ -46,6 +54,7 @@ describe('SceneHierarchyTreeItem', () => {
         selectionMode: 'single',
         remove,
         isViewing,
+        validationErrors: {},
       };
     });
 
@@ -123,6 +132,17 @@ describe('SceneHierarchyTreeItem', () => {
 
     const { container } = render(
       <SceneHierarchyTreeItem objectRef='1' name='Label 1' componentTypes={[KnownComponentType.ModelRef]} />,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render dynamic node with drag and drop disabled', () => {
+    isViewing.mockImplementationOnce(() => false);
+    (isDynamicNode as jest.Mock).mockReturnValueOnce(true);
+
+    const { container } = render(
+      <SceneHierarchyTreeItem objectRef='1' name='Label 1' componentTypes={[KnownComponentType.Tag]} />,
     );
 
     expect(container).toMatchSnapshot();

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/__snapshots__/SceneHierarchyTreeItem.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/__tests__/__snapshots__/SceneHierarchyTreeItem.spec.tsx.snap
@@ -2,24 +2,63 @@
 
 exports[`SceneHierarchyTreeItem should bubble up when expanded 1`] = `
 <div>
-  <enhancedtreeitem
+  <div
     acceptdrop="AcceptableDropTypes"
-    data="[object Object]"
+    data="{\\"ref\\":\\"1\\"}"
+    data-mocked="EnhancedTreeItem"
     datatype="modelRef"
-    labeltext="[object Object]"
     selectionmode="single"
-  />
+  >
+    <div>
+      <div
+        componenttypes="[\\"modelRef\\"]"
+        data-mocked="SceneNodeLabel"
+        labeltext="Label 1"
+        objectref="1"
+      />
+    </div>
+  </div>
 </div>
 `;
 
 exports[`SceneHierarchyTreeItem should render SubModelTree when item has a model, and not in view mode 1`] = `
 <div>
-  <enhancedtreeitem
+  <div
     acceptdrop="AcceptableDropTypes"
-    data="[object Object]"
+    data="{\\"ref\\":\\"1\\"}"
+    data-mocked="EnhancedTreeItem"
     datatype="ModelRef"
-    labeltext="[object Object]"
     selectionmode="single"
-  />
+  >
+    <div>
+      <div
+        componenttypes="[\\"ModelRef\\"]"
+        data-mocked="SceneNodeLabel"
+        labeltext="Label 1"
+        objectref="1"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SceneHierarchyTreeItem should render dynamic node with drag and drop disabled 1`] = `
+<div>
+  <div
+    acceptdrop="[]"
+    data="{\\"ref\\":\\"1\\"}"
+    data-mocked="EnhancedTreeItem"
+    datatype="Tag"
+    selectionmode="single"
+  >
+    <div>
+      <div
+        componenttypes="[\\"Tag\\"]"
+        data-mocked="SceneNodeLabel"
+        labeltext="Label 1"
+        objectref="1"
+      />
+    </div>
+  </div>
 </div>
 `;

--- a/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
@@ -17,6 +17,7 @@ import { findComponentByType, isEnvironmentNode } from '../../utils/nodeUtils';
 import { isLinearPlaneMotionIndicator } from '../../utils/sceneComponentUtils';
 import { toNumber } from '../../utils/stringUtils';
 import { RecursivePartial } from '../../utils/typeUtils';
+import { isDynamicNode } from '../../utils/entityModelUtils/sceneUtils';
 
 import { AddComponentMenu } from './AddComponentMenu';
 import { ExpandableInfoSection, Matrix3XInputGrid, TextInput, Triplet } from './CommonPanelComponents';
@@ -93,6 +94,8 @@ export const SceneNodeInspectorPanel: React.FC = () => {
   const isTagComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.Tag);
   const isOverlayComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.DataOverlay);
   const isSubModelComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.SubModelRef);
+
+  const debounceInterval = isDynamicNode(selectedSceneNode) ? 1000 : 100;
 
   const transformVisible = !isSubModelComponent || subModelMovementEnabled;
 
@@ -198,7 +201,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
               onChange={debounce((items) => {
                 handleInputChanges({ transform: { position: items } });
                 applySnapToFloorConstraint();
-              }, 100)}
+              }, debounceInterval)}
             />
             <Matrix3XInputGrid
               name={intl.formatMessage({ defaultMessage: 'Rotation', description: 'Input Grid title name' })}
@@ -211,7 +214,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
               onChange={debounce((items) => {
                 handleInputChanges({ transform: { rotation: items } });
                 applySnapToFloorConstraint();
-              }, 100)}
+              }, debounceInterval)}
             />
             {shouldShowScale && (
               <Matrix3XInputGrid
@@ -229,7 +232,7 @@ export const SceneNodeInspectorPanel: React.FC = () => {
                 onChange={debounce((items) => {
                   handleInputChanges({ transform: { scale: items } });
                   applySnapToFloorConstraint();
-                }, 100)}
+                }, debounceInterval)}
               />
             )}
             {isModelComponent && (

--- a/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.tsx
@@ -7,7 +7,6 @@ import { defineMessages, useIntl } from 'react-intl';
 import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { SCENE_ICONS } from '../../../common/constants';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
-import useDynamicScene from '../../../hooks/useDynamicScene';
 import {
   COMPOSER_FEATURES,
   DefaultAnchorStatus,
@@ -22,6 +21,7 @@ import { convertToIotTwinMakerNamespace, getSceneResourceInfo } from '../../../u
 import { colors } from '../../../utils/styleUtils';
 import { TextInput } from '../CommonPanelComponents';
 import { IComponentEditorProps } from '../ComponentEditor';
+import { isDynamicNode } from '../../../utils/entityModelUtils/sceneUtils';
 
 import { ValueDataBindingBuilder } from './common/ValueDataBindingBuilder';
 import { ColorSelectorCombo } from './tag-style/ColorSelectorCombo/ColorSelectorCombo';
@@ -64,7 +64,7 @@ export const AnchorComponentEditor: React.FC<IAnchorComponentEditorProps> = ({
 
   const intl = useIntl();
 
-  const dynamicSceneEnabled = useDynamicScene();
+  const isDynamic = isDynamicNode(node);
 
   const ruleMapIds = listSceneRuleMapIds();
   const filteredList: string[] = useMemo(
@@ -88,7 +88,7 @@ export const AnchorComponentEditor: React.FC<IAnchorComponentEditorProps> = ({
         const componentPartialWithRef: ISceneComponentInternal = { ref: component.ref, ...componentPartial };
         updateComponentInternal(node.ref, componentPartialWithRef, replace);
       },
-      dynamicSceneEnabled ? 1000 : 100,
+      isDynamic ? 1000 : 100,
     ), // TODO: Temporary solution for the error when updating entity too frequent. Will implement a better solution for GA.
     [node.ref, component.ref],
   );

--- a/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.spec.tsx
@@ -37,6 +37,7 @@ describe('DataOverlayComponentEditor', () => {
   };
   const node = {
     ref: 'node-ref',
+    properties: {},
   } as ISceneNodeInternal;
   const updateComponentInternalMock = jest.fn();
 

--- a/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditor.tsx
@@ -7,7 +7,7 @@ import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { Component } from '../../../models/SceneModels';
 import { IDataOverlayComponentInternal, ISceneComponentInternal, useStore } from '../../../store';
 import { IComponentEditorProps } from '../ComponentEditor';
-import useDynamicScene from '../../../hooks/useDynamicScene';
+import { isDynamicNode } from '../../../utils/entityModelUtils/sceneUtils';
 
 import { ComponentWithDataBindings, DataBindingMapEditor } from './common/DataBindingMapEditor';
 
@@ -26,7 +26,7 @@ export const DataOverlayComponentEditor: React.FC<IDataOverlayComponentEditorPro
   );
   const [newRows, setNewRows] = useState<Component.DataOverlayMarkdownRow[]>(component.dataRows);
 
-  const dynamicSceneEnabled = useDynamicScene();
+  const isDynamic = isDynamicNode(node);
 
   const { formatMessage } = useIntl();
   const onUpdateCallback = useCallback(
@@ -35,7 +35,7 @@ export const DataOverlayComponentEditor: React.FC<IDataOverlayComponentEditorPro
         const componentPartialWithRef = { ref: component.ref, ...componentPartial };
         updateComponentInternal(node.ref, componentPartialWithRef as ISceneComponentInternal, replace);
       },
-      dynamicSceneEnabled ? 1000 : 100,
+      isDynamic ? 1000 : 100,
     ), // TODO: Temporary solution for the error when updating entity too frequent. Will implement a better solution for GA.
     [node.ref, component.ref],
   );

--- a/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditorSnap.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/DataOverlayComponentEditorSnap.spec.tsx
@@ -49,6 +49,7 @@ describe('DataOverlayComponentEditorSnap', () => {
   };
   const node = {
     ref: 'node-ref',
+    properties: {},
   } as ISceneNodeInternal;
 
   const baseState = {

--- a/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
+++ b/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
@@ -138,60 +138,70 @@ ${mattertagItem.description}`,
     const { handleUpdateMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
     handleUpdateMatterportTag({ ref: '', node: testInternalNode, item: mattertagItem });
-    expect(updateSceneNodeInternal).toBeCalledWith('', {
-      name: mattertagItem.label,
-      transform: {
-        position: [mattertagItem.anchorPosition.x, mattertagItem.anchorPosition.y, mattertagItem.anchorPosition.z],
-      },
-      components: [
-        {
-          ...anchorComponent,
-          ref: '',
-          offset: [mattertagItem.stemVector.x, mattertagItem.stemVector.y, mattertagItem.stemVector.z],
+    expect(updateSceneNodeInternal).toBeCalledWith(
+      '',
+      {
+        name: mattertagItem.label,
+        transform: {
+          position: [mattertagItem.anchorPosition.x, mattertagItem.anchorPosition.y, mattertagItem.anchorPosition.z],
         },
-        {
-          ...dataOverlayComponent,
-          dataRows: [
-            {
-              rowType: Component.DataOverlayRowType.Markdown,
-              content: `#### **${mattertagItem.label}**  
+        components: [
+          {
+            ...anchorComponent,
+            ref: '',
+            offset: [mattertagItem.stemVector.x, mattertagItem.stemVector.y, mattertagItem.stemVector.z],
+          },
+          {
+            ...dataOverlayComponent,
+            dataRows: [
+              {
+                rowType: Component.DataOverlayRowType.Markdown,
+                content: `#### **${mattertagItem.label}**  
 ${mattertagItem.description}`,
-            },
-          ],
-        },
-      ],
-      properties: { [SceneNodeRuntimeProperty.LayerIds]: undefined },
-    });
+              },
+            ],
+          },
+        ],
+        properties: { [SceneNodeRuntimeProperty.LayerIds]: undefined },
+      },
+      false,
+      true,
+    );
   });
 
   it('should update matterport tag', () => {
     const { handleUpdateMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
     handleUpdateMatterportTag({ ref: '', node: testInternalNode, item: tagItem });
-    expect(updateSceneNodeInternal).toBeCalledWith('', {
-      name: tagItem.label,
-      transform: {
-        position: [tagItem.anchorPosition.x, tagItem.anchorPosition.y, tagItem.anchorPosition.z],
-      },
-      components: [
-        {
-          ...anchorComponent,
-          ref: '',
-          offset: [tagItem.stemVector.x, tagItem.stemVector.y, tagItem.stemVector.z],
+    expect(updateSceneNodeInternal).toBeCalledWith(
+      '',
+      {
+        name: tagItem.label,
+        transform: {
+          position: [tagItem.anchorPosition.x, tagItem.anchorPosition.y, tagItem.anchorPosition.z],
         },
-        {
-          ...dataOverlayComponent,
-          dataRows: [
-            {
-              rowType: Component.DataOverlayRowType.Markdown,
-              content: `#### **${mattertagItem.label}**  
+        components: [
+          {
+            ...anchorComponent,
+            ref: '',
+            offset: [tagItem.stemVector.x, tagItem.stemVector.y, tagItem.stemVector.z],
+          },
+          {
+            ...dataOverlayComponent,
+            dataRows: [
+              {
+                rowType: Component.DataOverlayRowType.Markdown,
+                content: `#### **${mattertagItem.label}**  
 ${mattertagItem.description}`,
-            },
-          ],
-        },
-      ],
-      properties: { [SceneNodeRuntimeProperty.LayerIds]: undefined },
-    });
+              },
+            ],
+          },
+        ],
+        properties: { [SceneNodeRuntimeProperty.LayerIds]: undefined },
+      },
+      false,
+      true,
+    );
   });
 
   it('should delete matterport mattertag or tag', () => {
@@ -291,16 +301,8 @@ ${mattertagItem.description}`,
         item: mattertagItem,
       });
       expect(updateSceneNodeInternal).toBeCalledTimes(1);
-      expect(updateSceneEntity).toBeCalledTimes(1);
-      expect(updateSceneEntity).toBeCalledWith({
-        workspaceId: undefined,
-        entityId: generateUUID(),
-        entityName: mattertagItem.label + '_' + generateUUID(),
-        componentUpdates: {
-          Node: expect.anything(),
-          [KnownComponentType.Tag]: expect.anything(),
-        },
-      });
+      expect(updateSceneNodeInternal).toBeCalledWith('random-uuid', expect.anything(), false, false);
+      expect(updateSceneEntity).not.toBeCalled();
     });
 
     it('should update matterport tag', async () => {
@@ -314,19 +316,11 @@ ${mattertagItem.description}`,
         item: tagItem,
       });
       expect(updateSceneNodeInternal).toBeCalledTimes(1);
-      expect(updateSceneEntity).toBeCalledTimes(1);
-      expect(updateSceneEntity).toBeCalledWith({
-        workspaceId: undefined,
-        entityId: generateUUID(),
-        entityName: tagItem.label + '_' + generateUUID(),
-        componentUpdates: {
-          Node: expect.anything(),
-          [KnownComponentType.Tag]: expect.anything(),
-        },
-      });
+      expect(updateSceneNodeInternal).toBeCalledWith('random-uuid', expect.anything(), false, false);
+      expect(updateSceneEntity).not.toBeCalled();
     });
 
-    it('should create matterport tag when existing tag is not linked to a layer', async () => {
+    it('should create matterport tag when existing tag is not a dynamic node yet', async () => {
       const { handleUpdateMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 
       await handleUpdateMatterportTag({
@@ -337,6 +331,7 @@ ${mattertagItem.description}`,
         item: tagItem,
       });
       expect(updateSceneNodeInternal).toBeCalledTimes(1);
+      expect(updateSceneNodeInternal).toBeCalledWith('random-uuid', expect.anything(), false, true);
       expect(updateSceneEntity).not.toBeCalled();
       expect(createSceneEntity).toBeCalledTimes(1);
       expect(createSceneEntity).toBeCalledWith({

--- a/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
+++ b/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
@@ -634,11 +634,11 @@ describe('serializationHelpers', () => {
     sceneNodeInternal.components = [...(node.components as ISceneComponentInternal[])];
     sceneNodeInternal.childRefs = ['testNode'];
     const nodes = {
-      testNode: sceneNodeInternal,
-      layerNode: { ...sceneNodeInternal, properties: { layerIds: ['layer'] } }, // Node from layer shouldn't be serialized
+      layerNode: { ...sceneNodeInternal, ref: 'layerNode', properties: { layerIds: ['layer'] } }, // Node from layer shouldn't be serialized
+      testNode: { ...sceneNodeInternal, ref: 'testNode' },
     };
 
-    const mappedObjectCollector = { Node: { testNode: 0 } };
+    const mappedObjectCollector = { Node: {} };
     const indexedObjectCollector = { testNode: [KnownComponentType.Camera] };
 
     const convertedNodes = exportsForTesting.convertNodes(nodes, mappedObjectCollector, indexedObjectCollector);

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -34,6 +34,7 @@ import {
   IEntityBindingComponentInternal,
   SceneNodeRuntimeProperty,
 } from '../internalInterfaces';
+import { isDynamicNode } from '../../utils/entityModelUtils/sceneUtils';
 
 import { addComponentToComponentNodeMap } from './componentMapHelpers';
 
@@ -615,14 +616,12 @@ function convertNodes(
 
   // create nodes first
   const exportedNodes: Node[] = [];
-  Object.getOwnPropertyNames(nodes).forEach((nodeRef, index) => {
+  Object.getOwnPropertyNames(nodes).forEach((nodeRef) => {
     const node = nodes[nodeRef]!;
     // Do not serialize dynamic nodes rendered from layers
-    if (!isEmpty(node.properties.layerIds)) {
+    if (isDynamicNode(node)) {
       return;
     }
-
-    nodeRefToIndexMap[node.ref] = index;
 
     const convertedComponents: any[] = [];
 
@@ -665,6 +664,8 @@ function convertNodes(
       components: convertedComponents,
       properties,
     });
+
+    nodeRefToIndexMap[node.ref] = exportedNodes.length - 1;
   });
 
   // filling the children

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
@@ -91,7 +91,7 @@ describe('createNodeEntityComponent', () => {
 
   it('should return expected node component with properties', () => {
     const result = createNodeEntityComponent({
-      properties: { matterportId: 'abc def', layerIds: ['layer-1'] },
+      properties: { matterportId: 'abc def', layerIds: ['layer-1'], alwaysVisible: true },
     } as ISceneNode);
 
     expect(result.properties).toEqual({
@@ -104,7 +104,10 @@ describe('createNodeEntityComponent', () => {
         value: {
           mapValue: {
             matterportId: {
-              stringValue: 'abc%20def',
+              stringValue: 'abc def',
+            },
+            alwaysVisible: {
+              stringValue: 'true',
             },
           },
         },
@@ -194,7 +197,8 @@ describe('parseNode', () => {
       {
         propertyName: 'properties',
         propertyValue: {
-          matterportId: 'abc%20def',
+          matterportId: 'abc def',
+          alwaysVisible: 'true',
         },
       },
     ],
@@ -224,6 +228,7 @@ describe('parseNode', () => {
       },
       properties: {
         matterportId: 'abc def',
+        alwaysVisible: true,
       },
     });
   });

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
@@ -72,7 +72,10 @@ export const createNodeEntityComponent = (node: ISceneNode, layerId?: string): C
       if (Object.values(SceneNodeRuntimeProperty).includes(k as SceneNodeRuntimeProperty)) {
         return;
       }
-      params[k] = { stringValue: encodeURI(node.properties![k]) };
+      const value = node.properties![k];
+      if (value !== undefined) {
+        params[k] = { stringValue: String(value) };
+      }
     });
     comp.properties![NodeComponentProperty.Properties] = {
       value: {
@@ -158,8 +161,9 @@ export const parseNode = (entity: DocumentType, nodeCompo: DocumentType): IScene
     nodeCompo['properties'].find((p) => p['propertyName'] === NodeComponentProperty.Properties)?.propertyValue ?? {};
 
   Object.keys(properties).forEach((k) => {
-    properties[k] = decodeURI(properties[k]);
+    properties[k] = k === 'alwaysVisible' || k === 'hiddenWhileImmersive' ? Boolean(properties[k]) : properties[k];
   });
+
   const node: ISceneNodeInternal = {
     ref: entity['entityId'],
     childRefs: [],

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.spec.ts
@@ -7,8 +7,15 @@ import {
   SCENE_ROOT_ENTITY_ID,
   SCENE_ROOT_ENTITY_NAME,
 } from '../../common/entityModelConstants';
+import { ISceneNodeInternal, SceneNodeRuntimeProperty } from '../../store/internalInterfaces';
 
-import { checkIfEntityAvailable, createSceneEntityId, createSceneRootEntity, prepareWorkspace } from './sceneUtils';
+import {
+  checkIfEntityAvailable,
+  createSceneEntityId,
+  createSceneRootEntity,
+  isDynamicNode,
+  prepareWorkspace,
+} from './sceneUtils';
 
 jest.mock('../mathUtils', () => ({
   generateUUID: jest.fn(() => 'random-uuid'),
@@ -136,5 +143,28 @@ describe('prepareWorkspace', () => {
     await prepareWorkspace(mockMetadataModule as TwinMakerSceneMetadataModule);
 
     expect(createSceneEntity).not.toBeCalled();
+  });
+});
+
+describe('isDynamicNode', () => {
+  it('should return true', () => {
+    expect(
+      isDynamicNode({
+        properties: {
+          [SceneNodeRuntimeProperty.LayerIds]: ['layer'],
+        },
+      } as ISceneNodeInternal),
+    ).toEqual(true);
+  });
+
+  it('should return false', () => {
+    expect(
+      isDynamicNode({
+        properties: {
+          [SceneNodeRuntimeProperty.LayerIds]: [] as string[],
+        },
+      } as ISceneNodeInternal),
+    ).toEqual(false);
+    expect(isDynamicNode({ properties: {} } as ISceneNodeInternal)).toEqual(false);
   });
 });

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
@@ -1,5 +1,6 @@
 import { CreateEntityCommandInput, CreateEntityCommandOutput } from '@aws-sdk/client-iottwinmaker';
 import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
+import { isEmpty } from 'lodash';
 
 import {
   LAYER_ROOT_ENTITY_ID,
@@ -9,6 +10,7 @@ import {
 } from '../../common/entityModelConstants';
 import { getGlobalSettings } from '../../common/GlobalSettings';
 import { generateUUID } from '../mathUtils';
+import { ISceneNodeInternal } from '../../store';
 
 export const createSceneEntityId = (sceneName: string): string => {
   return `SCENE_${sceneName}_${generateUUID()}`;
@@ -63,4 +65,8 @@ export const prepareWorkspace = async (sceneMetadataModule: TwinMakerSceneMetada
     );
   }
   await Promise.all(createRootRequests);
+};
+
+export const isDynamicNode = (node?: ISceneNodeInternal): boolean => {
+  return !isEmpty(node?.properties.layerIds);
 };

--- a/packages/scene-composer/src/utils/entityModelUtils/tagComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/tagComponent.spec.ts
@@ -52,10 +52,10 @@ describe('createTagEntityComponent', () => {
         value: {
           mapValue: {
             param1: {
-              stringValue: 'value%201',
+              stringValue: 'value 1',
             },
             param2: {
-              stringValue: 'value%202',
+              stringValue: 'value 2',
             },
           },
         },

--- a/packages/scene-composer/src/utils/entityModelUtils/tagComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/tagComponent.ts
@@ -41,7 +41,7 @@ export const createTagEntityComponent = (tag: IAnchorComponent): ComponentReques
     const params = {};
     Object.keys(tag.navLink.params).forEach((k) => {
       if (k) {
-        params[k] = { stringValue: encodeURI(tag.navLink?.params![k]) };
+        params[k] = { stringValue: tag.navLink?.params![k] };
       }
     });
     comp.properties![TagComponentProperty.NavLinkParams] = {

--- a/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
@@ -50,10 +50,36 @@ describe('updateEntity', () => {
     expect(updateOverlayEntityComponent).not.toHaveBeenCalled();
   });
 
+  it('should call update entity to update multiple components', async () => {
+    const tag = { type: KnownComponentType.Tag, ref: 'tag-ref' };
+    const overlay = { type: KnownComponentType.DataOverlay, ref: 'overlay-ref' };
+
+    await updateEntity(defaultNode, [tag, overlay], 'UPDATE');
+
+    expect(updateSceneEntity).toHaveBeenCalledTimes(1);
+    expect(updateSceneEntity).toHaveBeenCalledWith({
+      workspaceId: undefined,
+      entityId: defaultNode.ref,
+      entityName: defaultNode.name + '_' + defaultNode.ref,
+      componentUpdates: {
+        Node: { componentTypeId: '3d.node' },
+        Tag: { componentTypeId: '3d.tag' },
+        DataOverlay: { componentTypeId: '3d.overlay' },
+      },
+    });
+
+    expect(updateNodeEntityComponent).toHaveBeenCalledTimes(1);
+    expect(updateNodeEntityComponent).toHaveBeenCalledWith(defaultNode, undefined, 'UPDATE');
+    expect(updateTagEntityComponent).toHaveBeenCalledTimes(1);
+    expect(updateTagEntityComponent).toHaveBeenCalledWith(tag);
+    expect(updateOverlayEntityComponent).toHaveBeenCalledTimes(1);
+    expect(updateOverlayEntityComponent).toHaveBeenCalledWith(overlay);
+  });
+
   it('should call update entity to update tag component', async () => {
     const compToUpdate = { type: KnownComponentType.Tag, ref: 'tag-ref' };
 
-    await updateEntity(defaultNode, compToUpdate, 'UPDATE');
+    await updateEntity(defaultNode, [compToUpdate], 'UPDATE');
 
     expect(updateSceneEntity).toHaveBeenCalledTimes(1);
     expect(updateSceneEntity).toHaveBeenCalledWith({
@@ -76,7 +102,7 @@ describe('updateEntity', () => {
   it('should call update entity to update overlay component', async () => {
     const compToUpdate = { type: KnownComponentType.DataOverlay, ref: 'overlay-ref' };
 
-    await updateEntity(defaultNode, compToUpdate, 'UPDATE');
+    await updateEntity(defaultNode, [compToUpdate], 'UPDATE');
 
     expect(updateSceneEntity).toHaveBeenCalledTimes(1);
     expect(updateSceneEntity).toHaveBeenCalledWith({
@@ -99,7 +125,7 @@ describe('updateEntity', () => {
   it('should call update entity without entity binding component', async () => {
     const compToUpdate = { type: KnownComponentType.EntityBinding, ref: 'entity-binding-ref' };
 
-    await updateEntity(defaultNode, compToUpdate, 'UPDATE');
+    await updateEntity(defaultNode, [compToUpdate], 'UPDATE');
 
     expect(updateSceneEntity).toHaveBeenCalledTimes(1);
     expect(updateSceneEntity).toHaveBeenCalledWith({
@@ -120,7 +146,7 @@ describe('updateEntity', () => {
   it('should call update entity to delete tag component', async () => {
     const compToUpdate = { type: KnownComponentType.Tag, ref: 'tag-ref' };
 
-    await updateEntity(defaultNode, compToUpdate, 'DELETE');
+    await updateEntity(defaultNode, [compToUpdate], 'DELETE');
 
     expect(updateSceneEntity).toHaveBeenCalledTimes(1);
     expect(updateSceneEntity).toHaveBeenCalledWith({

--- a/packages/scene-composer/stories/components/scene-composer.tsx
+++ b/packages/scene-composer/stories/components/scene-composer.tsx
@@ -140,6 +140,13 @@ const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
               valueDataBindingProviders={bindingProvider}
               onSceneUpdated={handleSceneUpdated}
               dataStreams={source === 'local' ? convertDataInputToDataStreams(getTestDataInputContinuous()) : undefined}
+              showAssetBrowserCallback={(cb) => {
+                if (source == 'local') {
+                  cb(null, 'PALLET_JACK.glb');
+                } else {
+                  cb(null, 'CookieFactoryMixer.glb'); // Update the string to a model available in your S3 bucket
+                }
+              }}
               {...props}
             />
           </SceneComposerContainer>


### PR DESCRIPTION
## Overview
- Fix node index calculation for static nodes saved to scene file
- Debounce more for dynamic node's transform input box updates
- Remove the extra UpdateEntity call when clicking sync button to update tags
- Disable drag and drop to dynamic nodes

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
