### PR TITLE
fix: remove slashes from property alias when requesting latest in query editor

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/useLatestValues/entryIdFactory.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/useLatestValues/entryIdFactory.ts
@@ -50,8 +50,9 @@ export class EntryIdFactory {
     propertyId?: string;
     propertyAlias?: string;
   }) {
-    const trimmedPropertyAlias = this.#trimPropertyAlias(propertyAlias);
-    const joinedIdentifiers = Object.values({ assetId, propertyId, propertyAlias: trimmedPropertyAlias }).join('');
+    const trimmedAlias = this.#trimPropertyAlias(propertyAlias);
+    const aliasWithoutSlashes = this.#removeSlashesFromPropertyAlias(trimmedAlias);
+    const joinedIdentifiers = Object.values({ assetId, propertyId, propertyAlias: aliasWithoutSlashes }).join('');
     const identifiersWithoutDashes = this.#removeDashes(joinedIdentifiers);
 
     return identifiersWithoutDashes;
@@ -62,6 +63,12 @@ export class EntryIdFactory {
     const trimmedPropertyAlias = propertyAlias?.substring(0, this.#MAXIMUM_ENTRY_ID_LENGTH);
 
     return trimmedPropertyAlias;
+  }
+
+  #removeSlashesFromPropertyAlias(propertyAlias?: string): string | undefined {
+    const propertyAliasWithoutSlashes = propertyAlias?.split('/').join('');
+
+    return propertyAliasWithoutSlashes;
   }
 
   #removeDashes(joinedIdentifiers: string) {


### PR DESCRIPTION
## Overview
This change adds additional handling to allow retrieval of the latest values in the query editor of unmodeled data streams with the typical `/1/2/3/4` slash-based property alias tag hierarchy. The property alias is being reused as a unique identifier for batch data requests and this is causing a 400 error to be thrown.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
