### PR TITLE
feat(composer): utils to handle camera component in entity

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/CameraComponent/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/CameraComponent/index.tsx
@@ -11,6 +11,7 @@ import useSelectedNode from '../../../hooks/useSelectedNode';
 import useActiveCamera from '../../../hooks/useActiveCamera';
 import { getCameraSettings } from '../../../utils/cameraUtils';
 import { useEditorHelper } from '../../../hooks';
+import { CameraType } from '../../../models/SceneModels';
 
 interface ICameraComponentProps {
   node: ISceneNodeInternal;
@@ -38,7 +39,7 @@ const CameraComponent: React.FC<ICameraComponentProps> = ({ node, component }: I
 
       setActiveCameraSettings(
         getCameraSettings(object3D, {
-          cameraType: 'Perspective',
+          cameraType: CameraType.Perspective,
           fov,
           near,
           far,
@@ -49,7 +50,7 @@ const CameraComponent: React.FC<ICameraComponentProps> = ({ node, component }: I
   }, [activeCameraName]);
 
   let cameraNode: JSX.Element;
-  if (component.cameraType === 'Orthographic') {
+  if (component.cameraType === CameraType.Orthographic) {
     cameraNode = (
       <OrthographicCamera
         // TODO: Make Editable once we expose this camera type

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -222,7 +222,7 @@ export const AddObjectMenu = (): JSX.Element => {
     if (mainCameraObject) {
       const cameraComponent: ICameraComponent = {
         cameraType: activeCameraSettings.cameraType,
-        type: 'Camera',
+        type: KnownComponentType.Camera,
         fov: activeCameraSettings.fov,
         far: activeCameraSettings.far,
         near: activeCameraSettings.near,

--- a/packages/scene-composer/src/hooks/useActiveCamera.ts
+++ b/packages/scene-composer/src/hooks/useActiveCamera.ts
@@ -5,7 +5,7 @@ import { useSceneComposerId } from '../common/sceneComposerIdContext';
 import { useEditorState } from '../store';
 import { CameraControlMode, CameraSettings } from '../interfaces';
 import { DEFAULT_CAMERA_OPTIONS, DEFAULT_CAMERA_POSITION, DEFAULT_CAMERA_TARGET } from '../common/constants';
-import { Transform } from '../models/SceneModels';
+import { CameraType, Transform } from '../models/SceneModels';
 
 const useActiveCamera = () => {
   const sceneComposerId = useSceneComposerId();
@@ -20,7 +20,7 @@ const useActiveCamera = () => {
   } = useEditorState(sceneComposerId);
 
   const defaultCameraSettings: CameraSettings = {
-    cameraType: 'Perspective',
+    cameraType: CameraType.Perspective,
     fov: DEFAULT_CAMERA_OPTIONS.fov,
     far: DEFAULT_CAMERA_OPTIONS.far,
     near: DEFAULT_CAMERA_OPTIONS.near,

--- a/packages/scene-composer/src/interfaces/components.ts
+++ b/packages/scene-composer/src/interfaces/components.ts
@@ -123,10 +123,8 @@ export type SelectionChangedEventCallback = (event: ISelectionChangedEvent) => v
 
 export interface ILightComponent extends ISceneComponent, SceneModels.Component.Light {}
 
-export type CameraType = 'Perspective' | 'Orthographic';
-
 export interface ICameraBasics {
-  cameraType: CameraType;
+  cameraType: SceneModels.CameraType;
   fov?: number;
   near: number;
   far: number;

--- a/packages/scene-composer/src/store/slices/EditorStateSlice.ts
+++ b/packages/scene-composer/src/store/slices/EditorStateSlice.ts
@@ -13,6 +13,7 @@ import {
 import { RootState } from '../Store';
 import { CursorStyle, IDisplayMessage, IEditorConfig } from '../internalInterfaces';
 import { DEFAULT_CAMERA_OPTIONS, DEFAULT_CAMERA_POSITION } from '../../common/constants';
+import { CameraType } from '../../models/SceneModels';
 
 // The MappingWrapper is used to bypass immer's snapshotting/copy-on-write mechanism
 // Immer will make plain objects immutable which makes it impossible to update without
@@ -130,7 +131,7 @@ function createDefaultEditorState() {
     cursorVisible: false,
     cursorStyle: 'move',
     activeCameraSettings: {
-      cameraType: 'Perspective',
+      cameraType: CameraType.Perspective,
       fov: DEFAULT_CAMERA_OPTIONS.fov,
       far: DEFAULT_CAMERA_OPTIONS.far,
       near: DEFAULT_CAMERA_OPTIONS.near,

--- a/packages/scene-composer/src/utils/cameraUtils.ts
+++ b/packages/scene-composer/src/utils/cameraUtils.ts
@@ -3,6 +3,7 @@ import { Euler, Quaternion, Vector3 } from 'three';
 import { ICameraComponentInternal } from '../store';
 import { CameraSettings, ICameraBasics } from '../interfaces';
 import { DEFAULT_CAMERA_POSITION, DEFAULT_CAMERA_SETTINGS } from '../common/constants';
+import { CameraType } from '../models/SceneModels';
 
 export const getCameraSettings = (
   object3D: THREE.Object3D | undefined,
@@ -33,7 +34,7 @@ export const getCameraSettings = (
 
   return {
     ...DEFAULT_CAMERA_SETTINGS,
-    cameraType: 'Perspective',
+    cameraType: CameraType.Perspective,
     transform,
   };
 };

--- a/packages/scene-composer/src/utils/entityModelUtils/cameraComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/cameraComponent.spec.ts
@@ -1,0 +1,114 @@
+import { DEFAULT_CAMERA_OPTIONS } from '../../common/constants';
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { ICameraComponent, KnownComponentType } from '../../interfaces';
+import { CameraType } from '../../models/SceneModels';
+
+import { createCameraEntityComponent, parseCameraComp, updateCameraEntityComponent } from './cameraComponent';
+
+const camera: ICameraComponent = {
+  type: KnownComponentType.Camera,
+  ...DEFAULT_CAMERA_OPTIONS,
+  cameraType: CameraType.Orthographic,
+  zoom: 1,
+};
+
+describe('createCameraEntityComponent', () => {
+  it('should return expected camera component', () => {
+    expect(createCameraEntityComponent(camera)).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.Camera],
+      properties: {
+        cameraType: {
+          value: {
+            stringValue: CameraType.Orthographic,
+          },
+        },
+        fov: {
+          value: {
+            doubleValue: DEFAULT_CAMERA_OPTIONS.fov,
+          },
+        },
+        near: {
+          value: {
+            doubleValue: DEFAULT_CAMERA_OPTIONS.near,
+          },
+        },
+        far: {
+          value: {
+            doubleValue: DEFAULT_CAMERA_OPTIONS.far,
+          },
+        },
+        zoom: {
+          value: {
+            doubleValue: 1,
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('updateCameraEntityComponent', () => {
+  it('should return expected camera component', () => {
+    expect(updateCameraEntityComponent(camera)).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.Camera],
+      propertyUpdates: expect.objectContaining({
+        cameraType: {
+          value: {
+            stringValue: CameraType.Orthographic,
+          },
+        },
+      }),
+    });
+  });
+});
+
+describe('parseCameraComp', () => {
+  it('should parse to expected camera component', () => {
+    expect(
+      parseCameraComp({
+        properties: [
+          {
+            propertyName: 'cameraType',
+            propertyValue: 'Orthographic',
+          },
+          {
+            propertyName: 'fov',
+            propertyValue: 90,
+          },
+          {
+            propertyName: 'far',
+            propertyValue: 222,
+          },
+          {
+            propertyName: 'near',
+            propertyValue: 0.5,
+          },
+          {
+            propertyName: 'zoom',
+            propertyValue: 2,
+          },
+        ],
+      }),
+    ).toEqual({
+      ref: expect.any(String),
+      type: KnownComponentType.Camera,
+      cameraType: 'Orthographic',
+      fov: 90,
+      far: 222,
+      near: 0.5,
+      zoom: 2,
+    });
+  });
+
+  it('should parse to expected camera component with default values', () => {
+    expect(
+      parseCameraComp({
+        properties: [],
+      }),
+    ).toEqual({
+      ...camera,
+      ref: expect.any(String),
+      cameraType: CameraType.Perspective,
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/cameraComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/cameraComponent.ts
@@ -1,0 +1,95 @@
+import { ComponentRequest, ComponentUpdateRequest } from '@aws-sdk/client-iottwinmaker';
+import { DocumentType } from '@aws-sdk/types';
+
+import { ICameraComponent, KnownComponentType } from '../../interfaces';
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { ICameraComponentInternal } from '../../store';
+import { generateUUID } from '../mathUtils';
+import { CameraType } from '../../models/SceneModels';
+import { DEFAULT_CAMERA_OPTIONS } from '../../common/constants';
+
+enum CameraComponentProperty {
+  CameraType = 'cameraType',
+  Fov = 'fov',
+  Near = 'near',
+  Far = 'far',
+  Zoom = 'zoom',
+}
+
+export const createCameraEntityComponent = (camera: ICameraComponent): ComponentRequest => {
+  const comp: ComponentRequest = {
+    componentTypeId: componentTypeToId[KnownComponentType.Camera],
+    properties: {
+      [CameraComponentProperty.CameraType]: {
+        value: {
+          stringValue: camera.cameraType,
+        },
+      },
+    },
+  };
+
+  if (camera.fov) {
+    comp.properties![CameraComponentProperty.Fov] = {
+      value: {
+        doubleValue: camera.fov,
+      },
+    };
+  }
+  if (camera.near) {
+    comp.properties![CameraComponentProperty.Near] = {
+      value: {
+        doubleValue: camera.near,
+      },
+    };
+  }
+  if (camera.far) {
+    comp.properties![CameraComponentProperty.Far] = {
+      value: {
+        doubleValue: camera.far,
+      },
+    };
+  }
+  if (camera.zoom) {
+    comp.properties![CameraComponentProperty.Zoom] = {
+      value: {
+        doubleValue: camera.zoom,
+      },
+    };
+  }
+
+  return comp;
+};
+
+export const updateCameraEntityComponent = (camera: ICameraComponent): ComponentUpdateRequest => {
+  const request = createCameraEntityComponent(camera);
+  return {
+    componentTypeId: request.componentTypeId,
+    propertyUpdates: request.properties,
+  };
+};
+
+export const parseCameraComp = (comp: DocumentType): ICameraComponentInternal | undefined => {
+  if (!comp?.['properties']) {
+    return undefined;
+  }
+
+  const cameraComp: ICameraComponentInternal = {
+    ref: generateUUID(),
+    type: KnownComponentType.Camera,
+    cameraType:
+      comp['properties'].find((p) => p['propertyName'] === CameraComponentProperty.CameraType)?.propertyValue ??
+      CameraType.Perspective,
+    fov:
+      comp['properties'].find((p) => p['propertyName'] === CameraComponentProperty.Fov)?.propertyValue ??
+      DEFAULT_CAMERA_OPTIONS.fov,
+    near:
+      comp['properties'].find((p) => p['propertyName'] === CameraComponentProperty.Near)?.propertyValue ??
+      DEFAULT_CAMERA_OPTIONS.near,
+    far:
+      comp['properties'].find((p) => p['propertyName'] === CameraComponentProperty.Far)?.propertyValue ??
+      DEFAULT_CAMERA_OPTIONS.far,
+    zoom: comp['properties'].find((p) => p['propertyName'] === CameraComponentProperty.Zoom)?.propertyValue ?? 1,
+  };
+
+  return cameraComp;
+};


### PR DESCRIPTION
## Overview
Add util functions to handle create/update camera component request, and parse camera from entity model back to scene component model.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
