### PR TITLE
fix(icon rules): align icon-picker layout with target editor

### DIFF
--- a/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/AnchorComponentEditor.tsx
@@ -15,13 +15,13 @@ import {
   SceneResourceType,
 } from '../../../interfaces';
 import { IAnchorComponentInternal, ISceneComponentInternal, useSceneDocument, useStore } from '../../../store';
+import { isDynamicNode } from '../../../utils/entityModelUtils/sceneUtils';
 import { shallowEqualsArray } from '../../../utils/objectUtils';
 import { i18nSceneIconsKeysStrings } from '../../../utils/polarisUtils';
 import { convertToIotTwinMakerNamespace, getSceneResourceInfo } from '../../../utils/sceneResourceUtils';
 import { colors } from '../../../utils/styleUtils';
 import { TextInput } from '../CommonPanelComponents';
 import { IComponentEditorProps } from '../ComponentEditor';
-import { isDynamicNode } from '../../../utils/entityModelUtils/sceneUtils';
 
 import { ValueDataBindingBuilder } from './common/ValueDataBindingBuilder';
 import { ColorSelectorCombo } from './tag-style/ColorSelectorCombo/ColorSelectorCombo';

--- a/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetEditor.tsx
@@ -97,7 +97,7 @@ export const SceneRuleTargetEditor: React.FC<ISceneRuleTargetEditorProps> = ({
         })}
       />
       {targetInfo.type === SceneResourceType.Icon && (
-        <div>
+        <>
           <SceneRuleTargetIconEditor
             targetValue={targetInfo.value}
             onChange={(targetValue) => {
@@ -107,7 +107,7 @@ export const SceneRuleTargetEditor: React.FC<ISceneRuleTargetEditorProps> = ({
             customIcon={icon}
           />
           {isCustomStyle && (
-            <div>
+            <>
               <ColorSelectorCombo
                 color={chosenColor}
                 onSelectColor={(newColor) => {
@@ -145,9 +145,9 @@ export const SceneRuleTargetEditor: React.FC<ISceneRuleTargetEditorProps> = ({
                   description: 'Select an icon',
                 })}
               />
-            </div>
+            </>
           )}
-        </div>
+        </>
       )}
 
       {targetInfo.type === SceneResourceType.Color && (

--- a/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/__snapshots__/SceneRuleTargetEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/__snapshots__/SceneRuleTargetEditor.spec.tsx.snap
@@ -29,9 +29,7 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
       selectedarialabel="test message"
       selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"}"
     />
-    <div>
-      SceneRuleTargetIconEditor
-    </div>
+    SceneRuleTargetIconEditor
   </div>
 </div>
 `;
@@ -81,9 +79,7 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
       selectedarialabel="test message"
       selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"}"
     />
-    <div>
-      SceneRuleTargetIconEditor
-    </div>
+    SceneRuleTargetIconEditor
   </div>
 </div>
 `;


### PR DESCRIPTION
## Overview
Currently TargetEditor layout has a grid layout. So in order to fit the icon-picker we don't have to use a `div` that will align the layout within the IconTargetEditor. So removing the div will fix the issue. 
## Verifying Changes
npm run test

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
