### PR TITLE
fix(dashboard): correctly update aggregation and resolution configs

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
@@ -72,7 +72,7 @@ export const LineAndScatterStyleSettingsSection: React.FC = () => (
         })
       );
 
-      const [query, updateQuery] = useProperty(
+      const [query] = useProperty(
         (properties) => properties.queryConfig.query,
         (properties, updatedQuery) => ({
           ...properties,
@@ -86,6 +86,12 @@ export const LineAndScatterStyleSettingsSection: React.FC = () => (
         (properties) => properties.aggregationType,
         (properties, updatedAggregationType) => ({
           ...properties,
+          queryConfig: {
+            ...properties.queryConfig,
+            query: properties.queryConfig.query
+              ? applyAggregationToQuery(properties.queryConfig.query, updatedAggregationType)
+              : undefined,
+          },
           aggregationType: updatedAggregationType,
         })
       );
@@ -93,6 +99,12 @@ export const LineAndScatterStyleSettingsSection: React.FC = () => (
         (properties) => properties.resolution,
         (properties, updatedResolution) => ({
           ...properties,
+          queryConfig: {
+            ...properties.queryConfig,
+            query: properties.queryConfig.query
+              ? applyResolutionToQuery(properties.queryConfig.query, updatedResolution)
+              : undefined,
+          },
           resolution: updatedResolution,
         })
       );
@@ -123,19 +135,6 @@ export const LineAndScatterStyleSettingsSection: React.FC = () => (
       const filteredResolutionOptions = getResolutionOptions(true);
       const filteredAggregationOptions = getAggregationOptions(true, dataTypeSet, resolution);
 
-      const onUpdateAggregation = (updatedAggregationType: AggregateType) => {
-        updateAggregation(updatedAggregationType);
-        if (assetQuery) {
-          updateQuery(applyAggregationToQuery(assetQuery, updatedAggregationType));
-        }
-      };
-      const onUpdateResolution = (updatedResolution: string) => {
-        updateResolution(updatedResolution);
-        if (assetQuery) {
-          updateQuery(applyResolutionToQuery(assetQuery, updatedResolution));
-        }
-      };
-
       return (
         <>
           <TypeSection
@@ -162,8 +161,8 @@ export const LineAndScatterStyleSettingsSection: React.FC = () => (
           <AggregationAndResolutionSection
             aggregation={aggregationType}
             resolution={resolution}
-            updateAggregation={(updatedAggregationType) => onUpdateAggregation(updatedAggregationType as AggregateType)}
-            updateResolution={onUpdateResolution}
+            updateAggregation={(updatedAggregationType) => updateAggregation(updatedAggregationType as AggregateType)}
+            updateResolution={updateResolution}
             resolutionOptions={filteredResolutionOptions}
             aggregationOptions={filteredAggregationOptions}
           />

--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/typeSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/typeSection.tsx
@@ -10,7 +10,7 @@ const typeOptions = [
   defaultTypeOption,
   { label: 'Step before', value: 'step-start', description: 'Step points rendered at the end of the step.' },
   { label: 'Step middle', value: 'step-middle', description: 'Step points rendered in the middle of the step.' },
-  { label: 'Step after', value: 'step-after', description: 'Step points rendered at the beginning of the step.' },
+  { label: 'Step after', value: 'step-end', description: 'Step points rendered at the beginning of the step.' },
 ] as const;
 
 type TypeSectionOptions = {

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -145,7 +145,6 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (widge
     significantDigits: widgetSignificantDigits,
   } = widgetToDisplay.properties;
 
-  //debugger;
   const query = queryConfig.query;
   const filteredQuery = {
     ...query,


### PR DESCRIPTION
## Overview
Fix for updating the aggregation and resolution properties for line-scatter-widget. Update the setting and query in 1 method.

Also fix for the step after chart mapping.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
