### PR TITLE
fix(scene): fix camera returning to last target on mode change

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/EditorCamera.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EditorCamera.tsx
@@ -23,7 +23,7 @@ import useActiveCamera from '../../hooks/useActiveCamera';
 import { getSafeBoundingBox } from '../../utils/objectThreeUtils';
 import { getMatterportSdk } from '../../common/GlobalSettings';
 import { MapControls as MapControlsImpl, OrbitControls as OrbitControlsImpl } from '../../three/OrbitControls';
-import { isOrbitOrPanControl } from '../../utils/controlUtils';
+import { isOrbitOrPanControlImpl } from '../../utils/controlUtils';
 
 import { MapControls, OrbitControls, PointerLockControls } from './controls';
 
@@ -171,24 +171,25 @@ export const EditorMainCamera = forwardRef<Camera>((_, forwardedRef) => {
         },
       ];
 
-      if (isOrbitOrPanControl(cameraControlsType)) {
-        const controlRef = cameraControlsImplRef.current as OrbitControlsImpl | MapControlsImpl | undefined;
-        const currentTarget = getTweenValueFromVector3(controlRef?.target ?? DEFAULT_CAMERA_TARGET);
-        tweenConfigs.push({
-          from: currentTarget,
-          to: getTweenValueFromVector3(target),
-          onUpdate: () => {
-            controlRef?.target.set(currentTarget.x, currentTarget.y, currentTarget.z);
-          },
-          duration,
-        });
-      }
+      const controlRef: OrbitControlsImpl | MapControlsImpl | undefined =
+        cameraControlsImplRef.current && isOrbitOrPanControlImpl(cameraControlsImplRef.current)
+          ? (cameraControlsImplRef.current as OrbitControlsImpl | MapControlsImpl)
+          : undefined;
+      const currentTarget = getTweenValueFromVector3(controlRef?.target ?? DEFAULT_CAMERA_TARGET);
+      tweenConfigs.push({
+        from: currentTarget,
+        to: getTweenValueFromVector3(target),
+        onUpdate: () => {
+          controlRef?.target.set(currentTarget.x, currentTarget.y, currentTarget.z);
+        },
+        duration,
+      });
 
       log?.verbose('moving camera to target', position, target);
 
       setTween(...tweenConfigs);
     }
-  }, [cameraTarget, cameraControlsType]);
+  }, [cameraTarget]);
 
   // handle mouse events
   useEffect(() => {

--- a/packages/scene-composer/src/utils/controlUtils.spec.ts
+++ b/packages/scene-composer/src/utils/controlUtils.spec.ts
@@ -1,10 +1,20 @@
+import THREE from 'three';
+
+import { MapControls, OrbitControls } from '../three/OrbitControls';
+import { PointerLockControls } from '../three/PointerLockControls';
+
 import {
   isImmersiveControl,
   isPanControl,
   isPointerLockControl,
   isOrbitControl,
   isOrbitOrPanControl,
+  isOrbitControlImpl,
+  isPanControlImpl,
+  isPointerLockControlImpl,
+  isOrbitOrPanControlImpl,
 } from './controlUtils';
+
 describe('control utils', () => {
   it('should detect immersive correctly', () => {
     expect(isImmersiveControl('immersive')).toBeTruthy();
@@ -35,5 +45,32 @@ describe('control utils', () => {
     expect(isOrbitOrPanControl('orbit')).toBeTruthy();
     expect(isOrbitOrPanControl('pan')).toBeTruthy();
     expect(isOrbitOrPanControl('pointerLock')).toBeFalsy();
+  });
+});
+describe('control implementation utils', () => {
+  const camera = new THREE.PerspectiveCamera();
+  const orbit = new OrbitControls(camera);
+  const pan = new MapControls(camera);
+  const pointerLock = new PointerLockControls(camera);
+  it('should detect orbit correctly', () => {
+    expect(isOrbitControlImpl(orbit)).toBeTruthy();
+    //map is a extension of orbit
+    expect(isOrbitControlImpl(pan)).toBeTruthy();
+    expect(isOrbitControlImpl(pointerLock)).toBeFalsy();
+  });
+  it('should detect pan correctly', () => {
+    expect(isPanControlImpl(orbit)).toBeFalsy();
+    expect(isPanControlImpl(pan)).toBeTruthy();
+    expect(isPanControlImpl(pointerLock)).toBeFalsy();
+  });
+  it('should detect pointer lock correctly', () => {
+    expect(isPointerLockControlImpl(orbit)).toBeFalsy();
+    expect(isPointerLockControlImpl(pan)).toBeFalsy();
+    expect(isPointerLockControlImpl(pointerLock)).toBeTruthy();
+  });
+  it('should detect pan or orbit correctly', () => {
+    expect(isOrbitOrPanControlImpl(orbit)).toBeTruthy();
+    expect(isOrbitOrPanControlImpl(pan)).toBeTruthy();
+    expect(isOrbitOrPanControlImpl(pointerLock)).toBeFalsy();
   });
 });

--- a/packages/scene-composer/src/utils/controlUtils.ts
+++ b/packages/scene-composer/src/utils/controlUtils.ts
@@ -1,4 +1,8 @@
+import { MapControls, OrbitControls } from '../three/OrbitControls';
+import { PointerLockControls } from '../three/PointerLockControls';
 import { CameraControlsType } from '../interfaces';
+import { CameraControlImpl } from '../store/internalInterfaces';
+import { Pan } from '../assets/auto-gen/icons';
 
 export const isPointerLockControl = (controlType: CameraControlsType): boolean => {
   return controlType === 'pointerLock' ? true : false;
@@ -18,4 +22,21 @@ export const isImmersiveControl = (controlType: CameraControlsType): boolean => 
 
 export const isOrbitOrPanControl = (controlType: CameraControlsType): boolean => {
   return isOrbitControl(controlType) || isPanControl(controlType) ? true : false;
+};
+
+export const isPointerLockControlImpl = (controler: CameraControlImpl): boolean => {
+  return controler instanceof PointerLockControls ? true : false;
+};
+
+// note that MapControls is an extension of OrbitControls soMapControls will return true here also
+export const isOrbitControlImpl = (controler: CameraControlImpl): boolean => {
+  return controler instanceof OrbitControls ? true : false;
+};
+
+export const isPanControlImpl = (controler: CameraControlImpl): boolean => {
+  return controler instanceof MapControls ? true : false;
+};
+
+export const isOrbitOrPanControlImpl = (controler: CameraControlImpl): boolean => {
+  return isOrbitControlImpl(controler) || isPanControlImpl(controler) ? true : false;
 };


### PR DESCRIPTION
## Overview
When the camera mode is changed the camera is also returning to the position and target of the last camera command it received. For a fresh scene this is the starting location for example.

Video of Error:

https://github.com/awslabs/iot-app-kit/assets/109186219/5ff48342-1919-452d-b48f-85c64eb52462

Video of Fix:

https://github.com/awslabs/iot-app-kit/assets/109186219/e866463b-eae8-4c98-8510-c689f34535ca



## Verifying Changes
Open story book scene.  Pan camera away from center.  Swap form orbit to pan camera mod.  The camera should stay where it was, but the controls should swap properly.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
