### PR TITLE
feat(dynamic scene): crud functionalities for model ref

### DIFF
--- a/packages/scene-composer/src/utils/entityModelUtils/modelRefComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/modelRefComponent.spec.ts
@@ -1,0 +1,148 @@
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { KnownComponentType } from '../../interfaces';
+
+import { createModelRefComponent, parseModelRefComp, updateModelRefComponent } from './modelRefComponent';
+
+describe('createModelRefComponent', () => {
+  it('should return expected modelRef component with uri and modelType', () => {
+    const result = createModelRefComponent({ type: KnownComponentType.ModelRef, uri: 'abc', modelType: 'modelType' });
+
+    expect(result.properties).toEqual({
+      uri: {
+        value: { stringValue: 'abc' },
+      },
+      modelType: {
+        value: { stringValue: 'modelType' },
+      },
+    });
+  });
+
+  it('should return expected modelRef component by setting castShadow and receiveShadow to false', () => {
+    const result = createModelRefComponent({
+      type: KnownComponentType.ModelRef,
+      uri: 'abc',
+      modelType: 'modelType',
+      unitOfMeasure: 'decimeters',
+      localScale: [1, 1, 1],
+      castShadow: false,
+      receiveShadow: false,
+    });
+
+    expect(result.properties).toEqual({
+      uri: {
+        value: { stringValue: 'abc' },
+      },
+      modelType: {
+        value: { stringValue: 'modelType' },
+      },
+      unitOfMeasure: {
+        value: {
+          stringValue: 'decimeters',
+        },
+      },
+      localScale: {
+        value: {
+          listValue: [{ doubleValue: 1 }, { doubleValue: 1 }, { doubleValue: 1 }],
+        },
+      },
+      castShadow: {
+        value: {
+          booleanValue: false,
+        },
+      },
+      receiveShadow: {
+        value: {
+          booleanValue: false,
+        },
+      },
+    });
+  });
+
+  it('should return expected modelRef component by setting castShadow and receiveShadow to true ', () => {
+    const result = createModelRefComponent({
+      type: KnownComponentType.ModelRef,
+      uri: 'abc',
+      modelType: 'modelType',
+      unitOfMeasure: 'decimeters',
+      localScale: [1, 1, 1],
+      castShadow: true,
+      receiveShadow: true,
+    });
+
+    expect(result.properties).toEqual({
+      uri: {
+        value: { stringValue: 'abc' },
+      },
+      modelType: {
+        value: { stringValue: 'modelType' },
+      },
+      unitOfMeasure: {
+        value: {
+          stringValue: 'decimeters',
+        },
+      },
+      localScale: {
+        value: {
+          listValue: [{ doubleValue: 1 }, { doubleValue: 1 }, { doubleValue: 1 }],
+        },
+      },
+      castShadow: {
+        value: {
+          booleanValue: true,
+        },
+      },
+      receiveShadow: {
+        value: {
+          booleanValue: true,
+        },
+      },
+    });
+  });
+});
+
+describe('updateModelRefComponent', () => {
+  it('should update a model ref component', () => {
+    expect(updateModelRefComponent({ type: KnownComponentType.ModelRef, uri: 'abc', modelType: 'modelType' })).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.ModelRef],
+      propertyUpdates: {
+        uri: {
+          value: { stringValue: 'abc' },
+        },
+        modelType: {
+          value: {
+            stringValue: 'modelType',
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('parseModelRefComponent', () => {
+  it('should parse to expected model ref component', () => {
+    expect(
+      parseModelRefComp({
+        componentTypeId: componentTypeToId[KnownComponentType.ModelRef],
+        properties: [
+          {
+            propertyName: 'uri',
+            propertyValue: 'abc',
+          },
+          {
+            propertyName: 'modelType',
+            propertyValue: 'modelType',
+          },
+        ],
+      }),
+    ).toEqual({
+      ref: expect.any(String),
+      type: KnownComponentType.ModelRef,
+      uri: 'abc',
+      modelType: 'modelType',
+      castShadow: undefined,
+      localScale: undefined,
+      receiveShadow: undefined,
+      unitOfMeasure: undefined,
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/modelRefComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/modelRefComponent.ts
@@ -1,0 +1,96 @@
+import { ComponentRequest, ComponentUpdateRequest } from '@aws-sdk/client-iottwinmaker';
+import { DocumentType } from '@aws-sdk/types';
+
+import { IModelRefComponent, KnownComponentType } from '../../interfaces';
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { IModelRefComponentInternal } from '../../store';
+import { generateUUID } from '../mathUtils';
+
+enum ModelRefComponentProperty {
+  Uri = 'uri',
+  ModelType = 'modelType',
+  UnitOfMeasure = 'unitOfMeasure',
+  LocalScale = 'localScale',
+  CastShadow = 'castShadow',
+  ReceiveShadow = 'receiveShadow',
+}
+
+export const createModelRefComponent = (model: IModelRefComponent): ComponentRequest => {
+  const comp: ComponentRequest = {
+    componentTypeId: componentTypeToId[KnownComponentType.ModelRef],
+    properties: {
+      [ModelRefComponentProperty.Uri]: {
+        value: {
+          stringValue: model.uri,
+        },
+      },
+      [ModelRefComponentProperty.ModelType]: {
+        value: {
+          stringValue: model.modelType,
+        },
+      },
+    },
+  };
+
+  if (model.unitOfMeasure) {
+    comp.properties![ModelRefComponentProperty.UnitOfMeasure] = {
+      value: {
+        stringValue: model.unitOfMeasure,
+      },
+    };
+  }
+  if (model.localScale) {
+    comp.properties![ModelRefComponentProperty.LocalScale] = {
+      value: {
+        listValue: model.localScale.map((l) => ({ doubleValue: l })),
+      },
+    };
+  }
+  if (model.castShadow !== undefined) {
+    comp.properties![ModelRefComponentProperty.CastShadow] = {
+      value: {
+        booleanValue: model.castShadow,
+      },
+    };
+  }
+  if (model.receiveShadow !== undefined) {
+    comp.properties![ModelRefComponentProperty.ReceiveShadow] = {
+      value: {
+        booleanValue: model.receiveShadow,
+      },
+    };
+  }
+  return comp;
+};
+
+export const updateModelRefComponent = (model: IModelRefComponent): ComponentUpdateRequest => {
+  const request = createModelRefComponent(model);
+  return {
+    componentTypeId: request.componentTypeId,
+    propertyUpdates: request.properties,
+  };
+};
+
+export const parseModelRefComp = (model: DocumentType): IModelRefComponentInternal | undefined => {
+  const findUri = model?.['properties'].find((mp) => mp['propertyName'] === ModelRefComponentProperty.Uri);
+  const findModelType = model?.['properties'].find((mp) => mp['propertyName'] === ModelRefComponentProperty.ModelType);
+  if (!model?.['properties'] || !findUri || !findModelType) {
+    return undefined;
+  }
+
+  const modelComponent: IModelRefComponentInternal = {
+    ref: generateUUID(),
+    type: KnownComponentType.ModelRef,
+    uri: findUri?.propertyValue,
+    modelType: findModelType?.propertyValue,
+    unitOfMeasure: model['properties'].find((mp) => mp['propertyName'] === ModelRefComponentProperty.UnitOfMeasure)
+      ?.propertyValue,
+    localScale: model['properties'].find((mp) => mp['propertyName'] === ModelRefComponentProperty.LocalScale)
+      ?.propertyValue,
+    castShadow: model['properties'].find((mp) => mp['propertyName'] === ModelRefComponentProperty.CastShadow)
+      ?.propertyValue,
+    receiveShadow: model['properties'].find((mp) => mp['propertyName'] === ModelRefComponentProperty.ReceiveShadow)
+      ?.propertyValue,
+  };
+  return modelComponent;
+};


### PR DESCRIPTION
## Overview
* crud functionalities for model ref component. 
Followed the design doc to implement the model ref functionalities. 
* Create a model ref.
* Update a model ref.
* Parse the component. 
## Verifying Changes
npm run test:unit

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
