### PR TITLE
fix(camera): stop camera view inspector panel from overwriting changes

### DIFF
--- a/packages/scene-composer/src/components/panels/scene-components/CameraComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/CameraComponentEditor.spec.tsx
@@ -56,7 +56,7 @@ describe('CameraComponentEditor', () => {
       {
         ...mockNode.components[0],
         cameraType: CameraType.Perspective,
-        fov: expectedCamera.getEffectiveFOV(),
+        fov: expectedCamera.fov,
         near: expectedCamera.near,
         far: expectedCamera.far,
         zoom: expectedCamera.zoom,
@@ -91,7 +91,7 @@ describe('CameraComponentEditor', () => {
       {
         ...mockNode.components[0],
         cameraType: CameraType.Perspective,
-        fov: expectedCamera.getEffectiveFOV(),
+        fov: expectedCamera.fov,
         near: expectedCamera.near,
         far: expectedCamera.far,
         zoom: expectedCamera.zoom,
@@ -143,7 +143,7 @@ describe('CameraComponentEditor', () => {
       {
         ...mockNode.components[0],
         cameraType: CameraType.Perspective,
-        fov: expectedCamera.getEffectiveFOV(),
+        fov: expectedCamera.fov,
         near: expectedCamera.near,
         far: expectedCamera.far,
         zoom: expectedCamera.zoom,
@@ -177,7 +177,7 @@ describe('CameraComponentEditor', () => {
       {
         ...mockNode.components[0],
         cameraType: CameraType.Perspective,
-        fov: expectedCamera.getEffectiveFOV(),
+        fov: expectedCamera.fov,
         near: expectedCamera.near,
         far: expectedCamera.far,
         zoom: expectedCamera.zoom,
@@ -210,7 +210,7 @@ describe('CameraComponentEditor', () => {
       {
         ...mockNode.components[0],
         cameraType: CameraType.Perspective,
-        fov: expectedCamera.getEffectiveFOV(),
+        fov: expectedCamera.fov,
         near: expectedCamera.near,
         far: expectedCamera.far,
         zoom: expectedCamera.zoom,


### PR DESCRIPTION
## Overview
The camera view inspector panel will overwrite changes unexpectedly.
Changing one of the following four will reset all of the others back to default settings:
FOV, Zoom, Clipping Planes Far, Clipping Planes Near.

This fix makes it such that modifying FOV, Zoom, Clipping Planes Far, and Clipping Planes Near will not reset the other values back to default. Note: Focal length will be changed when FOV is changed; this is expected behavior.

## Verifying Changes
Camera settings before fix:

https://github.com/awslabs/iot-app-kit/assets/87334439/a9005765-ca55-49c8-ad36-782b8609fb85


Camera settings after fix:

https://github.com/awslabs/iot-app-kit/assets/87334439/6c24c563-75d5-4c75-a4d5-12e39dd63db0


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
