### PR TITLE
feat: resource explorer table preferences columns visibility

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTable.test.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTable.test.tsx
@@ -1,0 +1,33 @@
+import { AssetTableColumnDefinitionsFactory } from './assetTableColumnDefinitionsFactory';
+
+describe('AssetTableColumnDefinitionsFactory', () => {
+  describe('create', () => {
+    it('should return an array of column definitions', () => {
+      const columnDefinitionFactory = new AssetTableColumnDefinitionsFactory({
+        NameLink: () => null,
+        onClickNameLink: () => null,
+      });
+
+      const columnDefinitions = columnDefinitionFactory.create();
+
+      expect(Array.isArray(columnDefinitions)).toBe(true);
+      expect(columnDefinitions.length).toBeGreaterThan(0);
+    });
+
+    it('should include specific column definitions', () => {
+      const columnDefinitionFactory = new AssetTableColumnDefinitionsFactory({
+        NameLink: () => null,
+        onClickNameLink: () => null,
+      });
+
+      const columnDefinitions = columnDefinitionFactory.create();
+
+      expect(columnDefinitions.some((def) => def.id === 'arn')).toBe(true);
+      expect(columnDefinitions.some((def) => def.id === 'id')).toBe(true);
+      expect(columnDefinitions.some((def) => def.id === 'name')).toBe(true);
+      expect(columnDefinitions.some((def) => def.id === 'description')).toBe(true);
+      expect(columnDefinitions.some((def) => def.id === 'creationDate')).toBe(true);
+      expect(columnDefinitions.some((def) => def.id === 'lastUpdateDate')).toBe(true);
+    });
+  });
+});

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTableColumnDefinitionsFactory.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTableColumnDefinitionsFactory.tsx
@@ -22,7 +22,32 @@ export class AssetTableColumnDefinitionsFactory {
   }
 
   public create(): AssetTableColumnDefinitions {
-    return [this.#createNameField(), this.#createDescriptionField()];
+    return [
+      this.#createARNField(),
+      this.#createIDField(),
+      this.#createNameField(),
+      this.#createDescriptionField(),
+      this.#createCreationDateField(),
+      this.#createLastUpdateDateField(),
+    ];
+  }
+
+  #createARNField(): AssetTableColumnDefinitions[1] {
+    return {
+      id: 'arn',
+      header: 'ARN',
+      cell: ({ arn }) => arn,
+      sortingField: 'arn',
+    };
+  }
+
+  #createIDField(): AssetTableColumnDefinitions[1] {
+    return {
+      id: 'id',
+      header: 'ID',
+      cell: ({ id }) => id,
+      sortingField: 'id',
+    };
   }
 
   #createNameField(): AssetTableColumnDefinitions[0] {
@@ -48,6 +73,24 @@ export class AssetTableColumnDefinitionsFactory {
       header: 'Description',
       cell: ({ description }) => description,
       sortingField: 'description',
+    };
+  }
+
+  #createCreationDateField(): AssetTableColumnDefinitions[1] {
+    return {
+      id: 'creationDate',
+      header: 'Creation Date',
+      cell: ({ creationDate }) => creationDate?.toString() ?? '-',
+      sortingField: 'creationDate',
+    };
+  }
+
+  #createLastUpdateDateField(): AssetTableColumnDefinitions[1] {
+    return {
+      id: 'lastUpdateDate',
+      header: 'Last Update Date',
+      cell: ({ lastUpdateDate }) => lastUpdateDate?.toString() ?? '-',
+      sortingField: 'lastUpdateDate',
     };
   }
 }


### PR DESCRIPTION
## Overview
this PR adds the column visibility for all the columns in resource explorer visible column settings in asset preferences. #1980 
https://ibb.co/6bBzbzS

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
