### PR TITLE
fix: use widget ID as key

### DIFF
--- a/packages/dashboard/src/customization/widgets/barChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/component.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 
 import { BarChart, useViewport } from '@iot-app-kit/react-components';
 
-import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { BarChartWidget } from '.././types';
 import { useQueries } from '~/components/dashboard/queryContext';
@@ -32,7 +31,7 @@ const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
     iotSiteWiseQuery && queryConfig.query
       ? [iotSiteWiseQuery?.timeSeriesData({ assets: [], ...queryConfig.query })]
       : [];
-  const key = computeQueryConfigKey(undefined, queryConfig);
+  const key = widget.id;
   const aggregation = getAggregation(widget);
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
   // there may be better ways to fix this, i.e. not have -44 and let the chart container  take its parent height,

--- a/packages/dashboard/src/customization/widgets/kpi/component.tsx
+++ b/packages/dashboard/src/customization/widgets/kpi/component.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import { KPI, useViewport } from '@iot-app-kit/react-components';
-import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { KPIWidget } from '../types';
 import { Box } from '@cloudscape-design/components';
@@ -34,7 +33,7 @@ const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
 
   const { iotSiteWiseQuery } = useQueries();
   const query = iotSiteWiseQuery && queryConfig.query ? iotSiteWiseQuery?.timeSeriesData(queryConfig.query) : undefined;
-  const key = computeQueryConfigKey(viewport, queryConfig);
+  const key = widget.id;
   const aggregation = getAggregation(widget);
 
   const shouldShowEmptyState = query == null || !iotSiteWiseQuery;

--- a/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
+++ b/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { DashboardState } from '~/store/state';
 import { StatusTimelineWidget } from '../types';
 import { useQueries } from '~/components/dashboard/queryContext';
-import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
 import { getAggregation } from '../utils/widgetAggregationUtils';
 import WidgetTile from '~/components/widgets/tile';
@@ -24,7 +23,7 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (widget) =
 
   const { iotSiteWiseQuery } = useQueries();
   const queries = iotSiteWiseQuery && queryConfig.query ? [iotSiteWiseQuery?.timeSeriesData(queryConfig.query)] : [];
-  const key = computeQueryConfigKey(undefined, queryConfig);
+  const key = widget.id;
   const aggregation = getAggregation(widget);
 
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;

--- a/packages/dashboard/src/customization/widgets/status/component.tsx
+++ b/packages/dashboard/src/customization/widgets/status/component.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import { Status, useViewport } from '@iot-app-kit/react-components';
-import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { StatusWidget } from '../types';
 import { Box } from '@cloudscape-design/components';
@@ -33,7 +32,7 @@ const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
   const query = iotSiteWiseQuery && queryConfig.query ? iotSiteWiseQuery?.timeSeriesData(queryConfig.query) : undefined;
 
   const shouldShowEmptyState = query == null || !iotSiteWiseQuery;
-  const key = computeQueryConfigKey(viewport, queryConfig);
+  const key = widget.id;
   const aggregation = getAggregation(widget);
 
   if (shouldShowEmptyState) {

--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -6,7 +6,6 @@ import { Table, TableColumnDefinition, useViewport } from '@iot-app-kit/react-co
 
 import EmptyTableComponent from './emptyTableComponent';
 
-import { computeQueryConfigKey } from '../utils/computeQueryConfigKey';
 import type { DashboardState } from '~/store/state';
 import type { TableWidget } from '../types';
 import { useQueries } from '~/components/dashboard/queryContext';
@@ -43,7 +42,7 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
 
   const { iotSiteWiseQuery } = useQueries();
   const queries = iotSiteWiseQuery && queryConfig.query ? [iotSiteWiseQuery?.timeSeriesData(queryConfig.query)] : [];
-  const key = computeQueryConfigKey(viewport, widget.properties.queryConfig);
+  const key = widget.id;
 
   const items = useTableItems(queryConfig.query);
 

--- a/packages/dashboard/src/customization/widgets/utils/computeQueryConfigKey.ts
+++ b/packages/dashboard/src/customization/widgets/utils/computeQueryConfigKey.ts
@@ -1,9 +1,0 @@
-import type { Viewport } from '@iot-app-kit/core';
-import type { QueryProperties } from '../types';
-
-export const computeQueryConfigKey = (
-  viewport: Viewport | undefined,
-  { query, source }: QueryProperties['queryConfig']
-) => {
-  return `${JSON.stringify(viewport)}_${source}__${JSON.stringify(query?.assets)}`;
-};


### PR DESCRIPTION
## Overview
The purpose of this change is to move toward using the widget ID as the React component key, instead of stringifying viewport and query config, preventing unnecessary unmounting/mounting of widgets as the viewport or the query config change.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
