### PR TITLE
feat(composer): add utils to convert all nodes to entities

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -46,7 +46,7 @@
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --index-template tools/index-template.js -- src/assets/icons/",
     "release": "run-s compile copy-assets",
     "copy-assets": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" dist/",
-    "lint": "eslint . --max-warnings=575",
+    "lint": "eslint . --max-warnings=567",
     "fix": "eslint --fix .",
     "test": "jest --config jest.config.ts --coverage --silent",
     "test:dev": "jest --config jest.config.ts --coverage",

--- a/packages/scene-composer/src/components/panels/scene-components/motion-indicator/SpeedEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/motion-indicator/SpeedEditor.tsx
@@ -99,7 +99,7 @@ export const SpeedEditor: React.FC<ISpeedEditorProps> = ({ component, onUpdateCa
           onChange={(event) => {
             const updatedComponent = {
               ...component,
-              config: { ...component.config, defaultSpeed: event.target.value },
+              config: { ...component.config, defaultSpeed: Number(event.target.value) },
             };
             onUpdateCallback(updatedComponent, true);
           }}

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -48,7 +48,7 @@ export interface ISceneDocument {
   rootNodeRefs: string[];
   unit?: string;
   version: string;
-  properties?: Record<string, any>;
+  properties?: Partial<Record<KnownSceneProperty, any>>;
   specVersion?: string;
 }
 

--- a/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
+++ b/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
@@ -12,6 +12,7 @@ jest.mock('../../../utils/mathUtils', () => ({
 describe('serializationHelpers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (generateUUID as jest.Mock).mockReturnValue('test-uuid');
   });
 
   it('should appropriately create model ref componentAs or log errors when calling createModelRefComponent', () => {
@@ -43,8 +44,6 @@ describe('serializationHelpers', () => {
   });
 
   it('should appropriately create tag components or log errors when calling createTagComponent', () => {
-    (generateUUID as jest.Mock).mockReturnValue('test-uuid');
-
     const component = {
       icon: 'testIcon',
       ruleBasedMapId: 42,
@@ -86,8 +85,6 @@ describe('serializationHelpers', () => {
   });
 
   it('should appropriately create light components or log errors when calling createLightComponent', () => {
-    (generateUUID as jest.Mock).mockReturnValueOnce('test-uuid');
-
     const light = { lightType: 'Ambient', lightSettings: { volume: 'full' } };
     expect(exportsForTesting.createLightComponent(light as any, [])).toEqual({
       ref: 'test-uuid',
@@ -102,45 +99,39 @@ describe('serializationHelpers', () => {
   });
 
   it('should appropriately create model shader component or log errors when calling createModelShaderComponent', () => {
-    (generateUUID as jest.Mock).mockReturnValueOnce('test-uuid');
-
     const modelShaderComponent = exportsForTesting.createModelShaderComponent({ shader: 'test' } as any, []);
     expect(modelShaderComponent).toEqual({ ref: 'test-uuid', shader: 'test' });
   });
 
   it('should appropriately create motion indicator components or log errors when calling createMotionIndicatorComponent', () => {
-    (generateUUID as jest.Mock).mockReturnValueOnce('test-uuid');
-
-    const component = {
-      shape: 'LinearPlane',
+    const component: Component.MotionIndicator = {
+      type: KnownComponentType.MotionIndicator,
+      shape: Component.MotionIndicatorShape.LinearCylinder,
       valueDataBindings: {
         speed: {
-          ruleBasedMapId: 42,
-          valueDataBinding: { dataBindingContext: 'dataBindingContext' },
+          ruleBasedMapId: 42 as unknown as string,
+          valueDataBinding: { dataBindingContext: { entityId: 'eid' } },
         },
       },
       config: {
         numOfRepeatInY: 2,
         backgroundColorOpacity: 1,
+        defaultSpeed: '0.5' as unknown as number,
       },
     };
     const resolver = jest.fn();
     resolver.mockReturnValueOnce('here is a map');
     resolver.mockReturnValueOnce(undefined);
     const errorCollector = [];
-    const motionIndicator = exportsForTesting.createMotionIndicatorComponent(
-      component as any,
-      resolver,
-      errorCollector,
-    );
-    const error = exportsForTesting.createMotionIndicatorComponent(component as any, resolver, errorCollector);
+    const motionIndicator = exportsForTesting.createMotionIndicatorComponent(component, resolver, errorCollector);
+    const error = exportsForTesting.createMotionIndicatorComponent(component, resolver, errorCollector);
 
     expect(motionIndicator).toEqual({
       ref: 'test-uuid',
       type: 'MotionIndicator',
       valueDataBindings: component.valueDataBindings,
       shape: component.shape,
-      config: component.config,
+      config: { ...component.config, defaultSpeed: 0.5 },
     });
 
     expect(error).toEqual(motionIndicator);
@@ -156,8 +147,6 @@ describe('serializationHelpers', () => {
   });
 
   it('should appropriately create data overlay components or log errors when calling createDataOverlayComponent', () => {
-    (generateUUID as jest.Mock).mockReturnValue('test-uuid');
-
     const component: Component.DataOverlay = {
       type: KnownComponentType.DataOverlay,
       subType: Component.DataOverlaySubType.OverlayPanel,
@@ -195,8 +184,6 @@ describe('serializationHelpers', () => {
   });
 
   it('should appropriately create entity binding components when calling createEntityBindingComponent', () => {
-    (generateUUID as jest.Mock).mockReturnValue('test-uuid');
-
     const component: Component.EntityBindingComponent = {
       type: KnownComponentType.EntityBinding,
       valueDataBinding: {
@@ -213,8 +200,6 @@ describe('serializationHelpers', () => {
   });
 
   it('should create a scene node when calling createSceneNodeInternal', () => {
-    (generateUUID as jest.Mock).mockReturnValueOnce('test-uuid');
-
     const sceneNode = {
       ref: 'a2a91acc-3a47-4875-a146-b95741aedc2a',
       name: 'testNode',
@@ -249,8 +234,6 @@ describe('serializationHelpers', () => {
   });
 
   it('should create an indexed object resolver when calling createObjectResolver which validates input', () => {
-    (generateUUID as jest.Mock).mockReturnValueOnce('test-uuid');
-
     const scene = {
       specVersion: '1.0',
       version: '1.0',

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isNumber } from 'lodash';
+import { isNumber } from 'lodash';
 
 import DebugLogger from '../../logger/DebugLogger';
 import {
@@ -188,12 +188,14 @@ function createMotionIndicatorComponent(
     validateRuleBasedMapId(map.ruleBasedMapId, resolver, errorCollector);
   });
 
+  // defaultSpeed was saved as string in older version, convert it to number here
+  const defaultSpeed = component.config.defaultSpeed !== undefined ? Number(component.config.defaultSpeed) : undefined;
   return {
     ref: generateUUID(),
     type: 'MotionIndicator',
     shape: component.shape,
     valueDataBindings: component.valueDataBindings,
-    config: component.config,
+    config: { ...component.config, defaultSpeed },
   };
 }
 

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.spec.ts
@@ -1,0 +1,102 @@
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
+
+import { setTwinMakerSceneMetadataModule } from '../../common/GlobalSettings';
+import { defaultNode } from '../../../__mocks__/sceneNode';
+import { KnownComponentType } from '../../interfaces';
+
+import { createNodeEntityComponent } from './nodeComponent';
+import { createTagEntityComponent } from './tagComponent';
+import { createOverlayEntityComponent } from './overlayComponent';
+import { createCameraEntityComponent } from './cameraComponent';
+import { createMotionIndicatorEntityComponent } from './motionIndicatorComponent';
+import { createModelRefComponent } from './modelRefComponent';
+import { createNodeEntity } from './createNodeEntity';
+
+jest.mock('./nodeComponent', () => ({
+  createNodeEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.node' }),
+}));
+jest.mock('./tagComponent', () => ({
+  createTagEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.tag' }),
+}));
+jest.mock('./overlayComponent', () => ({
+  createOverlayEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.overlay' }),
+}));
+jest.mock('./cameraComponent', () => ({
+  createCameraEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.camera' }),
+}));
+jest.mock('./motionIndicatorComponent', () => ({
+  createMotionIndicatorEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.motionIndicator' }),
+}));
+jest.mock('./modelRefComponent', () => ({
+  createModelRefComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelRef' }),
+}));
+
+describe('createNodeEntity', () => {
+  const createSceneEntity = jest.fn();
+  const mockMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
+    createSceneEntity,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setTwinMakerSceneMetadataModule(mockMetadataModule as unknown as TwinMakerSceneMetadataModule);
+  });
+
+  it('should call create entity with only node component', async () => {
+    await createNodeEntity(defaultNode, 'parent', 'layer');
+
+    expect(createSceneEntity).toHaveBeenCalledTimes(1);
+    expect(createSceneEntity).toHaveBeenCalledWith({
+      workspaceId: undefined,
+      entityId: defaultNode.ref,
+      entityName: defaultNode.name + '_' + defaultNode.ref,
+      parentEntityId: 'parent',
+      components: {
+        Node: { componentTypeId: '3d.node' },
+      },
+    });
+
+    expect(createNodeEntityComponent).toHaveBeenCalledTimes(1);
+    expect(createNodeEntityComponent).toHaveBeenCalledWith(defaultNode, 'layer');
+  });
+
+  it('should call create entity to create multiple components', async () => {
+    const tag = { type: KnownComponentType.Tag, ref: 'tag-ref' };
+    const overlay = { type: KnownComponentType.DataOverlay, ref: 'overlay-ref' };
+    const camera = { type: KnownComponentType.Camera, ref: 'camera-ref' };
+    const motionIndicator = { type: KnownComponentType.MotionIndicator, ref: 'indicator-ref' };
+    const modelRef = { type: KnownComponentType.ModelRef, ref: 'modelref-ref' };
+    const node = { ...defaultNode, components: [tag, overlay, camera, motionIndicator, modelRef] };
+
+    await createNodeEntity(node, 'parent', 'layer');
+
+    expect(createSceneEntity).toHaveBeenCalledTimes(1);
+    expect(createSceneEntity).toHaveBeenCalledWith({
+      workspaceId: undefined,
+      entityId: defaultNode.ref,
+      entityName: defaultNode.name + '_' + defaultNode.ref,
+      parentEntityId: 'parent',
+      components: {
+        Node: { componentTypeId: '3d.node' },
+        Tag: { componentTypeId: '3d.tag' },
+        DataOverlay: { componentTypeId: '3d.overlay' },
+        Camera: { componentTypeId: '3d.camera' },
+        MotionIndicator: { componentTypeId: '3d.motionIndicator' },
+        ModelRef: { componentTypeId: '3d.modelRef' },
+      },
+    });
+
+    expect(createNodeEntityComponent).toHaveBeenCalledTimes(1);
+    expect(createNodeEntityComponent).toHaveBeenCalledWith(node, 'layer');
+    expect(createTagEntityComponent).toHaveBeenCalledTimes(1);
+    expect(createTagEntityComponent).toHaveBeenCalledWith(tag);
+    expect(createOverlayEntityComponent).toHaveBeenCalledTimes(1);
+    expect(createOverlayEntityComponent).toHaveBeenCalledWith(overlay);
+    expect(createCameraEntityComponent).toHaveBeenCalledTimes(1);
+    expect(createCameraEntityComponent).toHaveBeenCalledWith(camera);
+    expect(createMotionIndicatorEntityComponent).toHaveBeenCalledTimes(1);
+    expect(createMotionIndicatorEntityComponent).toHaveBeenCalledWith(motionIndicator);
+    expect(createModelRefComponent).toHaveBeenCalledTimes(1);
+    expect(createModelRefComponent).toHaveBeenCalledWith(modelRef);
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
@@ -1,0 +1,74 @@
+import {
+  ComponentUpdateRequest,
+  CreateEntityCommandInput,
+  CreateEntityCommandOutput,
+} from '@aws-sdk/client-iottwinmaker';
+
+import { getGlobalSettings } from '../../common/GlobalSettings';
+import {
+  ICameraComponent,
+  IDataOverlayComponent,
+  IModelRefComponent,
+  IMotionIndicatorComponent,
+  KnownComponentType,
+} from '../../interfaces';
+import { ISceneNodeInternal } from '../../store/internalInterfaces';
+
+import { createNodeEntityComponent } from './nodeComponent';
+import { createTagEntityComponent } from './tagComponent';
+import { createOverlayEntityComponent } from './overlayComponent';
+import { createMotionIndicatorEntityComponent } from './motionIndicatorComponent';
+import { createCameraEntityComponent } from './cameraComponent';
+import { createModelRefComponent } from './modelRefComponent';
+
+export const createNodeEntity = (
+  node: ISceneNodeInternal,
+  parentRef: string,
+  layerId: string,
+): Promise<CreateEntityCommandOutput> | undefined => {
+  const sceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
+
+  const nodecomp = createNodeEntityComponent(node, layerId);
+
+  const createEntity: CreateEntityCommandInput = {
+    workspaceId: undefined,
+    entityId: node.ref,
+    entityName: node.name + '_' + node.ref,
+    parentEntityId: parentRef,
+    components: {
+      Node: nodecomp,
+    },
+  };
+
+  node.components?.forEach((compToBeCreated) => {
+    if (compToBeCreated?.type !== KnownComponentType.EntityBinding) {
+      let comp: ComponentUpdateRequest | undefined = undefined;
+      switch (compToBeCreated?.type) {
+        case KnownComponentType.Tag:
+          comp = createTagEntityComponent(compToBeCreated);
+          break;
+        case KnownComponentType.DataOverlay:
+          comp = createOverlayEntityComponent(compToBeCreated as IDataOverlayComponent);
+          break;
+        case KnownComponentType.MotionIndicator:
+          comp = createMotionIndicatorEntityComponent(compToBeCreated as IMotionIndicatorComponent);
+          break;
+        case KnownComponentType.Camera:
+          comp = createCameraEntityComponent(compToBeCreated as ICameraComponent);
+          break;
+        case KnownComponentType.ModelRef:
+          comp = createModelRefComponent(compToBeCreated as IModelRefComponent);
+          break;
+
+        default:
+          throw new Error('Component type not supported');
+      }
+
+      if (comp) {
+        createEntity.components![compToBeCreated.type] = comp;
+      }
+    }
+  });
+
+  return sceneMetadataModule?.createSceneEntity(createEntity);
+};

--- a/packages/scene-composer/src/utils/entityModelUtils/dataBindingUtils.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/dataBindingUtils.spec.ts
@@ -35,6 +35,7 @@ describe('parseDataBinding', () => {
   it('should return undefined when binding map is empty', () => {
     expect(parseDataBinding(null)).toBeUndefined();
     expect(parseDataBinding({})).toBeUndefined();
+    expect(parseDataBinding({ random: 'random' })).toBeUndefined();
   });
 
   it('should return binding object with only entityId', () => {

--- a/packages/scene-composer/src/utils/entityModelUtils/motionIndicatorComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/motionIndicatorComponent.spec.ts
@@ -4,6 +4,7 @@ import { Component } from '../../models/SceneModels';
 import { IMotionIndicatorComponentInternal } from '../../store';
 
 import {
+  EMPTY_COLOR_STRING,
   createMotionIndicatorEntityComponent,
   parseMotionIndicatorComp,
   updateMotionIndicatorEntityComponent,
@@ -39,9 +40,14 @@ describe('createMotionIndicatorEntityComponent', () => {
             doubleValue: indicatorBase.config.backgroundColorOpacity,
           },
         },
-        appearanceBindings: {
+        config_defaultBackgroundColor: {
           value: {
-            listValue: [],
+            stringValue: EMPTY_COLOR_STRING,
+          },
+        },
+        config_defaultForegroundColor: {
+          value: {
+            stringValue: EMPTY_COLOR_STRING,
           },
         },
       },
@@ -81,7 +87,7 @@ describe('createMotionIndicatorEntityComponent', () => {
     });
   });
 
-  it('should return expected tag component with speed binding', () => {
+  it('should return expected motion indicator component with speed binding', () => {
     const result = createMotionIndicatorEntityComponent({
       ...indicatorBase,
       valueDataBindings: {
@@ -110,7 +116,30 @@ describe('createMotionIndicatorEntityComponent', () => {
     });
   });
 
-  it('should return expected tag component with background color binding', () => {
+  it('should return expected motion indicator component with empty speed binding', () => {
+    const result = createMotionIndicatorEntityComponent({
+      ...indicatorBase,
+      valueDataBindings: {
+        speed: undefined,
+      },
+    });
+
+    expect(result.properties!['appearanceBindings']).toEqual({
+      value: {
+        listValue: [
+          {
+            mapValue: {
+              bindingName: {
+                stringValue: 'speed',
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('should return expected motion indicator component with background color binding', () => {
     const result = createMotionIndicatorEntityComponent({
       ...indicatorBase,
       valueDataBindings: {
@@ -136,7 +165,7 @@ describe('createMotionIndicatorEntityComponent', () => {
     });
   });
 
-  it('should return expected tag component with multiple bindings', () => {
+  it('should return expected motion indicator component with multiple bindings', () => {
     const result = createMotionIndicatorEntityComponent({
       ...indicatorBase,
       valueDataBindings: {
@@ -187,7 +216,7 @@ describe('updateMotionIndicatorEntityComponent', () => {
 });
 
 describe('parseMotionIndicatorComp', () => {
-  const indicatorBaseProps = [
+  const indicatorBasePropsWithoutColors = [
     {
       propertyName: 'shape',
       propertyValue: 'LinearPlane',
@@ -199,6 +228,17 @@ describe('parseMotionIndicatorComp', () => {
     {
       propertyName: 'config_backgroundColorOpacity',
       propertyValue: 0,
+    },
+  ];
+  const indicatorBaseProps = [
+    ...indicatorBasePropsWithoutColors,
+    {
+      propertyName: 'config_defaultBackgroundColor',
+      propertyValue: EMPTY_COLOR_STRING,
+    },
+    {
+      propertyName: 'config_defaultForegroundColor',
+      propertyValue: EMPTY_COLOR_STRING,
     },
   ];
 
@@ -241,7 +281,7 @@ describe('parseMotionIndicatorComp', () => {
     const result = parseMotionIndicatorComp({
       componentTypeId: componentTypeToId[KnownComponentType.MotionIndicator],
       properties: [
-        ...indicatorBaseProps,
+        ...indicatorBasePropsWithoutColors,
         {
           propertyName: 'config_defaultBackgroundColor',
           propertyValue: '#abc',
@@ -256,7 +296,7 @@ describe('parseMotionIndicatorComp', () => {
     const result = parseMotionIndicatorComp({
       componentTypeId: componentTypeToId[KnownComponentType.MotionIndicator],
       properties: [
-        ...indicatorBaseProps,
+        ...indicatorBasePropsWithoutColors,
         {
           propertyName: 'config_defaultForegroundColor',
           propertyValue: '#abc',
@@ -292,7 +332,6 @@ describe('parseMotionIndicatorComp', () => {
           dataBindingContext: {
             entityId: 'eid',
           },
-          isStaticData: false,
         },
       },
     });
@@ -318,10 +357,6 @@ describe('parseMotionIndicatorComp', () => {
     expect(result?.valueDataBindings).toEqual({
       backgroundColor: {
         ruleBasedMapId: 'rule-id',
-        valueDataBinding: {
-          dataBindingContext: {},
-          isStaticData: false,
-        },
       },
     });
   });
@@ -355,15 +390,10 @@ describe('parseMotionIndicatorComp', () => {
           dataBindingContext: {
             entityId: 'eid',
           },
-          isStaticData: false,
         },
       },
       foregroundColor: {
         ruleBasedMapId: 'rule-id-2',
-        valueDataBinding: {
-          dataBindingContext: {},
-          isStaticData: false,
-        },
       },
     });
   });

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
@@ -114,6 +114,14 @@ describe('createNodeEntityComponent', () => {
       },
     });
   });
+
+  it('should return expected node component without properties when only runtime property exist', () => {
+    const result = createNodeEntityComponent({
+      properties: { layerIds: ['layer-1'] },
+    } as ISceneNode);
+
+    expect(result.properties!.properties).toBeUndefined();
+  });
 });
 
 describe('updateNodeEntityComponent', () => {
@@ -171,6 +179,42 @@ describe('parseNode', () => {
     componentTypeId: componentTypeToId.Tag,
     properties: [],
   };
+  const overlayComp = {
+    componentTypeId: componentTypeToId.DataOverlay,
+    properties: [
+      {
+        propertyName: 'subType',
+        propertyValue: 'TextAnnotation',
+      },
+    ],
+  };
+  const modelRefComp = {
+    componentTypeId: componentTypeToId.ModelRef,
+    properties: [
+      {
+        propertyName: 'uri',
+        propertyValue: 'uri.abc',
+      },
+      {
+        propertyName: 'modelType',
+        propertyValue: 'GLB',
+      },
+    ],
+  };
+  const cameraComp = {
+    componentTypeId: componentTypeToId.Camera,
+    properties: [],
+  };
+  const indicatorComp = {
+    componentTypeId: componentTypeToId.MotionIndicator,
+    properties: [
+      {
+        propertyName: 'shape',
+        propertyValue: 'LinearPlane',
+      },
+    ],
+  };
+
   const nodeComp = {
     componentTypeId: NODE_COMPONENT_TYPE_ID,
     properties: [
@@ -234,12 +278,28 @@ describe('parseNode', () => {
   });
 
   it('should parse to expected node component with components', () => {
-    const result = parseNode({ ...entity, components: [tagComp] }, nodeComp);
+    const result = parseNode(
+      { ...entity, components: [tagComp, overlayComp, modelRefComp, cameraComp, indicatorComp] },
+      nodeComp,
+    );
 
-    expect(result?.components).toEqual([
+    const expectedComponents = [
       expect.objectContaining({
         type: KnownComponentType.Tag,
       }),
-    ]);
+      expect.objectContaining({
+        type: KnownComponentType.DataOverlay,
+      }),
+      expect.objectContaining({
+        type: KnownComponentType.ModelRef,
+      }),
+      expect.objectContaining({
+        type: KnownComponentType.Camera,
+      }),
+      expect.objectContaining({
+        type: KnownComponentType.MotionIndicator,
+      }),
+    ];
+    expect(result?.components).toEqual(expectedComponents);
   });
 });

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
@@ -14,6 +14,9 @@ import { SceneNodeRuntimeProperty } from '../../store/internalInterfaces';
 import { attachToLayerRequest } from './sceneLayerUtils';
 import { parseTagComp } from './tagComponent';
 import { parseOverlayComp } from './overlayComponent';
+import { parseModelRefComp } from './modelRefComponent';
+import { parseCameraComp } from './cameraComponent';
+import { parseMotionIndicatorComp } from './motionIndicatorComponent';
 
 enum NodeComponentProperty {
   Name = 'name',
@@ -66,17 +69,18 @@ export const createNodeEntityComponent = (node: ISceneNode, layerId?: string): C
   if (layerId) {
     comp.properties = Object.assign(comp.properties!, attachToLayerRequest(layerId));
   }
-  if (!isEmpty(node.properties)) {
-    const params = {};
-    Object.keys(node.properties).forEach((k) => {
-      if (Object.values(SceneNodeRuntimeProperty).includes(k as SceneNodeRuntimeProperty)) {
-        return;
-      }
-      const value = node.properties![k];
-      if (value !== undefined) {
-        params[k] = { stringValue: String(value) };
-      }
-    });
+
+  const params = {};
+  Object.keys(node.properties || {}).forEach((k) => {
+    if (Object.values(SceneNodeRuntimeProperty).includes(k as SceneNodeRuntimeProperty)) {
+      return;
+    }
+    const value = node.properties![k];
+    if (value !== undefined) {
+      params[k] = { stringValue: String(value) };
+    }
+  });
+  if (!isEmpty(params)) {
     comp.properties![NodeComponentProperty.Properties] = {
       value: {
         mapValue: params,
@@ -137,6 +141,27 @@ const parseNodeComponents = (components: DocumentType): ISceneComponentInternal[
         const overlay = parseOverlayComp(comp);
         if (overlay) {
           results.push(overlay);
+        }
+        break;
+      }
+      case componentTypeToId.ModelRef: {
+        const modelRef = parseModelRefComp(comp);
+        if (modelRef) {
+          results.push(modelRef);
+        }
+        break;
+      }
+      case componentTypeToId.Camera: {
+        const camera = parseCameraComp(comp);
+        if (camera) {
+          results.push(camera);
+        }
+        break;
+      }
+      case componentTypeToId.MotionIndicator: {
+        const indicator = parseMotionIndicatorComp(comp);
+        if (indicator) {
+          results.push(indicator);
         }
         break;
       }

--- a/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
@@ -9,6 +9,9 @@ import { updateEntity } from './updateNodeEntity';
 import { updateNodeEntityComponent } from './nodeComponent';
 import { updateTagEntityComponent } from './tagComponent';
 import { updateOverlayEntityComponent } from './overlayComponent';
+import { updateCameraEntityComponent } from './cameraComponent';
+import { updateMotionIndicatorEntityComponent } from './motionIndicatorComponent';
+import { updateModelRefComponent } from './modelRefComponent';
 
 jest.mock('./nodeComponent', () => ({
   updateNodeEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.node' }),
@@ -18,6 +21,15 @@ jest.mock('./tagComponent', () => ({
 }));
 jest.mock('./overlayComponent', () => ({
   updateOverlayEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.overlay' }),
+}));
+jest.mock('./cameraComponent', () => ({
+  updateCameraEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.camera' }),
+}));
+jest.mock('./motionIndicatorComponent', () => ({
+  updateMotionIndicatorEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.motionIndicator' }),
+}));
+jest.mock('./modelRefComponent', () => ({
+  updateModelRefComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelRef' }),
 }));
 
 describe('updateEntity', () => {
@@ -53,8 +65,11 @@ describe('updateEntity', () => {
   it('should call update entity to update multiple components', async () => {
     const tag = { type: KnownComponentType.Tag, ref: 'tag-ref' };
     const overlay = { type: KnownComponentType.DataOverlay, ref: 'overlay-ref' };
+    const camera = { type: KnownComponentType.Camera, ref: 'camera-ref' };
+    const motionIndicator = { type: KnownComponentType.MotionIndicator, ref: 'indicator-ref' };
+    const modelRef = { type: KnownComponentType.ModelRef, ref: 'modelref-ref' };
 
-    await updateEntity(defaultNode, [tag, overlay], 'UPDATE');
+    await updateEntity(defaultNode, [tag, overlay, camera, motionIndicator, modelRef], 'UPDATE');
 
     expect(updateSceneEntity).toHaveBeenCalledTimes(1);
     expect(updateSceneEntity).toHaveBeenCalledWith({
@@ -65,6 +80,9 @@ describe('updateEntity', () => {
         Node: { componentTypeId: '3d.node' },
         Tag: { componentTypeId: '3d.tag' },
         DataOverlay: { componentTypeId: '3d.overlay' },
+        Camera: { componentTypeId: '3d.camera' },
+        MotionIndicator: { componentTypeId: '3d.motionIndicator' },
+        ModelRef: { componentTypeId: '3d.modelRef' },
       },
     });
 
@@ -74,6 +92,12 @@ describe('updateEntity', () => {
     expect(updateTagEntityComponent).toHaveBeenCalledWith(tag);
     expect(updateOverlayEntityComponent).toHaveBeenCalledTimes(1);
     expect(updateOverlayEntityComponent).toHaveBeenCalledWith(overlay);
+    expect(updateCameraEntityComponent).toHaveBeenCalledTimes(1);
+    expect(updateCameraEntityComponent).toHaveBeenCalledWith(camera);
+    expect(updateMotionIndicatorEntityComponent).toHaveBeenCalledTimes(1);
+    expect(updateMotionIndicatorEntityComponent).toHaveBeenCalledWith(motionIndicator);
+    expect(updateModelRefComponent).toHaveBeenCalledTimes(1);
+    expect(updateModelRefComponent).toHaveBeenCalledWith(modelRef);
   });
 
   it('should call update entity to update tag component', async () => {

--- a/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.ts
@@ -1,13 +1,22 @@
 import { ComponentUpdateRequest, ComponentUpdateType, UpdateEntityCommandInput } from '@aws-sdk/client-iottwinmaker';
 
 import { getGlobalSettings } from '../../common/GlobalSettings';
-import { IDataOverlayComponent, KnownComponentType } from '../../interfaces';
+import {
+  ICameraComponent,
+  IDataOverlayComponent,
+  IModelRefComponent,
+  IMotionIndicatorComponent,
+  KnownComponentType,
+} from '../../interfaces';
 import { ISceneComponentInternal, ISceneNodeInternal } from '../../store/internalInterfaces';
 import { componentTypeToId } from '../../common/entityModelConstants';
 
 import { updateNodeEntityComponent } from './nodeComponent';
 import { updateTagEntityComponent } from './tagComponent';
 import { updateOverlayEntityComponent } from './overlayComponent';
+import { updateModelRefComponent } from './modelRefComponent';
+import { updateCameraEntityComponent } from './cameraComponent';
+import { updateMotionIndicatorEntityComponent } from './motionIndicatorComponent';
 
 export const updateEntity = async (
   node: ISceneNodeInternal,
@@ -42,6 +51,15 @@ export const updateEntity = async (
             break;
           case KnownComponentType.DataOverlay:
             comp = updateOverlayEntityComponent(compToBeUpdated as IDataOverlayComponent);
+            break;
+          case KnownComponentType.ModelRef:
+            comp = updateModelRefComponent(compToBeUpdated as IModelRefComponent);
+            break;
+          case KnownComponentType.Camera:
+            comp = updateCameraEntityComponent(compToBeUpdated as ICameraComponent);
+            break;
+          case KnownComponentType.MotionIndicator:
+            comp = updateMotionIndicatorEntityComponent(compToBeUpdated as IMotionIndicatorComponent);
             break;
           default:
             throw new Error('Component type not supported');

--- a/packages/scene-composer/src/utils/nodeUtils.spec.ts
+++ b/packages/scene-composer/src/utils/nodeUtils.spec.ts
@@ -1,8 +1,15 @@
 import { Vector3, Object3D, Euler, MathUtils } from 'three';
 
 import { AddingWidgetInfo, KnownComponentType } from '../../src';
+import { defaultNode } from '../../__mocks__/sceneNode';
+import { ISceneNodeInternal } from '../store';
 
-import { createNodeWithPositionAndNormal, createNodeWithTransform, findComponentByType } from './nodeUtils';
+import {
+  createNodeWithPositionAndNormal,
+  createNodeWithTransform,
+  findComponentByType,
+  getFinalNodeTransform,
+} from './nodeUtils';
 
 describe('nodeUtils', () => {
   describe('findComponentByType', () => {
@@ -19,6 +26,32 @@ describe('nodeUtils', () => {
       const component = findComponentByType(node as any, KnownComponentType.Light);
 
       expect(component).toBeUndefined();
+    });
+  });
+
+  describe('getFinalNodeTransform', () => {
+    const tagNode: Partial<ISceneNodeInternal> = {
+      ...defaultNode,
+      components: [
+        {
+          ref: 'tag',
+          type: KnownComponentType.Tag,
+        },
+      ],
+    };
+    const object = new Object3D();
+    object.scale.set(22, 22, 22);
+
+    it('should return original scale for tag node', () => {
+      const transform = getFinalNodeTransform(tagNode as ISceneNodeInternal, object);
+
+      expect(transform.scale).toEqual(defaultNode.transform.scale);
+    });
+
+    it('should return calculated scale for non tag node', () => {
+      const transform = getFinalNodeTransform(defaultNode, object);
+
+      expect(transform.scale).toEqual([22, 22, 22]);
     });
   });
 


### PR DESCRIPTION
## Overview
- add utils to convert all nodes to entities
- fix some motion indicator property value issues

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
