### PR TITLE
fix: default resolution and aggregation

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/aggregationSettings/index.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/aggregationSettings/index.tsx
@@ -47,7 +47,7 @@ const RenderAggregationsPropertiesSection = ({
 }) => {
   const [aggregationMaybe, updateAggregation] = useProperty(
     // Default resolution is auto. We ensure the aggregation is defaulted to average instead of raw.
-    ({ aggregationType, resolution }) => (resolution == null && aggregationType == null ? 'AVERAGE' : aggregationType),
+    ({ aggregationType }) => aggregationType,
     (properties, updatedAggregationType) => {
       return {
         ...properties,

--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
@@ -86,8 +86,8 @@ const RenderLineAndScatterStyleSettingsSection = ({
   );
 
   const [aggregationMaybe, updateAggregation] = useProperty(
-    // Default resolution is auto. We ensure the aggregation is defaulted to average instead of raw.
-    ({ aggregationType, resolution }) => (resolution == null && aggregationType == null ? 'AVERAGE' : aggregationType),
+    // Default resolution is auto. We ensure the aggregation is defaulted to average instead of no aggregation.
+    ({ aggregationType }) => aggregationType,
     (properties, updatedAggregationType) => ({
       ...properties,
       queryConfig: {

--- a/packages/dashboard/src/customization/widgets/barChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/plugin.tsx
@@ -14,6 +14,8 @@ export const barChartPlugin: DashboardPlugin = {
         icon: BarIcon,
       },
       properties: () => ({
+        aggregationType: 'AVERAGE',
+        resolution: undefined,
         queryConfig: {
           source: 'iotsitewise',
           query: undefined,

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/plugin.tsx
@@ -14,6 +14,8 @@ export const lineScatterChartPlugin: DashboardPlugin = {
         icon: LineIcon,
       },
       properties: () => ({
+        aggregationType: 'AVERAGE',
+        resolution: undefined,
         queryConfig: {
           source: 'iotsitewise',
           query: undefined,

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -136,6 +136,8 @@ export type BarChartProperties = QueryProperties & {
   thresholdSettings?: ThresholdSettings;
   axis?: AxisSettings;
   significantDigits?: number;
+  resolution?: string;
+  aggregationType?: AggregateType;
 };
 export type BarChartPropertiesKeys = keyof BarChartProperties;
 


### PR DESCRIPTION
## Overview
This change provides required defaults for aggregation and resolution for widgets which expose aggregation and resolution controls.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
