### PR TITLE
fix(dashboard): minor threshold fixes

### DIFF
--- a/packages/dashboard/src/customization/propertiesSection.ts
+++ b/packages/dashboard/src/customization/propertiesSection.ts
@@ -131,7 +131,8 @@ export const useSelection = <W extends DashboardWidget>(
       ),
   ];
 
-  const type = compositeValue(selection.map((w) => w.type));
+  const types = selection.map((w) => w.type);
+  const type = compositeValue(types);
 
   const useProperty: PropertyLens<W> = (selector, updater) => {
     /**
@@ -157,6 +158,7 @@ export const useSelection = <W extends DashboardWidget>(
 
   return {
     type,
+    types,
     useSize,
     usePosition,
     useProperty,

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/index.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/index.tsx
@@ -7,53 +7,54 @@ import { StyledThreshold, ThresholdWithId } from '~/customization/settings';
 import { DashboardWidget } from '~/types';
 import ThresholdsSection from './thresholdsSection';
 import { getComparisonOperators } from './comparisonOperators';
+import { Maybe, maybeWithDefault } from '~/util/maybe';
 
-const thresholdsWithContainsOperator: readonly string[] = ['kpi', 'status', 'table'];
+const thresholdsWithContainsOperator: readonly string[] = ['kpi', 'status', 'status-timeline', 'table'];
 const thresholdsWithAnnotations: readonly string[] = ['line-chart', 'scatter-chart', 'bar-chart', 'status-timeline'];
 const thresholdsWithStyle: readonly string[] = ['xy-plot'];
 
-type ThresholdsProperties = { thresholds?: ThresholdWithId[] };
-type AnnotationsProperties = { thresholdSettings?: ThresholdSettings };
-type StyledThresholdProperties = { thresholds?: (ThresholdWithId & StyledThreshold)[] };
-
-export type ThresholdsWidget = DashboardWidget<ThresholdsProperties>;
-type ThresholdsWithAnnotationsWidget = DashboardWidget<ThresholdsProperties & AnnotationsProperties>;
-type ThresholdsWithStyleWidget = DashboardWidget<ThresholdsProperties & StyledThresholdProperties>;
-
-const supportsAnnotations = (w: DashboardWidget): w is ThresholdsWithAnnotationsWidget =>
-  thresholdsWithAnnotations.some((t) => t === w.type);
-const supportsContainsOperator = (w: DashboardWidget): w is ThresholdsWidget =>
-  thresholdsWithContainsOperator.some((t) => t === w.type);
-const supportsStyledThreshold = (w: DashboardWidget): w is ThresholdsWithStyleWidget =>
-  thresholdsWithStyle.some((t) => t === w.type);
-
-// there is no widget type overlap between the 2 lists
-const isThresholdWidgetSupportsContainsOperator = (w: DashboardWidget): w is ThresholdsWidget =>
-  supportsContainsOperator(w);
-const isThresholdWidgetSupportsAnnotations = (w: DashboardWidget): w is ThresholdsWithAnnotationsWidget =>
-  supportsAnnotations(w);
-const isStyledThresholdWidget = (w: DashboardWidget): w is ThresholdsWithStyleWidget => supportsStyledThreshold(w);
-
-const RenderThresholdsSettingsWithContains = ({ useProperty }: { useProperty: PropertyLens<ThresholdsWidget> }) => {
-  const [thresholds, updateThresholds] = useProperty(
-    (properties) => properties.thresholds,
-    (properties, updatedThresholds) => ({ ...properties, thresholds: updatedThresholds })
-  );
-
-  return (
-    <ThresholdsSection
-      thresholds={thresholds}
-      updateThresholds={updateThresholds}
-      comparisonOperators={getComparisonOperators({ supportsContains: true })}
-    />
-  );
+// Type encompassing all possible properties for a widget's thresholds
+type ThresholdProperties = {
+  thresholds?: (ThresholdWithId & StyledThreshold)[];
+  thresholdSettings?: ThresholdSettings;
 };
 
-const RenderThresholdsSettingsWithAnnotations = ({
+export type ThresholdsWidget = DashboardWidget<ThresholdProperties>;
+const isSupportedWidget = (w: DashboardWidget): w is ThresholdsWidget => {
+  const allSupportedThresholds = [
+    ...thresholdsWithAnnotations,
+    ...thresholdsWithContainsOperator,
+    ...thresholdsWithStyle,
+  ];
+  return allSupportedThresholds.some((t) => t === w.type);
+};
+
+const RenderThresholdsSettings = ({
+  type,
+  types,
   useProperty,
 }: {
-  useProperty: PropertyLens<ThresholdsWithAnnotationsWidget>;
+  type: Maybe<string>;
+  types: string[];
+  useProperty: PropertyLens<ThresholdsWidget>;
 }) => {
+  const widgetType = maybeWithDefault('', type);
+
+  let doesSupportAnnotations;
+  let doesSupportContainsOp;
+  let doesSupportStyledThreshold;
+
+  // Support setting thresholds for multiple widgets at once if they fall in the same type category
+  if (widgetType === '' && types.length > 1) {
+    doesSupportAnnotations = types.every((v) => thresholdsWithAnnotations.includes(v));
+    doesSupportContainsOp = types.every((v) => thresholdsWithContainsOperator.includes(v));
+    doesSupportStyledThreshold = types.every((v) => thresholdsWithStyle.includes(v));
+  } else {
+    doesSupportAnnotations = thresholdsWithAnnotations.some((t) => t === widgetType);
+    doesSupportContainsOp = thresholdsWithContainsOperator.some((t) => t === widgetType);
+    doesSupportStyledThreshold = thresholdsWithStyle.some((t) => t === widgetType);
+  }
+
   const [thresholds, updateThresholds] = useProperty(
     (properties) => properties.thresholds,
     (properties, updatedThresholds) => ({ ...properties, thresholds: updatedThresholds })
@@ -63,49 +64,40 @@ const RenderThresholdsSettingsWithAnnotations = ({
     (properties, updatedThresholdSettings) => ({ ...properties, thresholdSettings: updatedThresholdSettings })
   );
 
+  let props = {};
+  if (doesSupportContainsOp) {
+    props = {
+      thresholds: thresholds,
+      updateThresholds: updateThresholds,
+    };
+  }
+  if (doesSupportAnnotations) {
+    props = {
+      thresholds: thresholds,
+      updateThresholds: updateThresholds,
+      thresholdSettings: thresholdSettings,
+      updateThresholdSettings: updateThresholdSettings,
+    };
+  } else if (doesSupportStyledThreshold) {
+    props = {
+      styledThresholds: thresholds,
+      updateStyledThresholds: updateThresholds,
+    };
+  }
+
   return (
     <ThresholdsSection
-      thresholds={thresholds}
-      updateThresholds={updateThresholds}
-      comparisonOperators={getComparisonOperators({ supportsContains: false })}
-      thresholdSettings={thresholdSettings}
-      updateThresholdSettings={updateThresholdSettings}
-    />
-  );
-};
-
-const RenderThresholdsSettingsWithStyledQuery = ({
-  useProperty,
-}: {
-  useProperty: PropertyLens<ThresholdsWithStyleWidget>;
-}) => {
-  const [thresholds, updateThresholds] = useProperty(
-    (properties) => properties.thresholds,
-    (properties, updatedThresholds) => ({ ...properties, thresholds: updatedThresholds })
-  );
-
-  return (
-    <ThresholdsSection
-      comparisonOperators={getComparisonOperators({ supportsContains: false })}
-      styledThresholds={thresholds}
-      updateStyledThresholds={updateThresholds}
+      comparisonOperators={getComparisonOperators({ supportsContains: doesSupportContainsOp })}
+      {...props}
     />
   );
 };
 
 export const ThresholdSettingsConfiguration: React.FC = () => (
-  <>
-    <PropertiesSection
-      isVisible={isThresholdWidgetSupportsContainsOperator}
-      render={({ useProperty }) => <RenderThresholdsSettingsWithContains useProperty={useProperty} />}
-    />
-    <PropertiesSection
-      isVisible={isThresholdWidgetSupportsAnnotations}
-      render={({ useProperty }) => <RenderThresholdsSettingsWithAnnotations useProperty={useProperty} />}
-    />
-    <PropertiesSection
-      isVisible={isStyledThresholdWidget}
-      render={({ useProperty }) => <RenderThresholdsSettingsWithStyledQuery useProperty={useProperty} />}
-    />
-  </>
+  <PropertiesSection
+    isVisible={isSupportedWidget}
+    render={({ type, types, useProperty }) => (
+      <RenderThresholdsSettings type={type} types={types} useProperty={useProperty} />
+    )}
+  />
 );

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdComponent.tsx
@@ -75,6 +75,7 @@ export const ThresholdComponent: FC<{
             <div className='threshold-configuration' style={{ gap: awsui.spaceScaledS }}>
               <Box variant='span'>{defaultMessages.if}</Box>
               <Select
+                expandToViewport={true}
                 options={comparisonOptions}
                 selectedOption={selectedOption}
                 onChange={onUpdateComparator}

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.spec.tsx
@@ -8,15 +8,10 @@ import wrapper from '@cloudscape-design/components/test-utils/dom';
 const thresholdStyle: ThresholdStyleType = {
   visible: true,
 };
-const mockSetThresholdStyle = jest.fn();
 const mockUpdateAllThresholdStyles = jest.fn();
 
 const component = (
-  <ThresholdStyleSettings
-    thresholdStyle={thresholdStyle}
-    setThresholdStyle={mockSetThresholdStyle}
-    updateAllThresholdStyles={mockUpdateAllThresholdStyles}
-  />
+  <ThresholdStyleSettings thresholdStyle={thresholdStyle} updateAllThresholdStyles={mockUpdateAllThresholdStyles} />
 );
 
 describe('thresholdStyleSettings', () => {
@@ -33,7 +28,6 @@ describe('thresholdStyleSettings', () => {
     const select = cloudscapeWrapper.findSelect();
     select?.openDropdown();
     select?.selectOptionByValue('2');
-    expect(mockSetThresholdStyle).toBeCalled();
     expect(mockUpdateAllThresholdStyles).toBeCalled();
   });
 });

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.tsx
@@ -5,7 +5,6 @@ import { ThresholdStyleType } from '@iot-app-kit/react-components/src/components
 
 export type ThresholdStyleSettingsProps = {
   thresholdStyle: ThresholdStyleType;
-  setThresholdStyle: (thresholdStyle: ThresholdStyleType) => void;
   updateAllThresholdStyles: (thresholdStyle: ThresholdStyleType) => void;
 };
 
@@ -60,7 +59,6 @@ const convertThresholdStyleToOption = (thresholdStyle: ThresholdStyleType): Opti
 
 export const ThresholdStyleSettings: React.FC<ThresholdStyleSettingsProps> = ({
   thresholdStyle,
-  setThresholdStyle,
   updateAllThresholdStyles,
 }) => {
   const [selectedOption, setSelectedOption] = useState<SelectProps.Option>(
@@ -73,8 +71,6 @@ export const ThresholdStyleSettings: React.FC<ThresholdStyleSettingsProps> = ({
         onChange={({ detail }) => {
           setSelectedOption(detail.selectedOption);
           const thresholdStyle = convertOptionToThresholdStyle(detail.selectedOption);
-          // Update thresholdStyle state variable
-          setThresholdStyle(thresholdStyle);
           // Update styles of all thresholds
           updateAllThresholdStyles(thresholdStyle);
         }}


### PR DESCRIPTION
## Overview
Issues:
* Certain widgets within the dashboard are difficult to configure thresholds for due to the dropdown being squeezed.
* "=" thresholds should display as a line

Fixes:
* The dropdown for the comparison operator now always expands fully.
* For all thresholds with "=" in the expression there will be a dotted line. For all other expressions it uses the style to determine whether there is a region and/or dotted line.
* The timeline widget now supports the "Contains" comparison operator
* Selecting multiple widgets of the same threshold type then you can update thresholds for all of them at once. If selecting multiple widgets of different threshold types then you see text saying that you must select one threshold.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/87385528/bfaab770-b494-4ba2-9b54-03d32c824981

https://github.com/awslabs/iot-app-kit/assets/87385528/03f2a2e2-66da-4e75-8b2d-6b5274ca3d33


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
