### PR TITLE
fix: toggle working linechar

### DIFF
--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -115,6 +115,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (widge
     thresholds,
     line,
     symbol,
+    legend,
     significantDigits: widgetSignificantDigits,
   } = widget.properties;
 
@@ -172,6 +173,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (widge
         thresholds={thresholds}
         significantDigits={significantDigits}
         size={size}
+        legend={legend?.visible == true ? {} : undefined}
       />
     </WidgetTile>
   );

--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -163,9 +163,11 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
           )}
         </HotKeys>
       </Resizable>
-      <div style={{ height, width: rightLegendWidth }}>
-        <Legend series={series} graphic={trendCursors} datastreams={dataStreams} />
-      </div>
+      {options.legend && (
+        <div style={{ height, width: rightLegendWidth }}>
+          <Legend series={series} graphic={trendCursors} datastreams={dataStreams} />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Overview
Added legend prop to LineScatterChart that reads visible property controlled by toggle. It passes a empty object if true otherwise undefined. This gets read by the BaseChart component who has a conditional render of the legend depending on if the legend prop is defined. 


https://github.com/awslabs/iot-app-kit/assets/145582655/ef070b95-2ddc-4c8a-8139-fccbb77262a2




## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
