### PR TITLE
fix(composer): remove useCallback from menu event handlers

### DIFF
--- a/packages/scene-composer/src/components/toolbars/common/ToolbarItem.tsx
+++ b/packages/scene-composer/src/components/toolbars/common/ToolbarItem.tsx
@@ -50,40 +50,34 @@ export function ToolbarItem<T extends ToolbarItemOptions>({
     return null;
   };
 
-  const handleItemClick = useCallback(
-    (item: T) => {
+  const handleItemClick = (item: T) => {
+    type === 'mode-select' && setSelectedItem(item);
+    onSelect?.(item);
+  };
+
+  const handleItemKeyDown = (item: T, e, focusIndex?: number) => {
+    if (e.key === 'Enter') {
+      setShowMenu(true);
       type === 'mode-select' && setSelectedItem(item);
       onSelect?.(item);
-    },
-    [type],
-  );
-
-  const handleItemKeyDown = useCallback(
-    (item: T, e, focusIndex?: number) => {
-      if (e.key === 'Enter') {
-        setShowMenu(true);
-        type === 'mode-select' && setSelectedItem(item);
-        onSelect?.(item);
+    }
+    // if not a submenu item, return
+    if (focusIndex === undefined) {
+      return;
+    }
+    if (showMenu) {
+      if (e.key === 'Escape') {
+        itemContainerRef.current?.focus();
+        setShowMenu(false);
+      } else if (e.key === 'Tab' && !e.shiftKey && isItemLast(focusIndex) && firstItemRef.current) {
+        e.preventDefault(); // prevent tab from changing focus
+        firstItemRef.current.focus();
+      } else if (e.key === 'Tab' && e.shiftKey && isItemFirst(focusIndex) && lastItemRef.current) {
+        e.preventDefault(); // prevent tab + shift from changing focus
+        lastItemRef.current.focus();
       }
-      // if not a submenu item, return
-      if (focusIndex === undefined) {
-        return;
-      }
-      if (showMenu) {
-        if (e.key === 'Escape') {
-          itemContainerRef.current?.focus();
-          setShowMenu(false);
-        } else if (e.key === 'Tab' && !e.shiftKey && isItemLast(focusIndex) && firstItemRef.current) {
-          e.preventDefault(); // prevent tab from changing focus
-          firstItemRef.current.focus();
-        } else if (e.key === 'Tab' && e.shiftKey && isItemFirst(focusIndex) && lastItemRef.current) {
-          e.preventDefault(); // prevent tab + shift from changing focus
-          lastItemRef.current.focus();
-        }
-      }
-    },
-    [showMenu],
-  );
+    }
+  };
 
   useEffect(() => {
     initialSelectedItem && setSelectedItem(initialSelectedItem);


### PR DESCRIPTION
## Overview
Remove useCallback from event handlers for the toolbar menu -- it's currently causing a bug requiring multiple clicks/keypresses to execute some actions.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
