### PR TITLE
fix(dashboard): chart respects absolute min and max between data and thresholds

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.tsx
@@ -15,13 +15,13 @@ enum ThresholdStyleOptions {
   asLinesAndFilledRegion = 'As lines and filled region',
 }
 
-const options = [
+export const styledOptions = [
   { label: ThresholdStyleOptions.asLines, value: '1' },
   { label: ThresholdStyleOptions.asFilledRegion, value: '2' },
   { label: ThresholdStyleOptions.asLinesAndFilledRegion, value: '3' },
 ];
 
-const convertOptionToThresholdStyle = (selectedOption: OptionDefinition): ThresholdStyleType => {
+export const convertOptionToThresholdStyle = (selectedOption: OptionDefinition): ThresholdStyleType => {
   switch (selectedOption.label) {
     case ThresholdStyleOptions.asLines: {
       return {
@@ -48,13 +48,13 @@ const convertOptionToThresholdStyle = (selectedOption: OptionDefinition): Thresh
 
 const convertThresholdStyleToOption = (thresholdStyle: ThresholdStyleType): OptionDefinition => {
   if (!!thresholdStyle.visible && !thresholdStyle.fill) {
-    return options[0];
+    return styledOptions[0];
   } else if (!thresholdStyle.visible && !!thresholdStyle.fill) {
-    return options[1];
+    return styledOptions[1];
   } else if (!!thresholdStyle.visible && !!thresholdStyle.fill) {
-    return options[2];
+    return styledOptions[2];
   } else {
-    return options[0];
+    return styledOptions[0];
   }
 };
 
@@ -78,7 +78,7 @@ export const ThresholdStyleSettings: React.FC<ThresholdStyleSettingsProps> = ({
           // Update styles of all thresholds
           updateAllThresholdStyles(thresholdStyle);
         }}
-        options={options}
+        options={styledOptions}
         selectedOption={selectedOption}
       />
     </FormField>

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
@@ -15,7 +15,7 @@ import { ThresholdsList } from './thresholdsList';
 import { ComparisonOperators } from './comparisonOperators';
 import { AnnotationsSettings } from './annotations';
 import { CancelableEventHandler, ClickDetail } from '@cloudscape-design/components/internal/events';
-import { ThresholdStyleSettings } from './thresholdStyle';
+import { ThresholdStyleSettings, convertOptionToThresholdStyle, styledOptions } from './thresholdStyle';
 import { ThresholdStyleType } from '@iot-app-kit/react-components/src/components/chart/types';
 
 const ThresholdsExpandableSection: React.FC<React.PropsWithChildren<{ title: string }>> = ({ children, title }) => (
@@ -75,8 +75,8 @@ const ThresholdsSection: FC<ThresholdsSectionProps> = ({
     id: '1',
     visible: true,
   };
-  // Default style should match the first option of <ThresholdStyleSettings/> if no thresholds are added
-  let defaultThresholdStyle: ThresholdStyleType = { visible: true };
+  // Set default threshold style if no thresholds are added
+  let defaultThresholdStyle: ThresholdStyleType = convertOptionToThresholdStyle(styledOptions[2]);
   if (styledThresholdsAdded) {
     // All threshold styles are the same, check on any of the thresholds to determine the saved style
     const styledThreshold: (ThresholdWithId & StyledThreshold)[] = maybeWithDefault(

--- a/packages/react-components/src/components/chart/converters/convertThresholds.ts
+++ b/packages/react-components/src/components/chart/converters/convertThresholds.ts
@@ -8,9 +8,6 @@ const comparisonOperatorToLowerYAxis = (comparisonOperator: ComparisonOperator, 
     case COMPARISON_OPERATOR.GTE:
     case COMPARISON_OPERATOR.EQ:
       return value;
-    case COMPARISON_OPERATOR.LT:
-    case COMPARISON_OPERATOR.LTE:
-      return 0;
     default:
       return undefined;
   }

--- a/packages/react-components/src/components/chart/converters/converters.spec.ts
+++ b/packages/react-components/src/components/chart/converters/converters.spec.ts
@@ -241,7 +241,7 @@ it('converts thresholds to echarts markLine and markArea', async () => {
 
   expect(convertedThresholds).toHaveProperty('markArea.data[0][0].yAxis', 10);
   expect(convertedThresholds).toHaveProperty('markArea.data[0][1].yAxis', 10);
-  expect(convertedThresholds).toHaveProperty('markArea.data[1][0].yAxis', 0);
+  expect(convertedThresholds).toHaveProperty('markArea.data[1][0].yAxis', undefined);
   expect(convertedThresholds).toHaveProperty('markArea.data[1][1].yAxis', 15);
   expect(convertedThresholds).toHaveProperty('markArea.data[2][0].yAxis', 5);
   expect(convertedThresholds).toHaveProperty('markArea.data[2][1].yAxis', undefined);

--- a/packages/react-components/src/components/chart/converters/padYAxis.spec.ts
+++ b/packages/react-components/src/components/chart/converters/padYAxis.spec.ts
@@ -1,0 +1,182 @@
+import { YAxisOptions } from '../types';
+import { DataStream, Threshold } from '@iot-app-kit/core';
+import { padYAxis } from './padYAxis';
+
+describe('test padYAxis', () => {
+  it('does not update axis when values are manually set', () => {
+    const expectedMin = -20;
+    const expectedMax = 20;
+    const mockYAxis: YAxisOptions = {
+      yMin: expectedMin,
+      yMax: expectedMax,
+    };
+
+    const mockThresholds: Threshold[] = [
+      {
+        comparisonOperator: 'EQ',
+        color: '',
+        value: 50,
+      },
+    ];
+
+    const mockDataStreams: DataStream[] = [
+      {
+        id: 'abc-1',
+        data: [],
+        resolution: 0,
+        name: 'name1',
+      },
+    ];
+
+    const [actualMin, actualMax] = padYAxis(mockYAxis, mockThresholds, mockDataStreams);
+    expect(actualMin).toEqual(expectedMin);
+    expect(actualMax).toEqual(expectedMax);
+  });
+
+  it('only updates max if min is > 0', () => {
+    const expectedMin = 0;
+    const expectedMax = 200;
+    const mockYAxis: YAxisOptions = {};
+
+    const mockThresholds: Threshold[] = [
+      {
+        comparisonOperator: 'EQ',
+        color: '',
+        value: 150, // Max, padded to 200
+      },
+    ];
+
+    const mockDataStreams: DataStream[] = [
+      {
+        id: 'abc-1',
+        data: [
+          { x: 1630005300000, y: 50 },
+          { x: 1630005400000, y: 55 },
+          { x: 1630005500000, y: 60 },
+          { x: 1630005600000, y: 65 },
+        ],
+        resolution: 0,
+        name: 'name1',
+      },
+    ];
+
+    const [actualMin, actualMax] = padYAxis(mockYAxis, mockThresholds, mockDataStreams);
+    expect(actualMin).toEqual(expectedMin);
+    expect(actualMax).toEqual(expectedMax);
+  });
+
+  it('only updates min if max is < 0', () => {
+    const expectedMin = -200;
+    const expectedMax = 0;
+    const mockYAxis: YAxisOptions = {};
+
+    const mockThresholds: Threshold[] = [
+      {
+        comparisonOperator: 'EQ',
+        color: '',
+        value: -10,
+      },
+    ];
+
+    const mockDataStreams: DataStream[] = [
+      {
+        id: 'abc-1',
+        data: [
+          { x: 1630005300000, y: -45 },
+          { x: 1630005400000, y: -50 },
+          { x: 1630005500000, y: -20 },
+          { x: 1630005600000, y: -170 }, // Min, padded to -200
+        ],
+        resolution: 0,
+        name: 'name1',
+      },
+    ];
+
+    const [actualMin, actualMax] = padYAxis(mockYAxis, mockThresholds, mockDataStreams);
+    expect(actualMin).toEqual(expectedMin);
+    expect(actualMax).toEqual(expectedMax);
+  });
+
+  it('updates both min and max', () => {
+    const expectedMin = -0.2;
+    const expectedMax = 0.5;
+    const mockYAxis: YAxisOptions = {
+      yMin: expectedMin,
+      yMax: expectedMax,
+    };
+
+    const mockThresholds: Threshold[] = [
+      {
+        comparisonOperator: 'EQ',
+        color: '',
+        value: -0.15, // Min, padded to -0.2
+      },
+    ];
+
+    const mockDataStreams: DataStream[] = [
+      {
+        id: 'abc-1',
+        data: [
+          { x: 1630005300000, y: 0.123 },
+          { x: 1630005400000, y: 0.095 },
+          { x: 1630005500000, y: 0.244 },
+          { x: 1630005600000, y: 0.41 }, // Max, padded to 0.5
+        ],
+        resolution: 0,
+        name: 'name1',
+      },
+    ];
+
+    const [actualMin, actualMax] = padYAxis(mockYAxis, mockThresholds, mockDataStreams);
+    expect(actualMin).toEqual(expectedMin);
+    expect(actualMax).toEqual(expectedMax);
+  });
+
+  it('updates both min and max for multiple data streams and thresholds', () => {
+    const expectedMin = -80;
+    const expectedMax = 90;
+    const mockYAxis: YAxisOptions = {};
+
+    const mockThresholds: Threshold[] = [
+      {
+        comparisonOperator: 'LTE',
+        color: '',
+        value: 77, // Max, padded to 90
+      },
+      {
+        comparisonOperator: 'EQ',
+        color: '',
+        value: -20,
+      },
+    ];
+
+    const mockDataStreams: DataStream[] = [
+      {
+        id: 'abc-1',
+        data: [
+          { x: 1630005300000, y: 55 },
+          { x: 1630005400000, y: -40 },
+          { x: 1630005500000, y: -65 }, // Min, padded to -80
+          { x: 1630005600000, y: 70 },
+        ],
+        resolution: 0,
+        name: 'name1',
+      },
+      {
+        id: 'abc-2',
+        data: [
+          { x: 1630005300000, y: -40 },
+          { x: 1630005400000, y: 0 },
+          { x: 1630005500000, y: 6 },
+          { x: 1630005600000, y: -3 },
+        ],
+        resolution: 0,
+        name: 'name2',
+      },
+    ];
+
+    const [actualMin, actualMax] = padYAxis(mockYAxis, mockThresholds, mockDataStreams);
+    expect(actualMin).toEqual(expectedMin);
+    expect(actualMax).toEqual(expectedMax);
+  });
+});

--- a/packages/react-components/src/components/chart/converters/padYAxis.ts
+++ b/packages/react-components/src/components/chart/converters/padYAxis.ts
@@ -1,0 +1,150 @@
+import { DataPoint, DataStream, Threshold } from '@iot-app-kit/core';
+
+import maxBy from 'lodash.maxby';
+import minBy from 'lodash.minby';
+
+import { ScaleDataValue } from 'echarts/types/src/util/types';
+import { dataValue } from './convertSeriesAndYAxis';
+import { YAxisOptions } from '../types';
+
+const PADDING_FACTOR = 0.1;
+
+type AxisValue =
+  | ScaleDataValue
+  | 'dataMin'
+  | 'dataMax'
+  | ((extent: { min: number; max: number }) => ScaleDataValue)
+  | undefined;
+
+// Verify that the input value is a valid number
+export const validateValue = (value: string | undefined) => {
+  return value !== undefined ? +value : undefined;
+};
+
+// Convert a threshold to a data point with a y value
+const thresholdToDataPoint = (threshold: Threshold): DataPoint => {
+  const value = validateValue(threshold.value.toString());
+  return { x: 0, y: value !== undefined ? value : 0 };
+};
+
+// Calculate the order of magnitude of a number
+const orderOfMagnitude = (n: number): number => {
+  const o = Math.log10(Math.abs(n));
+  return Math.ceil(o);
+};
+
+// Round a decimal up to the closest order of magnitude of 10
+// Ex: 0.00123 --> 0.001
+const roundDecimalToMagnitude = (decimal: number): string => {
+  if (decimal === 0) {
+    return '0';
+  }
+  const roundedUpMag = Math.abs(orderOfMagnitude(decimal) - 1);
+  return decimal.toFixed(roundedUpMag);
+};
+
+// Calculate a number's power of 10
+// Ex: 5432 --> 1000, 42 --> 10
+const roundedMagnitudeOfTen = (n: number) => {
+  const m = orderOfMagnitude(n) - 1;
+  return n > 0 ? 10 ** m : -1 * 10 ** m;
+};
+
+// Round number to closest magnitude
+const roundToOrderOfMagnitude = (n: number): number => {
+  if (n === 0) {
+    return 0;
+  }
+  const roundedMag = roundedMagnitudeOfTen(n);
+  const a = n / roundedMag;
+  const b = roundedMag;
+  return Math.ceil(a) * b;
+};
+
+/**
+ * Padding cases:
+ * 1. min and max are undefined, don't need to do any padding
+ * 2. min is undefined, max is defined. Need to pad max, default min is the min of data if < 0 or 0
+ * 3. min is defined, max is undefined. Need to pad min, default max is the max of data if > 0 or 0
+ * 4. Both are defined, need to pad both
+ */
+const applyPadding = (min: AxisValue, max: AxisValue, padMin: boolean, padMax: boolean, data: DataPoint[]) => {
+  let maxPadding = 0;
+  let minPadding = 0;
+  const minValue = (min ? validateValue(min.toString()) : 0) ?? 0;
+  const maxValue = (max ? validateValue(max.toString()) : 0) ?? 0;
+
+  if (!min && max && padMax) {
+    // If only max is defined then pad max
+    const dataMin = minBy(data, dataValue);
+    const dataMinValue = (dataMin && validateValue(dataMin.y.toString())) ?? 0;
+    const dataDiff = dataMinValue < 0 ? maxValue - dataMinValue : maxValue;
+    maxPadding = PADDING_FACTOR * roundedMagnitudeOfTen(dataDiff);
+  } else if (min && !max && padMin) {
+    // If only min is defined then pad min
+    const dataMax = maxBy(data, dataValue);
+    const dataMaxValue = (dataMax && validateValue(dataMax.y.toString())) ?? 0;
+    const dataDiff = dataMaxValue > 0 ? dataMaxValue - minValue : minValue;
+    minPadding = PADDING_FACTOR * roundedMagnitudeOfTen(dataDiff);
+  } else if (min && max && padMin && padMax) {
+    // If both are defined then pad both
+    minPadding = maxPadding = PADDING_FACTOR * roundedMagnitudeOfTen(maxValue - minValue);
+  }
+
+  // Don't round values if they are set manually
+  if (minPadding === 0 && maxPadding === 0) {
+    return [minValue, maxValue];
+  }
+
+  // Round the padded values to the closest order of magnitude of 10, and round off any decimals
+  const resultMin = roundDecimalToMagnitude(roundToOrderOfMagnitude(minValue - minPadding));
+  const resultMax = roundDecimalToMagnitude(roundToOrderOfMagnitude(maxValue + maxPadding));
+  return [+resultMin, +resultMax];
+};
+
+/**
+ * Calculate the absolute min and max of the chart based on the existing data and thresholds.
+ * If the default yAxis already has a min or max then it takes priority and will not be updated.
+ * Otherwise, if there are thresholds that are outside the default yAxis set a new min and max
+ * to display them with some padding on either side.
+ *
+ * @param yAxis is the default yAxis of the chart
+ * @param thresholds are the list of thresholds defined on the chart
+ * @param datastreams are the properties with data on the chart
+ * @returns a new yAxis with min and max updated based on the padded absolute min and max
+ */
+export const padYAxis = (yAxis: YAxisOptions, thresholds: Threshold[], datastreams: DataStream[]) => {
+  // Combine datastreams and thresholds into a flat list of DataPoints
+  const thresholdsData = thresholds.map((t) => thresholdToDataPoint(t));
+  const initData: DataPoint[] = [];
+  const data = datastreams.reduce((acc, datastream) => [...acc, ...datastream.data], initData);
+  const combinedData = [...thresholdsData, ...data];
+
+  let { yMin, yMax } = yAxis;
+  // Only calculate new min/max if there are thresholds that can be out of bounds
+  if (thresholds.length > 0) {
+    let padMin = false;
+    if (yMin === undefined) {
+      const dataMin: DataPoint | undefined = minBy(combinedData, dataValue);
+      const dataMinValue = dataMin && validateValue(dataMin.y.toString());
+      if (dataMinValue && dataMinValue < 0) {
+        yMin = dataMinValue;
+        padMin = true;
+      }
+    }
+
+    let padMax = false;
+    if (yMax === undefined) {
+      const dataMax: DataPoint | undefined = maxBy(combinedData, dataValue);
+      const dataMaxValue = dataMax && validateValue(dataMax.y.toString());
+      if (dataMaxValue && dataMaxValue > 0) {
+        yMax = dataMaxValue;
+        padMax = true;
+      }
+    }
+
+    [yMin, yMax] = applyPadding(yMin, yMax, padMin, padMax, combinedData);
+  }
+
+  return [yMin, yMax];
+};


### PR DESCRIPTION
## Overview
When a threshold is defined higher than the max or lower than the min of the yAxis on the line and scatter chart it did not show up.

Updated the following:
* When there are no properties or property data customer can still add/edit/delete thresholds. They will just not be shown on the chart.
* When a threshold is set >max or <min and the y-axis is on "Auto" then the axis will be updated to have at least that max/min with some padding
* Thresholds will not work when multiple y-axis are on the chart. Will need to wait to get feedback about that feature in general and this will not be in scope.
* The default threshold style setting is line + filled region

## Verifying Changes
Verified with unit tests and manual tests.

Some edge cases:
1. yAxis is set manually - manual min and/or max is always prioritized and observed
2. yAxis is auto, there is data and no thresholds, yAxis is automatically set by echarts
3. yAxis is auto, there is no data and thresholds, nothing show up on the chart
4. yAxis is auto, there is data and thresholds, absolute min > 0, absolute max > data, yAxis max is updated and padded to the nearest whole num / multiple power of 10
5. yAxis is auto, there is data and thresholds, absolute min < data, absolute max < 0, yAxis min is updated and padded to the nearest whole num / multiple power of 10
6. yAxis is auto, there is data and thresholds, absolute min < 0, absolute max > data, yAxis min and max are updated and padded to the nearest whole num / multiple power of 10
7. Absolute min / max is a decimal, padded correctly
8. Absolute min / max is a negative num, padded correctly
9. Absolute min / max is a very large num, padded correctly

https://github.com/awslabs/iot-app-kit/assets/87385528/a658a005-6150-4cae-a112-555ce9fd3276


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
