### PR TITLE
fix: fix broken synchro-charts widgets

### DIFF
--- a/packages/dashboard/src/customization/widgets/barChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/component.tsx
@@ -33,7 +33,7 @@ const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
     iotSiteWiseQuery && queryConfig.query
       ? [iotSiteWiseQuery?.timeSeriesData(queryConfig.query as SiteWiseAssetQuery)]
       : [];
-  const key = computeQueryConfigKey(viewport, queryConfig);
+  const key = computeQueryConfigKey(undefined, queryConfig);
   const aggregation = getAggregation(widget);
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
   // there may be better ways to fix this, i.e. not have -44 and let the chart container  take its parent height,

--- a/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
+++ b/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
@@ -28,7 +28,7 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (widget) =
     iotSiteWiseQuery && queryConfig.query
       ? [iotSiteWiseQuery?.timeSeriesData(queryConfig.query as SiteWiseAssetQuery)]
       : [];
-  const key = computeQueryConfigKey(viewport, queryConfig);
+  const key = computeQueryConfigKey(undefined, queryConfig);
   const aggregation = getAggregation(widget);
 
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;


### PR DESCRIPTION
## Overview
synchro-charts widgets were being unmounted/remounted on viewport change (so all the time) removed the viewport from the key generation to prevent this issue with Synchro-charts

fixes broken gestures, time machine not applying, broken viewport sync across charts

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
