### PR TITLE
feat: ability to toggle property visibility in config panel

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.css
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.css
@@ -12,3 +12,48 @@
   display: flex;
   align-items: center;
 }
+
+.property-display-toggle {
+  position: relative;
+}
+
+.property-display-toggle .tooltiptext {
+  position: absolute;
+  border-style: solid;
+  text-align: center;
+  z-index: 9;
+  visibility: hidden;
+  transform: translateX(-50%);
+  min-width: 60px;
+  left: 50%;
+  bottom: 100%;
+}
+
+.property-display-toggle .tooltiptext::before,
+.property-display-toggle .tooltiptext::after {
+  content: "";
+  position: absolute;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  left: 50%;
+  right: 50%;
+  margin: auto;
+  margin-left: -10px;
+  top: 100%;
+}
+
+.property-display-toggle .tooltiptext::before {
+  border-top: 11px solid #9ba7b6;
+  margin-bottom: 5px;
+}
+
+.property-display-toggle .tooltiptext::after {
+  border-top: 10px solid var(--colors-white);
+  margin-top: -2px;
+  z-index: 1;
+}
+
+.property-display-toggle:hover .tooltiptext {
+  visibility: visible;
+  display: block;
+}

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
@@ -16,6 +16,16 @@ import './propertyComponent.css';
 import { StyledAssetPropertyQuery, YAxisOptions } from '~/customization/widgets/types';
 import { getPropertyDisplay } from './getPropertyDetails';
 import type { AssetSummary } from '../../../hooks/useAssetDescriptionQueries';
+import {
+  colorBackgroundHomeHeader,
+  colorBackgroundLayoutMain,
+  colorBorderButtonNormalDisabled,
+  spaceScaledM,
+  spaceScaledXxxs,
+  spaceStaticXs,
+} from '@cloudscape-design/design-tokens';
+import { StatusEyeHidden, StatusEyeVisible } from './icons';
+import { ClickDetail, NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 
 const YAxisPropertyConfig = ({
   resetStyles,
@@ -88,21 +98,51 @@ export type StyledPropertyComponentProps = {
   updateStyle: (newStyles: object) => void;
   assetSummary: AssetSummary;
   property: StyledAssetPropertyQuery;
+  onHideAssetQuery: () => void;
   onDeleteAssetQuery?: () => void;
   colorable: boolean;
+  isPropertyVisible: boolean;
 };
 
 export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
   assetSummary,
   property,
   updateStyle,
+  onHideAssetQuery,
   onDeleteAssetQuery,
   colorable,
+  isPropertyVisible,
 }) => {
   const { display, label } = getPropertyDisplay(property.propertyId, assetSummary);
+  const [onMouseOver, setOnMouseOver] = useState(false);
+  const isAssetQueryVisible = !onMouseOver ? isPropertyVisible : !isPropertyVisible;
+  const propertyVisibilityIcon = isAssetQueryVisible ? StatusEyeVisible : StatusEyeHidden;
+  const tooltipStyle = {
+    fontSize: spaceScaledM,
+    color: colorBackgroundHomeHeader,
+    backgroundColor: colorBackgroundLayoutMain,
+    padding: `${spaceStaticXs} ${spaceStaticXs}`,
+    borderRadius: spaceStaticXs,
+    borderWidth: spaceScaledXxxs,
+    borderColor: colorBorderButtonNormalDisabled,
+    boxShadow: `${spaceScaledXxxs} ${spaceScaledXxxs} ${spaceScaledXxxs} ${colorBorderButtonNormalDisabled}`,
+  };
 
   const resetStyles = (styleToReset: object) => {
     updateStyle(styleToReset); // as we add more sections, reset style values here
+  };
+
+  const onToggleAssetQuery: NonCancelableEventHandler<ClickDetail> = (e) => {
+    e.stopPropagation();
+    onHideAssetQuery();
+  };
+
+  const handleMouseEnter = () => {
+    setOnMouseOver(true);
+  };
+
+  const handleMouseLeave = () => {
+    setOnMouseOver(false);
   };
 
   const YAxisHeader = (
@@ -111,7 +151,13 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
         <ColorPicker color={property.color || ''} updateColor={(newColor) => updateStyle({ color: newColor })} />
       )}
       <div style={{ fontWeight: 'normal' }}>{label}</div>
-      {/* <Button onClick={() => {}} variant='icon' iconSvg={StatusEyeVisible} /> TODO */}
+      <div className='property-display-toggle' onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        <Button onClick={onToggleAssetQuery} variant='icon' iconSvg={propertyVisibilityIcon} />
+        <span className='tooltiptext' style={tooltipStyle}>
+          {onMouseOver && isPropertyVisible ? 'hide' : 'unhide'}
+        </span>
+      </div>
+
       <Button onClick={onDeleteAssetQuery} variant='icon' iconName='remove' />
     </SpaceBetween>
   );

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledSection.tsx
@@ -72,6 +72,32 @@ export const StyledPropertiesAlarmsSection: FC<StyledPropertiesAlarmsSectionProp
       updateSiteWiseAssetQuery(newQuery);
     };
 
+    const onHideAssetQuery = (updatedAssetId: string, updatedPropertyId: string) => {
+      const newQuery = {
+        ...styledAssetQuery,
+        assets:
+          styledAssetQuery?.assets.map((asset) => {
+            if (asset.assetId === updatedAssetId) {
+              return {
+                ...asset,
+                properties: asset.properties.map((property) => {
+                  if (property.propertyId === updatedPropertyId) {
+                    const visible = property.visible !== undefined ? !property.visible : false;
+                    return { ...property, visible };
+                  } else {
+                    return property;
+                  }
+                }),
+              };
+            } else {
+              return asset;
+            }
+          }) ?? [],
+      };
+
+      updateSiteWiseAssetQuery(newQuery);
+    };
+
     const components = styledAssetQuery?.assets.flatMap(({ assetId, properties }) =>
       properties.map((property) =>
         describedAssetsMap[assetId] ? (
@@ -80,6 +106,7 @@ export const StyledPropertiesAlarmsSection: FC<StyledPropertiesAlarmsSectionProp
             assetSummary={describedAssetsMap[assetId]}
             property={property}
             updateStyle={(newStyles: object) => onUpdatePropertyStyles(assetId, property.propertyId, newStyles)}
+            onHideAssetQuery={() => onHideAssetQuery(assetId, property.propertyId)}
             onDeleteAssetQuery={onDeleteAssetQuery({
               assetId,
               propertyId: property.propertyId,
@@ -87,6 +114,7 @@ export const StyledPropertiesAlarmsSection: FC<StyledPropertiesAlarmsSectionProp
               updateSiteWiseAssetQuery,
             })}
             colorable={colorable}
+            isPropertyVisible={property.visible ?? true}
           />
         ) : null
       )

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -119,10 +119,25 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (widge
   } = widget.properties;
 
   const query = queryConfig.query;
-  const { iotSiteWiseQuery } = useQueries();
-  const queries = iotSiteWiseQuery && query ? [iotSiteWiseQuery?.timeSeriesData(query)] : [];
+  const filteredQuery = {
+    ...query,
+    assets:
+      query?.assets
+        .map((asset) => {
+          const { assetId, properties } = asset;
+          return {
+            assetId,
+            properties: properties.filter((p) => p.visible ?? true),
+          };
+        })
+        .filter((asset) => asset.properties.length > 0) ?? [],
+  };
 
-  const styleSettings = useAdaptedStyleSettings({ line, symbol }, query);
+  const { iotSiteWiseQuery } = useQueries();
+
+  const queries = iotSiteWiseQuery && filteredQuery ? [iotSiteWiseQuery?.timeSeriesData(filteredQuery)] : [];
+
+  const styleSettings = useAdaptedStyleSettings({ line, symbol }, filteredQuery);
 
   const aggregation = getAggregation(widget);
 

--- a/packages/source-iotsitewise/src/time-series-data/types.ts
+++ b/packages/source-iotsitewise/src/time-series-data/types.ts
@@ -21,6 +21,7 @@ export type AssetPropertyQuery = {
   cacheSettings?: CacheSettings;
   aggregationType?: AggregateType;
   alarms?: boolean;
+  visible?: boolean;
 };
 
 export type PropertyAliasQuery = {


### PR DESCRIPTION
## Overview
added ability to toggle property visibility in config panel and it includes

1. property toggle now toggles the properties on the chart
2. mouse over shows 'hide' or 'unhide' tooltip wrt property visibility status and also shows opposite visibility icons 

## Verifying Changes


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
