### PR TITLE
feat(composer): convert nodes to entities UI

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -46,7 +46,7 @@
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --index-template tools/index-template.js -- src/assets/icons/",
     "release": "run-s compile copy-assets",
     "copy-assets": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" dist/",
-    "lint": "eslint . --max-warnings=567",
+    "lint": "eslint . --max-warnings=510",
     "fix": "eslint --fix .",
     "test": "jest --config jest.config.ts --coverage --silent",
     "test:dev": "jest --config jest.config.ts --coverage",

--- a/packages/scene-composer/src/components/ConvertSceneModal.spec.tsx
+++ b/packages/scene-composer/src/components/ConvertSceneModal.spec.tsx
@@ -1,0 +1,287 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import flushPromises from 'flush-promises';
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
+
+import { useStore } from '../store';
+import {
+  checkIfEntityAvailable,
+  convertAllNodesToEntities,
+  createSceneRootEntity,
+  prepareWorkspace,
+  staticNodeCount,
+} from '../utils/entityModelUtils/sceneUtils';
+import { createLayer } from '../utils/entityModelUtils/sceneLayerUtils';
+import { KnownSceneProperty } from '../interfaces';
+import { setTwinMakerSceneMetadataModule } from '../common/GlobalSettings';
+import { LayerType } from '../common/entityModelConstants';
+import { defaultNode } from '../../__mocks__/sceneNode';
+
+import ConvertSceneModal from './ConvertSceneModal';
+
+jest.mock('../utils/entityModelUtils/sceneLayerUtils', () => ({
+  createLayer: jest.fn(),
+}));
+
+jest.mock('../utils/entityModelUtils/sceneUtils', () => ({
+  createSceneRootEntity: jest.fn(),
+  prepareWorkspace: jest.fn(),
+  checkIfEntityAvailable: jest.fn(),
+  staticNodeCount: jest.fn(),
+  convertAllNodesToEntities: jest.fn(),
+}));
+
+describe('ConvertSceneModal', () => {
+  const setConvertSceneModalVisibility = jest.fn();
+  const setSceneProperty = jest.fn();
+  const updateSceneNodeInternal = jest.fn();
+  const getObject3DBySceneNodeRef = jest.fn();
+  const getSceneProperty = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useStore('default').setState({
+      setConvertSceneModalVisibility,
+      setSceneProperty,
+      updateSceneNodeInternal,
+      getObject3DBySceneNodeRef,
+      getSceneProperty,
+    });
+    (createLayer as jest.Mock).mockImplementation((name, _) => {
+      return Promise.resolve({ entityId: name });
+    });
+    (createSceneRootEntity as jest.Mock).mockImplementation(() => {
+      return Promise.resolve({ entityId: 'scene-root-id' });
+    });
+    (prepareWorkspace as jest.Mock).mockResolvedValue(undefined);
+
+    getSceneProperty.mockImplementation((p) => {
+      if (p == KnownSceneProperty.LayerIds) {
+        return ['layer-id'];
+      } else if (p == KnownSceneProperty.SceneRootEntityId) {
+        return 'scene-root-id';
+      } else {
+        return undefined;
+      }
+    });
+
+    (checkIfEntityAvailable as jest.Mock).mockReturnValue(true);
+    (staticNodeCount as jest.Mock).mockReturnValue(2);
+
+    setTwinMakerSceneMetadataModule({
+      getSceneId: jest.fn().mockReturnValue('test-scene'),
+    } as Partial<TwinMakerSceneMetadataModule> as TwinMakerSceneMetadataModule);
+  });
+
+  it('should render with correct confirmation view', () => {
+    const { container, queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    const cancelButton = queryByTestId('cancel-button');
+
+    expect(confirmButton).toBeTruthy();
+    expect(cancelButton).toBeTruthy();
+    expect(container).toMatchSnapshot();
+
+    act(() => {
+      cancelButton!.click();
+    });
+
+    expect(setConvertSceneModalVisibility).toBeCalledWith(false);
+  });
+
+  it('should call prepareWorkspace when converting scene', async () => {
+    const { container, queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+    expect(container).toMatchSnapshot();
+    expect(queryByTestId('confirm-button')?.getAttribute('disabled')).not.toBeNull();
+
+    expect(prepareWorkspace).toBeCalledTimes(1);
+    expect(createLayer as jest.Mock).not.toBeCalled();
+    expect(createSceneRootEntity as jest.Mock).not.toBeCalled();
+    expect(setSceneProperty).not.toBeCalled();
+  });
+
+  it('should create a default layer and root entity when none available', async () => {
+    getSceneProperty.mockReturnValue(undefined);
+    const { queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(createLayer as jest.Mock).toBeCalledTimes(1);
+    expect(createLayer as jest.Mock).toBeCalledWith('test-scene_Default', LayerType.Relationship);
+    expect(createSceneRootEntity as jest.Mock).toBeCalledTimes(1);
+    expect(setSceneProperty).toBeCalledTimes(2);
+    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.LayerIds, ['test-scene_Default']);
+    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.SceneRootEntityId, 'scene-root-id');
+  });
+
+  it('should create a default layer entity when it does not exist', async () => {
+    (checkIfEntityAvailable as jest.Mock).mockImplementation((entityId) => {
+      if (entityId == 'layer-id') {
+        return Promise.resolve(false);
+      }
+      return Promise.resolve(true);
+    });
+
+    const { queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(createLayer as jest.Mock).toBeCalledTimes(1);
+    expect(createLayer as jest.Mock).toBeCalledWith('test-scene_Default', LayerType.Relationship);
+    expect(createSceneRootEntity as jest.Mock).not.toBeCalled();
+    expect(setSceneProperty).toBeCalledTimes(1);
+    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.LayerIds, ['test-scene_Default']);
+  });
+
+  it('should create a default scene entity when it does not exist', async () => {
+    (checkIfEntityAvailable as jest.Mock).mockImplementation((entityId) => {
+      if (entityId == 'scene-root-id') {
+        return Promise.resolve(false);
+      }
+      return Promise.resolve(true);
+    });
+
+    const { queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(createLayer as jest.Mock).not.toBeCalled();
+    expect(createSceneRootEntity as jest.Mock).toBeCalledTimes(1);
+    expect(setSceneProperty).toBeCalledTimes(1);
+    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.SceneRootEntityId, 'scene-root-id');
+  });
+
+  it('should call convertAllNodesToEntities and convert scene successfully', async () => {
+    (convertAllNodesToEntities as jest.Mock).mockImplementation(({ onSuccess }) => {
+      act(() => {
+        onSuccess({ ...defaultNode, ref: 'success-1' });
+        onSuccess({ ...defaultNode, ref: 'success-2' });
+      });
+    });
+
+    const { rerender, container, queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(convertAllNodesToEntities).toBeCalledTimes(1);
+    expect(updateSceneNodeInternal).toBeCalledTimes(2);
+    expect(updateSceneNodeInternal).toHaveBeenNthCalledWith(
+      1,
+      'success-1',
+      { ...defaultNode, ref: 'success-1' },
+      false,
+      true,
+    );
+    expect(updateSceneNodeInternal).toHaveBeenNthCalledWith(
+      2,
+      'success-2',
+      { ...defaultNode, ref: 'success-2' },
+      false,
+      true,
+    );
+
+    act(() => {
+      rerender(<ConvertSceneModal />);
+    });
+
+    const okButton = queryByTestId('ok-button');
+    expect(okButton).toBeTruthy();
+
+    expect(container).toMatchSnapshot();
+
+    act(() => {
+      okButton!.click();
+    });
+    expect(setConvertSceneModalVisibility).toBeCalledTimes(1);
+    expect(setConvertSceneModalVisibility).toBeCalledWith(false);
+  });
+
+  it('should render with converting scene failure', async () => {
+    (convertAllNodesToEntities as jest.Mock).mockImplementation(({ onSuccess, onFailure }) => {
+      act(() => {
+        onSuccess({ ...defaultNode, ref: 'success-node-ref' });
+        onFailure({ ...defaultNode, ref: 'failure-node-ref', name: 'failure-node' });
+      });
+    });
+
+    const { rerender, container, queryByTestId, queryByText } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(convertAllNodesToEntities).toBeCalledTimes(1);
+    expect(updateSceneNodeInternal).toBeCalledTimes(1);
+    expect(updateSceneNodeInternal).toHaveBeenNthCalledWith(
+      1,
+      'success-node-ref',
+      { ...defaultNode, ref: 'success-node-ref' },
+      false,
+      true,
+    );
+
+    act(() => {
+      rerender(<ConvertSceneModal />);
+    });
+
+    const errorMessage = queryByText('failure-node');
+    expect(errorMessage).toBeTruthy();
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with preparing workspace failure', async () => {
+    (prepareWorkspace as jest.Mock).mockRejectedValue(new Error('prepare workspace error'));
+    const { rerender, container, queryByTestId, queryByText } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(convertAllNodesToEntities).not.toBeCalled();
+    expect(updateSceneNodeInternal).not.toBeCalled();
+
+    act(() => {
+      rerender(<ConvertSceneModal />);
+    });
+
+    const errorMessage = queryByText('prepare workspace error');
+    expect(errorMessage).toBeTruthy();
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/ConvertSceneModal.tsx
+++ b/packages/scene-composer/src/components/ConvertSceneModal.tsx
@@ -1,0 +1,212 @@
+import { isEmpty } from 'lodash';
+import { Alert, Box, Button, Header, SpaceBetween } from '@awsui/components-react';
+import React, { useCallback, useContext, useState } from 'react';
+import { useIntl } from 'react-intl';
+
+import { sceneComposerIdContext } from '../common/sceneComposerIdContext';
+import { ISceneNodeInternal, useStore } from '../store';
+import { KnownSceneProperty } from '../interfaces';
+import {
+  checkIfEntityAvailable,
+  convertAllNodesToEntities,
+  createSceneRootEntity,
+  prepareWorkspace,
+  staticNodeCount,
+} from '../utils/entityModelUtils/sceneUtils';
+import { createLayer } from '../utils/entityModelUtils/sceneLayerUtils';
+import { LayerType } from '../common/entityModelConstants';
+import { getGlobalSettings } from '../common/GlobalSettings';
+
+import CenteredContainer from './CenteredContainer';
+import { ConvertingProgress } from './ConvertingProgress';
+
+interface ConvertProgress {
+  total: number;
+  converted: number;
+  failedNodes: ISceneNodeInternal[];
+  succeededNodes: ISceneNodeInternal[];
+}
+interface ConvertResult {
+  failedNodes?: ISceneNodeInternal[];
+  succeededNodes?: ISceneNodeInternal[];
+  errorMessage?: string;
+}
+
+const ConvertSceneModal: React.FC = () => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const setConvertSceneModalVisibility = useStore(sceneComposerId)((state) => state.setConvertSceneModalVisibility);
+  const document = useStore(sceneComposerId)((state) => state.document);
+
+  const setSceneProperty = useStore(sceneComposerId)((state) => state.setSceneProperty);
+  const updateSceneNodeInternal = useStore(sceneComposerId)((state) => state.updateSceneNodeInternal);
+  const getObject3DBySceneNodeRef = useStore(sceneComposerId)((state) => state.getObject3DBySceneNodeRef);
+
+  const sceneRootId = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<string>(KnownSceneProperty.SceneRootEntityId),
+  );
+  const sceneLayerIds = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<string[]>(KnownSceneProperty.LayerIds),
+  );
+
+  const { formatMessage } = useIntl();
+
+  const [progress, setProgress] = useState<ConvertProgress | undefined>();
+  const [result, setResult] = useState<ConvertResult | undefined>();
+
+  const onClose = useCallback(() => {
+    setConvertSceneModalVisibility(false);
+    setResult(undefined);
+    setProgress(undefined);
+  }, [setConvertSceneModalVisibility]);
+
+  const onConfirm = useCallback(async () => {
+    try {
+      const progress: ConvertProgress = {
+        total: staticNodeCount(document.nodeMap),
+        converted: 0,
+        succeededNodes: [],
+        failedNodes: [],
+      };
+      setProgress(progress);
+
+      let layerId = sceneLayerIds?.at(0);
+      let rootId = sceneRootId;
+      const sceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
+      const layerName = `${sceneMetadataModule?.getSceneId()}_Default`;
+
+      if (sceneMetadataModule) {
+        // Before backend can create the new default roots, the client side code will
+        // create them temporarily here.
+        await prepareWorkspace(sceneMetadataModule);
+
+        // Create default layer and default scene root node
+        if (!layerId || isEmpty(layerId) || !(await checkIfEntityAvailable(layerId, sceneMetadataModule))) {
+          const layer = await createLayer(layerName, LayerType.Relationship);
+          layerId = layer?.entityId;
+          setSceneProperty(KnownSceneProperty.LayerIds, [layerId]);
+        }
+        if (!sceneRootId || isEmpty(sceneRootId) || !(await checkIfEntityAvailable(sceneRootId, sceneMetadataModule))) {
+          const root = await createSceneRootEntity();
+          rootId = root?.entityId;
+          setSceneProperty(KnownSceneProperty.SceneRootEntityId, rootId);
+        }
+      }
+
+      if (rootId && layerId) {
+        convertAllNodesToEntities({
+          document,
+          sceneRootEntityId: rootId,
+          layerId,
+          getObject3DBySceneNodeRef,
+          onSuccess: (convertedNode) => {
+            progress.converted++;
+            progress.succeededNodes.push(convertedNode);
+
+            if (progress.converted === progress.total) {
+              setProgress(undefined);
+              setResult({ failedNodes: progress.failedNodes, succeededNodes: progress.succeededNodes });
+            } else {
+              setProgress(progress);
+            }
+            updateSceneNodeInternal(convertedNode.ref, convertedNode, false, true);
+          },
+          onFailure: (convertedNode) => {
+            progress.converted++;
+            progress.failedNodes.push(convertedNode);
+
+            if (progress.converted === progress.total) {
+              setProgress(undefined);
+              setResult({ failedNodes: progress.failedNodes, succeededNodes: progress.succeededNodes });
+            } else {
+              setProgress(progress);
+            }
+          },
+        });
+      }
+    } catch (e) {
+      setProgress(undefined);
+      setResult({ errorMessage: (e as Error).message });
+    }
+  }, [document, sceneLayerIds, sceneRootId, setSceneProperty, updateSceneNodeInternal]);
+
+  return (
+    <CenteredContainer
+      header={
+        <Header variant='h2'>
+          {formatMessage({ description: 'modal header text', defaultMessage: 'Convert scene' })}
+        </Header>
+      }
+      footer={
+        <Box float='right' padding={{ bottom: 's' }}>
+          {result ? (
+            <Button data-testid='ok-button' onClick={onClose}>
+              {formatMessage({ description: 'button label', defaultMessage: 'Ok' })}
+            </Button>
+          ) : (
+            <SpaceBetween size='s' direction='horizontal'>
+              <Button data-testid='cancel-button' onClick={onClose}>
+                {formatMessage({ description: 'button label', defaultMessage: 'Cancel' })}
+              </Button>
+
+              <Button data-testid='confirm-button' variant='primary' onClick={onConfirm} disabled={!!progress}>
+                {formatMessage({ description: 'button label', defaultMessage: 'Confirm' })}
+              </Button>
+            </SpaceBetween>
+          )}
+        </Box>
+      }
+    >
+      {!progress && !result && (
+        <Alert
+          type='warning'
+          header={formatMessage({ description: 'alert header text', defaultMessage: 'Converting scene' })}
+        >
+          {formatMessage({
+            description: 'alert body text',
+            defaultMessage:
+              'Proceeding with this action will permanently change your scene. You cannot undo this action',
+          })}
+        </Alert>
+      )}
+      {progress && <ConvertingProgress total={progress.total} converted={progress.converted} />}
+      {result &&
+        (isEmpty(result.failedNodes) && !result.errorMessage ? (
+          <Alert
+            type='success'
+            header={formatMessage({
+              description: 'alert header text',
+              defaultMessage: 'Convert to entities successful',
+            })}
+          >
+            {formatMessage({
+              description: 'alert body text',
+              defaultMessage: 'All nodes have been converted successfully',
+            })}
+          </Alert>
+        ) : (
+          <Alert
+            type='error'
+            header={formatMessage({ description: 'alert header text', defaultMessage: 'Convert to entities failed' })}
+          >
+            {result.errorMessage && <Box>{result.errorMessage}</Box>}
+
+            {!isEmpty(result.failedNodes) && (
+              <Box>
+                {formatMessage({ description: 'alert body text', defaultMessage: 'Some node conversion failed:' })}
+              </Box>
+            )}
+            {result.failedNodes &&
+              result.failedNodes.map((node) => (
+                <Box key={node.ref} padding={{ left: 's' }}>
+                  {node.name}
+                </Box>
+              ))}
+          </Alert>
+        ))}
+    </CenteredContainer>
+  );
+};
+
+ConvertSceneModal.displayName = 'ConvertSceneModal';
+
+export default ConvertSceneModal;

--- a/packages/scene-composer/src/components/ConvertingProgress.spec.tsx
+++ b/packages/scene-composer/src/components/ConvertingProgress.spec.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { ConvertingProgress } from './ConvertingProgress';
+
+describe('ConvertingProgress', () => {
+  it('should render with correct progress with 0% done', () => {
+    const { container, queryByText } = render(<ConvertingProgress total={10} converted={0} />);
+
+    const progressBar = queryByText('0 out of 10 converted');
+    expect(progressBar).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with correct progress with partially done', () => {
+    const { container, queryByText } = render(<ConvertingProgress total={9} converted={2} />);
+
+    const progressBar = queryByText('2 out of 9 converted');
+    expect(progressBar).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with correct progress with all done', () => {
+    const { container, queryByText } = render(<ConvertingProgress total={10} converted={10} />);
+
+    const progressBar = queryByText('10 out of 10 converted');
+    expect(progressBar).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/ConvertingProgress.tsx
+++ b/packages/scene-composer/src/components/ConvertingProgress.tsx
@@ -1,0 +1,41 @@
+import { Box, Container, ProgressBar } from '@awsui/components-react';
+import React from 'react';
+import { useIntl } from 'react-intl';
+import styled from 'styled-components';
+import * as awsui from '@awsui/design-tokens';
+
+const ConvertingProgressContainer = styled(Container)`
+  width: 100%;
+`;
+
+const ConvertingProgressDescriptionBox = styled(Box)`
+  color: ${awsui.colorTextBodySecondary}!important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const ConvertingProgress: React.FC<{ total: number; converted: number }> = ({ total, converted }) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <ConvertingProgressContainer data-testid='progress-container'>
+      <ProgressBar
+        status='in-progress'
+        value={(converted / total) * 100}
+        additionalInfo={
+          <ConvertingProgressDescriptionBox>
+            {formatMessage(
+              {
+                defaultMessage: '{convertedNumber} out of {totalNumber} converted',
+                description: 'Progress Bar description',
+              },
+              { convertedNumber: converted, totalNumber: total },
+            )}
+          </ConvertingProgressDescriptionBox>
+        }
+        label={formatMessage({ defaultMessage: 'Converting nodes', description: 'Progress Bar label' })}
+      />
+    </ConvertingProgressContainer>
+  );
+};

--- a/packages/scene-composer/src/components/StateManager.spec.tsx
+++ b/packages/scene-composer/src/components/StateManager.spec.tsx
@@ -30,6 +30,7 @@ import useActiveCamera from '../hooks/useActiveCamera';
 import { COMPOSER_FEATURES, KnownComponentType, SceneComposerInternalConfig } from '..';
 import * as THREE from 'three';
 import { SCENE_CAPABILITY_MATTERPORT } from '../common/constants';
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 
 jest.mock('../hooks/useActiveCamera', () => {
   return jest.fn().mockReturnValue({
@@ -90,7 +91,7 @@ describe('StateManager', () => {
     getSceneInfo,
     updateSceneInfo,
     get3pConnectionList,
-  };
+  } as unknown as TwinMakerSceneMetadataModule;
   const mockDataStreams: DataStream[] = [numberStream, stringStream];
 
   beforeEach(() => {

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -101,6 +101,8 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
   const dataProviderRef = useRef<ProviderWithViewport<TimeSeriesData[]> | undefined>(undefined);
   const prevSelection = useRef<string | undefined>(undefined);
 
+  const convertSceneModalVisible = useStore(sceneComposerId)((state) => !!state.convertSceneModalVisible);
+
   const { setActiveCameraSettings, setActiveCameraName } = useActiveCamera();
 
   const standardUriModifier = useMemo(
@@ -396,6 +398,7 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
     <SceneLayout
       isViewing={isViewing}
       showMessageModal={showMessageModal}
+      showConvertSceneModal={convertSceneModalVisible}
       externalLibraryConfig={updatedExternalLibraryConfig}
       LoadingView={
         <IntlProvider locale={config.locale}>

--- a/packages/scene-composer/src/components/__snapshots__/ConvertSceneModal.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/ConvertSceneModal.spec.tsx.snap
@@ -1,0 +1,305 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConvertSceneModal should call convertAllNodesToEntities and convert scene successfully 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        Convert scene
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Button"
+          data-testid="ok-button"
+        >
+          Ok
+        </div>
+      </div>
+    </div>
+    <div
+      data-mocked="Alert"
+      header="Convert to entities successful"
+      type="success"
+    >
+      All nodes have been converted successfully
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertSceneModal should call prepareWorkspace when converting scene 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c2 {
+  color: !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        Convert scene
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+          direction="horizontal"
+        >
+          <div
+            data-mocked="Button"
+            data-testid="cancel-button"
+          >
+            Cancel
+          </div>
+          <div
+            data-mocked="Button"
+            data-testid="confirm-button"
+            disabled=""
+            variant="primary"
+          >
+            Confirm
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c1"
+      data-mocked="Container"
+      data-testid="progress-container"
+    >
+      <div
+        data-mocked="ProgressBar"
+        label="Converting nodes"
+        status="in-progress"
+        value="0"
+      >
+        <div>
+          <div
+            class="c2"
+            data-mocked="Box"
+          >
+            0 out of 2 converted
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertSceneModal should render with converting scene failure 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        Convert scene
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Button"
+          data-testid="ok-button"
+        >
+          Ok
+        </div>
+      </div>
+    </div>
+    <div
+      data-mocked="Alert"
+      header="Convert to entities failed"
+      type="error"
+    >
+      <div
+        data-mocked="Box"
+      >
+        Some node conversion failed:
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"s\\"}"
+      >
+        failure-node
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertSceneModal should render with correct confirmation view 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        Convert scene
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+          direction="horizontal"
+        >
+          <div
+            data-mocked="Button"
+            data-testid="cancel-button"
+          >
+            Cancel
+          </div>
+          <div
+            data-mocked="Button"
+            data-testid="confirm-button"
+            variant="primary"
+          >
+            Confirm
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-mocked="Alert"
+      header="Converting scene"
+      type="warning"
+    >
+      Proceeding with this action will permanently change your scene. You cannot undo this action
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertSceneModal should render with preparing workspace failure 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        Convert scene
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Button"
+          data-testid="ok-button"
+        >
+          Ok
+        </div>
+      </div>
+    </div>
+    <div
+      data-mocked="Alert"
+      header="Convert to entities failed"
+      type="error"
+    >
+      <div
+        data-mocked="Box"
+      >
+        prepare workspace error
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/__snapshots__/ConvertingProgress.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/ConvertingProgress.spec.tsx.snap
@@ -1,0 +1,112 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConvertingProgress should render with correct progress with 0% done 1`] = `
+.c0 {
+  width: 100%;
+}
+
+.c1 {
+  color: !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+    data-testid="progress-container"
+  >
+    <div
+      data-mocked="ProgressBar"
+      label="Converting nodes"
+      status="in-progress"
+      value="0"
+    >
+      <div>
+        <div
+          class="c1"
+          data-mocked="Box"
+        >
+          0 out of 10 converted
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertingProgress should render with correct progress with all done 1`] = `
+.c0 {
+  width: 100%;
+}
+
+.c1 {
+  color: !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+    data-testid="progress-container"
+  >
+    <div
+      data-mocked="ProgressBar"
+      label="Converting nodes"
+      status="in-progress"
+      value="100"
+    >
+      <div>
+        <div
+          class="c1"
+          data-mocked="Box"
+        >
+          10 out of 10 converted
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertingProgress should render with correct progress with partially done 1`] = `
+.c0 {
+  width: 100%;
+}
+
+.c1 {
+  color: !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+    data-testid="progress-container"
+  >
+    <div
+      data-mocked="ProgressBar"
+      label="Converting nodes"
+      status="in-progress"
+      value="22.22222222222222"
+    >
+      <div>
+        <div
+          class="c1"
+          data-mocked="Box"
+        >
+          2 out of 9 converted
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/__snapshots__/StateManager.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/StateManager.spec.tsx.snap
@@ -10,6 +10,7 @@ exports[`StateManager should render correctly 1`] = `
   externalLibraryConfig={Object {}}
   isViewing={false}
   onPointerMissed={[Function]}
+  showConvertSceneModal={false}
   showMessageModal={true}
 />
 `;
@@ -32,6 +33,7 @@ exports[`StateManager should render correctly with Matterport configuration 1`] 
   }
   isViewing={false}
   onPointerMissed={[Function]}
+  showConvertSceneModal={false}
   showMessageModal={true}
 />
 `;
@@ -45,6 +47,7 @@ exports[`StateManager should render correctly with error in Matterport configura
   }
   isViewing={false}
   onPointerMissed={[Function]}
+  showConvertSceneModal={false}
   showMessageModal={true}
 />
 `;

--- a/packages/scene-composer/src/components/panels/SettingsPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SettingsPanel.tsx
@@ -11,11 +11,13 @@ import { pascalCase } from '../../utils/stringUtils';
 import { getGlobalSettings } from '../../common/GlobalSettings';
 import { Component } from '../../models/SceneModels';
 import { Divider } from '../Divider';
+import useDynamicScene from '../../hooks/useDynamicScene';
 
 import { ExpandableInfoSection } from './CommonPanelComponents';
 import { MatterportIntegration, SceneDataBindingTemplateEditor, SceneTagSettingsEditor } from './scene-settings';
 import { ComponentVisibilityToggle } from './scene-settings/ComponentVisibilityToggle';
 import { OverlayPanelVisibilityToggle } from './scene-settings/OverlayPanelVisibilityToggle';
+import { ConvertSceneSettings } from './scene-settings/ConvertSceneSettings';
 
 export interface SettingsPanelProps {
   valueDataBindingProvider?: IValueDataBindingProvider;
@@ -33,6 +35,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
   const tagResizeEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagResize];
   const matterportEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Matterport];
   const overlayEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Overlay];
+  const dynamicSceneEnabled = useDynamicScene();
 
   const selectedEnvPreset = useStore(sceneComposerId)((state) =>
     state.getSceneProperty<string>(KnownSceneProperty.EnvironmentPreset),
@@ -207,9 +210,21 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
             description: 'ExpandableInfoSection Title',
             defaultMessage: '3rd Party Resources',
           })}
-          defaultExpanded
+          defaultExpanded={false}
         >
           <MatterportIntegration />
+        </ExpandableInfoSection>
+      )}
+
+      {dynamicSceneEnabled && isEditing && (
+        <ExpandableInfoSection
+          title={intl.formatMessage({
+            description: 'ExpandableInfoSection Title',
+            defaultMessage: 'Convert scene',
+          })}
+          defaultExpanded={false}
+        >
+          <ConvertSceneSettings />
         </ExpandableInfoSection>
       )}
     </Fragment>

--- a/packages/scene-composer/src/components/panels/__snapshots__/SettingsPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__snapshots__/SettingsPanel.spec.tsx.snap
@@ -229,6 +229,135 @@ exports[`SettingsPanel contains expected elements. should contains default eleme
 </div>
 `;
 
+exports[`SettingsPanel contains expected elements. should contains settings element for converting scene in editing. 1`] = `
+.c0 {
+  height: 1px;
+  border-width: 0px;
+  background-color: colorBorderDividerDefault;
+}
+
+<div>
+  <div
+    data-mocked="ExpandableInfoSection"
+    title="Current View Settings"
+  >
+    <div
+      data-mocked="FormField"
+    >
+      <div>
+        <div
+          data-mocked="Box"
+          font-weight="bold"
+        >
+          Toggle visibility
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Animation
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
+      <hr
+        class="c0"
+      />
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Motion indicator
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
+      <hr
+        class="c0"
+      />
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Tag
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-mocked="ExpandableInfoSection"
+    title="Scene Settings"
+  >
+    <div
+      data-mocked="SpaceBetween"
+    >
+      <div
+        data-mocked="FormField"
+        label="Environment Preset"
+      >
+        <div
+          data-mocked="Select"
+          options="[{\\"label\\":\\"No Preset\\",\\"value\\":\\"n/a\\"},{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"},{\\"label\\":\\"Directional\\",\\"value\\":\\"directional\\"},{\\"label\\":\\"Chromatic\\",\\"value\\":\\"chromatic\\"}]"
+          placeholder="Choose an environment"
+          selectedarialabel="Selected"
+          selectedoption="{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"}"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    data-mocked="ExpandableInfoSection"
+    title="Convert scene"
+  >
+    <div
+      data-mocked="ConvertSceneSettings"
+    />
+  </div>
+</div>
+`;
+
 exports[`SettingsPanel contains expected elements. should contains settings element for overlay in editing. 1`] = `
 .c0 {
   height: 1px;

--- a/packages/scene-composer/src/components/panels/scene-settings/ConvertSceneSettings.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/ConvertSceneSettings.spec.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+import { useStore } from '../../../store';
+import { staticNodeCount } from '../../../utils/entityModelUtils/sceneUtils';
+
+import { ConvertSceneSettings } from './ConvertSceneSettings';
+
+jest.mock('../../../utils/entityModelUtils/sceneUtils');
+
+describe('ConvertSceneSettings', () => {
+  const setConvertSceneModalVisibility = jest.fn();
+  const baseState = {
+    setConvertSceneModalVisibility,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render correctly with convert button disabled', () => {
+    useStore('default').setState(baseState);
+    (staticNodeCount as jest.Mock).mockReturnValue(0);
+
+    const { container, queryByTestId } = render(<ConvertSceneSettings />);
+
+    expect(queryByTestId('convert-button')?.getAttribute('disabled')).not.toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render correctly with convert button enabled', () => {
+    useStore('default').setState(baseState);
+    (staticNodeCount as jest.Mock).mockReturnValue(1);
+
+    const { container, queryByTestId } = render(<ConvertSceneSettings />);
+
+    expect(queryByTestId('convert-button')?.getAttribute('disabled')).toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should set convert scene modal to visible on convert button click', () => {
+    useStore('default').setState(baseState);
+    (staticNodeCount as jest.Mock).mockReturnValue(1);
+
+    const { queryByTestId } = render(<ConvertSceneSettings />);
+    const button = queryByTestId('convert-button');
+    fireEvent.click(button!);
+
+    expect(setConvertSceneModalVisibility).toBeCalledTimes(1);
+    expect(setConvertSceneModalVisibility).toBeCalledWith(true);
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-settings/ConvertSceneSettings.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/ConvertSceneSettings.tsx
@@ -1,0 +1,37 @@
+import React, { useCallback, useContext } from 'react';
+import { useIntl } from 'react-intl';
+import { Box, Button } from '@awsui/components-react';
+
+import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import { staticNodeCount } from '../../../utils/entityModelUtils/sceneUtils';
+import { useStore } from '../../../store';
+
+export const ConvertSceneSettings: React.FC = () => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const { formatMessage } = useIntl();
+  const document = useStore(sceneComposerId)((state) => state.document);
+
+  const setConvertSceneModalVisibility = useStore(sceneComposerId)((state) => state.setConvertSceneModalVisibility);
+
+  const convertScene = useCallback(() => {
+    setConvertSceneModalVisibility(true);
+  }, [setConvertSceneModalVisibility]);
+
+  return (
+    <>
+      <Box variant='p' fontWeight='bold' margin={{ bottom: 'xxs' }}>
+        {formatMessage({ description: 'Sub-Section Header', defaultMessage: 'Convert to entities' })}
+      </Box>
+      <Box variant='p' margin={{ bottom: 'xxs' }}>
+        {formatMessage({
+          defaultMessage: 'Converting your scene to entities enables auto updating, filtering and querying your scene.',
+          description: 'Sub-Section Description',
+        })}
+      </Box>
+
+      <Button data-testid='convert-button' onClick={convertScene} disabled={staticNodeCount(document.nodeMap) === 0}>
+        {formatMessage({ description: 'Button text', defaultMessage: 'Convert scene' })}
+      </Button>
+    </>
+  );
+};

--- a/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/ConvertSceneSettings.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/ConvertSceneSettings.spec.tsx.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConvertSceneSettings should render correctly with convert button disabled 1`] = `
+<div>
+  <div
+    data-mocked="Box"
+    font-weight="bold"
+    margin="{\\"bottom\\":\\"xxs\\"}"
+    variant="p"
+  >
+    Convert to entities
+  </div>
+  <div
+    data-mocked="Box"
+    margin="{\\"bottom\\":\\"xxs\\"}"
+    variant="p"
+  >
+    Converting your scene to entities enables auto updating, filtering and querying your scene.
+  </div>
+  <div
+    data-mocked="Button"
+    data-testid="convert-button"
+    disabled=""
+  >
+    Convert scene
+  </div>
+</div>
+`;
+
+exports[`ConvertSceneSettings should render correctly with convert button enabled 1`] = `
+<div>
+  <div
+    data-mocked="Box"
+    font-weight="bold"
+    margin="{\\"bottom\\":\\"xxs\\"}"
+    variant="p"
+  >
+    Convert to entities
+  </div>
+  <div
+    data-mocked="Box"
+    margin="{\\"bottom\\":\\"xxs\\"}"
+    variant="p"
+  >
+    Converting your scene to entities enables auto updating, filtering and querying your scene.
+  </div>
+  <div
+    data-mocked="Button"
+    data-testid="convert-button"
+  >
+    Convert scene
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.spec.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.spec.tsx
@@ -28,6 +28,8 @@ jest.mock('../../components/panels/TopBar', () => {
 
 jest.mock('../../hooks/useSelectedNode', () => jest.fn());
 
+jest.mock('../../components/ConvertSceneModal', () => 'ConvertSceneModal');
+
 class ResizeObserver {
   observe = jest.fn();
   unobserve = jest.fn();
@@ -63,13 +65,14 @@ describe('SceneLayout', () => {
   [
     ['Edit mode', { isViewing: false, showMessageModal: false }],
     ['Viewing mode', { isViewing: true, showMessageModal: false }],
-    ['Edit mode with Modal', { isViewing: false, showMessageModal: true }],
-    ['Viewing mode with modal', { isViewing: true, showMessageModal: true }],
+    ['Edit mode with message modal', { isViewing: false, showMessageModal: true }],
+    ['Viewing mode with message modal', { isViewing: true, showMessageModal: true }],
   ].forEach((value) => {
     it(`should render correctly in ${value[0]}`, () => {
       const container = create(
         <SceneLayout
           onPointerMissed={() => {}}
+          showConvertSceneModal={false}
           LoadingView={<div data-test-id='Loading view' />}
           {...(value[1] as { isViewing: boolean; showMessageModal: boolean })}
         />,
@@ -77,6 +80,20 @@ describe('SceneLayout', () => {
 
       expect(container).toMatchSnapshot();
     });
+  });
+
+  it('should render correctly in edit mode with convert scene modal open', () => {
+    const container = create(
+      <SceneLayout
+        onPointerMissed={() => {}}
+        showConvertSceneModal={true}
+        LoadingView={<div data-test-id='Loading view' />}
+        isViewing={false}
+        showMessageModal={false}
+      />,
+    );
+
+    expect(container).toMatchSnapshot();
   });
 
   it('should render camera preview if editing and camera component is on selectedNode', () => {

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
@@ -29,6 +29,7 @@ import { CameraPreview } from '../../components/three-fiber/CameraPreview';
 import useMatterportViewer from '../../hooks/useMatterportViewer';
 import useSelectedNode from '../../hooks/useSelectedNode';
 import { findComponentByType } from '../../utils/nodeUtils';
+import ConvertSceneModal from '../../components/ConvertSceneModal';
 
 import { Direction } from './components/utils';
 import ScenePanel from './components/ScenePanel';
@@ -97,12 +98,14 @@ interface SceneLayoutProps {
   onPointerMissed: (event: ThreeEvent<PointerEvent>) => void;
   LoadingView: ReactNode;
   showMessageModal: boolean;
+  showConvertSceneModal?: boolean;
   externalLibraryConfig?: ExternalLibraryConfig;
 }
 const SceneLayout: FC<SceneLayoutProps> = ({
   isViewing,
   LoadingView = null,
   showMessageModal,
+  showConvertSceneModal,
   externalLibraryConfig,
 }) => {
   const sceneComposerId = useContext(sceneComposerIdContext);
@@ -177,8 +180,8 @@ const SceneLayout: FC<SceneLayoutProps> = ({
           </LogProvider>
         </Fragment>
       }
-      showModal={showMessageModal}
-      modalContent={<MessageModal />}
+      showModal={showMessageModal || (showConvertSceneModal && !isViewing)}
+      modalContent={showConvertSceneModal && !isViewing ? <ConvertSceneModal /> : <MessageModal />}
       header={!isViewing && <MenuBar />}
       leftPanel={isViewing ? viewingModeScenePanel : leftPanel}
       rightPanel={!isViewing && rightPanel}

--- a/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
+++ b/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
@@ -870,7 +870,7 @@ exports[`SceneLayout should render correctly in Edit mode 1`] = `
 </div>
 `;
 
-exports[`SceneLayout should render correctly in Edit mode with Modal 1`] = `
+exports[`SceneLayout should render correctly in Edit mode with message modal 1`] = `
 .c2 {
   width: 600px;
   margin: auto;
@@ -1717,7 +1717,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
 </div>
 `;
 
-exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
+exports[`SceneLayout should render correctly in Viewing mode with message modal 1`] = `
 .c2 {
   width: 600px;
   margin: auto;
@@ -2290,6 +2290,301 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SceneLayout should render correctly in edit mode with convert scene modal open 1`] = `
+.c8 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background-color: colorBackgroundLayoutMain;
+}
+
+.c2 {
+  background-color: colorBackgroundContainerHeader;
+  z-index: 100;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  position: relative;
+  overflow: hidden;
+}
+
+.c5 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  background-color: colorBackgroundContainerContent;
+}
+
+.c7 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  overflow: hidden;
+  padding: 4px;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background-color: rgba(0,0,0,0.7);
+}
+
+.c4 {
+  background-color: colorBackgroundContainerContent;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 99;
+}
+
+.c9 {
+  background-color: colorBackgroundContainerContent;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  height: 100%;
+}
+
+<div
+  className="c0"
+  data-mocked="Box"
+>
+  <div
+    className="c1"
+  >
+    <ConvertSceneModal />
+  </div>
+  <div
+    className="c2"
+    data-mocked="Box"
+  />
+  <div
+    className="c3"
+    data-mocked="Box"
+  >
+    <div
+      className="c4"
+      data-mocked="Box"
+      isFloating={false}
+    >
+      <div
+        className="tm-wrapper-left"
+      >
+        <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneHierarchyPanel />,
+                    "id": "Hierarchy",
+                    "label": "Hierarchy",
+                  },
+                  Object {
+                    "content": <SceneRulesPanel />,
+                    "id": "Rules",
+                    "label": "Rules",
+                  },
+                  Object {
+                    "content": <SettingsPanel />,
+                    "id": "Settings",
+                    "label": "Settings",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
+          className="tm-handle"
+          data-testid="handle"
+          onClick={[Function]}
+        >
+          <div
+            data-mocked="Icon"
+            name="angle-left"
+            size="small"
+            variant="normal"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="c5"
+      data-mocked="Box"
+    >
+      <div
+        className="c6"
+        data-mocked="Box"
+        padding="xxs"
+      >
+        <TopBar />
+      </div>
+      <div
+        className="c7"
+        data-mocked="Box"
+      >
+        <div
+          className="c0"
+          data-mocked="Box"
+        >
+          <div
+            className="c1"
+          >
+            <div
+              className="c8"
+              data-mocked="Container"
+            >
+              <div>
+                <div
+                  data-mocked="Header"
+                  variant="h2"
+                >
+                  Error
+                </div>
+              </div>
+              <div
+                data-mocked="TextContent"
+              >
+                <p>
+                  Cannot convert undefined or null to object
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            className="c3"
+            data-mocked="Box"
+          >
+            <div
+              className="c5"
+              data-mocked="Box"
+            >
+              <div
+                className="c7"
+                data-mocked="Box"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c9"
+      data-mocked="Box"
+    >
+      <div
+        className="tm-wrapper-right"
+      >
+        <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneNodeInspectorPanel />,
+                    "id": "Inspector",
+                    "label": "Inspector",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
+          className="tm-handle"
+          data-testid="handle"
+          onClick={[Function]}
+        >
+          <div
+            data-mocked="Icon"
+            name="angle-right"
+            size="small"
+            variant="normal"
+          />
         </div>
       </div>
     </div>

--- a/packages/scene-composer/src/store/StoreOperations.ts
+++ b/packages/scene-composer/src/store/StoreOperations.ts
@@ -13,6 +13,7 @@ export type SceneComposerEditorOperation =
   | 'setCameraTarget'
   | 'addMessages'
   | 'clearMessages'
+  | 'setConvertSceneModalVisibility'
   | 'setAddingWidget'
   | 'setCursorPosition'
   | 'setCursorLookAt'
@@ -80,6 +81,7 @@ export const SceneComposerOperationTypeMap: Record<SceneComposerOperation, Opera
   setCameraTarget: 'UPDATE_EDITOR',
   addMessages: 'UPDATE_EDITOR',
   clearMessages: 'UPDATE_EDITOR',
+  setConvertSceneModalVisibility: 'UPDATE_EDITOR',
   setAddingWidget: 'UPDATE_EDITOR',
   setCursorPosition: 'UPDATE_EDITOR',
   setCursorLookAt: 'UPDATE_EDITOR',

--- a/packages/scene-composer/src/store/slices/EditorStateSlice.ts
+++ b/packages/scene-composer/src/store/slices/EditorStateSlice.ts
@@ -61,6 +61,9 @@ export interface IEditorStateSlice {
   clearMessages(): void;
   getMessages(): IDisplayMessage[];
 
+  convertSceneModalVisible?: boolean;
+  setConvertSceneModalVisibility(visible: boolean): void;
+
   // Selection and highlights
   selectedSceneNodeRef?: string;
   selectedSceneSubmodelRef?: SubModelRef;
@@ -112,11 +115,9 @@ export interface IEditorStateSlice {
   setMainCameraObject(camera?: THREE.Camera);
 }
 
-function createDefaultEditorState() {
+function createDefaultEditorState(): Partial<IEditorStateSlice> {
   return {
     isLoadingModel: false,
-    isInViewpointTransition: false,
-    isAddingWidget: false,
     messages: [],
     selectedSceneNodeRef: undefined,
     highlightedSceneNodeRef: undefined,
@@ -143,7 +144,11 @@ function createDefaultEditorState() {
   };
 }
 
-export const createEditStateSlice = (set: SetState<RootState>, get: GetState<RootState>, _api: StoreApi<RootState>) =>
+export const createEditStateSlice = (
+  set: SetState<RootState>,
+  get: GetState<RootState>,
+  _api: StoreApi<RootState>,
+): IEditorStateSlice =>
   ({
     ...createDefaultEditorState(),
 
@@ -211,6 +216,13 @@ export const createEditStateSlice = (set: SetState<RootState>, get: GetState<Roo
 
     getMessages() {
       return get().messages;
+    },
+
+    setConvertSceneModalVisibility(visible) {
+      set((draft) => {
+        draft.convertSceneModalVisible = visible;
+        draft.lastOperation = 'setConvertSceneModalVisibility';
+      });
     },
 
     setSelectedSceneNodeRef(nodeRef?: string) {

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
@@ -85,12 +85,14 @@ export const convertAllNodesToEntities = ({
   layerId,
   getObject3DBySceneNodeRef,
   onSuccess,
+  onFailure,
 }: {
   document: ISceneDocumentInternal;
   sceneRootEntityId: string;
   layerId: string;
   getObject3DBySceneNodeRef: (nodeRef: string) => THREE.Object3D | undefined;
   onSuccess?: (node: ISceneNodeInternal) => void;
+  onFailure?: (node: ISceneNodeInternal, error: Error) => void;
 }): void => {
   Object.keys(document.nodeMap).forEach((nodeRef) => {
     const node = document.nodeMap[nodeRef];
@@ -110,9 +112,13 @@ export const convertAllNodesToEntities = ({
         },
       };
 
-      createNodeEntity(worldTransformNode, sceneRootEntityId, layerId)?.then(() => {
-        onSuccess?.(worldTransformNode);
-      });
+      createNodeEntity(worldTransformNode, sceneRootEntityId, layerId)
+        ?.then(() => {
+          onSuccess?.(worldTransformNode);
+        })
+        .catch((error) => {
+          onFailure?.(worldTransformNode, error);
+        });
     }
   });
 };

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -15,6 +15,10 @@
     "note": "Light Type in a dropdown menu",
     "text": "Ambient"
   },
+  "+RIFYb": {
+    "note": "alert body text",
+    "text": "All nodes have been converted successfully"
+  },
   "+SQx9E": {
     "note": "Menu Item label",
     "text": "Add component"
@@ -82,6 +86,10 @@
   "1cVQu5": {
     "note": "label for an input component selecting number of arrows",
     "text": "# of arrows"
+  },
+  "1fLT/q": {
+    "note": "button label",
+    "text": "Cancel"
   },
   "1kXRWn": {
     "note": "Progress Bar status",
@@ -231,6 +239,10 @@
     "note": "Menu Item label",
     "text": "Empty node"
   },
+  "9D+o0B": {
+    "note": "alert body text",
+    "text": "Proceeding with this action will permanently change your scene. You cannot undo this action"
+  },
   "9I3nDM": {
     "note": "Menu Item label",
     "text": "Undo"
@@ -266,6 +278,14 @@
   "B5EPL8": {
     "note": "Menu Item",
     "text": "Add 3D model"
+  },
+  "B6QsMN": {
+    "note": "button label",
+    "text": "Confirm"
+  },
+  "BK/UYP": {
+    "note": "alert header text",
+    "text": "Convert to entities failed"
   },
   "BNscqX": {
     "note": "Default Message for before an animation is selected",
@@ -422,6 +442,10 @@
   "KnEACH": {
     "note": "Hyperlink title",
     "text": "Learn More"
+  },
+  "KoTFFN": {
+    "note": "Button text",
+    "text": "Convert scene"
   },
   "KsFvzR": {
     "note": "Placeholder hint message for searching across entities",
@@ -663,6 +687,10 @@
     "note": "checkbox option",
     "text": "Enable Shadow"
   },
+  "YPkcJC": {
+    "note": "alert header text",
+    "text": "Converting scene"
+  },
   "ZKJ6Ci": {
     "note": "Toolbar label",
     "text": "Delete"
@@ -702,6 +730,10 @@
   "azq+4C": {
     "note": "Form section title",
     "text": "Link Parameters"
+  },
+  "bO1OgH": {
+    "note": "Progress Bar label",
+    "text": "Converting nodes"
   },
   "bVAsrx": {
     "note": "Form Field label",
@@ -750,6 +782,10 @@
   "e9HZHd": {
     "note": "FormField label",
     "text": "Indicator shape"
+  },
+  "eElB3q": {
+    "note": "Sub-Section Description",
+    "text": "Converting your scene to entities enables auto updating, filtering and querying your scene."
   },
   "eKQvAU": {
     "note": "placeholder",
@@ -947,6 +983,10 @@
     "note": "Sub-Section Description",
     "text": "Connecting your Matterport account enables viewing spaces in your TwinMaker scene."
   },
+  "oECZco": {
+    "note": "button label",
+    "text": "Ok"
+  },
   "oEXVJ5": {
     "note": "Motion Indicator Shape in a dropdown menu",
     "text": "Linear Plane"
@@ -975,6 +1015,10 @@
     "note": "Status indicator label",
     "text": "Tags sync failed"
   },
+  "pqZzsr": {
+    "note": "alert header text",
+    "text": "Convert to entities successful"
+  },
   "pyg21P": {
     "note": "Number of Triangles in a scene",
     "text": "Triangles : {sceneInfoTriangles, number}"
@@ -986,6 +1030,10 @@
   "qU9dRt": {
     "note": "Form Field label",
     "text": "Scale"
+  },
+  "qZiKXL": {
+    "note": "ExpandableInfoSection Title",
+    "text": "Convert scene"
   },
   "r0JN3A": {
     "note": "Menu Item",
@@ -1079,6 +1127,10 @@
     "note": "Enter your Matterport model id placeholder",
     "text": "Enter your Matterport model id"
   },
+  "ujFSQs": {
+    "note": "alert body text",
+    "text": "Some node conversion failed:"
+  },
   "v+Dj24": {
     "note": "hex validations messages",
     "text": "Invalid hex code"
@@ -1086,6 +1138,10 @@
   "v+tpx1": {
     "note": "Menu Item label",
     "text": "Light"
+  },
+  "v6Z7tj": {
+    "note": "Progress Bar description",
+    "text": "{convertedNumber} out of {totalNumber} converted"
   },
   "v7BBG+": {
     "note": "Error message wrong input",
@@ -1130,6 +1186,14 @@
   "x8NTqi": {
     "note": "Menu Item",
     "text": "Add empty node"
+  },
+  "xyFy7p": {
+    "note": "modal header text",
+    "text": "Convert scene"
+  },
+  "y9R3yg": {
+    "note": "Sub-Section Header",
+    "text": "Convert to entities"
   },
   "yXdV0F": {
     "note": "ExpandableInfoSection Title",


### PR DESCRIPTION
## Overview
Add convert scene button to settings to convert all static scene nodes into dynamic entities


https://github.com/awslabs/iot-app-kit/assets/9315598/7945637d-00a3-4b21-b1ef-0a6acf5b1133


https://github.com/awslabs/iot-app-kit/assets/9315598/0deb8465-d779-4207-9123-c4921b23d1db


## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
