### PR TITLE
fix(scene): fix transform controls being clickable

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/EditorTransformControls.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EditorTransformControls.tsx
@@ -4,7 +4,6 @@ import { useThree } from '@react-three/fiber';
 
 import useLogger from '../../logger/react-logger/hooks/useLogger';
 import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
-import useOverwriteRaycaster from '../../hooks/useOverwriteRaycaster';
 import { useStore } from '../../store';
 import { TransformControls as TransformControlsImpl } from '../../three/TransformControls';
 import { snapObjectToFloor } from '../../three/transformUtils';
@@ -27,7 +26,6 @@ export function EditorTransformControls() {
   const addingWidget = useStore(sceneComposerId)((state) => state.addingWidget);
 
   const [transformControls] = useState(() => new TransformControlsImpl(camera, domElement));
-  const overwriteRaycaster = useOverwriteRaycaster(transformControls);
   const subModelMovementEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.SubModelMovement];
 
   const isTagComponent = !!findComponentByType(selectedSceneNode, KnownComponentType.Tag);
@@ -41,7 +39,6 @@ export function EditorTransformControls() {
   // Set transform controls' camera
   useEffect(() => {
     setTransformControls(transformControls);
-    overwriteRaycaster();
     if (camera) {
       // @ts-ignore: transformControls has a camera prop that TS does not know.
       transformControls.camera = camera;

--- a/packages/scene-composer/src/hooks/useOverwriteRaycaster.spec.ts
+++ b/packages/scene-composer/src/hooks/useOverwriteRaycaster.spec.ts
@@ -33,12 +33,19 @@ describe('useOverwriteRaycaster', () => {
     expect(intersectObjects.length).toBe(4);
 
     const mockRaycaster = jest.fn();
-    const overwriteRayCaster = renderHook(() => useOverwriteRaycaster(parentCube, mockRaycaster)).result.current;
+    const [overwriteRayCaster, restoreRaycaster] = renderHook(() => useOverwriteRaycaster(parentCube, mockRaycaster))
+      .result.current;
     overwriteRayCaster();
     const intersectObjects2 = raycaster.intersectObjects([parentCube]);
 
     expect(mockRaycaster).toBeCalledTimes(2);
     expect(intersectObjects2.length).toBe(0);
+
+    restoreRaycaster();
+    const intersectObjects3 = raycaster.intersectObjects([parentCube]);
+
+    expect(mockRaycaster).toBeCalledTimes(2);
+    expect(intersectObjects3.length).toBe(4);
   });
 
   it('it overwrite the raycaster for all objects with default no op function', () => {
@@ -58,9 +65,40 @@ describe('useOverwriteRaycaster', () => {
     //hit each cube on enter and leave
     expect(intersectObjects.length).toBe(4);
 
-    const overwriteRayCaster = renderHook(() => useOverwriteRaycaster(parentCube)).result.current;
+    const [overwriteRayCaster, restoreRaycaster] = renderHook(() => useOverwriteRaycaster(parentCube)).result.current;
     overwriteRayCaster();
     const intersectObjects2 = raycaster.intersectObjects([parentCube]);
     expect(intersectObjects2.length).toBe(0);
+
+    restoreRaycaster();
+    const intersectObjects3 = raycaster.intersectObjects([parentCube]);
+    expect(intersectObjects3.length).toBe(4);
+  });
+
+  it('call restore first should keep previous raycast', () => {
+    const parentCube = new THREE.Mesh(geometry, material);
+    parentCube.translateX(position.x);
+    parentCube.translateY(position.y);
+    parentCube.translateZ(position.z);
+    parentCube.updateMatrixWorld();
+    const cube2 = new THREE.Mesh(geometry, material);
+    cube2.translateX(position.x + 1);
+    cube2.translateY(position.y);
+    cube2.translateZ(position.z);
+    parentCube.add(cube2);
+    cube2.updateMatrixWorld();
+
+    const mockRaycaster = jest.fn();
+    const restoreRaycaster = renderHook(() => useOverwriteRaycaster(parentCube, mockRaycaster)).result.current[1];
+
+    const intersectObjects = raycaster.intersectObjects([parentCube]);
+    //hit each cube on enter and leave
+    expect(intersectObjects.length).toBe(4);
+
+    restoreRaycaster();
+    const intersectObjects2 = raycaster.intersectObjects([parentCube]);
+    expect(intersectObjects2.length).toBe(4);
+
+    expect(mockRaycaster).toBeCalledTimes(0);
   });
 });


### PR DESCRIPTION
## Overview
Ray-casting for the transform controls were disabled to make them on interfere with ray-casting during camera activation, but this may them unclickable for mouse interactions.

https://github.com/awslabs/iot-app-kit/assets/109186219/e9c1ef72-e519-488a-815f-a59907507938

Now ray-casting should only be temporarily disabled for the transform controls while a camera command raycast is being done so the camera looks in the right direction but are restored for user editing after the camera is done moving.

https://github.com/awslabs/iot-app-kit/assets/109186219/a21ba5ab-14e3-4919-b16e-1edadbaf5684


## Verifying Changes

Test in scene composer with a scene that has a camera
1. use all three transform control option on an object (scale, rotation, position)
2. select in the scene hierarchy a camera
3. select that camera in the camera view and ensure the camera is the right position after being set as the active camera
4. again confirm that all 3 transform controls work on an object

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
