### PR TITLE
feat(composer): add key events to transform controls

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/EditorTransformControls.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EditorTransformControls.spec.tsx
@@ -448,4 +448,52 @@ describe('EditorTransformControls', () => {
     expect(mockSetTransformControlMode).toBeCalledTimes(1);
     expect(mockSetTransformControlMode).toBeCalledWith('translate');
   });
+
+  it('should transform selected node with key events', async () => {
+    mockGetSceneNodeByRef.mockReturnValue({ ...baseNode, components: [{ type: KnownComponentType.Light }] });
+    mockFindComponentByType.mockReturnValue({ type: KnownComponentType.Light });
+    useStore('default').setState({ ...baseState, transformControlMode: 'translate' });
+
+    const mockTransformControlObject = {
+      position: {
+        x: 111,
+        y: 222,
+        z: 333,
+      },
+      rotation: {
+        x: 11,
+        y: 22,
+        z: 33,
+      },
+      scale: {
+        x: 1,
+        y: 2,
+        z: 3,
+      },
+    };
+    const mockTransformBase = {
+      position: Object.values(mockTransformControlObject.position),
+      rotation: Object.values(mockTransformControlObject.rotation),
+      scale: Object.values(mockTransformControlObject.scale),
+    };
+
+    const mockNode = {
+      ...baseNode,
+      parentRef: 'bbb',
+      transformConstraint: {
+        snapToFloor: true,
+      },
+    };
+    const expected = {
+      transform: {
+        ...mockTransformBase,
+        position: [112, 222, 333],
+      },
+    };
+    const renderer = render(<EditorTransformControls />);
+    MockTransformControls.instance.object = mockTransformControlObject;
+    useStore('default').setState((state) => state.setKeyEvent({ key: 'ArrowRight' } as KeyboardEvent));
+    renderer.rerender(<EditorTransformControls />);
+    expect(mockUpdateSceneNodeInternal).toBeCalledWith(mockNode.ref, expected);
+  });
 });

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
@@ -48,6 +48,7 @@ const R3FWrapper = (props: { matterportConfig?: MatterportConfig; children?: Rea
   const ContextBridge = useContextBridge(LoggingContext, sceneComposerIdContext, ThemeContext);
   const { enableMatterportViewer } = useMatterportViewer();
   const loadMatterport = enableMatterportViewer && matterportConfig && !isEmpty(matterportConfig.modelId);
+  const setKeyEvent = useStore(sceneComposerId)((state) => state.setKeyEvent);
 
   useEffect(() => {
     if (!loadMatterport) {
@@ -61,6 +62,13 @@ const R3FWrapper = (props: { matterportConfig?: MatterportConfig; children?: Rea
   if (!sceneLoaded) {
     return null;
   }
+
+  const handleKeyDown = (event) => {
+    if (event.key) {
+      setKeyEvent(event);
+    }
+    event.stopPropagataion();
+  };
 
   return loadMatterport ? (
     <MatterportViewer
@@ -84,7 +92,7 @@ const R3FWrapper = (props: { matterportConfig?: MatterportConfig; children?: Rea
       </ContextBridge>
     </MatterportViewer>
   ) : (
-    <UnselectableCanvas shadows dpr={window.devicePixelRatio}>
+    <UnselectableCanvas shadows dpr={window.devicePixelRatio} tabIndex={0} onKeyDown={handleKeyDown}>
       <ContextBridge>
         <Suspense fallback={null}>{children}</Suspense>
       </ContextBridge>

--- a/packages/scene-composer/src/store/Store.ts
+++ b/packages/scene-composer/src/store/Store.ts
@@ -116,6 +116,7 @@ const editorStateSelector = (state: RootState) => ({
   cursorLookAt: state.cursorLookAt,
   cursorVisible: state.cursorVisible,
   cursorStyle: state.cursorStyle,
+  keyPressEvent: state.keyPressEvent,
 
   setEditorConfig: state.setEditorConfig,
   getObject3DBySceneNodeRef: state.getObject3DBySceneNodeRef,

--- a/packages/scene-composer/src/store/StoreOperations.ts
+++ b/packages/scene-composer/src/store/StoreOperations.ts
@@ -18,6 +18,7 @@ export type SceneComposerEditorOperation =
   | 'setCursorLookAt'
   | 'setCursorVisible'
   | 'setCursorStyle'
+  | 'setKeyEvent'
   | 'setActiveCameraSettings'
   | 'setActiveCameraName'
   | 'setMainCameraObject';
@@ -85,6 +86,7 @@ export const SceneComposerOperationTypeMap: Record<SceneComposerOperation, Opera
   setCursorLookAt: 'UPDATE_EDITOR',
   setCursorVisible: 'UPDATE_EDITOR',
   setCursorStyle: 'UPDATE_EDITOR',
+  setKeyEvent: 'UPDATE_EDITOR',
   setActiveCameraSettings: 'UPDATE_EDITOR',
   setActiveCameraName: 'UPDATE_EDITOR',
   setMainCameraObject: 'UPDATE_EDITOR',

--- a/packages/scene-composer/src/store/slices/EditorStateSlice.ts
+++ b/packages/scene-composer/src/store/slices/EditorStateSlice.ts
@@ -101,6 +101,10 @@ export interface IEditorStateSlice {
   cursorStyle: CursorStyle;
   setCursorStyle(style: CursorStyle): void;
 
+  // Global key event data
+  keyPressEvent?: KeyboardEvent | undefined;
+  setKeyEvent(event: KeyboardEvent | undefined): void;
+
   // Active Camera Settings
   activeCameraSettings: CameraSettings;
   setActiveCameraSettings(cameraSettings: CameraSettings);
@@ -130,6 +134,7 @@ function createDefaultEditorState() {
     cursorLookAt: new THREE.Vector3(0, 0, 0),
     cursorVisible: false,
     cursorStyle: 'move',
+    keyPressEvent: undefined,
     activeCameraSettings: {
       cameraType: CameraType.Perspective,
       fov: DEFAULT_CAMERA_OPTIONS.fov,
@@ -317,6 +322,13 @@ export const createEditStateSlice = (set: SetState<RootState>, get: GetState<Roo
       set((draft) => {
         draft.cursorStyle = style;
         draft.lastOperation = 'setCursorStyle';
+      });
+    },
+
+    setKeyEvent(event: KeyboardEvent | undefined) {
+      set((draft) => {
+        draft.keyPressEvent = event;
+        draft.lastOperation = 'setKeyEvent';
       });
     },
 

--- a/packages/scene-composer/src/utils/keyboardUtils.spec.ts
+++ b/packages/scene-composer/src/utils/keyboardUtils.spec.ts
@@ -1,0 +1,54 @@
+import { Object3D } from 'three';
+
+import { getPropertyForKeyEvent, handleKeyEventTransform } from './keyboardUtils';
+
+describe('Keyboard utils', () => {
+  const translateProperty = getPropertyForKeyEvent('translate');
+  const rotateProperty = getPropertyForKeyEvent('rotate');
+  const scaleProperty = getPropertyForKeyEvent('scale');
+
+  it('should return a property and value from a mode', () => {
+    expect(translateProperty.property).toBe('position');
+    expect(translateProperty.amount).toBeGreaterThan(0);
+    expect(rotateProperty.property).toBe('rotation');
+    expect(rotateProperty.amount).toBeGreaterThan(0);
+    expect(scaleProperty.property).toBe('scale');
+    expect(scaleProperty.amount).toBeGreaterThan(0);
+  });
+
+  it('should transform an object based on key events', () => {
+    const mockObject = new Object3D();
+    const leftKeyEvent = {
+      key: 'ArrowLeft',
+    } as KeyboardEvent;
+    const rightKeyEvent = {
+      key: 'ArrowRight',
+    } as KeyboardEvent;
+    const upKeyEvent = {
+      key: 'ArrowUp',
+    } as KeyboardEvent;
+    const downKeyEvent = {
+      key: 'ArrowDown',
+    } as KeyboardEvent;
+    const upShiftKeyEvent = {
+      key: 'ArrowUp',
+      shiftKey: true,
+    } as KeyboardEvent;
+    const downShiftKeyEvent = {
+      key: 'ArrowDown',
+      shiftKey: true,
+    } as KeyboardEvent;
+    handleKeyEventTransform(mockObject, leftKeyEvent, 'position', 1);
+    expect(mockObject.position.x).toBe(-1);
+    handleKeyEventTransform(mockObject, rightKeyEvent, 'position', 1);
+    expect(mockObject.position.x).toBe(0);
+    handleKeyEventTransform(mockObject, upKeyEvent, 'position', 1);
+    expect(mockObject.position.y).toBe(1);
+    handleKeyEventTransform(mockObject, downKeyEvent, 'position', 1);
+    expect(mockObject.position.y).toBe(0);
+    handleKeyEventTransform(mockObject, downShiftKeyEvent, 'position', 1);
+    expect(mockObject.position.z).toBe(-1);
+    handleKeyEventTransform(mockObject, upShiftKeyEvent, 'position', 1);
+    expect(mockObject.position.z).toBe(0);
+  });
+});

--- a/packages/scene-composer/src/utils/keyboardUtils.ts
+++ b/packages/scene-composer/src/utils/keyboardUtils.ts
@@ -1,0 +1,43 @@
+import { MathUtils } from 'three';
+
+import { TransformControlMode } from '../interfaces';
+
+export const getPropertyForKeyEvent = (mode: TransformControlMode) => {
+  const propertyMap = {
+    translate: { property: 'position', amount: 1 },
+    rotate: { property: 'rotation', amount: MathUtils.degToRad(5) },
+    scale: { property: 'scale', amount: 1 },
+  };
+  return propertyMap[mode];
+};
+
+export const handleKeyEventTransform = (
+  controlledObject: THREE.Object3D,
+  keyPressEvent: KeyboardEvent,
+  property: string,
+  amount: number,
+) => {
+  switch (keyPressEvent.key) {
+    case 'ArrowRight':
+      controlledObject[property].x += amount;
+      break;
+    case 'ArrowLeft':
+      controlledObject[property].x -= amount;
+      break;
+    case 'ArrowUp':
+      // hold shift to control z axis
+      if (keyPressEvent.shiftKey) {
+        controlledObject[property].z += amount;
+      } else {
+        controlledObject[property].y += amount;
+      }
+      break;
+    case 'ArrowDown':
+      if (keyPressEvent.shiftKey) {
+        controlledObject[property].z -= amount;
+      } else {
+        controlledObject[property].y -= amount;
+      }
+      break;
+  }
+};


### PR DESCRIPTION
## Overview
Users should be able to transform elements on screen using keyboard, as lack of keyboard control was flagged as a concern by our a11y auditor.  

This PR allows users to manipulate nodes with the arrow keys. When a user focuses the canvas, left/right arrows adjust x axis, up/down arrows adjust y axis, and shift + up/down adjusts z. 

Demo:

https://github.com/awslabs/iot-app-kit/assets/73560269/28437578-0b91-4f3c-a89c-fe016df660a8


## Verifying Changes
### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
