### PR TITLE
feat(scene composer): icon picker rule changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24116,7 +24116,6 @@
     "node_modules/@testing-library/user-event": {
       "version": "14.4.3",
       "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
-      "dev": true,
       "engines": {
         "node": ">=12",
         "npm": ">=6"
@@ -60117,6 +60116,7 @@
         "@react-three/postprocessing": "2.6.2",
         "@react-three/test-renderer": "^8.1.3",
         "@tanstack/react-query": "^4.29.15",
+        "@testing-library/user-event": "^14.4.3",
         "@tweenjs/tween.js": "^20.0.3",
         "3d-tiles-renderer": "0.3.16",
         "arraybuffer-to-string": "1.0.2",
@@ -71977,6 +71977,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/react-hooks": "^8.0.1",
+        "@testing-library/user-event": "^14.4.3",
         "@tweenjs/tween.js": "^20.0.3",
         "@types/debug": "^4.1.8",
         "@types/jest": "^27.5.2",
@@ -81198,8 +81199,7 @@
     },
     "@testing-library/user-event": {
       "version": "14.4.3",
-      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
-      "dev": true
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -150,6 +150,7 @@
     "@react-three/postprocessing": "2.6.2",
     "@react-three/test-renderer": "^8.1.3",
     "@tanstack/react-query": "^4.29.15",
+    "@testing-library/user-event": "^14.4.3",
     "@tweenjs/tween.js": "^20.0.3",
     "3d-tiles-renderer": "0.3.16",
     "arraybuffer-to-string": "1.0.2",

--- a/packages/scene-composer/src/assets/anchors/IconSvgs.tsx
+++ b/packages/scene-composer/src/assets/anchors/IconSvgs.tsx
@@ -69,8 +69,8 @@ export const CustomIconSvgString = `
     <g fill='none' fillRule='evenodd' transform='translate(2 2)'>
       <ellipse cx='26' cy='26' rx='21' ry='21' stroke='${colors.customBlue}' stroke-width='2' />
       <circle cx='26' cy='26' r='16' fill='${colors.customBlue}'/>
-      <g transform='translate(26,26) scale(0.03) translate(${iconWidth}, ${iconHeight})'>
-        <path d='M22 80a48 48 0 1 1 96 0A48 48 0 1 1 48 80zM 224c0-17.7 14.3-32 32-32H96c17.7 0 32 14.3 32 32V448h32c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H64V256H32c-17.7 0-32-14.3-32-32z' fill='${colors.infoRingWhite}' />
+      <g transform='translate(26,26) scale(0.03) translate(${iconWidth}, ${iconHeight})' fill=''>
+        <path d='M22 80a48 48 0 1 1 96 0A48 48 0 1 1 48 80zM 224c0-17.7 14.3-32 32-32H96c17.7 0 32 14.3 32 32V448h32c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H64V256H32c-17.7 0-32-14.3-32-32z' fill=''/>
       </g>
     </g>
   </svg>

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/__tests__/AnchorWidget.spec.tsx
@@ -143,7 +143,10 @@ describe('AnchorWidget', () => {
             statements: [
               {
                 expression: "alarm_status == 'ACTIVE'",
-                target: 'iottwinmaker.common.icon:Custom-#ffffff',
+                target: 'iottwinmaker.common.icon:Custom',
+                targetMetadata: {
+                  color: '#ffffff',
+                },
               },
             ],
           }

--- a/packages/scene-composer/src/components/panels/SceneRulesPanel.spec.tsx
+++ b/packages/scene-composer/src/components/panels/SceneRulesPanel.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { render } from '@testing-library/react';
+import React from 'react';
 
 import { SceneRulesPanel } from './SceneRulesPanel';
 
@@ -35,7 +35,6 @@ jest.mock('../../store/Store', () => {
 describe('SceneRulesPanel returns expected elements.', () => {
   it('SceneRulesPanel returns expected elements.', async () => {
     const { container } = render(<SceneRulesPanel />);
-
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
@@ -11,11 +11,11 @@ import {
 } from '@awsui/components-react';
 import { useIntl } from 'react-intl';
 
+import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
+import LogProvider from '../../logger/react-logger/log-provider';
 import { useSceneDocument } from '../../store';
 import { IRuleBasedMapInternal, IRuleStatementInternal } from '../../store/internalInterfaces';
-import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
 import { validateRuleId } from '../../utils/inputValidationUtils';
-import LogProvider from '../../logger/react-logger/log-provider';
 
 import { ExpandableInfoSection } from './CommonPanelComponents';
 import { SceneRuleTargetEditor } from './scene-rule-components/SceneRuleTargetEditor';
@@ -76,6 +76,7 @@ export const SceneRuleMapExpandableInfoSection: React.FC<
   const items: IRuleStatementInternal[] = ruleMap.statements.map((rule) => ({
     expression: rule.expression,
     target: rule.target,
+    targetMetadata: rule.targetMetadata,
   }));
   if (newRule) {
     items.push(newRule);
@@ -112,7 +113,13 @@ export const SceneRuleMapExpandableInfoSection: React.FC<
                   defaultMessage: 'e.g. value > 0',
                   description: 'AttributeEditor control placeholder',
                 })}
-                onChange={(event) => onUpdateRule(itemIndex, { expression: event.detail.value, target: item.target })}
+                onChange={(event) =>
+                  onUpdateRule(itemIndex, {
+                    expression: event.detail.value,
+                    target: item.target,
+                    targetMetadata: item.targetMetadata,
+                  })
+                }
               />
             ),
           },
@@ -121,7 +128,10 @@ export const SceneRuleMapExpandableInfoSection: React.FC<
             control: (item, itemIndex) => (
               <SceneRuleTargetEditor
                 target={item.target}
-                onChange={(target) => onUpdateRule(itemIndex, { expression: item.expression, target })}
+                targetMetadata={item.targetMetadata}
+                onChange={(target, targetMetadata) => {
+                  onUpdateRule(itemIndex, { expression: item.expression, target, targetMetadata });
+                }}
               />
             ),
           },
@@ -179,6 +189,7 @@ export const SceneRulesPanel: React.FC = () => {
             errorText={errorMessage}
           >
             <Input
+              data-testid='input-rule'
               value={newRuleBasedMapId}
               onChange={(event) => {
                 setNewRuleBasedMapId(event.detail.value);

--- a/packages/scene-composer/src/components/panels/__snapshots__/SceneRulesPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__snapshots__/SceneRulesPanel.spec.tsx.snap
@@ -39,6 +39,7 @@ exports[`SceneRulesPanel returns expected elements. SceneRulesPanel returns expe
         >
           <div
             data-mocked="Input"
+            data-testid="input-rule"
             value="mapId"
           />
         </div>

--- a/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.spec.tsx
@@ -39,6 +39,8 @@ jest.mock('../../../../src/store/Store', () => {
     __esModule: true,
     ...originalModule,
     useSceneDocument: jest.fn(() => ({
+      getSceneProperty: jest.fn(),
+      getSceneRuleMapById: jest.fn(),
       listSceneRuleMapIds: jest.fn(() => {
         return ['rule1'];
       }),

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/AnchorComponentEditor.spec.tsx.snap
@@ -106,7 +106,7 @@ exports[`AnchorComponentEditor should render with no tag style 1`] = `
       <div
         data-mocked="Select"
         data-testid="anchor-rule-id-select"
-        options="[{\\"label\\":\\"rule1\\",\\"value\\":\\"rule1\\"},{\\"label\\":\\"No Rule\\",\\"value\\":\\"No Rule\\"}]"
+        options="[{\\"label\\":\\"No Rule\\",\\"value\\":\\"No Rule\\"}]"
         placeholder="Choose a rule"
         selectedarialabel="Selected"
         selectedoption="{\\"label\\":\\"rule1\\",\\"value\\":\\"rule1\\"}"
@@ -246,7 +246,7 @@ exports[`AnchorComponentEditor should render with tag style 1`] = `
       <div
         data-mocked="Select"
         data-testid="anchor-rule-id-select"
-        options="[{\\"label\\":\\"rule1\\",\\"value\\":\\"rule1\\"},{\\"label\\":\\"No Rule\\",\\"value\\":\\"No Rule\\"}]"
+        options="[{\\"label\\":\\"No Rule\\",\\"value\\":\\"No Rule\\"}]"
         placeholder="Choose a rule"
         selectedarialabel="Selected"
         selectedoption="{\\"label\\":\\"rule1\\",\\"value\\":\\"rule1\\"}"

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo.tsx
@@ -6,6 +6,7 @@ import { useIntl } from 'react-intl';
 import '../IconPicker/IconPickerUtils/IconPicker-aws-overrides.scss';
 import { ColorRepresentation } from 'three';
 
+import { colors } from '../../../../../utils/styleUtils';
 import { IColorPickerProps } from '../interface';
 import { ColorPicker } from '../../../ColorPicker/ColorPicker';
 import { hexString } from '../../../ColorPicker/ColorPickerHelpers';
@@ -34,9 +35,11 @@ export const ColorSelectorCombo = ({
   const [showChromePicker, setShowChromePicker] = useState<boolean>(false);
   const [hexCodeError, setHexCodeError] = useState<string>(''); // State variable for hex code error
   const [customInternalColors, setCustomInternalColors] = useState<string[]>(customColors ?? []);
+  const [customColor, setCustomColor] = useState<string | undefined>(undefined);
   const generateRandomString = Math.random().toString(16).slice(2);
   const [randomDomId] = useState<string>(generateRandomString);
   const intl = useIntl();
+
   /**
    * This method uses a regular expression (`hexRegex`) to validate a hex color code.
    * The regex checks if the hex code starts with a "#" symbol, followed by either a
@@ -73,12 +76,16 @@ export const ColorSelectorCombo = ({
     };
   }, [showPicker, handleOutsideClick]);
 
-  const checkIfCustomColor = (color): void => {
-    if (!Object.values(palleteColors).includes(color)) {
-      setCustomInternalColors(customInternalColors.concat(color));
-      onUpdateCustomColors?.([...new Set(customInternalColors)]);
-    }
-  };
+  const checkIfCustomColor = useCallback(
+    (color): void => {
+      if (!Object.values(palleteColors).includes(color) && color !== colors.infoBlue) {
+        const updatedColors: string[] = customColors ? customColors.concat(color) : [color];
+        setCustomInternalColors(updatedColors);
+        onUpdateCustomColors?.([...new Set(updatedColors)]);
+      }
+    },
+    [customColors, onUpdateCustomColors],
+  );
 
   const handleShowChromePicker = () => {
     setShowChromePicker(true);
@@ -100,6 +107,7 @@ export const ColorSelectorCombo = ({
       setHexCodeError(''); // Clear any existing error message
       setNewColor(color.hex);
       onSelectColor(color.hex);
+      setCustomColor(color.hex);
     },
     [color, onSelectColor, onUpdateCustomColors],
   );
@@ -128,10 +136,6 @@ export const ColorSelectorCombo = ({
 
   useEffect(() => {
     setNewColor(color);
-  }, [color]);
-
-  useEffect(() => {
-    checkIfCustomColor(color);
   }, [color]);
 
   return (
@@ -181,7 +185,7 @@ export const ColorSelectorCombo = ({
                   <CirclePicker
                     width='300px'
                     colors={[...new Set(customInternalColors)]}
-                    color={newColor}
+                    color={customColor}
                     onChange={handleColorChange}
                   />
                   <button style={tmAddButton} onClick={handleShowChromePicker}>

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorSelectorCombo/ColorSelectorComboUtils/DecodeSvgString.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorSelectorCombo/ColorSelectorComboUtils/DecodeSvgString.tsx
@@ -25,7 +25,6 @@ export const DecodeSvgString = ({
   const decodeCustomIcon = (
     Array.isArray(customIcon?.icon[4]) ? customIcon?.icon[4].join('') : customIcon?.icon[4]
   ) as string;
-
   const svgCode = useSvgParser({ selectedColor, iconString, decodeCustomIcon, iconWidth, iconHeight });
   return (
     <img aria-label={ariaLabel} src={`data:image/svg+xml;base64,${btoa(svgCode)}`} width={width} height={height} />

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorSelectorCombo/ColorSelectorComboUtils/SvgParserHelper.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorSelectorCombo/ColorSelectorComboUtils/SvgParserHelper.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { colors } from '../../../../../../utils/styleUtils';
+
 export const replaceFillAttribute = (
   element: Element,
   selectedColor: string,
@@ -19,6 +21,7 @@ export const replaceFillAttribute = (
   }
   if (tagName === 'path') {
     element.setAttribute('d', customIcon);
+    element.setAttribute('fill', colors.infoRingWhite);
   }
   adjustIconSize(element, iconWidth, iconHeight);
 };

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPicker.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPicker.tsx
@@ -1,7 +1,8 @@
 import { Button, FormField, SpaceBetween, TextContent, TextFilter } from '@awsui/components-react';
-import { IconDefinition, IconLookup, library } from '@fortawesome/fontawesome-svg-core';
+import { IconDefinition, IconLookup, IconName, IconPrefix, library } from '@fortawesome/fontawesome-svg-core';
 import { fas } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { IIconPicker } from '../interface';
@@ -17,9 +18,13 @@ export const IconPicker = ({
   iconPickerLabel,
   iconFilterText,
   iconFilterTextAriaLabel,
+  iconButtonText,
 }: IIconPicker): JSX.Element => {
   const [filteringText, setFilteringText] = useState<string>('');
-  const [icon, setIcon] = useState<IconLookup>(selectedIcon);
+  const [icon, setIcon] = useState<IconLookup>({
+    prefix: selectedIcon.prefix as IconPrefix,
+    iconName: selectedIcon.iconName as IconName,
+  });
   const [showPicker, setShowPicker] = useState<boolean>(false);
   const iconsPerPage = 8; // Number of icons per page
   const defaultRows = 3; // Number of rows to display by default
@@ -78,10 +83,7 @@ export const IconPicker = ({
 
   const filteredIcons = filterIcons(Object.values(fas));
 
-  useEffect(() => {
-    setIcon(selectedIcon);
-  }, [selectedIcon]);
-
+  const emptyIcon = isEmpty(icon.iconName) && isEmpty(icon.prefix);
   return (
     <SpaceBetween size='l' direction='horizontal'>
       <TextContent>
@@ -92,10 +94,12 @@ export const IconPicker = ({
           id={'button-svg' + `${randomDomId}`}
           className='tm-icon-picker-button'
           data-testid='icon-button'
-          iconSvg={<FontAwesomeIcon icon={icon} />}
+          iconSvg={!emptyIcon ? <FontAwesomeIcon icon={icon} /> : null}
           iconAlign='right'
           onClick={() => setShowPicker(!showPicker)}
-        />
+        >
+          {emptyIcon && iconButtonText}
+        </Button>
         <div id={'icon-picker' + `${randomDomId}`} style={tmIconPickerContainer}>
           {showPicker && (
             <div data-testid='icon-popover' style={tmIconPickerPopover}>
@@ -115,7 +119,7 @@ export const IconPicker = ({
                   {currentIcons.map((icon, index) => {
                     return <FontAwesomeIcon key={index} icon={icon} onClick={() => handleIconClick(icon)} />;
                   })}
-                </div>{' '}
+                </div>
               </SpaceBetween>
             </div>
           )}

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPickerUtils/IconPicker-aws-overrides.scss
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPickerUtils/IconPicker-aws-overrides.scss
@@ -1,13 +1,17 @@
 .tm-icon-picker-button {
   border-radius: 10px !important; // This overrides the AWSUI border-radius
   position: 'absolute';
-  width: 100px;
+  padding: 0%;
+  width: 150px;
   height: 32px;
+  display: 'flex';
+  flex-wrap: nowrap;
 }
 
 .tm-color-picker-button {
+    display: 'flex';
     border-radius: 10px !important; // This overrides the AWSUI border-radius
     position: 'absolute';
-    width: 210px;
+    width: 200px;
     height: 32px;
 }

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPickerUtils/IconPickerStyles.ts
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPickerUtils/IconPickerStyles.ts
@@ -6,7 +6,7 @@ export const tmIconPickerPopover: CSSProperties = {
   zIndex: 1,
   top: '100%',
   left: '80%',
-  transform: 'translateX(-50%)',
+  transform: 'translateX(-40%)',
   background: colorBackgroundHomeHeader,
   borderRadius: '25px',
   padding: '20px',

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/interface.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/interface.tsx
@@ -1,4 +1,4 @@
-import { IconLookup } from '@fortawesome/fontawesome-svg-core';
+import { IIconLookup } from '../../../../models/SceneModels';
 
 export interface TagStyle {
   colorPicker?: React.ReactNode;
@@ -18,9 +18,10 @@ export interface IColorPickerProps {
 }
 
 export interface IIconPicker {
-  selectedIcon: IconLookup;
-  onSelectIconChange: (selectedIcon: string) => void;
+  selectedIcon: IIconLookup;
+  onSelectIconChange: (selectedIcon: IIconLookup) => void;
   iconPickerLabel?: string;
   iconFilterText?: string;
   iconFilterTextAriaLabel?: string;
+  iconButtonText?: string;
 }

--- a/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetEditor.tsx
@@ -1,17 +1,21 @@
-import React, { useEffect, useState } from 'react';
-import { useIntl, defineMessages } from 'react-intl';
 import { Grid, Select } from '@awsui/components-react';
+import React, { useContext, useState } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
 
-import { COMPOSER_FEATURES, SceneResourceType } from '../../../interfaces';
+import { getGlobalSettings } from '../../../common/GlobalSettings';
+import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import useFeature from '../../../hooks/useFeature';
+import { COMPOSER_FEATURES, KnownSceneProperty, SceneResourceType, TargetMetadata } from '../../../interfaces';
+import { IIconLookup } from '../../../models/SceneModels';
+import { useSceneDocument, useStore } from '../../../store';
 import {
   convertToIotTwinMakerNamespace,
   getSceneResourceDefaultValue,
   getSceneResourceInfo,
 } from '../../../utils/sceneResourceUtils';
-import useFeature from '../../../hooks/useFeature';
-import { getGlobalSettings } from '../../../common/GlobalSettings';
-import { ColorSelectorCombo } from '../scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo';
 import { colors } from '../../../utils/styleUtils';
+import { ColorSelectorCombo } from '../scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo';
+import { IconPicker } from '../scene-components/tag-style/IconPicker/IconPicker';
 
 import { SceneRuleTargetColorEditor } from './SceneRuleTargetColorEditor';
 import { SceneRuleTargetIconEditor } from './SceneRuleTargetIconEditor';
@@ -38,20 +42,25 @@ const i18nSceneResourceTypeStrings = defineMessages({
 
 interface ISceneRuleTargetEditorProps {
   target: string;
-  onChange: (target: string) => void;
+  onChange: (target: string, targetMetadata?: TargetMetadata) => void;
+  targetMetadata?: TargetMetadata;
 }
 
 export const SceneRuleTargetEditor: React.FC<ISceneRuleTargetEditorProps> = ({
   target,
   onChange,
+  targetMetadata,
 }: ISceneRuleTargetEditorProps) => {
-  const getCustomColor: string = target.includes('Custom-') ? target.split('-')[1] : colors.customBlue;
   const targetInfo = getSceneResourceInfo(target);
   const { formatMessage } = useIntl();
-
+  const sceneComposerId = useContext(sceneComposerIdContext);
   const [{ variation: opacityRuleEnabled }] = useFeature(COMPOSER_FEATURES[COMPOSER_FEATURES.OpacityRule]);
   const tagStyle = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagStyle];
-  const [chosenColor, setChosenColor] = useState<string>(getCustomColor);
+  const [chosenColor, setChosenColor] = useState<string>(targetMetadata?.color ?? colors.customBlue);
+  const [icon, setIcon] = useState<IIconLookup>({
+    prefix: targetMetadata?.iconPrefix as string,
+    iconName: targetMetadata?.iconName as string,
+  });
   const options = Object.values(SceneResourceType)
     .filter((type) => {
       return opacityRuleEnabled === 'C' ? type !== SceneResourceType.Opacity : true;
@@ -60,12 +69,12 @@ export const SceneRuleTargetEditor: React.FC<ISceneRuleTargetEditorProps> = ({
       label: formatMessage(i18nSceneResourceTypeStrings[SceneResourceType[type]]) || SceneResourceType[type],
       value: SceneResourceType[type],
     }));
+  const { getSceneProperty } = useSceneDocument(sceneComposerId);
+
+  const tagStyleColors = getSceneProperty<string[]>(KnownSceneProperty.TagCustomColors, []);
+  const setSceneProperty = useStore(sceneComposerId)((state) => state.setSceneProperty);
+
   const isCustomStyle = tagStyle && targetInfo.value === 'Custom';
-
-  useEffect(() => {
-    setChosenColor(getCustomColor);
-  }, [getCustomColor]);
-
   return (
     <Grid gridDefinition={[{ colspan: 4 }, { colspan: 8 }]}>
       <Select
@@ -88,30 +97,59 @@ export const SceneRuleTargetEditor: React.FC<ISceneRuleTargetEditorProps> = ({
         })}
       />
       {targetInfo.type === SceneResourceType.Icon && (
-        <>
+        <div>
           <SceneRuleTargetIconEditor
             targetValue={targetInfo.value}
             onChange={(targetValue) => {
-              const colorWithIcon = targetValue === 'Custom' ? `${targetValue}-${chosenColor}` : targetValue;
-              onChange(convertToIotTwinMakerNamespace(targetInfo.type, colorWithIcon));
+              onChange(convertToIotTwinMakerNamespace(targetInfo.type, targetValue));
             }}
             chosenColor={chosenColor}
+            customIcon={icon}
           />
           {isCustomStyle && (
-            <ColorSelectorCombo
-              color={chosenColor}
-              onSelectColor={(newColor) => {
-                const colorWithIcon =
-                  targetInfo.value === 'Custom' ? `${targetInfo.value}-${newColor}` : targetInfo.value;
-                onChange(convertToIotTwinMakerNamespace(targetInfo.type, colorWithIcon));
-                setChosenColor(newColor);
-              }}
-              colorPickerLabel={formatMessage({ defaultMessage: 'Colors', description: 'Colors' })}
-              customColorLabel={formatMessage({ defaultMessage: 'Custom colors', description: 'Custom colors' })}
-            />
+            <div>
+              <ColorSelectorCombo
+                color={chosenColor}
+                onSelectColor={(newColor) => {
+                  onChange(convertToIotTwinMakerNamespace(targetInfo.type, targetInfo.value), {
+                    ...targetMetadata,
+                    color: newColor,
+                  } as TargetMetadata);
+                  setChosenColor(newColor);
+                }}
+                customColors={tagStyleColors}
+                onUpdateCustomColors={(customColors) =>
+                  setSceneProperty(KnownSceneProperty.TagCustomColors, customColors)
+                }
+                colorPickerLabel={formatMessage({ defaultMessage: 'Colors', description: 'Colors' })}
+                customColorLabel={formatMessage({ defaultMessage: 'Custom colors', description: 'Custom colors' })}
+              />
+              <IconPicker
+                onSelectIconChange={(pickedIcon) => {
+                  onChange(convertToIotTwinMakerNamespace(targetInfo.type, targetInfo.value), {
+                    ...targetMetadata,
+                    iconPrefix: pickedIcon.prefix,
+                    iconName: pickedIcon.iconName,
+                  } as TargetMetadata);
+                  setIcon(pickedIcon);
+                }}
+                selectedIcon={icon}
+                iconPickerLabel={formatMessage({ defaultMessage: 'Icon', description: 'Icon' })}
+                iconFilterText={formatMessage({ defaultMessage: 'Find icons', description: 'Find icons' })}
+                iconFilterTextAriaLabel={formatMessage({
+                  defaultMessage: 'Filter icons',
+                  description: 'Filter icons',
+                })}
+                iconButtonText={formatMessage({
+                  defaultMessage: 'Select an icon',
+                  description: 'Select an icon',
+                })}
+              />
+            </div>
           )}
-        </>
+        </div>
       )}
+
       {targetInfo.type === SceneResourceType.Color && (
         <SceneRuleTargetColorEditor
           targetValue={targetInfo.value}

--- a/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetIconEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetIconEditor.tsx
@@ -1,10 +1,12 @@
 import { Grid, Select } from '@awsui/components-react';
+import { IconLookup, findIconDefinition } from '@fortawesome/fontawesome-svg-core';
 import React, { useMemo, useState } from 'react';
-import { useIntl, defineMessages } from 'react-intl';
+import { defineMessages, useIntl } from 'react-intl';
 
 import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { SCENE_ICONS } from '../../../common/constants';
 import { COMPOSER_FEATURES, DefaultAnchorStatus } from '../../../interfaces';
+import { IIconLookup } from '../../../models/SceneModels';
 import { i18nSceneIconsKeysStrings } from '../../../utils/polarisUtils';
 import { colors } from '../../../utils/styleUtils';
 import { DecodeSvgString } from '../scene-components/tag-style/ColorSelectorCombo/ColorSelectorComboUtils/DecodeSvgString';
@@ -13,12 +15,14 @@ interface ISceneRuleTargetIconEditorProps {
   targetValue: string;
   onChange: (target: string) => void;
   chosenColor?: string;
+  customIcon?: IIconLookup;
 }
 
 export const SceneRuleTargetIconEditor: React.FC<ISceneRuleTargetIconEditorProps> = ({
   targetValue,
   onChange,
   chosenColor,
+  customIcon,
 }: ISceneRuleTargetIconEditorProps) => {
   const propsSelectedIcon = DefaultAnchorStatus[targetValue] ?? DefaultAnchorStatus.Info;
   const [selectedIcon, setSelectedIcon] = useState<DefaultAnchorStatus>(propsSelectedIcon);
@@ -46,6 +50,7 @@ export const SceneRuleTargetIconEditor: React.FC<ISceneRuleTargetIconEditorProps
     [DefaultAnchorStatus.Video]: { defaultMessage: 'Video icon', description: 'Icon name label' },
     [DefaultAnchorStatus.Custom]: { defaultMessage: 'Custom icon', description: 'Icon name label' },
   });
+  const iconInfo = (customIcon ?? { prefix: 'fas', iconName: 'info' }) as IconLookup;
 
   return (
     <Grid gridDefinition={[{ colspan: 9 }, { colspan: 2 }]}>
@@ -73,6 +78,7 @@ export const SceneRuleTargetIconEditor: React.FC<ISceneRuleTargetIconEditorProps
         <DecodeSvgString
           selectedColor={chosenColor ?? colors.customBlue}
           iconString={iconString}
+          customIcon={findIconDefinition(iconInfo)}
           width='32px'
           height='32px'
           ariaLabel={intl.formatMessage(i18nIconStrings[targetValue])}

--- a/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/__snapshots__/SceneRuleTargetEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/__snapshots__/SceneRuleTargetEditor.spec.tsx.snap
@@ -29,7 +29,9 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
       selectedarialabel="test message"
       selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"}"
     />
-    SceneRuleTargetIconEditor
+    <div>
+      SceneRuleTargetIconEditor
+    </div>
   </div>
 </div>
 `;
@@ -79,7 +81,9 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
       selectedarialabel="test message"
       selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"}"
     />
-    SceneRuleTargetIconEditor
+    <div>
+      SceneRuleTargetIconEditor
+    </div>
   </div>
 </div>
 `;

--- a/packages/scene-composer/src/components/three-fiber/AnchorComponent/__tests__/AnchorComponent.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/AnchorComponent/__tests__/AnchorComponent.spec.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { create } from 'react-test-renderer';
 
 import AnchorComponent from '..';
-import { IAnchorComponentInternal, ISceneNodeInternal } from '../../../../store';
 import { DefaultAnchorStatus } from '../../../..';
+import { IAnchorComponentInternal, ISceneNodeInternal } from '../../../../store';
 
 jest.mock('../../../../augmentations/components/three-fiber/anchor/AnchorWidget', () => ({
   AnchorWidget: 'AnchorWidget',

--- a/packages/scene-composer/src/components/three-fiber/AnchorComponent/__tests__/__snapshots__/AnchorComponent.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/AnchorComponent/__tests__/__snapshots__/AnchorComponent.spec.tsx.snap
@@ -5,12 +5,6 @@ exports[`AnchorComponent should render correctly with default icon 1`] = `
   name="TAG_COMPONENT_testRef"
 >
   <AnchorWidget
-    customIcon={
-      Object {
-        "iconName": "info",
-        "prefix": "fas",
-      }
-    }
     defaultIcon="Info"
     navLink="https://test.url"
     node={
@@ -33,12 +27,6 @@ exports[`AnchorComponent should render correctly with set icon 1`] = `
   name="TAG_COMPONENT_testRef"
 >
   <AnchorWidget
-    customIcon={
-      Object {
-        "iconName": "info",
-        "prefix": "fas",
-      }
-    }
     defaultIcon="Error"
     navLink="https://test.url"
     node={

--- a/packages/scene-composer/src/components/three-fiber/AnchorComponent/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/AnchorComponent/index.tsx
@@ -11,7 +11,6 @@ interface IAnchorComponentProps {
 }
 
 const AnchorComponent: React.FC<IAnchorComponentProps> = ({ node, component }: IAnchorComponentProps) => {
-  const customIcon = component.customIcon ?? { prefix: 'fas', iconName: 'info' };
   return (
     <group name={getComponentGroupName(node.ref, 'TAG')}>
       <AnchorWidget
@@ -21,7 +20,7 @@ const AnchorComponent: React.FC<IAnchorComponentProps> = ({ node, component }: I
         ruleBasedMapId={component.ruleBasedMapId}
         valueDataBinding={component.valueDataBinding}
         chosenColor={component.chosenColor}
-        customIcon={customIcon}
+        customIcon={component.customIcon}
       />
     </group>
   );

--- a/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/index.tsx
@@ -27,7 +27,7 @@ const ColorOverlayComponent: React.FC<IColorOverlayComponentProps> = ({
   const ruleResult = useRuleResult({ ruleMapId: ruleBasedMapId, dataBinding: valueDataBinding });
 
   const ruleColor = useMemo(() => {
-    const { type, value } = getSceneResourceInfo(ruleResult as string);
+    const { type, value } = getSceneResourceInfo(ruleResult.target as string);
 
     switch (type) {
       case SceneResourceType.Color:

--- a/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/MotionIndicatorComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/MotionIndicatorComponent.tsx
@@ -1,19 +1,19 @@
+import { Primitive } from '@iot-app-kit/core';
 import React, { useMemo } from 'react';
 import { Color } from 'three';
-import { Primitive } from '@iot-app-kit/core';
 
-import { ISceneNodeInternal, IMotionIndicatorComponentInternal, useStore, useViewOptionState } from '../../../store';
 import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
-import { getComponentGroupName } from '../../../utils/objectThreeUtils';
-import { Component } from '../../../models/SceneModels';
-import { dataBindingValuesProvider, ruleEvaluator } from '../../../utils/dataBindingUtils';
-import { getSceneResourceInfo, parseColorWithAlpha } from '../../../utils/sceneResourceUtils';
-import { IValueDataBinding, KnownComponentType, SceneResourceType } from '../../../interfaces';
 import useBindingData from '../../../hooks/useBindingData';
+import { IValueDataBinding, KnownComponentType, SceneResourceType } from '../../../interfaces';
+import { Component } from '../../../models/SceneModels';
+import { IMotionIndicatorComponentInternal, ISceneNodeInternal, useStore, useViewOptionState } from '../../../store';
+import { dataBindingValuesProvider, ruleEvaluator } from '../../../utils/dataBindingUtils';
+import { getComponentGroupName } from '../../../utils/objectThreeUtils';
+import { getSceneResourceInfo, parseColorWithAlpha } from '../../../utils/sceneResourceUtils';
 
-import { LinearPlaneMotionIndicator } from './LinearPlaneMotionIndicator';
-import { LinearCylinderMotionIndicator } from './LinearCylinderMotionIndicator';
 import { CircularCylinderMotionIndicator } from './CircularCylinderMotionIndicator';
+import { LinearCylinderMotionIndicator } from './LinearCylinderMotionIndicator';
+import { LinearPlaneMotionIndicator } from './LinearPlaneMotionIndicator';
 
 interface IMotionIndicatorComponentProps {
   node: ISceneNodeInternal;
@@ -72,7 +72,7 @@ const MotionIndicatorComponent: React.FC<IMotionIndicatorComponentProps> = ({
         dataBindingTemplate,
       );
 
-    const result = ruleEvaluator(0, values, speedRule) as number;
+    const result = ruleEvaluator(0, values, speedRule).target as number;
     return result >= 0 ? result : 0;
   }, [
     speedRule,
@@ -104,7 +104,7 @@ const MotionIndicatorComponent: React.FC<IMotionIndicatorComponentProps> = ({
         dataBindingTemplate,
       );
     const result = ruleEvaluator('', values, foregroundColorRule);
-    const ruleTargetInfo = getSceneResourceInfo(result as string);
+    const ruleTargetInfo = getSceneResourceInfo(result.target as string);
 
     return ruleTargetInfo.type === SceneResourceType.Color
       ? parseColorWithAlpha(ruleTargetInfo.value)?.color
@@ -140,7 +140,7 @@ const MotionIndicatorComponent: React.FC<IMotionIndicatorComponentProps> = ({
         dataBindingTemplate,
       );
     const result = ruleEvaluator('', values, backgroundColorRule);
-    const ruleTargetInfo = getSceneResourceInfo(result as string);
+    const ruleTargetInfo = getSceneResourceInfo(result.target as string);
 
     return ruleTargetInfo.type === SceneResourceType.Color
       ? parseColorWithAlpha(ruleTargetInfo.value)?.color
@@ -160,7 +160,7 @@ const MotionIndicatorComponent: React.FC<IMotionIndicatorComponentProps> = ({
     <group name={getComponentGroupName(node.ref, 'MOTION_INDICATOR')} visible={motionIndicatorVisible}>
       {component.shape === 'LinearPlane' && (
         <LinearPlaneMotionIndicator
-          speed={speed}
+          speed={speed as number}
           foregroundColor={foregroundColor}
           backgroundColor={backgroundColor}
           config={component.config as Component.ILinearPlaneMotionIndicatorConfig}
@@ -169,7 +169,7 @@ const MotionIndicatorComponent: React.FC<IMotionIndicatorComponentProps> = ({
       )}
       {component.shape === 'LinearCylinder' && (
         <LinearCylinderMotionIndicator
-          speed={speed}
+          speed={speed as number}
           foregroundColor={foregroundColor}
           backgroundColor={backgroundColor}
           config={component.config as Component.ILinearCylinderMotionIndicatorConfig}
@@ -178,7 +178,7 @@ const MotionIndicatorComponent: React.FC<IMotionIndicatorComponentProps> = ({
       )}
       {component.shape === 'CircularCylinder' && (
         <CircularCylinderMotionIndicator
-          speed={speed}
+          speed={speed as number}
           foregroundColor={foregroundColor}
           backgroundColor={backgroundColor}
           config={component.config as Component.ICircularCylinderMotionIndicatorConfig}

--- a/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/__tests__/MotionIndicatorComponentSnap.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/__tests__/MotionIndicatorComponentSnap.spec.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
 import { render } from '@testing-library/react';
+import React from 'react';
 
-import MotionIndicatorComponent from '../MotionIndicatorComponent';
-import { useStore } from '../../../../store';
 import { SceneResourceType } from '../../../../interfaces';
 import { Component } from '../../../../models/SceneModels';
-import { getSceneResourceInfo } from '../../../../utils/sceneResourceUtils';
+import { useStore } from '../../../../store';
 import { dataBindingValuesProvider, ruleEvaluator } from '../../../../utils/dataBindingUtils';
+import { getSceneResourceInfo } from '../../../../utils/sceneResourceUtils';
+import MotionIndicatorComponent from '../MotionIndicatorComponent';
 
 jest.mock('../../../../hooks/useBindingData', () => jest.fn().mockReturnValue({ data: [{ alarm_status: 'ACTIVE' }] }));
 
@@ -75,7 +75,7 @@ describe('MotionIndicatorComponent', () => {
 
     mockGetSceneResourceInfo.mockReturnValue({ type: SceneResourceType.Color, value: 'black' });
     mockDataBindingValuesProvider.mockReturnValue({});
-    mockRuleEvaluator.mockReturnValue(3);
+    mockRuleEvaluator.mockReturnValue({ target: 3 });
     mockGetSceneRuleMapById.mockImplementation((id) => id);
   });
 

--- a/packages/scene-composer/src/hooks/useRuleResult.spec.ts
+++ b/packages/scene-composer/src/hooks/useRuleResult.spec.ts
@@ -29,7 +29,7 @@ describe('useRuleResult', () => {
   it('should return default when binding is empty', () => {
     const data = renderHook(() => useRuleResult({ ruleMapId: 'rule-id', defaultValue: 'default' })).result.current;
 
-    expect(data).toEqual('default');
+    expect(data).toEqual({ target: 'default', targetMetadata: undefined });
   });
 
   it('should return default when rule is not found', () => {
@@ -41,11 +41,11 @@ describe('useRuleResult', () => {
       }),
     ).result.current;
 
-    expect(data).toEqual('default');
+    expect(data).toEqual({ target: 'default', targetMetadata: undefined });
   });
 
   it('should return expected target value ', () => {
-    const expectedData = 'iottwinmaker.common.icon:Error';
+    const expectedData = { target: 'iottwinmaker.common.icon:Error', targetMetadata: undefined };
     const data = renderHook(() =>
       useRuleResult({
         ruleMapId: 'rule-id',

--- a/packages/scene-composer/src/hooks/useRuleResult.ts
+++ b/packages/scene-composer/src/hooks/useRuleResult.ts
@@ -1,10 +1,10 @@
-import { useMemo } from 'react';
 import { Primitive } from '@iot-app-kit/core';
+import { useMemo } from 'react';
 
-import { IValueDataBinding } from '../interfaces';
-import { useSceneDocument, useDataStore } from '../store';
 import { useSceneComposerId } from '../common/sceneComposerIdContext';
-import { dataBindingValuesProvider, ruleEvaluator } from '../utils/dataBindingUtils';
+import { IValueDataBinding } from '../interfaces';
+import { useDataStore, useSceneDocument } from '../store';
+import { RuleReturnResult, dataBindingValuesProvider, ruleEvaluator } from '../utils/dataBindingUtils';
 
 import useBindingData from './useBindingData';
 
@@ -16,7 +16,7 @@ const useRuleResult = ({
   ruleMapId?: string;
   dataBinding?: IValueDataBinding;
   defaultValue?: string;
-}) => {
+}): RuleReturnResult => {
   const sceneComposerId = useSceneComposerId();
   const { getSceneRuleMapById } = useSceneDocument(sceneComposerId);
   const { dataBindingTemplate, dataInput } = useDataStore(sceneComposerId);
@@ -29,7 +29,6 @@ const useRuleResult = ({
       bindingData ?? dataBindingValuesProvider(dataInput, dataBinding, dataBindingTemplate);
     return ruleEvaluator(defaultValue || '', values, rule);
   }, [rule, dataInput, dataBinding, bindingData, dataBindingTemplate, defaultValue]);
-
   return ruleResult;
 };
 

--- a/packages/scene-composer/src/interfaces/components.ts
+++ b/packages/scene-composer/src/interfaces/components.ts
@@ -48,9 +48,9 @@ export interface IAnchorComponent extends ISceneComponent {
   navLink?: INavLink;
   offset?: Vector3;
   chosenColor?: string;
-  customColors?: string[];
   customIcon?: SceneModels.IIconLookup;
 }
+
 export interface IAnimationComponent extends ISceneComponent {
   selector?: number;
   uri: string;
@@ -79,7 +79,6 @@ export interface ITagData {
   chosenColor?: string;
   navLink?: INavLink;
   dataBindingContext?: unknown;
-  customColors?: string[];
   customIcon?: SceneModels.IIconLookup;
 }
 

--- a/packages/scene-composer/src/interfaces/dataTypes.ts
+++ b/packages/scene-composer/src/interfaces/dataTypes.ts
@@ -33,7 +33,12 @@ export interface ITransformConstraint {
   snapToFloor?: boolean;
 }
 
-export type { IValueDataBinding, ITwinMakerEntityDataBindingContext } from '@iot-app-kit/source-iottwinmaker';
+export type { ITwinMakerEntityDataBindingContext, IValueDataBinding } from '@iot-app-kit/source-iottwinmaker';
+export interface TargetMetadata {
+  color?: string;
+  iconPrefix?: string;
+  iconName?: string;
+}
 
 export interface INavLink {
   destination?: string;
@@ -43,6 +48,7 @@ export interface INavLink {
 export interface IRuleStatement {
   expression: string;
   target: string;
+  targetMetadata?: TargetMetadata;
 }
 
 export interface IRuleBasedMap {

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -72,6 +72,7 @@ export enum KnownSceneProperty {
   MatterportModelId = 'matterportModelId',
   LayerIds = 'layerIds',
   SceneRootEntityId = 'sceneRootEntityId',
+  TagCustomColors = 'tagCustomColors',
 }
 
 /************************************************

--- a/packages/scene-composer/src/store/slices/SceneDocumentSlice.spec.ts
+++ b/packages/scene-composer/src/store/slices/SceneDocumentSlice.spec.ts
@@ -1,16 +1,16 @@
 /* eslint-disable dot-notation, jest/no-conditional-expect */
 import { cloneDeep } from 'lodash';
 
-import serializationHelpers from '../helpers/serializationHelpers';
-import interfaceHelpers from '../helpers/interfaceHelpers';
-import { mergeDeep } from '../../utils/objectUtils';
-import { KnownComponentType, KnownSceneProperty } from '../..';
-import { containsMatchingEntityComponent } from '../../utils/dataBindingUtils';
 import { IAnchorComponentInternal, IDataOverlayComponentInternal, ISceneNodeInternal } from '..';
+import { KnownComponentType, KnownSceneProperty } from '../..';
 import { Component } from '../../models/SceneModels';
-import { updateEntity } from '../../utils/entityModelUtils/updateNodeEntity';
-import { SceneNodeRuntimeProperty } from '../internalInterfaces';
+import { containsMatchingEntityComponent } from '../../utils/dataBindingUtils';
 import { deleteNodeEntity } from '../../utils/entityModelUtils/deleteNodeEntity';
+import { updateEntity } from '../../utils/entityModelUtils/updateNodeEntity';
+import { mergeDeep } from '../../utils/objectUtils';
+import interfaceHelpers from '../helpers/interfaceHelpers';
+import serializationHelpers from '../helpers/serializationHelpers';
+import { SceneNodeRuntimeProperty } from '../internalInterfaces';
 
 import { createSceneDocumentSlice } from './SceneDocumentSlice';
 

--- a/packages/scene-composer/src/utils/dataBindingUtils.spec.ts
+++ b/packages/scene-composer/src/utils/dataBindingUtils.spec.ts
@@ -196,7 +196,7 @@ describe('dataBindingValuesProvider', () => {
 describe('ruleEvaluator', () => {
   it('should return default state with no rules', async () => {
     const result = ruleEvaluator('mockDefaultState', {});
-    expect(result).toBe('mockDefaultState');
+    expect(result).toEqual({ target: 'mockDefaultState', targetMetadata: undefined });
   });
 
   it('should return default state with empty value', async () => {
@@ -210,7 +210,7 @@ describe('ruleEvaluator', () => {
     };
 
     const result = ruleEvaluator('mockDefaultState', {}, rule);
-    expect(result).toBe('mockDefaultState');
+    expect(result).toEqual({ target: 'mockDefaultState', targetMetadata: undefined });
   });
 
   it('should return rule target if it matches', async () => {
@@ -228,7 +228,7 @@ describe('ruleEvaluator', () => {
       ],
     };
     const result = ruleEvaluator('mockDefaultState', value, rule);
-    expect(result).toBe('mockTarget2');
+    expect(result).toEqual({ target: 'mockTarget2', targetMetadata: undefined });
   });
 
   it('should return rule evaluation result if target is number', async () => {
@@ -241,8 +241,11 @@ describe('ruleEvaluator', () => {
         },
       ],
     };
-    expect(ruleEvaluator('mockDefaultState', value, rule)).toEqual(2);
-    expect(ruleEvaluator('mockDefaultState', { temperature: 10 }, rule)).toEqual(3);
+    expect(ruleEvaluator('mockDefaultState', value, rule)).toEqual({ target: 2, targetMetadata: undefined });
+    expect(ruleEvaluator('mockDefaultState', { temperature: 10 }, rule)).toEqual({
+      target: 3,
+      targetMetadata: undefined,
+    });
   });
 
   it('should return default state if rule evaluation result is a number while target is number', async () => {
@@ -255,7 +258,10 @@ describe('ruleEvaluator', () => {
         },
       ],
     };
-    expect(ruleEvaluator('mockDefaultState', value, rule)).toEqual('mockDefaultState');
+    expect(ruleEvaluator('mockDefaultState', value, rule)).toEqual({
+      target: 'mockDefaultState',
+      targetMetadata: undefined,
+    });
   });
 
   it('should return default state if no rule matches', async () => {
@@ -273,7 +279,24 @@ describe('ruleEvaluator', () => {
       ],
     };
     const result = ruleEvaluator('mockDefaultState', value, rule);
-    expect(result).toBe('mockDefaultState');
+    expect(result).toEqual({ target: 'mockDefaultState', targetMetadata: undefined });
+  });
+
+  it('should return default state if rule matches', async () => {
+    const value = { temperature: 20 };
+    const rule: IRuleBasedMap = {
+      statements: [
+        {
+          expression: 'temperature == 20',
+          target: 'mockTarget1',
+          targetMetadata: {
+            color: '#ffffff',
+          },
+        },
+      ],
+    };
+    const result = ruleEvaluator('mockDefaultState', value, rule);
+    expect(result).toEqual({ target: 'mockTarget1', targetMetadata: { color: '#ffffff' } });
   });
 
   it('should property names with special characters should work correctly', async () => {
@@ -296,6 +319,6 @@ describe('ruleEvaluator', () => {
       ],
     };
     const result = ruleEvaluator('mockDefaultState', value, rule);
-    expect(result).toBe('mockTarget2');
+    expect(result).toEqual({ target: 'mockTarget2', targetMetadata: undefined });
   });
 });

--- a/packages/scene-composer/src/utils/eventDataUtils.ts
+++ b/packages/scene-composer/src/utils/eventDataUtils.ts
@@ -21,7 +21,6 @@ export const getBindingsFromTag = (
 ): ITagData => {
   return {
     chosenColor: component.chosenColor,
-    customColors: component.customColors,
     customIcon: component.customIcon,
     navLink: component.navLink,
     dataBindingContext: !component.valueDataBinding?.dataBindingContext

--- a/packages/scene-composer/src/utils/sceneResourceUtils.ts
+++ b/packages/scene-composer/src/utils/sceneResourceUtils.ts
@@ -55,7 +55,7 @@ export const getSceneResourceInfo = (target: string | undefined): SceneResourceI
     if (mapKey) {
       type = map[mapKey];
       const statuses = DefaultAnchorStatus;
-      const newValue = target.substring(mapKey.length).split('-')[0];
+      const newValue = target.substring(mapKey.length);
 
       switch (type) {
         case SceneResourceType.Icon:

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -31,6 +31,10 @@
     "note": "Distance Units in a dropdown menu",
     "text": "Custom Scale"
   },
+  "/j+uhN": {
+    "note": "Select an icon",
+    "text": "Select an icon"
+  },
   "/kZshs": {
     "note": "Scene Resource types in a dropdown menu",
     "text": "Color"


### PR DESCRIPTION
## Overview
This contains following changes,
* Icon rule changes added to part of rule.
* Unit tests
## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/54058998/c913f708-3e68-492d-86e0-12bfe9e91799


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
