### PR TITLE
fix: enable changing resolution and aggregation of unmodeled data streams

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/aggregationSettings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/aggregationSettings/section.tsx
@@ -105,7 +105,13 @@ const AggregationSettings: FC<AggregationSettingsProps> = ({ queryConfig, update
       })),
     }));
 
-    updateQuery({ assets });
+    const properties = siteWiseAssetQuery.properties?.map((property) => ({
+      ...property,
+      resolution: detail.selectedOption.value,
+      aggregationType: newAggregation as AggregateType,
+    }));
+
+    updateQuery({ assets, properties });
   };
 
   const onUpdateAggregation: SelectProps['onChange'] = ({ detail }) => {
@@ -124,7 +130,13 @@ const AggregationSettings: FC<AggregationSettingsProps> = ({ queryConfig, update
       })),
     }));
 
-    updateQuery({ assets });
+    const properties = siteWiseAssetQuery.properties?.map((property) => ({
+      ...property,
+      resolution: newResolution,
+      aggregationType: newAggregation,
+    }));
+
+    updateQuery({ assets, properties });
   };
 
   return (


### PR DESCRIPTION
## Overview
This change fixes a bug preventing changing resolution and aggregation settings for unmodeled data streams.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
