### PR TITLE
fix(ResourceExplorer): implement toggling on/off of properties visibi…

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/sectionTypes.ts
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/sectionTypes.ts
@@ -7,7 +7,7 @@ export type OnDeleteAssetQuery = (params: {
   assetId: string;
   propertyId: string;
   siteWiseAssetQuery: IoTSiteWiseDataStreamQuery | StyledAssetQuery;
-  updateSiteWiseAssetQuery: (newQuery: IoTSiteWiseDataStreamQuery) => void;
+  updateSiteWiseAssetQuery: (newQuery: StyledAssetQuery) => void;
 }) => () => void;
 
 export type PropertiesAlarmsSectionProps = {

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
@@ -15,7 +15,20 @@ import type { FC } from 'react';
 import './propertyComponent.css';
 import { StyledAssetPropertyQuery, YAxisOptions } from '~/customization/widgets/types';
 import { getPropertyDisplay } from './getPropertyDisplay';
-import type { AssetSummary } from '../../../hooks/useAssetDescriptionQueries';
+import type { AssetSummary } from '~/hooks/useAssetDescriptionQueries';
+import {
+  colorBackgroundHomeHeader,
+  colorBackgroundLayoutMain,
+  colorBorderButtonNormalDisabled,
+  spaceScaledM,
+  spaceScaledXxxs,
+  spaceStaticXs,
+} from '@cloudscape-design/design-tokens';
+import {
+  StatusEyeHidden,
+  StatusEyeVisible,
+} from '~/customization/propertiesSections/propertiesAndAlarmsSettings/icons';
+import { ClickDetail, NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 
 const YAxisPropertyConfig = ({
   resetStyles,
@@ -88,19 +101,22 @@ export type StyledPropertyComponentProps = {
   updateStyle: (newStyles: object) => void;
   assetSummary: AssetSummary;
   property: StyledAssetPropertyQuery;
+  onHideAssetQuery: () => void;
   onDeleteAssetQuery?: () => void;
   colorable: boolean;
+  isPropertyVisible: boolean;
 };
 
 export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
   assetSummary,
   property,
   updateStyle,
+  onHideAssetQuery,
   onDeleteAssetQuery,
   colorable,
+  isPropertyVisible,
 }) => {
   const { display, label } = getPropertyDisplay(property.propertyId, assetSummary);
-  /*
   const [onMouseOver, setOnMouseOver] = useState(false);
   const isAssetQueryVisible = !onMouseOver ? isPropertyVisible : !isPropertyVisible;
   const propertyVisibilityIcon = isAssetQueryVisible ? StatusEyeVisible : StatusEyeHidden;
@@ -127,7 +143,6 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
   const handleMouseLeave = () => {
     setOnMouseOver(false);
   };
-  */
 
   const resetStyles = (styleToReset: object) => {
     updateStyle(styleToReset); // as we add more sections, reset style values here
@@ -139,14 +154,12 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
         <ColorPicker color={property.color || ''} updateColor={(newColor) => updateStyle({ color: newColor })} />
       )}
       <div style={{ fontWeight: 'normal' }}>{label}</div>
-      {/* 
-        <div className='property-display-toggle' onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-          <Button onClick={onToggleAssetQuery} variant='icon' iconSvg={propertyVisibilityIcon} />
-          <span className='tooltiptext' style={tooltipStyle}>
-            {onMouseOver && isPropertyVisible ? 'hide' : 'unhide'}
-          </span>
-        </div>
-      */}
+      <div className='property-display-toggle' onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        <Button onClick={onToggleAssetQuery} variant='icon' iconSvg={propertyVisibilityIcon} />
+        <span className='tooltiptext' style={tooltipStyle}>
+          {onMouseOver && isPropertyVisible ? 'hide' : 'unhide'}
+        </span>
+      </div>
 
       <Button onClick={onDeleteAssetQuery} variant='icon' iconName='remove' />
     </SpaceBetween>

--- a/packages/dashboard/src/customization/widgets/barChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/component.tsx
@@ -28,7 +28,10 @@ const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
   } = widget.properties;
 
   const { iotSiteWiseQuery } = useQueries();
-  const queries = iotSiteWiseQuery && queryConfig.query ? [iotSiteWiseQuery?.timeSeriesData(queryConfig.query)] : [];
+  const queries =
+    iotSiteWiseQuery && queryConfig.query
+      ? [iotSiteWiseQuery?.timeSeriesData({ assets: [], ...queryConfig.query })]
+      : [];
   const key = computeQueryConfigKey(undefined, queryConfig);
   const aggregation = getAggregation(widget);
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -107,7 +107,28 @@ const convertAxis = (axis: ChartAxisOptions | undefined) => ({
   yMax: axis?.yMax,
 });
 
+const removeHiddenDataStreams = (widget: LineScatterChartWidget): LineScatterChartWidget => ({
+  ...widget,
+  properties: {
+    ...widget.properties,
+    queryConfig: {
+      ...widget.properties.queryConfig,
+      query: {
+        assets:
+          widget.properties.queryConfig?.query?.assets?.map((asset) => ({
+            ...asset,
+            properties: asset.properties.filter((property) => {
+              return property.visible !== false;
+            }),
+          })) || [],
+        properties: widget.properties.queryConfig?.query?.properties?.filter((property) => property.visible !== false),
+      },
+    },
+  },
+});
+
 const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (widget) => {
+  const widgetToDisplay = removeHiddenDataStreams(widget);
   const { viewport } = useViewport();
   const readOnly = useSelector((state: DashboardState) => state.readOnly);
   const chartSize = useChartSize(widget);
@@ -121,7 +142,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (widge
     line,
     symbol,
     significantDigits: widgetSignificantDigits,
-  } = widget.properties;
+  } = widgetToDisplay.properties;
 
   //debugger;
   const query = queryConfig.query;

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -4,7 +4,7 @@ import type {
   SiteWiseAssetQuery,
   SiteWisePropertyAliasQuery,
 } from '@iot-app-kit/source-iotsitewise';
-import type { DashboardWidget, IoTSiteWiseDataStreamQuery } from '~/types';
+import type { DashboardWidget } from '~/types';
 import type { AxisSettings, ComplexFontSettings, SimpleFontSettings, ThresholdWithId } from '../settings';
 import type { TableColumnDefinition, TableItem } from '@iot-app-kit/react-components/src';
 import { AggregateType } from '@aws-sdk/client-iotsitewise';
@@ -65,6 +65,7 @@ export type LineAndScatterStyles = {
   line?: LineStyles;
   aggregationType?: AggregateType;
   resolution?: string;
+  visible?: boolean; // defaults to true
 };
 export type LineStyles = {
   connectionStyle?: 'none' | 'linear' | 'curve' | 'step-start' | 'step-middle' | 'step-end';
@@ -118,7 +119,7 @@ type ChartLegend = {
   visible?: boolean;
 };
 
-export type StyledSiteWiseQueryConfig = QueryConfig<'iotsitewise', IoTSiteWiseDataStreamQuery | undefined>;
+export type StyledSiteWiseQueryConfig = QueryConfig<'iotsitewise', StyledAssetQuery | undefined>;
 
 export type LineScatterChartProperties = LineAndScatterStyles & {
   title?: string;

--- a/packages/source-iotsitewise/src/time-series-data/types.ts
+++ b/packages/source-iotsitewise/src/time-series-data/types.ts
@@ -21,7 +21,6 @@ export type AssetPropertyQuery = {
   cacheSettings?: CacheSettings;
   aggregationType?: AggregateType;
   alarms?: boolean;
-  visible?: boolean;
 };
 
 export type PropertyAliasQuery = {


### PR DESCRIPTION
This PR provides the basic functionality to toggle visibility of data streams on widgets, resolving issue https://github.com/awslabs/iot-app-kit/issues/1986.

Removed alterations to the public API made in https://github.com/awslabs/iot-app-kit/pull/2005/files, as `visible` 

Attached is a screen shot demonstrating that a hidden property is reflected in the widget by no longer being visualized:
![Screenshot 2023-09-29 at 3 00 40 PM](https://github.com/awslabs/iot-app-kit/assets/77755322/85cb26ae-74cb-4f92-9fbd-6a9b6c896100)

Note: this feature will only work with line and scatter chart.

---

Additionally this PR fixes the build process on dashboard that exists currently within `main` branch, where it fails to build the typescript types.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
