### PR TITLE
fix(composer): split overlay content into parts

### DIFF
--- a/packages/scene-composer/src/common/entityModelConstants.ts
+++ b/packages/scene-composer/src/common/entityModelConstants.ts
@@ -1,5 +1,7 @@
 import { KnownComponentType } from '../interfaces';
 
+export const MAX_PROPERTY_STRING_LENGTH = 256;
+
 // Scene Nodes
 const SCENE_COMPONENT_TYPE_ID_PREFIX = 'com.amazon.iottwinmaker.3d';
 export const NODE_COMPONENT_TYPE_ID = `${SCENE_COMPONENT_TYPE_ID_PREFIX}.node`;

--- a/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.spec.ts
@@ -64,6 +64,52 @@ describe('createOverlayEntityComponent', () => {
     });
   });
 
+  it('should return expected overlay component with data rows having long content', () => {
+    const longContent = new Array(60).fill('0123456789').join('');
+    const result = createOverlayEntityComponent({
+      type: KnownComponentType.DataOverlay,
+      subType: Component.DataOverlaySubType.TextAnnotation,
+      dataRows: [
+        {
+          rowType: Component.DataOverlayRowType.Markdown,
+          content: longContent,
+        },
+      ],
+      valueDataBindings: [],
+    });
+
+    expect(result.properties).toEqual({
+      subType: {
+        value: { stringValue: Component.DataOverlaySubType.TextAnnotation },
+      },
+      dataRows: {
+        value: {
+          listValue: [
+            {
+              mapValue: {
+                rowType: {
+                  stringValue: Component.DataOverlayRowType.Markdown,
+                },
+                content: {
+                  stringValue:
+                    '0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345',
+                },
+                content_1: {
+                  stringValue:
+                    '6789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901',
+                },
+                content_2: {
+                  stringValue:
+                    '2345678901234567890123456789012345678901234567890123456789012345678901234567890123456789',
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it('should return expected tag component with rowBindings', () => {
     const result = createOverlayEntityComponent({
       type: KnownComponentType.DataOverlay,
@@ -181,6 +227,42 @@ describe('parseOverlayComp', () => {
         {
           rowType: Component.DataOverlayRowType.Markdown,
           content: '${abc} def',
+        },
+      ],
+      valueDataBindings: [],
+    });
+  });
+
+  it('should parse to expected overlay component with data rows having long content', () => {
+    const result = parseOverlayComp({
+      componentTypeId: componentTypeToId[KnownComponentType.DataOverlay],
+      properties: [
+        {
+          propertyName: 'subType',
+          propertyValue: Component.DataOverlaySubType.TextAnnotation,
+        },
+        {
+          propertyName: 'dataRows',
+          propertyValue: [
+            {
+              rowType: Component.DataOverlayRowType.Markdown,
+              content: '0123456789',
+              content_1: '0123456789',
+              content_2: '0123456789',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      ref: expect.anything(),
+      type: KnownComponentType.DataOverlay,
+      subType: Component.DataOverlaySubType.TextAnnotation,
+      dataRows: [
+        {
+          rowType: Component.DataOverlayRowType.Markdown,
+          content: '012345678901234567890123456789',
         },
       ],
       valueDataBindings: [],

--- a/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.ts
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash';
 import { DocumentType } from '@aws-sdk/types';
 
 import { IDataOverlayComponent, KnownComponentType } from '../../interfaces';
-import { componentTypeToId } from '../../common/entityModelConstants';
+import { MAX_PROPERTY_STRING_LENGTH, componentTypeToId } from '../../common/entityModelConstants';
 import { Component } from '../../models/SceneModels';
 import { IDataOverlayComponentInternal } from '../../store';
 import { generateUUID } from '../mathUtils';
@@ -31,14 +31,27 @@ export const createOverlayEntityComponent = (overlay: IDataOverlayComponent): Co
       [OverlayComponentProperty.DataRows]: {
         value: {
           listValue: overlay.dataRows.map((r) => {
+            const contents: Record<string, { stringValue: string }> = {};
+            const encodedContent = encodeURI(r.content);
+            // Split the content into multiple parts to avoid the max string length being exceeded
+            for (let index = 0; index < Math.ceil(encodedContent.length / MAX_PROPERTY_STRING_LENGTH); index++) {
+              // the ket for first content part will not have index suffix so existing overlays can continue to work
+              const key =
+                index === 0 ? OverlayComponentProperty.Content : `${OverlayComponentProperty.Content}_${index}`;
+              contents[key] = {
+                stringValue: encodedContent.substring(
+                  index * MAX_PROPERTY_STRING_LENGTH,
+                  Math.min(encodedContent.length, (index + 1) * MAX_PROPERTY_STRING_LENGTH),
+                ),
+              };
+            }
+
             return {
               mapValue: {
                 [OverlayComponentProperty.RowType]: {
                   stringValue: r.rowType,
                 },
-                [OverlayComponentProperty.Content]: {
-                  stringValue: encodeURI(r.content),
-                },
+                ...contents,
               },
             };
           }),
@@ -85,10 +98,18 @@ export const parseOverlayComp = (comp: DocumentType): IDataOverlayComponentInter
     }));
   const rows: Component.DataOverlayMarkdownRow[] = comp['properties']
     .find((p) => p['propertyName'] === OverlayComponentProperty.DataRows)
-    ?.propertyValue?.map((r) => ({
-      content: decodeURI(r[OverlayComponentProperty.Content]),
-      rowType: r[OverlayComponentProperty.RowType],
-    }));
+    ?.propertyValue?.map((r) => {
+      let index = 1;
+      let content = r[OverlayComponentProperty.Content];
+      while (r[`${OverlayComponentProperty.Content}_${index}`]) {
+        content += r[`${OverlayComponentProperty.Content}_${index}`];
+        index++;
+      }
+      return {
+        content: decodeURI(content),
+        rowType: r[OverlayComponentProperty.RowType],
+      };
+    });
 
   const overlayComp: IDataOverlayComponentInternal = {
     ref: generateUUID(),


### PR DESCRIPTION
## Overview
split overlay content into parts to avoid the issue with content over string length limit

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
