### PR TITLE
feat: side-panels toggle open hit and tool-tip on mouse-over

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/collapsiblePanel.tsx
+++ b/packages/dashboard/src/components/internalDashboard/collapsiblePanel.tsx
@@ -11,6 +11,7 @@ import Box, { BoxProps } from '@cloudscape-design/components/box';
 import Button from '@cloudscape-design/components/button';
 import { IconProps } from '@cloudscape-design/components/icon';
 import { DEFAULT_COLLAPSED_SIDE_PANE_WIDTH } from '../resizablePanes/constants';
+import Tooltip from '../tooltip/tooltip';
 
 type CollapsiblePanelProps = {
   isPanelCollapsed: boolean;
@@ -63,20 +64,21 @@ export function CollapsiblePanel(props: CollapsiblePanelProps) {
   );
 
   const collapsedPanel = (
-    <div
-      style={{
-        backgroundColor: colorBackgroundButtonPrimaryDefault,
-        margin: spaceContainerHorizontal,
-      }}
-      className='side_panels_collapsed_style'
+    <Tooltip
+      content={borderSide === 'Left' ? 'Configuration' : 'Resource explorer'}
+      position={borderSide === 'Left' ? 'left' : 'right'}
     >
-      <img
-        src={props.icon}
-        alt={props.icon}
+      <div
+        style={{
+          backgroundColor: colorBackgroundButtonPrimaryDefault,
+          margin: spaceContainerHorizontal,
+        }}
+        className='side_panels_collapsed_style'
         onClick={props.onCollapsedPanelClick}
-        data-testid={`collapsed-${props.side}-panel-icon`}
-      />
-    </div>
+      >
+        <img src={props.icon} alt={props.icon} data-testid={`collapsed-${props.side}-panel-icon`} />
+      </div>
+    </Tooltip>
   );
 
   return (

--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -10,6 +10,7 @@
     */
   text-align: initial;
 }
+
 .dashboard * {
   box-sizing: initial;
 }
@@ -75,7 +76,6 @@
 }
 
 .collapsible-panel {
-  overflow: auto;
   position: relative;
 }
 

--- a/packages/dashboard/src/components/tooltip/tooltip.css
+++ b/packages/dashboard/src/components/tooltip/tooltip.css
@@ -1,0 +1,133 @@
+.tooltip-container {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip-text {
+  position: absolute;
+  white-space: nowrap;
+  visibility: hidden;
+  z-index: 9999;
+}
+
+.tooltip-container:hover .tooltip-text {
+  visibility: visible;
+}
+
+.top {
+  bottom: 30%;
+  left: 35%;
+  transform: translateX(-50%) translateY(-100%);
+}
+
+.bottom {
+  top: 90%;
+  left: 50%;
+  transform: translateX(-50%) translateY(0);
+}
+
+.left {
+  top: 50%;
+  left: 10%;
+  transform: translateX(-100%) translateY(-50%);
+}
+
+.right {
+  top: 50%;
+  left: 90%;
+  transform: translateX(0) translateY(-50%);
+}
+
+.tooltip-text::before {
+  content: "";
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 6px;
+  border-color: transparent;
+}
+
+.top::before,
+.top::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+}
+
+.top::before {
+  border-top: 10px solid black;
+}
+
+.top::after {
+  border-top: 10px solid white;
+  margin-top: -2px;
+  z-index: 1;
+}
+
+.tooltip-text.bottom::before,
+.tooltip-text.bottom::after {
+  content: "";
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  border-width: 10px;
+  transform: translateX(-50%);
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+}
+
+.tooltip-text.bottom::before {
+  border-bottom: 10px solid black;
+}
+
+.tooltip-text.bottom::after {
+  border-bottom: 10px solid white;
+  margin-bottom: -2px;
+  z-index: 1;
+}
+
+.left::before,
+.left::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  transform: translateY(-50%);
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+}
+
+.left::before {
+  border-left: 10px solid black;
+}
+
+.left::after {
+  border-left: 10px solid white;
+  margin-left: -2px;
+  z-index: 1;
+}
+
+.right::before,
+.right::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 100%;
+  transform: translateY(-50%);
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+}
+
+.right::before {
+  border-right: 10px solid black;
+}
+
+.right::after {
+  border-right: 10px solid white;
+  margin-right: -2px;
+  z-index: 1;
+}

--- a/packages/dashboard/src/components/tooltip/tooltip.test.tsx
+++ b/packages/dashboard/src/components/tooltip/tooltip.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Tooltip from './tooltip';
+
+describe('Tooltip', () => {
+  it('renders the children correctly', () => {
+    const { getByText } = render(
+      <Tooltip content='Tooltip content' position='top'>
+        {' '}
+        <button>Button</button>{' '}
+      </Tooltip>
+    );
+    expect(getByText('Button')).toBeInTheDocument();
+  });
+
+  it('renders the tooltip content correctly', () => {
+    const { getByText } = render(
+      <Tooltip content='Tooltip content' position='top'>
+        {' '}
+        <button>Button</button>{' '}
+      </Tooltip>
+    );
+    expect(getByText('Tooltip content')).toBeInTheDocument();
+  });
+
+  it('applies the correct position class', () => {
+    const { container } = render(
+      <Tooltip content='Tooltip content' position='top'>
+        {' '}
+        <button>Button</button>{' '}
+      </Tooltip>
+    );
+    expect(container.querySelector('.tooltip-text.top')).toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/components/tooltip/tooltip.tsx
+++ b/packages/dashboard/src/components/tooltip/tooltip.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import './tooltip.css';
+import {
+  colorBackgroundHomeHeader,
+  colorBackgroundLayoutMain,
+  spaceScaledM,
+  spaceStaticS,
+  spaceStaticXs,
+  spaceStaticXxxs,
+} from '@cloudscape-design/design-tokens';
+
+const Tooltip = ({
+  content,
+  position,
+  children,
+}: {
+  content: string;
+  position: 'top' | 'bottom' | 'left' | 'right';
+  children: React.ReactNode;
+}) => {
+  const tooltipStyle = {
+    fontSize: spaceScaledM,
+    color: colorBackgroundHomeHeader,
+    backgroundColor: colorBackgroundLayoutMain,
+    padding: spaceStaticS,
+    borderRadius: spaceStaticXs,
+    border: `${spaceStaticXxxs} solid ${colorBackgroundHomeHeader}`,
+  };
+
+  return (
+    <div className='tooltip-container'>
+      {children}
+      <div className={`tooltip-text ${position}`} style={tooltipStyle}>
+        {content}
+      </div>
+    </div>
+  );
+};
+
+export default Tooltip;


### PR DESCRIPTION
## Overview
This PR is for ticket #2003 and it includes

1. The entire circle button is "hit target" for the "resource explorer" and "config panel" buttons
2. config panel tool tip should say "Configuration"
3. resource explorer tool tip should say "Resource explorer"

https://ibb.co/jwZfhqg

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
