### PR TITLE
fix(dashboard): improve widget drag and resize

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, rc ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, rc ]
   schedule:
     - cron: '40 16 * * 4'
 

--- a/packages/dashboard/e2e/tests/utils/grid.ts
+++ b/packages/dashboard/e2e/tests/utils/grid.ts
@@ -1,14 +1,13 @@
 import { Locator, Page } from '@playwright/test';
 
 import { DragPosition, dragAndDrop } from './dragAndDrop';
-import { topCenter } from './mousePosition';
+import { center } from './mousePosition';
 import { BoundingBox, getBoundingBox } from './locator';
 
 export const GRID_SIZE = 10;
 
 const WidgetSelector = '[data-gesture=widget]';
 const SelectionSelector = '[data-gesture=selection]';
-const MoveableSelector = '[data-gesture=moveable]';
 const GridSelector = '#container';
 
 const WidgetSelectorMap = {
@@ -76,11 +75,11 @@ export const gridUtil = (page: Page) => {
       await page.mouse.up({ button: 'left' });
     },
     /**
-     * @param widgetLocator - click the top center of the locator
+     * @param widgetLocator - click the center of the locator
      */
     clickWidget: async (widgetLocator: Locator) => {
       const bounds = await getBoundingBox(widgetLocator);
-      await page.mouse.move(...topCenter(bounds));
+      await page.mouse.move(...center(bounds));
       await page.mouse.down({ button: 'left' });
       await page.mouse.up({ button: 'left' });
     },
@@ -109,7 +108,7 @@ export const gridUtil = (page: Page) => {
      * @param targetPosition - the position offset of the selection to move to
      */
     moveSelection: async (targetPosition: DragPosition) => {
-      const selectionLocator = page.locator(MoveableSelector);
+      const selectionLocator = page.locator(SelectionSelector);
       await dragGenerator(selectionLocator).dragTo(gridArea, {
         targetPosition,
       });

--- a/packages/dashboard/playwright.config.ts
+++ b/packages/dashboard/playwright.config.ts
@@ -54,5 +54,6 @@ export default defineConfig({
     command: 'npm run start',
     reuseExistingServer: true,
     port: 6006,
+    timeout: 300 * 1000, // 5 minutes
   },
 });

--- a/packages/dashboard/src/components/internalDashboard/collapsiblePanel.tsx
+++ b/packages/dashboard/src/components/internalDashboard/collapsiblePanel.tsx
@@ -11,6 +11,7 @@ import Box, { BoxProps } from '@cloudscape-design/components/box';
 import Button from '@cloudscape-design/components/button';
 import { IconProps } from '@cloudscape-design/components/icon';
 import { DEFAULT_COLLAPSED_SIDE_PANE_WIDTH } from '../resizablePanes/constants';
+import Tooltip from '../tooltip/tooltip';
 
 type CollapsiblePanelProps = {
   isPanelCollapsed: boolean;
@@ -63,20 +64,21 @@ export function CollapsiblePanel(props: CollapsiblePanelProps) {
   );
 
   const collapsedPanel = (
-    <div
-      style={{
-        backgroundColor: colorBackgroundButtonPrimaryDefault,
-        margin: spaceContainerHorizontal,
-      }}
-      className='side_panels_collapsed_style'
+    <Tooltip
+      content={borderSide === 'Left' ? 'Configuration' : 'Resource explorer'}
+      position={borderSide === 'Left' ? 'left' : 'right'}
     >
-      <img
-        src={props.icon}
-        alt={props.icon}
+      <div
+        style={{
+          backgroundColor: colorBackgroundButtonPrimaryDefault,
+          margin: spaceContainerHorizontal,
+        }}
+        className='side_panels_collapsed_style'
         onClick={props.onCollapsedPanelClick}
-        data-testid={`collapsed-${props.side}-panel-icon`}
-      />
-    </div>
+      >
+        <img src={props.icon} alt={props.icon} data-testid={`collapsed-${props.side}-panel-icon`} />
+      </div>
+    </Tooltip>
   );
 
   return (

--- a/packages/dashboard/src/components/internalDashboard/gestures/determineTargetGestures.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/determineTargetGestures.ts
@@ -5,7 +5,7 @@ const GESTURE_ATTRIBUTE = 'data-gesture';
 const ANCHOR_ATTRIBUTE = 'data-anchor';
 const ID_ATTRIBUTE = 'data-id';
 
-type GestureAttribute = 'grid' | 'resize' | 'selection' | 'widget' | 'moveable';
+type GestureAttribute = 'grid' | 'resize' | 'selection' | 'widget';
 
 export const idable = (id: string) => ({
   [ID_ATTRIBUTE]: id,

--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -10,6 +10,7 @@
     */
   text-align: initial;
 }
+
 .dashboard * {
   box-sizing: initial;
 }
@@ -75,7 +76,6 @@
 }
 
 .collapsible-panel {
-  overflow: auto;
   position: relative;
 }
 

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/createModeledDataStreamColumnDefinitions.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/createModeledDataStreamColumnDefinitions.ts
@@ -1,10 +1,7 @@
 import type { ModeledDataStream } from '../types';
 import { type TableProps } from '@cloudscape-design/components/table';
-import { useLatestValues } from '../../../useLatestValues';
 
-export function createModeledDataStreamColumnDefinitions(
-  getLatestValue: ReturnType<typeof useLatestValues>['getLatestValue']
-): TableProps<
+export function createModeledDataStreamColumnDefinitions(): TableProps<
   ModeledDataStream & { latestValue?: number | string | boolean; latestValueTime?: number }
 >['columnDefinitions'] {
   return [
@@ -17,14 +14,13 @@ export function createModeledDataStreamColumnDefinitions(
     {
       id: 'latestValue',
       header: 'Latest value',
-      cell: ({ assetId = '', propertyId = '' }) => getLatestValue({ assetId, propertyId } as ModeledDataStream)?.value,
+      cell: ({ latestValue }) => latestValue,
       sortingField: 'latestValue',
     },
     {
       id: 'latestValueTime',
       header: 'Latest value time',
-      cell: ({ assetId = '', propertyId = '' }) =>
-        getLatestValue({ assetId, propertyId } as ModeledDataStream)?.timestamp,
+      cell: ({ latestValueTime }) => latestValueTime,
       sortingField: 'latestValueTime',
     },
     {

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -45,20 +45,31 @@ export function ModeledDataStreamTable({
     client,
   });
 
-  const { items, collectionProps, paginationProps, propertyFilterProps, actions } = useCollection(modeledDataStreams, {
-    propertyFiltering: {
-      filteringProperties: MODELED_DATA_STREAM_TABLE_FILTERING_PROPERTIES,
-    },
-    pagination: { pageSize: preferences.pageSize },
-    selection: {},
-    sorting: {},
-  });
+  const modeledDataStreamsWithLatestValues =
+    modeledDataStreams?.map((item) => ({
+      ...item,
+      latestValue: getLatestValue({ assetId: item.assetId, propertyId: item.propertyId } as ModeledDataStream)?.value,
+      latestValueTime: getLatestValue({ assetId: item.assetId, propertyId: item.propertyId } as ModeledDataStream)
+        ?.timestamp,
+    })) ?? [];
+
+  const { items, collectionProps, paginationProps, propertyFilterProps, actions } = useCollection(
+    modeledDataStreamsWithLatestValues,
+    {
+      propertyFiltering: {
+        filteringProperties: MODELED_DATA_STREAM_TABLE_FILTERING_PROPERTIES,
+      },
+      pagination: { pageSize: preferences.pageSize },
+      selection: { keepSelection: true, trackBy: 'name' },
+      sorting: {},
+    }
+  );
 
   return (
     <Table
       {...collectionProps}
       items={items}
-      columnDefinitions={createModeledDataStreamColumnDefinitions(getLatestValue)}
+      columnDefinitions={createModeledDataStreamColumnDefinitions()}
       trackBy={(item) => `${item.assetId}---${item.propertyId}`}
       variant='embedded'
       loading={isLoading}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 import Box from '@cloudscape-design/components/box';
@@ -8,7 +9,6 @@ import Pagination from '@cloudscape-design/components/pagination';
 import PropertyFilter from '@cloudscape-design/components/property-filter';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import Table from '@cloudscape-design/components/table';
-import React from 'react';
 
 import type { UnmodeledDataStream } from '../types';
 import { useExplorerPreferences } from '../../useExplorerPreferences';
@@ -42,8 +42,15 @@ export function UnmodeledDataStreamTable({
     client,
   });
 
+  const unmodeledDataStreamsWithLatestValues =
+    unmodeledDataStreams?.map((item) => ({
+      ...item,
+      latestValue: getLatestValue(item)?.value,
+      latestValueTime: getLatestValue(item)?.timestamp,
+    })) ?? [];
+
   const { items, collectionProps, paginationProps, propertyFilterProps, actions } = useCollection(
-    unmodeledDataStreams,
+    unmodeledDataStreamsWithLatestValues,
     {
       propertyFiltering: {
         filteringProperties: [
@@ -74,7 +81,7 @@ export function UnmodeledDataStreamTable({
         ],
       },
       pagination: { pageSize: preferences.pageSize },
-      selection: {},
+      selection: { keepSelection: true, trackBy: 'propertyAlias' },
       sorting: {},
     }
   );
@@ -122,13 +129,13 @@ export function UnmodeledDataStreamTable({
         {
           id: 'latestValue',
           header: 'Latest value',
-          cell: (unmodeledDataStream) => getLatestValue(unmodeledDataStream)?.value,
+          cell: ({ latestValue }) => latestValue,
           sortingField: 'latestValue',
         },
         {
           id: 'latestValueTime',
           header: 'Latest value time',
-          cell: (unmodeledDataStream) => getLatestValue(unmodeledDataStream)?.timestamp,
+          cell: ({ latestValueTime }) => latestValueTime,
           sortingField: 'latestValueTime',
         },
         {

--- a/packages/dashboard/src/components/tooltip/tooltip.css
+++ b/packages/dashboard/src/components/tooltip/tooltip.css
@@ -1,0 +1,133 @@
+.tooltip-container {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip-text {
+  position: absolute;
+  white-space: nowrap;
+  visibility: hidden;
+  z-index: 9999;
+}
+
+.tooltip-container:hover .tooltip-text {
+  visibility: visible;
+}
+
+.top {
+  bottom: 30%;
+  left: 35%;
+  transform: translateX(-50%) translateY(-100%);
+}
+
+.bottom {
+  top: 90%;
+  left: 50%;
+  transform: translateX(-50%) translateY(0);
+}
+
+.left {
+  top: 50%;
+  left: 10%;
+  transform: translateX(-100%) translateY(-50%);
+}
+
+.right {
+  top: 50%;
+  left: 90%;
+  transform: translateX(0) translateY(-50%);
+}
+
+.tooltip-text::before {
+  content: "";
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 6px;
+  border-color: transparent;
+}
+
+.top::before,
+.top::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+}
+
+.top::before {
+  border-top: 10px solid black;
+}
+
+.top::after {
+  border-top: 10px solid white;
+  margin-top: -2px;
+  z-index: 1;
+}
+
+.tooltip-text.bottom::before,
+.tooltip-text.bottom::after {
+  content: "";
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  border-width: 10px;
+  transform: translateX(-50%);
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+}
+
+.tooltip-text.bottom::before {
+  border-bottom: 10px solid black;
+}
+
+.tooltip-text.bottom::after {
+  border-bottom: 10px solid white;
+  margin-bottom: -2px;
+  z-index: 1;
+}
+
+.left::before,
+.left::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  transform: translateY(-50%);
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+}
+
+.left::before {
+  border-left: 10px solid black;
+}
+
+.left::after {
+  border-left: 10px solid white;
+  margin-left: -2px;
+  z-index: 1;
+}
+
+.right::before,
+.right::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 100%;
+  transform: translateY(-50%);
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+}
+
+.right::before {
+  border-right: 10px solid black;
+}
+
+.right::after {
+  border-right: 10px solid white;
+  margin-right: -2px;
+  z-index: 1;
+}

--- a/packages/dashboard/src/components/tooltip/tooltip.test.tsx
+++ b/packages/dashboard/src/components/tooltip/tooltip.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Tooltip from './tooltip';
+
+describe('Tooltip', () => {
+  it('renders the children correctly', () => {
+    const { getByText } = render(
+      <Tooltip content='Tooltip content' position='top'>
+        {' '}
+        <button>Button</button>{' '}
+      </Tooltip>
+    );
+    expect(getByText('Button')).toBeInTheDocument();
+  });
+
+  it('renders the tooltip content correctly', () => {
+    const { getByText } = render(
+      <Tooltip content='Tooltip content' position='top'>
+        {' '}
+        <button>Button</button>{' '}
+      </Tooltip>
+    );
+    expect(getByText('Tooltip content')).toBeInTheDocument();
+  });
+
+  it('applies the correct position class', () => {
+    const { container } = render(
+      <Tooltip content='Tooltip content' position='top'>
+        {' '}
+        <button>Button</button>{' '}
+      </Tooltip>
+    );
+    expect(container.querySelector('.tooltip-text.top')).toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/components/tooltip/tooltip.tsx
+++ b/packages/dashboard/src/components/tooltip/tooltip.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import './tooltip.css';
+import {
+  colorBackgroundHomeHeader,
+  colorBackgroundLayoutMain,
+  spaceScaledM,
+  spaceStaticS,
+  spaceStaticXs,
+  spaceStaticXxxs,
+} from '@cloudscape-design/design-tokens';
+
+const Tooltip = ({
+  content,
+  position,
+  children,
+}: {
+  content: string;
+  position: 'top' | 'bottom' | 'left' | 'right';
+  children: React.ReactNode;
+}) => {
+  const tooltipStyle = {
+    fontSize: spaceScaledM,
+    color: colorBackgroundHomeHeader,
+    backgroundColor: colorBackgroundLayoutMain,
+    padding: spaceStaticS,
+    borderRadius: spaceStaticXs,
+    border: `${spaceStaticXxxs} solid ${colorBackgroundHomeHeader}`,
+  };
+
+  return (
+    <div className='tooltip-container'>
+      {children}
+      <div className={`tooltip-text ${position}`} style={tooltipStyle}>
+        {content}
+      </div>
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, SyntheticEvent, useState } from 'react';
+import React, { PropsWithChildren, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import Box from '@cloudscape-design/components/box';
@@ -21,7 +21,6 @@ import { DashboardState } from '~/store/state';
 
 import './tile.css';
 import { onChangeDashboardGridEnabledAction } from '~/store/actions';
-import { gestureable } from '~/components/internalDashboard/gestures/determineTargetGestures';
 
 type DeletableTileActionProps = {
   handleDelete: CancelableEventHandler<ClickDetail>;
@@ -58,14 +57,6 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
 
   const isRemoveable = !isReadOnly && removeable;
   const headerVisible = !isReadOnly || title;
-
-  const disableGridMovement = (_event: SyntheticEvent) => {
-    dispatch(onChangeDashboardGridEnabledAction({ enabled: false }));
-  };
-
-  const enableGridMovement = (_event: SyntheticEvent) => {
-    dispatch(onChangeDashboardGridEnabledAction({ enabled: true }));
-  };
 
   const handleDelete: CancelableEventHandler<ClickDetail> = (e) => {
     e.preventDefault();
@@ -104,7 +95,6 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
             padding: `${spaceScaledXs} ${spaceScaledXs} ${spaceScaledXxs} ${spaceScaledM}`,
             borderBottom: `2px solid ${colorBorderDividerDefault}`,
           }}
-          {...gestureable('moveable')}
         >
           <Box variant='h1' fontSize='body-m'>
             {title}
@@ -134,9 +124,7 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
           </SpaceBetween>
         </div>
       )}
-      <div className='widget-tile-body' onPointerEnter={disableGridMovement} onPointerLeave={enableGridMovement}>
-        {children}
-      </div>
+      <div className='widget-tile-body'>{children}</div>
     </div>
   );
 };

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
@@ -30,6 +30,11 @@ import {
 } from '~/customization/propertiesSections/propertiesAndAlarmsSettings/icons';
 import { ClickDetail, NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 
+const numberOrUndefined = (number: string) => {
+  const parsed = Number(number);
+  return isNaN(parsed) || number.length === 0 ? undefined : parsed;
+};
+
 const YAxisPropertyConfig = ({
   resetStyles,
   property,
@@ -76,7 +81,7 @@ const YAxisPropertyConfig = ({
                 controlId='y-axis-min'
                 value={`${property.yAxis?.yMin ?? ''}`}
                 type='number'
-                onChange={({ detail }) => onUpdateYAxis({ ...property.yAxis, yMin: parseInt(detail.value) })}
+                onChange={({ detail }) => onUpdateYAxis({ ...property.yAxis, yMin: numberOrUndefined(detail.value) })}
               />
             </SpaceBetween>
             <SpaceBetween size='s' direction='horizontal'>
@@ -87,7 +92,7 @@ const YAxisPropertyConfig = ({
                 controlId='y-axis-max'
                 value={`${property.yAxis?.yMax ?? ''}`}
                 type='number'
-                onChange={({ detail }) => onUpdateYAxis({ ...property.yAxis, yMax: parseInt(detail.value) })}
+                onChange={({ detail }) => onUpdateYAxis({ ...property.yAxis, yMax: numberOrUndefined(detail.value) })}
               />
             </SpaceBetween>
           </SpaceBetween>

--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -88,7 +88,7 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
 
   const viewportInMs = useViewportToMS(utilizedViewport);
 
-  const xAxis = getXAxis(options.axis);
+  const xAxis = getXAxis(viewportInMs, options.axis);
 
   // this will handle all the Trend Cursors operations
   const { onContextMenuClickHandler, trendCursors, hotKeyHandlers } = useTrendCursors({
@@ -112,7 +112,6 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
   const convertedOptions = useConvertedOptions({
     series,
     options,
-    shouldShowYAxisLegend,
   });
 
   // determine the set option settings
@@ -145,6 +144,7 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
         width={chartWidth}
         onResize={onResize}
         axis='x'
+        handle={<span className='react-resizable-handle react-resizable-handle-se' data-gesture='resize' />}
         minConstraints={minConstraints}
         maxConstraints={maxConstraints}
         onResizeStart={(e) => e.stopPropagation()}

--- a/packages/react-components/src/components/chart/converters/convertGrid.ts
+++ b/packages/react-components/src/components/chart/converters/convertGrid.ts
@@ -6,19 +6,12 @@ const unsetGutter = {
   top: DEFAULT_MARGIN,
 };
 
-export const convertGrid = (legend: ChartOptions['legend'], shouldShowYAxisLegend: boolean) => {
+export const convertGrid = (legend: ChartOptions['legend']) => {
   const legendPosition = legend?.position ?? 'bottom';
-
-  const multiYAxisPadding = shouldShowYAxisLegend
-    ? {
-        left: 5,
-      }
-    : {};
 
   return {
     ...DEFAULT_GRID,
     ...unsetGutter,
-    ...multiYAxisPadding,
     [legendPosition]: DEFAULT_MARGIN,
   };
 };

--- a/packages/react-components/src/components/chart/converters/convertOptions.ts
+++ b/packages/react-components/src/components/chart/converters/convertOptions.ts
@@ -19,11 +19,9 @@ type ConvertChartOptions = Pick<
 export const useConvertedOptions = ({
   series,
   options,
-  shouldShowYAxisLegend,
 }: {
   options: ConvertChartOptions;
   series: SeriesOption[];
-  shouldShowYAxisLegend: boolean;
 }): EChartsOption => {
   const { backgroundColor, significantDigits, titleText } = options;
   const text = series.length === 0 ? 'No data present' : titleText ?? '';
@@ -37,9 +35,9 @@ export const useConvertedOptions = ({
         top: 10,
       },
       backgroundColor,
-      grid: convertGrid(options.legend, shouldShowYAxisLegend),
+      grid: convertGrid(options.legend),
       tooltip: convertTooltip(significantDigits),
     }),
-    [backgroundColor, significantDigits, text, options.legend, shouldShowYAxisLegend]
+    [backgroundColor, significantDigits, text, options.legend]
   );
 };

--- a/packages/react-components/src/components/chart/converters/convertSeriesAndYAxis.ts
+++ b/packages/react-components/src/components/chart/converters/convertSeriesAndYAxis.ts
@@ -16,7 +16,7 @@ import { padYAxis, validateValue } from './padYAxis';
 
 const yAxisLegendGenerator =
   (options: Pick<YAxisLegendOption, 'datastream' | 'color' | 'significantDigits'>) =>
-  (value: DataPoint): YAxisLegendOption => ({ ...options, value });
+  (value?: DataPoint): YAxisLegendOption => ({ ...options, value });
 
 export const dataValue = (point: DataPoint) => point.y;
 
@@ -133,8 +133,8 @@ export const convertSeriesAndYAxis = (styles: ChartStyleSettingsWithDefaults) =>
   return {
     series,
     yAxis,
-    yMin: yMin && toYAxisLegend(yMin),
-    yMax: yMax && toYAxisLegend(yMax),
+    yMin: toYAxisLegend(yMin),
+    yMax: toYAxisLegend(yMax),
   };
 };
 
@@ -175,11 +175,11 @@ export const reduceSeriesAndYAxis = (
     yAxis: yAxis ? [...acc.yAxis, yAxis] : [...acc.yAxis],
     yMins:
       yAxis && yMin
-        ? [...acc.yMins, { ...yMin, value: { x: 0, y: (yAxis.min as number) ?? yMin.value.y } }]
+        ? [...acc.yMins, { ...yMin, value: yAxis.min ? { x: 0, y: yAxis.min as number } : yMin.value }]
         : [...acc.yMins],
     yMaxs:
       yAxis && yMax
-        ? [...acc.yMaxs, { ...yMax, value: { x: 0, y: (yAxis.max as number) ?? yMax.value.y } }]
+        ? [...acc.yMaxs, { ...yMax, value: yAxis.max ? { x: 0, y: yAxis.max as number } : yMax.value }]
         : [...acc.yMaxs],
   };
 };

--- a/packages/react-components/src/components/chart/converters/converters.spec.ts
+++ b/packages/react-components/src/components/chart/converters/converters.spec.ts
@@ -90,11 +90,11 @@ describe('testing converters', () => {
   });
 
   it('converts grid to echarts grid', async () => {
-    const convertedGrid = convertGrid(MOCK_LEGEND, false);
+    const convertedGrid = convertGrid(MOCK_LEGEND);
 
     expect(convertedGrid).toHaveProperty('bottom', 50);
     expect(convertedGrid).toHaveProperty('top', 50);
-    expect(convertedGrid).toHaveProperty('containLabel', false);
+    expect(convertedGrid).toHaveProperty('containLabel');
   });
 
   it('converts legend to echarts legend', async () => {
@@ -110,7 +110,6 @@ describe('testing converters', () => {
       useConvertedOptions({
         options: { backgroundColor: 'white', axis: MOCK_AXIS, legend: MOCK_LEGEND, significantDigits: 2 },
         series: [],
-        shouldShowYAxisLegend: false,
       })
     );
 

--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -90,7 +90,7 @@ export const CHART_RESIZE_MIN_FACTOR = 0.3;
 // this is an arbitrary value, so that user can almost "close" the legend section if they want to
 export const CHART_RESIZE_MAX_FACTOR = 0.85;
 
-export const MULTI_Y_AXIS_LEGEND_WIDTH = 128;
+export const MULTI_Y_AXIS_LEGEND_WIDTH = 170;
 
 // style constants
 export const EMPHASIZE_SCALE_CONSTANT = 2;

--- a/packages/react-components/src/components/chart/legend/multiYAxis.tsx
+++ b/packages/react-components/src/components/chart/legend/multiYAxis.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 
+import { spaceScaledXs } from '@cloudscape-design/design-tokens';
+
 import { YAxisLegend } from './yAxisMenu';
-import { MULTI_Y_AXIS_LEGEND_WIDTH } from '../eChartsConstants';
+import { DEFAULT_MARGIN, MULTI_Y_AXIS_LEGEND_WIDTH } from '../eChartsConstants';
+import { YAxisLegendOption } from '../types';
 
 import './multiYAxis.css';
-import { YAxisLegendOption } from '../types';
 
 type MultiYAxisLegendOptions = {
   height: number;
@@ -19,9 +21,18 @@ type MultiYAxisLegendOptions = {
  *  yMax: list of YAxisLegendOption for the max values of a datastream with a custom yAxis
  */
 export const MultiYAxisLegend = ({ height, yMax, yMin }: MultiYAxisLegendOptions) => {
-  const maxHeight = height / 2;
+  const marginHeight = DEFAULT_MARGIN * 2;
+  const maxHeight = (height - marginHeight) / 2;
   return (
-    <div className='multi-y-axis-legend' style={{ width: MULTI_Y_AXIS_LEGEND_WIDTH, paddingBottom: '4px' }}>
+    <div
+      className='multi-y-axis-legend'
+      style={{
+        width: MULTI_Y_AXIS_LEGEND_WIDTH,
+        paddingLeft: spaceScaledXs,
+        paddingTop: DEFAULT_MARGIN,
+        paddingBottom: DEFAULT_MARGIN,
+      }}
+    >
       <YAxisLegend maxHeight={maxHeight} label='Y-Max' axes={yMax} />
       <YAxisLegend maxHeight={maxHeight} label='Y-Min' axes={yMin} menuPosition='top' />
     </div>

--- a/packages/react-components/src/components/chart/legend/yAxisMenu.css
+++ b/packages/react-components/src/components/chart/legend/yAxisMenu.css
@@ -1,9 +1,15 @@
 .axis-menu {
-  box-sizing: border-box;
+  /* important required because dashboard styles override it */
+  box-sizing: border-box !important;
   overflow-y: auto;
+}
+
+.axis-menu-option {
+  gap: 8px;
 }
 
 .axis-menu-option-value {
   text-overflow: ellipsis;
   overflow: hidden;
+  font-size: 14px;
 }

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -175,4 +175,4 @@ export interface ondragUpdateTrendCursorElementsProps {
   timeInMs: number;
 }
 
-export type YAxisLegendOption = { datastream: DataStream; value: DataPoint; color: string; significantDigits: number };
+export type YAxisLegendOption = { datastream: DataStream; value?: DataPoint; color: string; significantDigits: number };

--- a/packages/react-components/src/components/chart/utils/getXAxis.ts
+++ b/packages/react-components/src/components/chart/utils/getXAxis.ts
@@ -1,8 +1,8 @@
-import { ChartAxisOptions } from '../types';
+import { ChartAxisOptions, ViewportInMs } from '../types';
 import { DEFAULT_X_AXIS, DEFAULT_X_AXIS_ID } from '../eChartsConstants';
 import { XAXisOption } from 'echarts/types/dist/shared';
 
-export function getXAxis(axis?: ChartAxisOptions): XAXisOption {
+export const getXAxis = (viewportInMs: ViewportInMs, axis?: ChartAxisOptions): XAXisOption => {
   return {
     id: DEFAULT_X_AXIS_ID,
     show: axis?.showX ?? DEFAULT_X_AXIS.show,
@@ -19,6 +19,6 @@ export function getXAxis(axis?: ChartAxisOptions): XAXisOption {
     },
     splitNumber: 6,
     min: 0,
-    max: Date.now(),
+    max: viewportInMs.isDurationViewport ? viewportInMs.end : undefined,
   };
-}
+};

--- a/packages/react-components/src/components/menu/menu.css
+++ b/packages/react-components/src/components/menu/menu.css
@@ -3,7 +3,7 @@
     adding hardcoded shadow because cloudscape does not
     have drop shadow tokens
   */
-  box-shadow: rgb(0 7 22 / 10%) 0 4px 20px 1px;
+  box-shadow: 0 4px 20px 0 rgb(0 7 22 / 12%);
 }
 
 .menu-placement {

--- a/packages/react-components/src/components/menu/option.tsx
+++ b/packages/react-components/src/components/menu/option.tsx
@@ -23,6 +23,8 @@ export type MenuOptionProps = {
   disabled?: boolean;
   label?: string;
   classNames?: string;
+  styles?: React.CSSProperties;
+  highlighted?: boolean;
   iconStart?: () => React.ReactElement | React.ReactNode;
   iconEnd?: () => React.ReactElement | React.ReactNode;
   onPointerEnter?: (e: React.PointerEvent) => void;
@@ -45,7 +47,9 @@ export const MenuOption: React.FC<PropsWithChildren<MenuOptionProps>> = ({
   disabled,
   label,
   classNames,
+  styles,
   children,
+  highlighted,
   iconStart,
   iconEnd,
   onPointerEnter,
@@ -72,7 +76,7 @@ export const MenuOption: React.FC<PropsWithChildren<MenuOptionProps>> = ({
     else if (onClick && isPointerEvent(e)) onClick(e);
   };
 
-  const hoverStyle = hover && {
+  const hoverStyle = (hover || highlighted) && {
     backgroundColor: colorBackgroundDropdownItemHover,
     boxShadow: `0 0 0 ${spaceScaledXxxs} ${colorBorderControlDefault}`,
   };
@@ -92,6 +96,7 @@ export const MenuOption: React.FC<PropsWithChildren<MenuOptionProps>> = ({
         lineHeight: spaceScaledL,
         borderRadius,
         borderBottom: `1px solid ${colorBorderDividerDefault}`,
+        ...styles,
       }}
       className={`menu-option ${classNames}`}
       onPointerEnter={handlePointerEnter}

--- a/packages/react-components/src/hooks/useECharts/useResizeableEChart.ts
+++ b/packages/react-components/src/hooks/useECharts/useResizeableEChart.ts
@@ -8,7 +8,9 @@ import {
 import { ResizeCallbackData } from 'react-resizable';
 import { useMeasure } from 'react-use';
 
-const getChartWidth = (width: number) => width * CHART_RESIZE_INITIAL_FACTOR;
+const getChartWidth = (width: number, staticWidth: number) => {
+  return width * CHART_RESIZE_INITIAL_FACTOR - staticWidth;
+};
 
 /**
  * hook to set up the size of an echarts instance within the base chart component
@@ -31,7 +33,9 @@ export const useResizeableEChart = (
 ) => {
   const { width, height } = size;
   const [leftLegendRef, { width: leftLegendWidth }] = useMeasure<HTMLDivElement>();
-  const [chartWidth, setWidth] = useState(getChartWidth(width));
+  const [chartWidth, setWidth] = useState(getChartWidth(width, leftLegendWidth));
+
+  const rightLegendWidth = useMemo(() => width - leftLegendWidth - chartWidth, [width, leftLegendWidth, chartWidth]);
 
   const onResize = (_event: SyntheticEvent, data: ResizeCallbackData) => {
     _event.stopPropagation();
@@ -39,7 +43,7 @@ export const useResizeableEChart = (
   };
 
   useEffect(() => {
-    setWidth(getChartWidth(width));
+    setWidth(getChartWidth(width, leftLegendWidth));
   }, [width, leftLegendWidth]);
 
   useEffect(() => {
@@ -59,7 +63,7 @@ export const useResizeableEChart = (
     height,
     chartWidth,
     leftLegendWidth,
-    rightLegendWidth: width - leftLegendWidth - chartWidth,
+    rightLegendWidth,
     onResize,
     minConstraints,
     maxConstraints,

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -4,7 +4,7 @@
  * carefully consider what should be part of the public API. Attempt to minimize the overall API surface area.
  */
 
-export { VideoPlayer } from './components/video-player';
+export { RequestVideoUpload, VideoPlayer } from './components/video-player';
 export { ResourceExplorer } from './components';
 export { Table } from './components/table';
 export { LineChart } from './components/line-chart';

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -46,7 +46,7 @@
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --index-template tools/index-template.js -- src/assets/icons/",
     "release": "run-s compile copy-assets",
     "copy-assets": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" dist/",
-    "lint": "eslint . --max-warnings=567",
+    "lint": "eslint . --max-warnings=510",
     "fix": "eslint --fix .",
     "test": "jest --config jest.config.ts --coverage --silent",
     "test:dev": "jest --config jest.config.ts --coverage",

--- a/packages/scene-composer/src/components/ConvertSceneModal.spec.tsx
+++ b/packages/scene-composer/src/components/ConvertSceneModal.spec.tsx
@@ -1,0 +1,287 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import flushPromises from 'flush-promises';
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
+
+import { useStore } from '../store';
+import {
+  checkIfEntityAvailable,
+  convertAllNodesToEntities,
+  createSceneRootEntity,
+  prepareWorkspace,
+  staticNodeCount,
+} from '../utils/entityModelUtils/sceneUtils';
+import { createLayer } from '../utils/entityModelUtils/sceneLayerUtils';
+import { KnownSceneProperty } from '../interfaces';
+import { setTwinMakerSceneMetadataModule } from '../common/GlobalSettings';
+import { LayerType } from '../common/entityModelConstants';
+import { defaultNode } from '../../__mocks__/sceneNode';
+
+import ConvertSceneModal from './ConvertSceneModal';
+
+jest.mock('../utils/entityModelUtils/sceneLayerUtils', () => ({
+  createLayer: jest.fn(),
+}));
+
+jest.mock('../utils/entityModelUtils/sceneUtils', () => ({
+  createSceneRootEntity: jest.fn(),
+  prepareWorkspace: jest.fn(),
+  checkIfEntityAvailable: jest.fn(),
+  staticNodeCount: jest.fn(),
+  convertAllNodesToEntities: jest.fn(),
+}));
+
+describe('ConvertSceneModal', () => {
+  const setConvertSceneModalVisibility = jest.fn();
+  const setSceneProperty = jest.fn();
+  const updateSceneNodeInternal = jest.fn();
+  const getObject3DBySceneNodeRef = jest.fn();
+  const getSceneProperty = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useStore('default').setState({
+      setConvertSceneModalVisibility,
+      setSceneProperty,
+      updateSceneNodeInternal,
+      getObject3DBySceneNodeRef,
+      getSceneProperty,
+    });
+    (createLayer as jest.Mock).mockImplementation((name, _) => {
+      return Promise.resolve({ entityId: name });
+    });
+    (createSceneRootEntity as jest.Mock).mockImplementation(() => {
+      return Promise.resolve({ entityId: 'scene-root-id' });
+    });
+    (prepareWorkspace as jest.Mock).mockResolvedValue(undefined);
+
+    getSceneProperty.mockImplementation((p) => {
+      if (p == KnownSceneProperty.LayerIds) {
+        return ['layer-id'];
+      } else if (p == KnownSceneProperty.SceneRootEntityId) {
+        return 'scene-root-id';
+      } else {
+        return undefined;
+      }
+    });
+
+    (checkIfEntityAvailable as jest.Mock).mockReturnValue(true);
+    (staticNodeCount as jest.Mock).mockReturnValue(2);
+
+    setTwinMakerSceneMetadataModule({
+      getSceneId: jest.fn().mockReturnValue('test-scene'),
+    } as Partial<TwinMakerSceneMetadataModule> as TwinMakerSceneMetadataModule);
+  });
+
+  it('should render with correct confirmation view', () => {
+    const { container, queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    const cancelButton = queryByTestId('cancel-button');
+
+    expect(confirmButton).toBeTruthy();
+    expect(cancelButton).toBeTruthy();
+    expect(container).toMatchSnapshot();
+
+    act(() => {
+      cancelButton!.click();
+    });
+
+    expect(setConvertSceneModalVisibility).toBeCalledWith(false);
+  });
+
+  it('should call prepareWorkspace when converting scene', async () => {
+    const { container, queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+    expect(container).toMatchSnapshot();
+    expect(queryByTestId('confirm-button')?.getAttribute('disabled')).not.toBeNull();
+
+    expect(prepareWorkspace).toBeCalledTimes(1);
+    expect(createLayer as jest.Mock).not.toBeCalled();
+    expect(createSceneRootEntity as jest.Mock).not.toBeCalled();
+    expect(setSceneProperty).not.toBeCalled();
+  });
+
+  it('should create a default layer and root entity when none available', async () => {
+    getSceneProperty.mockReturnValue(undefined);
+    const { queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(createLayer as jest.Mock).toBeCalledTimes(1);
+    expect(createLayer as jest.Mock).toBeCalledWith('test-scene_Default', LayerType.Relationship);
+    expect(createSceneRootEntity as jest.Mock).toBeCalledTimes(1);
+    expect(setSceneProperty).toBeCalledTimes(2);
+    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.LayerIds, ['test-scene_Default']);
+    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.SceneRootEntityId, 'scene-root-id');
+  });
+
+  it('should create a default layer entity when it does not exist', async () => {
+    (checkIfEntityAvailable as jest.Mock).mockImplementation((entityId) => {
+      if (entityId == 'layer-id') {
+        return Promise.resolve(false);
+      }
+      return Promise.resolve(true);
+    });
+
+    const { queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(createLayer as jest.Mock).toBeCalledTimes(1);
+    expect(createLayer as jest.Mock).toBeCalledWith('test-scene_Default', LayerType.Relationship);
+    expect(createSceneRootEntity as jest.Mock).not.toBeCalled();
+    expect(setSceneProperty).toBeCalledTimes(1);
+    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.LayerIds, ['test-scene_Default']);
+  });
+
+  it('should create a default scene entity when it does not exist', async () => {
+    (checkIfEntityAvailable as jest.Mock).mockImplementation((entityId) => {
+      if (entityId == 'scene-root-id') {
+        return Promise.resolve(false);
+      }
+      return Promise.resolve(true);
+    });
+
+    const { queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(createLayer as jest.Mock).not.toBeCalled();
+    expect(createSceneRootEntity as jest.Mock).toBeCalledTimes(1);
+    expect(setSceneProperty).toBeCalledTimes(1);
+    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.SceneRootEntityId, 'scene-root-id');
+  });
+
+  it('should call convertAllNodesToEntities and convert scene successfully', async () => {
+    (convertAllNodesToEntities as jest.Mock).mockImplementation(({ onSuccess }) => {
+      act(() => {
+        onSuccess({ ...defaultNode, ref: 'success-1' });
+        onSuccess({ ...defaultNode, ref: 'success-2' });
+      });
+    });
+
+    const { rerender, container, queryByTestId } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(convertAllNodesToEntities).toBeCalledTimes(1);
+    expect(updateSceneNodeInternal).toBeCalledTimes(2);
+    expect(updateSceneNodeInternal).toHaveBeenNthCalledWith(
+      1,
+      'success-1',
+      { ...defaultNode, ref: 'success-1' },
+      false,
+      true,
+    );
+    expect(updateSceneNodeInternal).toHaveBeenNthCalledWith(
+      2,
+      'success-2',
+      { ...defaultNode, ref: 'success-2' },
+      false,
+      true,
+    );
+
+    act(() => {
+      rerender(<ConvertSceneModal />);
+    });
+
+    const okButton = queryByTestId('ok-button');
+    expect(okButton).toBeTruthy();
+
+    expect(container).toMatchSnapshot();
+
+    act(() => {
+      okButton!.click();
+    });
+    expect(setConvertSceneModalVisibility).toBeCalledTimes(1);
+    expect(setConvertSceneModalVisibility).toBeCalledWith(false);
+  });
+
+  it('should render with converting scene failure', async () => {
+    (convertAllNodesToEntities as jest.Mock).mockImplementation(({ onSuccess, onFailure }) => {
+      act(() => {
+        onSuccess({ ...defaultNode, ref: 'success-node-ref' });
+        onFailure({ ...defaultNode, ref: 'failure-node-ref', name: 'failure-node' });
+      });
+    });
+
+    const { rerender, container, queryByTestId, queryByText } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(convertAllNodesToEntities).toBeCalledTimes(1);
+    expect(updateSceneNodeInternal).toBeCalledTimes(1);
+    expect(updateSceneNodeInternal).toHaveBeenNthCalledWith(
+      1,
+      'success-node-ref',
+      { ...defaultNode, ref: 'success-node-ref' },
+      false,
+      true,
+    );
+
+    act(() => {
+      rerender(<ConvertSceneModal />);
+    });
+
+    const errorMessage = queryByText('failure-node');
+    expect(errorMessage).toBeTruthy();
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with preparing workspace failure', async () => {
+    (prepareWorkspace as jest.Mock).mockRejectedValue(new Error('prepare workspace error'));
+    const { rerender, container, queryByTestId, queryByText } = render(<ConvertSceneModal />);
+
+    const confirmButton = queryByTestId('confirm-button');
+    act(() => {
+      confirmButton!.click();
+    });
+
+    await flushPromises();
+
+    expect(convertAllNodesToEntities).not.toBeCalled();
+    expect(updateSceneNodeInternal).not.toBeCalled();
+
+    act(() => {
+      rerender(<ConvertSceneModal />);
+    });
+
+    const errorMessage = queryByText('prepare workspace error');
+    expect(errorMessage).toBeTruthy();
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/ConvertSceneModal.tsx
+++ b/packages/scene-composer/src/components/ConvertSceneModal.tsx
@@ -1,0 +1,212 @@
+import { isEmpty } from 'lodash';
+import { Alert, Box, Button, Header, SpaceBetween } from '@awsui/components-react';
+import React, { useCallback, useContext, useState } from 'react';
+import { useIntl } from 'react-intl';
+
+import { sceneComposerIdContext } from '../common/sceneComposerIdContext';
+import { ISceneNodeInternal, useStore } from '../store';
+import { KnownSceneProperty } from '../interfaces';
+import {
+  checkIfEntityAvailable,
+  convertAllNodesToEntities,
+  createSceneRootEntity,
+  prepareWorkspace,
+  staticNodeCount,
+} from '../utils/entityModelUtils/sceneUtils';
+import { createLayer } from '../utils/entityModelUtils/sceneLayerUtils';
+import { LayerType } from '../common/entityModelConstants';
+import { getGlobalSettings } from '../common/GlobalSettings';
+
+import CenteredContainer from './CenteredContainer';
+import { ConvertingProgress } from './ConvertingProgress';
+
+interface ConvertProgress {
+  total: number;
+  converted: number;
+  failedNodes: ISceneNodeInternal[];
+  succeededNodes: ISceneNodeInternal[];
+}
+interface ConvertResult {
+  failedNodes?: ISceneNodeInternal[];
+  succeededNodes?: ISceneNodeInternal[];
+  errorMessage?: string;
+}
+
+const ConvertSceneModal: React.FC = () => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const setConvertSceneModalVisibility = useStore(sceneComposerId)((state) => state.setConvertSceneModalVisibility);
+  const document = useStore(sceneComposerId)((state) => state.document);
+
+  const setSceneProperty = useStore(sceneComposerId)((state) => state.setSceneProperty);
+  const updateSceneNodeInternal = useStore(sceneComposerId)((state) => state.updateSceneNodeInternal);
+  const getObject3DBySceneNodeRef = useStore(sceneComposerId)((state) => state.getObject3DBySceneNodeRef);
+
+  const sceneRootId = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<string>(KnownSceneProperty.SceneRootEntityId),
+  );
+  const sceneLayerIds = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<string[]>(KnownSceneProperty.LayerIds),
+  );
+
+  const { formatMessage } = useIntl();
+
+  const [progress, setProgress] = useState<ConvertProgress | undefined>();
+  const [result, setResult] = useState<ConvertResult | undefined>();
+
+  const onClose = useCallback(() => {
+    setConvertSceneModalVisibility(false);
+    setResult(undefined);
+    setProgress(undefined);
+  }, [setConvertSceneModalVisibility]);
+
+  const onConfirm = useCallback(async () => {
+    try {
+      const progress: ConvertProgress = {
+        total: staticNodeCount(document.nodeMap),
+        converted: 0,
+        succeededNodes: [],
+        failedNodes: [],
+      };
+      setProgress(progress);
+
+      let layerId = sceneLayerIds?.at(0);
+      let rootId = sceneRootId;
+      const sceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
+      const layerName = `${sceneMetadataModule?.getSceneId()}_Default`;
+
+      if (sceneMetadataModule) {
+        // Before backend can create the new default roots, the client side code will
+        // create them temporarily here.
+        await prepareWorkspace(sceneMetadataModule);
+
+        // Create default layer and default scene root node
+        if (!layerId || isEmpty(layerId) || !(await checkIfEntityAvailable(layerId, sceneMetadataModule))) {
+          const layer = await createLayer(layerName, LayerType.Relationship);
+          layerId = layer?.entityId;
+          setSceneProperty(KnownSceneProperty.LayerIds, [layerId]);
+        }
+        if (!sceneRootId || isEmpty(sceneRootId) || !(await checkIfEntityAvailable(sceneRootId, sceneMetadataModule))) {
+          const root = await createSceneRootEntity();
+          rootId = root?.entityId;
+          setSceneProperty(KnownSceneProperty.SceneRootEntityId, rootId);
+        }
+      }
+
+      if (rootId && layerId) {
+        convertAllNodesToEntities({
+          document,
+          sceneRootEntityId: rootId,
+          layerId,
+          getObject3DBySceneNodeRef,
+          onSuccess: (convertedNode) => {
+            progress.converted++;
+            progress.succeededNodes.push(convertedNode);
+
+            if (progress.converted === progress.total) {
+              setProgress(undefined);
+              setResult({ failedNodes: progress.failedNodes, succeededNodes: progress.succeededNodes });
+            } else {
+              setProgress(progress);
+            }
+            updateSceneNodeInternal(convertedNode.ref, convertedNode, false, true);
+          },
+          onFailure: (convertedNode) => {
+            progress.converted++;
+            progress.failedNodes.push(convertedNode);
+
+            if (progress.converted === progress.total) {
+              setProgress(undefined);
+              setResult({ failedNodes: progress.failedNodes, succeededNodes: progress.succeededNodes });
+            } else {
+              setProgress(progress);
+            }
+          },
+        });
+      }
+    } catch (e) {
+      setProgress(undefined);
+      setResult({ errorMessage: (e as Error).message });
+    }
+  }, [document, sceneLayerIds, sceneRootId, setSceneProperty, updateSceneNodeInternal]);
+
+  return (
+    <CenteredContainer
+      header={
+        <Header variant='h2'>
+          {formatMessage({ description: 'modal header text', defaultMessage: 'Convert scene' })}
+        </Header>
+      }
+      footer={
+        <Box float='right' padding={{ bottom: 's' }}>
+          {result ? (
+            <Button data-testid='ok-button' onClick={onClose}>
+              {formatMessage({ description: 'button label', defaultMessage: 'Ok' })}
+            </Button>
+          ) : (
+            <SpaceBetween size='s' direction='horizontal'>
+              <Button data-testid='cancel-button' onClick={onClose}>
+                {formatMessage({ description: 'button label', defaultMessage: 'Cancel' })}
+              </Button>
+
+              <Button data-testid='confirm-button' variant='primary' onClick={onConfirm} disabled={!!progress}>
+                {formatMessage({ description: 'button label', defaultMessage: 'Confirm' })}
+              </Button>
+            </SpaceBetween>
+          )}
+        </Box>
+      }
+    >
+      {!progress && !result && (
+        <Alert
+          type='warning'
+          header={formatMessage({ description: 'alert header text', defaultMessage: 'Converting scene' })}
+        >
+          {formatMessage({
+            description: 'alert body text',
+            defaultMessage:
+              'Proceeding with this action will permanently change your scene. You cannot undo this action',
+          })}
+        </Alert>
+      )}
+      {progress && <ConvertingProgress total={progress.total} converted={progress.converted} />}
+      {result &&
+        (isEmpty(result.failedNodes) && !result.errorMessage ? (
+          <Alert
+            type='success'
+            header={formatMessage({
+              description: 'alert header text',
+              defaultMessage: 'Convert to entities successful',
+            })}
+          >
+            {formatMessage({
+              description: 'alert body text',
+              defaultMessage: 'All nodes have been converted successfully',
+            })}
+          </Alert>
+        ) : (
+          <Alert
+            type='error'
+            header={formatMessage({ description: 'alert header text', defaultMessage: 'Convert to entities failed' })}
+          >
+            {result.errorMessage && <Box>{result.errorMessage}</Box>}
+
+            {!isEmpty(result.failedNodes) && (
+              <Box>
+                {formatMessage({ description: 'alert body text', defaultMessage: 'Some node conversion failed:' })}
+              </Box>
+            )}
+            {result.failedNodes &&
+              result.failedNodes.map((node) => (
+                <Box key={node.ref} padding={{ left: 's' }}>
+                  {node.name}
+                </Box>
+              ))}
+          </Alert>
+        ))}
+    </CenteredContainer>
+  );
+};
+
+ConvertSceneModal.displayName = 'ConvertSceneModal';
+
+export default ConvertSceneModal;

--- a/packages/scene-composer/src/components/ConvertingProgress.spec.tsx
+++ b/packages/scene-composer/src/components/ConvertingProgress.spec.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { ConvertingProgress } from './ConvertingProgress';
+
+describe('ConvertingProgress', () => {
+  it('should render with correct progress with 0% done', () => {
+    const { container, queryByText } = render(<ConvertingProgress total={10} converted={0} />);
+
+    const progressBar = queryByText('0 out of 10 converted');
+    expect(progressBar).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with correct progress with partially done', () => {
+    const { container, queryByText } = render(<ConvertingProgress total={9} converted={2} />);
+
+    const progressBar = queryByText('2 out of 9 converted');
+    expect(progressBar).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with correct progress with all done', () => {
+    const { container, queryByText } = render(<ConvertingProgress total={10} converted={10} />);
+
+    const progressBar = queryByText('10 out of 10 converted');
+    expect(progressBar).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/ConvertingProgress.tsx
+++ b/packages/scene-composer/src/components/ConvertingProgress.tsx
@@ -1,0 +1,41 @@
+import { Box, Container, ProgressBar } from '@awsui/components-react';
+import React from 'react';
+import { useIntl } from 'react-intl';
+import styled from 'styled-components';
+import * as awsui from '@awsui/design-tokens';
+
+const ConvertingProgressContainer = styled(Container)`
+  width: 100%;
+`;
+
+const ConvertingProgressDescriptionBox = styled(Box)`
+  color: ${awsui.colorTextBodySecondary}!important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const ConvertingProgress: React.FC<{ total: number; converted: number }> = ({ total, converted }) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <ConvertingProgressContainer data-testid='progress-container'>
+      <ProgressBar
+        status='in-progress'
+        value={(converted / total) * 100}
+        additionalInfo={
+          <ConvertingProgressDescriptionBox>
+            {formatMessage(
+              {
+                defaultMessage: '{convertedNumber} out of {totalNumber} converted',
+                description: 'Progress Bar description',
+              },
+              { convertedNumber: converted, totalNumber: total },
+            )}
+          </ConvertingProgressDescriptionBox>
+        }
+        label={formatMessage({ defaultMessage: 'Converting nodes', description: 'Progress Bar label' })}
+      />
+    </ConvertingProgressContainer>
+  );
+};

--- a/packages/scene-composer/src/components/StateManager.spec.tsx
+++ b/packages/scene-composer/src/components/StateManager.spec.tsx
@@ -30,6 +30,7 @@ import useActiveCamera from '../hooks/useActiveCamera';
 import { COMPOSER_FEATURES, KnownComponentType, SceneComposerInternalConfig } from '..';
 import * as THREE from 'three';
 import { SCENE_CAPABILITY_MATTERPORT } from '../common/constants';
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 
 jest.mock('../hooks/useActiveCamera', () => {
   return jest.fn().mockReturnValue({
@@ -90,7 +91,7 @@ describe('StateManager', () => {
     getSceneInfo,
     updateSceneInfo,
     get3pConnectionList,
-  };
+  } as unknown as TwinMakerSceneMetadataModule;
   const mockDataStreams: DataStream[] = [numberStream, stringStream];
 
   beforeEach(() => {

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -101,6 +101,8 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
   const dataProviderRef = useRef<ProviderWithViewport<TimeSeriesData[]> | undefined>(undefined);
   const prevSelection = useRef<string | undefined>(undefined);
 
+  const convertSceneModalVisible = useStore(sceneComposerId)((state) => !!state.convertSceneModalVisible);
+
   const { setActiveCameraSettings, setActiveCameraName } = useActiveCamera();
 
   const standardUriModifier = useMemo(
@@ -396,6 +398,7 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
     <SceneLayout
       isViewing={isViewing}
       showMessageModal={showMessageModal}
+      showConvertSceneModal={convertSceneModalVisible}
       externalLibraryConfig={updatedExternalLibraryConfig}
       LoadingView={
         <IntlProvider locale={config.locale}>

--- a/packages/scene-composer/src/components/__snapshots__/ConvertSceneModal.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/ConvertSceneModal.spec.tsx.snap
@@ -1,0 +1,305 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConvertSceneModal should call convertAllNodesToEntities and convert scene successfully 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        Convert scene
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Button"
+          data-testid="ok-button"
+        >
+          Ok
+        </div>
+      </div>
+    </div>
+    <div
+      data-mocked="Alert"
+      header="Convert to entities successful"
+      type="success"
+    >
+      All nodes have been converted successfully
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertSceneModal should call prepareWorkspace when converting scene 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c2 {
+  color: !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        Convert scene
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+          direction="horizontal"
+        >
+          <div
+            data-mocked="Button"
+            data-testid="cancel-button"
+          >
+            Cancel
+          </div>
+          <div
+            data-mocked="Button"
+            data-testid="confirm-button"
+            disabled=""
+            variant="primary"
+          >
+            Confirm
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c1"
+      data-mocked="Container"
+      data-testid="progress-container"
+    >
+      <div
+        data-mocked="ProgressBar"
+        label="Converting nodes"
+        status="in-progress"
+        value="0"
+      >
+        <div>
+          <div
+            class="c2"
+            data-mocked="Box"
+          >
+            0 out of 2 converted
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertSceneModal should render with converting scene failure 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        Convert scene
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Button"
+          data-testid="ok-button"
+        >
+          Ok
+        </div>
+      </div>
+    </div>
+    <div
+      data-mocked="Alert"
+      header="Convert to entities failed"
+      type="error"
+    >
+      <div
+        data-mocked="Box"
+      >
+        Some node conversion failed:
+      </div>
+      <div
+        data-mocked="Box"
+        padding="{\\"left\\":\\"s\\"}"
+      >
+        failure-node
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertSceneModal should render with correct confirmation view 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        Convert scene
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+          direction="horizontal"
+        >
+          <div
+            data-mocked="Button"
+            data-testid="cancel-button"
+          >
+            Cancel
+          </div>
+          <div
+            data-mocked="Button"
+            data-testid="confirm-button"
+            variant="primary"
+          >
+            Confirm
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-mocked="Alert"
+      header="Converting scene"
+      type="warning"
+    >
+      Proceeding with this action will permanently change your scene. You cannot undo this action
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertSceneModal should render with preparing workspace failure 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        Convert scene
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Button"
+          data-testid="ok-button"
+        >
+          Ok
+        </div>
+      </div>
+    </div>
+    <div
+      data-mocked="Alert"
+      header="Convert to entities failed"
+      type="error"
+    >
+      <div
+        data-mocked="Box"
+      >
+        prepare workspace error
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/__snapshots__/ConvertingProgress.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/ConvertingProgress.spec.tsx.snap
@@ -1,0 +1,112 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConvertingProgress should render with correct progress with 0% done 1`] = `
+.c0 {
+  width: 100%;
+}
+
+.c1 {
+  color: !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+    data-testid="progress-container"
+  >
+    <div
+      data-mocked="ProgressBar"
+      label="Converting nodes"
+      status="in-progress"
+      value="0"
+    >
+      <div>
+        <div
+          class="c1"
+          data-mocked="Box"
+        >
+          0 out of 10 converted
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertingProgress should render with correct progress with all done 1`] = `
+.c0 {
+  width: 100%;
+}
+
+.c1 {
+  color: !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+    data-testid="progress-container"
+  >
+    <div
+      data-mocked="ProgressBar"
+      label="Converting nodes"
+      status="in-progress"
+      value="100"
+    >
+      <div>
+        <div
+          class="c1"
+          data-mocked="Box"
+        >
+          10 out of 10 converted
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConvertingProgress should render with correct progress with partially done 1`] = `
+.c0 {
+  width: 100%;
+}
+
+.c1 {
+  color: !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+    data-testid="progress-container"
+  >
+    <div
+      data-mocked="ProgressBar"
+      label="Converting nodes"
+      status="in-progress"
+      value="22.22222222222222"
+    >
+      <div>
+        <div
+          class="c1"
+          data-mocked="Box"
+        >
+          2 out of 9 converted
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/__snapshots__/StateManager.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/StateManager.spec.tsx.snap
@@ -10,6 +10,7 @@ exports[`StateManager should render correctly 1`] = `
   externalLibraryConfig={Object {}}
   isViewing={false}
   onPointerMissed={[Function]}
+  showConvertSceneModal={false}
   showMessageModal={true}
 />
 `;
@@ -32,6 +33,7 @@ exports[`StateManager should render correctly with Matterport configuration 1`] 
   }
   isViewing={false}
   onPointerMissed={[Function]}
+  showConvertSceneModal={false}
   showMessageModal={true}
 />
 `;
@@ -45,6 +47,7 @@ exports[`StateManager should render correctly with error in Matterport configura
   }
   isViewing={false}
   onPointerMissed={[Function]}
+  showConvertSceneModal={false}
   showMessageModal={true}
 />
 `;

--- a/packages/scene-composer/src/components/panels/SettingsPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SettingsPanel.tsx
@@ -11,11 +11,13 @@ import { pascalCase } from '../../utils/stringUtils';
 import { getGlobalSettings } from '../../common/GlobalSettings';
 import { Component } from '../../models/SceneModels';
 import { Divider } from '../Divider';
+import useDynamicScene from '../../hooks/useDynamicScene';
 
 import { ExpandableInfoSection } from './CommonPanelComponents';
 import { MatterportIntegration, SceneDataBindingTemplateEditor, SceneTagSettingsEditor } from './scene-settings';
 import { ComponentVisibilityToggle } from './scene-settings/ComponentVisibilityToggle';
 import { OverlayPanelVisibilityToggle } from './scene-settings/OverlayPanelVisibilityToggle';
+import { ConvertSceneSettings } from './scene-settings/ConvertSceneSettings';
 
 export interface SettingsPanelProps {
   valueDataBindingProvider?: IValueDataBindingProvider;
@@ -33,6 +35,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
   const tagResizeEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagResize];
   const matterportEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Matterport];
   const overlayEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Overlay];
+  const dynamicSceneEnabled = useDynamicScene();
 
   const selectedEnvPreset = useStore(sceneComposerId)((state) =>
     state.getSceneProperty<string>(KnownSceneProperty.EnvironmentPreset),
@@ -207,9 +210,21 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
             description: 'ExpandableInfoSection Title',
             defaultMessage: '3rd Party Resources',
           })}
-          defaultExpanded
+          defaultExpanded={false}
         >
           <MatterportIntegration />
+        </ExpandableInfoSection>
+      )}
+
+      {dynamicSceneEnabled && isEditing && (
+        <ExpandableInfoSection
+          title={intl.formatMessage({
+            description: 'ExpandableInfoSection Title',
+            defaultMessage: 'Convert scene',
+          })}
+          defaultExpanded={false}
+        >
+          <ConvertSceneSettings />
         </ExpandableInfoSection>
       )}
     </Fragment>

--- a/packages/scene-composer/src/components/panels/__snapshots__/SettingsPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__snapshots__/SettingsPanel.spec.tsx.snap
@@ -229,6 +229,135 @@ exports[`SettingsPanel contains expected elements. should contains default eleme
 </div>
 `;
 
+exports[`SettingsPanel contains expected elements. should contains settings element for converting scene in editing. 1`] = `
+.c0 {
+  height: 1px;
+  border-width: 0px;
+  background-color: colorBorderDividerDefault;
+}
+
+<div>
+  <div
+    data-mocked="ExpandableInfoSection"
+    title="Current View Settings"
+  >
+    <div
+      data-mocked="FormField"
+    >
+      <div>
+        <div
+          data-mocked="Box"
+          font-weight="bold"
+        >
+          Toggle visibility
+        </div>
+      </div>
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Animation
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
+      <hr
+        class="c0"
+      />
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Motion indicator
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
+      <hr
+        class="c0"
+      />
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Tag
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-mocked="ExpandableInfoSection"
+    title="Scene Settings"
+  >
+    <div
+      data-mocked="SpaceBetween"
+    >
+      <div
+        data-mocked="FormField"
+        label="Environment Preset"
+      >
+        <div
+          data-mocked="Select"
+          options="[{\\"label\\":\\"No Preset\\",\\"value\\":\\"n/a\\"},{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"},{\\"label\\":\\"Directional\\",\\"value\\":\\"directional\\"},{\\"label\\":\\"Chromatic\\",\\"value\\":\\"chromatic\\"}]"
+          placeholder="Choose an environment"
+          selectedarialabel="Selected"
+          selectedoption="{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"}"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    data-mocked="ExpandableInfoSection"
+    title="Convert scene"
+  >
+    <div
+      data-mocked="ConvertSceneSettings"
+    />
+  </div>
+</div>
+`;
+
 exports[`SettingsPanel contains expected elements. should contains settings element for overlay in editing. 1`] = `
 .c0 {
   height: 1px;

--- a/packages/scene-composer/src/components/panels/scene-settings/ConvertSceneSettings.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/ConvertSceneSettings.spec.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+import { useStore } from '../../../store';
+import { staticNodeCount } from '../../../utils/entityModelUtils/sceneUtils';
+
+import { ConvertSceneSettings } from './ConvertSceneSettings';
+
+jest.mock('../../../utils/entityModelUtils/sceneUtils');
+
+describe('ConvertSceneSettings', () => {
+  const setConvertSceneModalVisibility = jest.fn();
+  const baseState = {
+    setConvertSceneModalVisibility,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render correctly with convert button disabled', () => {
+    useStore('default').setState(baseState);
+    (staticNodeCount as jest.Mock).mockReturnValue(0);
+
+    const { container, queryByTestId } = render(<ConvertSceneSettings />);
+
+    expect(queryByTestId('convert-button')?.getAttribute('disabled')).not.toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render correctly with convert button enabled', () => {
+    useStore('default').setState(baseState);
+    (staticNodeCount as jest.Mock).mockReturnValue(1);
+
+    const { container, queryByTestId } = render(<ConvertSceneSettings />);
+
+    expect(queryByTestId('convert-button')?.getAttribute('disabled')).toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should set convert scene modal to visible on convert button click', () => {
+    useStore('default').setState(baseState);
+    (staticNodeCount as jest.Mock).mockReturnValue(1);
+
+    const { queryByTestId } = render(<ConvertSceneSettings />);
+    const button = queryByTestId('convert-button');
+    fireEvent.click(button!);
+
+    expect(setConvertSceneModalVisibility).toBeCalledTimes(1);
+    expect(setConvertSceneModalVisibility).toBeCalledWith(true);
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-settings/ConvertSceneSettings.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/ConvertSceneSettings.tsx
@@ -1,0 +1,37 @@
+import React, { useCallback, useContext } from 'react';
+import { useIntl } from 'react-intl';
+import { Box, Button } from '@awsui/components-react';
+
+import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import { staticNodeCount } from '../../../utils/entityModelUtils/sceneUtils';
+import { useStore } from '../../../store';
+
+export const ConvertSceneSettings: React.FC = () => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const { formatMessage } = useIntl();
+  const document = useStore(sceneComposerId)((state) => state.document);
+
+  const setConvertSceneModalVisibility = useStore(sceneComposerId)((state) => state.setConvertSceneModalVisibility);
+
+  const convertScene = useCallback(() => {
+    setConvertSceneModalVisibility(true);
+  }, [setConvertSceneModalVisibility]);
+
+  return (
+    <>
+      <Box variant='p' fontWeight='bold' margin={{ bottom: 'xxs' }}>
+        {formatMessage({ description: 'Sub-Section Header', defaultMessage: 'Convert to entities' })}
+      </Box>
+      <Box variant='p' margin={{ bottom: 'xxs' }}>
+        {formatMessage({
+          defaultMessage: 'Converting your scene to entities enables auto updating, filtering and querying your scene.',
+          description: 'Sub-Section Description',
+        })}
+      </Box>
+
+      <Button data-testid='convert-button' onClick={convertScene} disabled={staticNodeCount(document.nodeMap) === 0}>
+        {formatMessage({ description: 'Button text', defaultMessage: 'Convert scene' })}
+      </Button>
+    </>
+  );
+};

--- a/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/ConvertSceneSettings.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/ConvertSceneSettings.spec.tsx.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConvertSceneSettings should render correctly with convert button disabled 1`] = `
+<div>
+  <div
+    data-mocked="Box"
+    font-weight="bold"
+    margin="{\\"bottom\\":\\"xxs\\"}"
+    variant="p"
+  >
+    Convert to entities
+  </div>
+  <div
+    data-mocked="Box"
+    margin="{\\"bottom\\":\\"xxs\\"}"
+    variant="p"
+  >
+    Converting your scene to entities enables auto updating, filtering and querying your scene.
+  </div>
+  <div
+    data-mocked="Button"
+    data-testid="convert-button"
+    disabled=""
+  >
+    Convert scene
+  </div>
+</div>
+`;
+
+exports[`ConvertSceneSettings should render correctly with convert button enabled 1`] = `
+<div>
+  <div
+    data-mocked="Box"
+    font-weight="bold"
+    margin="{\\"bottom\\":\\"xxs\\"}"
+    variant="p"
+  >
+    Convert to entities
+  </div>
+  <div
+    data-mocked="Box"
+    margin="{\\"bottom\\":\\"xxs\\"}"
+    variant="p"
+  >
+    Converting your scene to entities enables auto updating, filtering and querying your scene.
+  </div>
+  <div
+    data-mocked="Button"
+    data-testid="convert-button"
+  >
+    Convert scene
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.spec.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.spec.tsx
@@ -28,6 +28,8 @@ jest.mock('../../components/panels/TopBar', () => {
 
 jest.mock('../../hooks/useSelectedNode', () => jest.fn());
 
+jest.mock('../../components/ConvertSceneModal', () => 'ConvertSceneModal');
+
 class ResizeObserver {
   observe = jest.fn();
   unobserve = jest.fn();
@@ -63,13 +65,14 @@ describe('SceneLayout', () => {
   [
     ['Edit mode', { isViewing: false, showMessageModal: false }],
     ['Viewing mode', { isViewing: true, showMessageModal: false }],
-    ['Edit mode with Modal', { isViewing: false, showMessageModal: true }],
-    ['Viewing mode with modal', { isViewing: true, showMessageModal: true }],
+    ['Edit mode with message modal', { isViewing: false, showMessageModal: true }],
+    ['Viewing mode with message modal', { isViewing: true, showMessageModal: true }],
   ].forEach((value) => {
     it(`should render correctly in ${value[0]}`, () => {
       const container = create(
         <SceneLayout
           onPointerMissed={() => {}}
+          showConvertSceneModal={false}
           LoadingView={<div data-test-id='Loading view' />}
           {...(value[1] as { isViewing: boolean; showMessageModal: boolean })}
         />,
@@ -77,6 +80,20 @@ describe('SceneLayout', () => {
 
       expect(container).toMatchSnapshot();
     });
+  });
+
+  it('should render correctly in edit mode with convert scene modal open', () => {
+    const container = create(
+      <SceneLayout
+        onPointerMissed={() => {}}
+        showConvertSceneModal={true}
+        LoadingView={<div data-test-id='Loading view' />}
+        isViewing={false}
+        showMessageModal={false}
+      />,
+    );
+
+    expect(container).toMatchSnapshot();
   });
 
   it('should render camera preview if editing and camera component is on selectedNode', () => {

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
@@ -29,6 +29,7 @@ import { CameraPreview } from '../../components/three-fiber/CameraPreview';
 import useMatterportViewer from '../../hooks/useMatterportViewer';
 import useSelectedNode from '../../hooks/useSelectedNode';
 import { findComponentByType } from '../../utils/nodeUtils';
+import ConvertSceneModal from '../../components/ConvertSceneModal';
 
 import { Direction } from './components/utils';
 import ScenePanel from './components/ScenePanel';
@@ -97,12 +98,14 @@ interface SceneLayoutProps {
   onPointerMissed: (event: ThreeEvent<PointerEvent>) => void;
   LoadingView: ReactNode;
   showMessageModal: boolean;
+  showConvertSceneModal?: boolean;
   externalLibraryConfig?: ExternalLibraryConfig;
 }
 const SceneLayout: FC<SceneLayoutProps> = ({
   isViewing,
   LoadingView = null,
   showMessageModal,
+  showConvertSceneModal,
   externalLibraryConfig,
 }) => {
   const sceneComposerId = useContext(sceneComposerIdContext);
@@ -177,8 +180,8 @@ const SceneLayout: FC<SceneLayoutProps> = ({
           </LogProvider>
         </Fragment>
       }
-      showModal={showMessageModal}
-      modalContent={<MessageModal />}
+      showModal={showMessageModal || (showConvertSceneModal && !isViewing)}
+      modalContent={showConvertSceneModal && !isViewing ? <ConvertSceneModal /> : <MessageModal />}
       header={!isViewing && <MenuBar />}
       leftPanel={isViewing ? viewingModeScenePanel : leftPanel}
       rightPanel={!isViewing && rightPanel}

--- a/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
+++ b/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
@@ -870,7 +870,7 @@ exports[`SceneLayout should render correctly in Edit mode 1`] = `
 </div>
 `;
 
-exports[`SceneLayout should render correctly in Edit mode with Modal 1`] = `
+exports[`SceneLayout should render correctly in Edit mode with message modal 1`] = `
 .c2 {
   width: 600px;
   margin: auto;
@@ -1717,7 +1717,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
 </div>
 `;
 
-exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
+exports[`SceneLayout should render correctly in Viewing mode with message modal 1`] = `
 .c2 {
   width: 600px;
   margin: auto;
@@ -2290,6 +2290,301 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SceneLayout should render correctly in edit mode with convert scene modal open 1`] = `
+.c8 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background-color: colorBackgroundLayoutMain;
+}
+
+.c2 {
+  background-color: colorBackgroundContainerHeader;
+  z-index: 100;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  position: relative;
+  overflow: hidden;
+}
+
+.c5 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  background-color: colorBackgroundContainerContent;
+}
+
+.c7 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  overflow: hidden;
+  padding: 4px;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background-color: rgba(0,0,0,0.7);
+}
+
+.c4 {
+  background-color: colorBackgroundContainerContent;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 99;
+}
+
+.c9 {
+  background-color: colorBackgroundContainerContent;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  height: 100%;
+}
+
+<div
+  className="c0"
+  data-mocked="Box"
+>
+  <div
+    className="c1"
+  >
+    <ConvertSceneModal />
+  </div>
+  <div
+    className="c2"
+    data-mocked="Box"
+  />
+  <div
+    className="c3"
+    data-mocked="Box"
+  >
+    <div
+      className="c4"
+      data-mocked="Box"
+      isFloating={false}
+    >
+      <div
+        className="tm-wrapper-left"
+      >
+        <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneHierarchyPanel />,
+                    "id": "Hierarchy",
+                    "label": "Hierarchy",
+                  },
+                  Object {
+                    "content": <SceneRulesPanel />,
+                    "id": "Rules",
+                    "label": "Rules",
+                  },
+                  Object {
+                    "content": <SettingsPanel />,
+                    "id": "Settings",
+                    "label": "Settings",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
+          className="tm-handle"
+          data-testid="handle"
+          onClick={[Function]}
+        >
+          <div
+            data-mocked="Icon"
+            name="angle-left"
+            size="small"
+            variant="normal"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="c5"
+      data-mocked="Box"
+    >
+      <div
+        className="c6"
+        data-mocked="Box"
+        padding="xxs"
+      >
+        <TopBar />
+      </div>
+      <div
+        className="c7"
+        data-mocked="Box"
+      >
+        <div
+          className="c0"
+          data-mocked="Box"
+        >
+          <div
+            className="c1"
+          >
+            <div
+              className="c8"
+              data-mocked="Container"
+            >
+              <div>
+                <div
+                  data-mocked="Header"
+                  variant="h2"
+                >
+                  Error
+                </div>
+              </div>
+              <div
+                data-mocked="TextContent"
+              >
+                <p>
+                  Cannot convert undefined or null to object
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            className="c3"
+            data-mocked="Box"
+          >
+            <div
+              className="c5"
+              data-mocked="Box"
+            >
+              <div
+                className="c7"
+                data-mocked="Box"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c9"
+      data-mocked="Box"
+    >
+      <div
+        className="tm-wrapper-right"
+      >
+        <div
+          className="tm-content"
+        >
+          <div
+            className="tm-collapse-panel open"
+          >
+            <div
+              className="tm-sidePanelTabs"
+              data-mocked="Tabs"
+              tabs={
+                Array [
+                  Object {
+                    "content": <SceneNodeInspectorPanel />,
+                    "id": "Inspector",
+                    "label": "Inspector",
+                  },
+                ]
+              }
+            />
+          </div>
+        </div>
+        <div
+          className="tm-handle"
+          data-testid="handle"
+          onClick={[Function]}
+        >
+          <div
+            data-mocked="Icon"
+            name="angle-right"
+            size="small"
+            variant="normal"
+          />
         </div>
       </div>
     </div>

--- a/packages/scene-composer/src/store/StoreOperations.ts
+++ b/packages/scene-composer/src/store/StoreOperations.ts
@@ -13,6 +13,7 @@ export type SceneComposerEditorOperation =
   | 'setCameraTarget'
   | 'addMessages'
   | 'clearMessages'
+  | 'setConvertSceneModalVisibility'
   | 'setAddingWidget'
   | 'setCursorPosition'
   | 'setCursorLookAt'
@@ -80,6 +81,7 @@ export const SceneComposerOperationTypeMap: Record<SceneComposerOperation, Opera
   setCameraTarget: 'UPDATE_EDITOR',
   addMessages: 'UPDATE_EDITOR',
   clearMessages: 'UPDATE_EDITOR',
+  setConvertSceneModalVisibility: 'UPDATE_EDITOR',
   setAddingWidget: 'UPDATE_EDITOR',
   setCursorPosition: 'UPDATE_EDITOR',
   setCursorLookAt: 'UPDATE_EDITOR',

--- a/packages/scene-composer/src/store/slices/EditorStateSlice.ts
+++ b/packages/scene-composer/src/store/slices/EditorStateSlice.ts
@@ -61,6 +61,9 @@ export interface IEditorStateSlice {
   clearMessages(): void;
   getMessages(): IDisplayMessage[];
 
+  convertSceneModalVisible?: boolean;
+  setConvertSceneModalVisibility(visible: boolean): void;
+
   // Selection and highlights
   selectedSceneNodeRef?: string;
   selectedSceneSubmodelRef?: SubModelRef;
@@ -112,11 +115,9 @@ export interface IEditorStateSlice {
   setMainCameraObject(camera?: THREE.Camera);
 }
 
-function createDefaultEditorState() {
+function createDefaultEditorState(): Partial<IEditorStateSlice> {
   return {
     isLoadingModel: false,
-    isInViewpointTransition: false,
-    isAddingWidget: false,
     messages: [],
     selectedSceneNodeRef: undefined,
     highlightedSceneNodeRef: undefined,
@@ -143,7 +144,11 @@ function createDefaultEditorState() {
   };
 }
 
-export const createEditStateSlice = (set: SetState<RootState>, get: GetState<RootState>, _api: StoreApi<RootState>) =>
+export const createEditStateSlice = (
+  set: SetState<RootState>,
+  get: GetState<RootState>,
+  _api: StoreApi<RootState>,
+): IEditorStateSlice =>
   ({
     ...createDefaultEditorState(),
 
@@ -211,6 +216,13 @@ export const createEditStateSlice = (set: SetState<RootState>, get: GetState<Roo
 
     getMessages() {
       return get().messages;
+    },
+
+    setConvertSceneModalVisibility(visible) {
+      set((draft) => {
+        draft.convertSceneModalVisible = visible;
+        draft.lastOperation = 'setConvertSceneModalVisibility';
+      });
     },
 
     setSelectedSceneNodeRef(nodeRef?: string) {

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.spec.ts
@@ -11,6 +11,7 @@ import { createCameraEntityComponent } from './cameraComponent';
 import { createMotionIndicatorEntityComponent } from './motionIndicatorComponent';
 import { createModelRefComponent } from './modelRefComponent';
 import { createNodeEntity } from './createNodeEntity';
+import { createModelShaderEntityComponent } from './modelShaderComponent';
 
 jest.mock('./nodeComponent', () => ({
   createNodeEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.node' }),
@@ -29,6 +30,9 @@ jest.mock('./motionIndicatorComponent', () => ({
 }));
 jest.mock('./modelRefComponent', () => ({
   createModelRefComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelRef' }),
+}));
+jest.mock('./modelShaderComponent', () => ({
+  createModelShaderEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelShader' }),
 }));
 
 describe('createNodeEntity', () => {
@@ -66,7 +70,8 @@ describe('createNodeEntity', () => {
     const camera = { type: KnownComponentType.Camera, ref: 'camera-ref' };
     const motionIndicator = { type: KnownComponentType.MotionIndicator, ref: 'indicator-ref' };
     const modelRef = { type: KnownComponentType.ModelRef, ref: 'modelref-ref' };
-    const node = { ...defaultNode, components: [tag, overlay, camera, motionIndicator, modelRef] };
+    const modelShader = { type: KnownComponentType.ModelShader, ref: 'modelShader-ref' };
+    const node = { ...defaultNode, components: [tag, overlay, camera, motionIndicator, modelRef, modelShader] };
 
     await createNodeEntity(node, 'parent', 'layer');
 
@@ -83,6 +88,7 @@ describe('createNodeEntity', () => {
         Camera: { componentTypeId: '3d.camera' },
         MotionIndicator: { componentTypeId: '3d.motionIndicator' },
         ModelRef: { componentTypeId: '3d.modelRef' },
+        ModelShader: { componentTypeId: '3d.modelShader' },
       },
     });
 
@@ -98,5 +104,7 @@ describe('createNodeEntity', () => {
     expect(createMotionIndicatorEntityComponent).toHaveBeenCalledWith(motionIndicator);
     expect(createModelRefComponent).toHaveBeenCalledTimes(1);
     expect(createModelRefComponent).toHaveBeenCalledWith(modelRef);
+    expect(createModelShaderEntityComponent).toHaveBeenCalledTimes(1);
+    expect(createModelShaderEntityComponent).toHaveBeenCalledWith(modelShader);
   });
 });

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
@@ -7,6 +7,7 @@ import {
 import { getGlobalSettings } from '../../common/GlobalSettings';
 import {
   ICameraComponent,
+  IColorOverlayComponent,
   IDataOverlayComponent,
   IModelRefComponent,
   IMotionIndicatorComponent,
@@ -20,6 +21,7 @@ import { createOverlayEntityComponent } from './overlayComponent';
 import { createMotionIndicatorEntityComponent } from './motionIndicatorComponent';
 import { createCameraEntityComponent } from './cameraComponent';
 import { createModelRefComponent } from './modelRefComponent';
+import { createModelShaderEntityComponent } from './modelShaderComponent';
 
 export const createNodeEntity = (
   node: ISceneNodeInternal,
@@ -58,6 +60,9 @@ export const createNodeEntity = (
           break;
         case KnownComponentType.ModelRef:
           comp = createModelRefComponent(compToBeCreated as IModelRefComponent);
+          break;
+        case KnownComponentType.ModelShader:
+          comp = createModelShaderEntityComponent(compToBeCreated as IColorOverlayComponent);
           break;
 
         default:

--- a/packages/scene-composer/src/utils/entityModelUtils/modelShaderComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/modelShaderComponent.spec.ts
@@ -1,0 +1,134 @@
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { KnownComponentType } from '../../interfaces';
+
+import {
+  createModelShaderEntityComponent,
+  parseModelShaderComp,
+  updateModelShaderEntityComponent,
+} from './modelShaderComponent';
+
+describe('createModelShaderEntityComponent', () => {
+  it('should return expected empty model shader component', () => {
+    expect(createModelShaderEntityComponent({ type: KnownComponentType.ModelShader })).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.ModelShader],
+      properties: {},
+    });
+  });
+
+  it('should return expected model shader component with rule id', () => {
+    const result = createModelShaderEntityComponent({
+      type: KnownComponentType.ModelShader,
+      ruleBasedMapId: 'rule-id',
+    });
+
+    expect(result.properties).toEqual({
+      dataBinding: {
+        value: {
+          mapValue: {
+            ruleBasedMapId: {
+              stringValue: 'rule-id',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected model shader component with data binding context', () => {
+    const result = createModelShaderEntityComponent({
+      type: KnownComponentType.ModelShader,
+      valueDataBinding: {
+        dataBindingContext: {
+          entityId: 'eid',
+          componentName: 'cname',
+          propertyName: 'pname',
+        },
+      },
+    });
+
+    expect(result.properties).toEqual({
+      dataBinding: {
+        value: {
+          mapValue: {
+            entityId: {
+              stringValue: 'eid',
+            },
+            componentName: {
+              stringValue: 'cname',
+            },
+            propertyName: {
+              stringValue: 'pname',
+            },
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('updateModelShaderEntityComponent', () => {
+  it('should return expected empty model shader component', () => {
+    expect(updateModelShaderEntityComponent({ type: KnownComponentType.ModelShader })).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.ModelShader],
+      propertyUpdates: {},
+    });
+  });
+});
+
+describe('parseModelShaderComp', () => {
+  it('should parse to expected empty model shader component', () => {
+    expect(
+      parseModelShaderComp({
+        componentTypeId: componentTypeToId[KnownComponentType.ModelShader],
+        properties: [],
+      }),
+    ).toEqual({
+      ref: expect.any(String),
+      type: KnownComponentType.ModelShader,
+      ruleBasedMapId: undefined,
+      valueDataBinding: undefined,
+    });
+  });
+
+  it('should parse to expected model shader component with rule id', () => {
+    const result = parseModelShaderComp({
+      componentTypeId: componentTypeToId[KnownComponentType.ModelShader],
+      properties: [
+        {
+          propertyName: 'dataBinding',
+          propertyValue: {
+            ruleBasedMapId: 'rule-id',
+          },
+        },
+      ],
+    });
+
+    expect(result?.ruleBasedMapId).toEqual('rule-id');
+  });
+
+  it('should parse to expected model shader component with data binding context', () => {
+    const result = parseModelShaderComp({
+      componentTypeId: componentTypeToId[KnownComponentType.ModelShader],
+      properties: [
+        {
+          propertyName: 'dataBinding',
+          propertyValue: {
+            entityId: 'eid',
+            componentName: 'cname',
+            propertyName: 'pname',
+            isStaticData: 'true',
+          },
+        },
+      ],
+    });
+
+    expect(result?.valueDataBinding).toEqual({
+      dataBindingContext: {
+        entityId: 'eid',
+        componentName: 'cname',
+        propertyName: 'pname',
+      },
+      isStaticData: true,
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/modelShaderComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/modelShaderComponent.ts
@@ -1,0 +1,60 @@
+import { ComponentRequest, ComponentUpdateRequest } from '@aws-sdk/client-iottwinmaker';
+import { DocumentType } from '@aws-sdk/types';
+
+import { IColorOverlayComponent, KnownComponentType } from '../../interfaces';
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { IColorOverlayComponentInternal } from '../../store';
+import { generateUUID } from '../mathUtils';
+
+import { createDataBindingMap, parseDataBinding } from './dataBindingUtils';
+
+enum ModelShaderComponentProperty {
+  DataBinding = 'dataBinding',
+  RuleBasedMapId = 'ruleBasedMapId',
+}
+
+export const createModelShaderEntityComponent = (shader: IColorOverlayComponent): ComponentRequest => {
+  const comp: ComponentRequest = {
+    componentTypeId: componentTypeToId[KnownComponentType.ModelShader],
+    properties: {},
+  };
+  if (shader.ruleBasedMapId || shader.valueDataBinding?.dataBindingContext) {
+    const map = createDataBindingMap(shader.valueDataBinding);
+    if (shader.ruleBasedMapId) {
+      map[ModelShaderComponentProperty.RuleBasedMapId] = { stringValue: shader.ruleBasedMapId };
+    }
+
+    comp.properties![ModelShaderComponentProperty.DataBinding] = {
+      value: {
+        mapValue: map,
+      },
+    };
+  }
+
+  return comp;
+};
+
+export const updateModelShaderEntityComponent = (modelShader: IColorOverlayComponent): ComponentUpdateRequest => {
+  const request = createModelShaderEntityComponent(modelShader);
+  return {
+    componentTypeId: request.componentTypeId,
+    propertyUpdates: request.properties,
+  };
+};
+
+export const parseModelShaderComp = (comp: DocumentType): IColorOverlayComponentInternal | undefined => {
+  if (!comp?.['properties']) {
+    return undefined;
+  }
+
+  const binding = comp['properties'].find(
+    (p) => p['propertyName'] === ModelShaderComponentProperty.DataBinding,
+  )?.propertyValue;
+  const modelShaderComp: IColorOverlayComponentInternal = {
+    ref: generateUUID(),
+    type: KnownComponentType.ModelShader,
+    ruleBasedMapId: !binding ? undefined : binding[ModelShaderComponentProperty.RuleBasedMapId],
+    valueDataBinding: parseDataBinding(binding),
+  };
+  return modelShaderComp;
+};

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
@@ -214,6 +214,10 @@ describe('parseNode', () => {
       },
     ],
   };
+  const modelShaderComp = {
+    componentTypeId: componentTypeToId.ModelShader,
+    properties: [],
+  };
 
   const nodeComp = {
     componentTypeId: NODE_COMPONENT_TYPE_ID,
@@ -279,7 +283,7 @@ describe('parseNode', () => {
 
   it('should parse to expected node component with components', () => {
     const result = parseNode(
-      { ...entity, components: [tagComp, overlayComp, modelRefComp, cameraComp, indicatorComp] },
+      { ...entity, components: [tagComp, overlayComp, modelRefComp, cameraComp, indicatorComp, modelShaderComp] },
       nodeComp,
     );
 
@@ -298,6 +302,9 @@ describe('parseNode', () => {
       }),
       expect.objectContaining({
         type: KnownComponentType.MotionIndicator,
+      }),
+      expect.objectContaining({
+        type: KnownComponentType.ModelShader,
       }),
     ];
     expect(result?.components).toEqual(expectedComponents);

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
@@ -17,6 +17,7 @@ import { parseOverlayComp } from './overlayComponent';
 import { parseModelRefComp } from './modelRefComponent';
 import { parseCameraComp } from './cameraComponent';
 import { parseMotionIndicatorComp } from './motionIndicatorComponent';
+import { parseModelShaderComp } from './modelShaderComponent';
 
 enum NodeComponentProperty {
   Name = 'name',
@@ -165,6 +166,14 @@ const parseNodeComponents = (components: DocumentType): ISceneComponentInternal[
         }
         break;
       }
+      case componentTypeToId.ModelShader: {
+        const modelShader = parseModelShaderComp(comp);
+        if (modelShader) {
+          results.push(modelShader);
+        }
+        break;
+      }
+
       case NODE_COMPONENT_TYPE_ID:
         // Ignore node component
         break;

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
@@ -85,12 +85,14 @@ export const convertAllNodesToEntities = ({
   layerId,
   getObject3DBySceneNodeRef,
   onSuccess,
+  onFailure,
 }: {
   document: ISceneDocumentInternal;
   sceneRootEntityId: string;
   layerId: string;
   getObject3DBySceneNodeRef: (nodeRef: string) => THREE.Object3D | undefined;
   onSuccess?: (node: ISceneNodeInternal) => void;
+  onFailure?: (node: ISceneNodeInternal, error: Error) => void;
 }): void => {
   Object.keys(document.nodeMap).forEach((nodeRef) => {
     const node = document.nodeMap[nodeRef];
@@ -110,9 +112,13 @@ export const convertAllNodesToEntities = ({
         },
       };
 
-      createNodeEntity(worldTransformNode, sceneRootEntityId, layerId)?.then(() => {
-        onSuccess?.(worldTransformNode);
-      });
+      createNodeEntity(worldTransformNode, sceneRootEntityId, layerId)
+        ?.then(() => {
+          onSuccess?.(worldTransformNode);
+        })
+        .catch((error) => {
+          onFailure?.(worldTransformNode, error);
+        });
     }
   });
 };

--- a/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
@@ -12,6 +12,7 @@ import { updateOverlayEntityComponent } from './overlayComponent';
 import { updateCameraEntityComponent } from './cameraComponent';
 import { updateMotionIndicatorEntityComponent } from './motionIndicatorComponent';
 import { updateModelRefComponent } from './modelRefComponent';
+import { updateModelShaderEntityComponent } from './modelShaderComponent';
 
 jest.mock('./nodeComponent', () => ({
   updateNodeEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.node' }),
@@ -30,6 +31,9 @@ jest.mock('./motionIndicatorComponent', () => ({
 }));
 jest.mock('./modelRefComponent', () => ({
   updateModelRefComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelRef' }),
+}));
+jest.mock('./modelShaderComponent', () => ({
+  updateModelShaderEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelShader' }),
 }));
 
 describe('updateEntity', () => {
@@ -68,8 +72,9 @@ describe('updateEntity', () => {
     const camera = { type: KnownComponentType.Camera, ref: 'camera-ref' };
     const motionIndicator = { type: KnownComponentType.MotionIndicator, ref: 'indicator-ref' };
     const modelRef = { type: KnownComponentType.ModelRef, ref: 'modelref-ref' };
+    const modelShader = { type: KnownComponentType.ModelShader, ref: 'modelshader-ref' };
 
-    await updateEntity(defaultNode, [tag, overlay, camera, motionIndicator, modelRef], 'UPDATE');
+    await updateEntity(defaultNode, [tag, overlay, camera, motionIndicator, modelRef, modelShader], 'UPDATE');
 
     expect(updateSceneEntity).toHaveBeenCalledTimes(1);
     expect(updateSceneEntity).toHaveBeenCalledWith({
@@ -83,6 +88,7 @@ describe('updateEntity', () => {
         Camera: { componentTypeId: '3d.camera' },
         MotionIndicator: { componentTypeId: '3d.motionIndicator' },
         ModelRef: { componentTypeId: '3d.modelRef' },
+        ModelShader: { componentTypeId: '3d.modelShader' },
       },
     });
 
@@ -98,6 +104,8 @@ describe('updateEntity', () => {
     expect(updateMotionIndicatorEntityComponent).toHaveBeenCalledWith(motionIndicator);
     expect(updateModelRefComponent).toHaveBeenCalledTimes(1);
     expect(updateModelRefComponent).toHaveBeenCalledWith(modelRef);
+    expect(updateModelShaderEntityComponent).toHaveBeenCalledTimes(1);
+    expect(updateModelShaderEntityComponent).toHaveBeenCalledWith(modelShader);
   });
 
   it('should call update entity to update tag component', async () => {

--- a/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.ts
@@ -3,6 +3,7 @@ import { ComponentUpdateRequest, ComponentUpdateType, UpdateEntityCommandInput }
 import { getGlobalSettings } from '../../common/GlobalSettings';
 import {
   ICameraComponent,
+  IColorOverlayComponent,
   IDataOverlayComponent,
   IModelRefComponent,
   IMotionIndicatorComponent,
@@ -17,6 +18,7 @@ import { updateOverlayEntityComponent } from './overlayComponent';
 import { updateModelRefComponent } from './modelRefComponent';
 import { updateCameraEntityComponent } from './cameraComponent';
 import { updateMotionIndicatorEntityComponent } from './motionIndicatorComponent';
+import { updateModelShaderEntityComponent } from './modelShaderComponent';
 
 export const updateEntity = async (
   node: ISceneNodeInternal,
@@ -61,6 +63,10 @@ export const updateEntity = async (
           case KnownComponentType.MotionIndicator:
             comp = updateMotionIndicatorEntityComponent(compToBeUpdated as IMotionIndicatorComponent);
             break;
+          case KnownComponentType.ModelShader:
+            comp = updateModelShaderEntityComponent(compToBeUpdated as IColorOverlayComponent);
+            break;
+
           default:
             throw new Error('Component type not supported');
         }

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -15,6 +15,10 @@
     "note": "Light Type in a dropdown menu",
     "text": "Ambient"
   },
+  "+RIFYb": {
+    "note": "alert body text",
+    "text": "All nodes have been converted successfully"
+  },
   "+SQx9E": {
     "note": "Menu Item label",
     "text": "Add component"
@@ -82,6 +86,10 @@
   "1cVQu5": {
     "note": "label for an input component selecting number of arrows",
     "text": "# of arrows"
+  },
+  "1fLT/q": {
+    "note": "button label",
+    "text": "Cancel"
   },
   "1kXRWn": {
     "note": "Progress Bar status",
@@ -231,6 +239,10 @@
     "note": "Menu Item label",
     "text": "Empty node"
   },
+  "9D+o0B": {
+    "note": "alert body text",
+    "text": "Proceeding with this action will permanently change your scene. You cannot undo this action"
+  },
   "9I3nDM": {
     "note": "Menu Item label",
     "text": "Undo"
@@ -266,6 +278,14 @@
   "B5EPL8": {
     "note": "Menu Item",
     "text": "Add 3D model"
+  },
+  "B6QsMN": {
+    "note": "button label",
+    "text": "Confirm"
+  },
+  "BK/UYP": {
+    "note": "alert header text",
+    "text": "Convert to entities failed"
   },
   "BNscqX": {
     "note": "Default Message for before an animation is selected",
@@ -422,6 +442,10 @@
   "KnEACH": {
     "note": "Hyperlink title",
     "text": "Learn More"
+  },
+  "KoTFFN": {
+    "note": "Button text",
+    "text": "Convert scene"
   },
   "KsFvzR": {
     "note": "Placeholder hint message for searching across entities",
@@ -663,6 +687,10 @@
     "note": "checkbox option",
     "text": "Enable Shadow"
   },
+  "YPkcJC": {
+    "note": "alert header text",
+    "text": "Converting scene"
+  },
   "ZKJ6Ci": {
     "note": "Toolbar label",
     "text": "Delete"
@@ -702,6 +730,10 @@
   "azq+4C": {
     "note": "Form section title",
     "text": "Link Parameters"
+  },
+  "bO1OgH": {
+    "note": "Progress Bar label",
+    "text": "Converting nodes"
   },
   "bVAsrx": {
     "note": "Form Field label",
@@ -750,6 +782,10 @@
   "e9HZHd": {
     "note": "FormField label",
     "text": "Indicator shape"
+  },
+  "eElB3q": {
+    "note": "Sub-Section Description",
+    "text": "Converting your scene to entities enables auto updating, filtering and querying your scene."
   },
   "eKQvAU": {
     "note": "placeholder",
@@ -947,6 +983,10 @@
     "note": "Sub-Section Description",
     "text": "Connecting your Matterport account enables viewing spaces in your TwinMaker scene."
   },
+  "oECZco": {
+    "note": "button label",
+    "text": "Ok"
+  },
   "oEXVJ5": {
     "note": "Motion Indicator Shape in a dropdown menu",
     "text": "Linear Plane"
@@ -975,6 +1015,10 @@
     "note": "Status indicator label",
     "text": "Tags sync failed"
   },
+  "pqZzsr": {
+    "note": "alert header text",
+    "text": "Convert to entities successful"
+  },
   "pyg21P": {
     "note": "Number of Triangles in a scene",
     "text": "Triangles : {sceneInfoTriangles, number}"
@@ -986,6 +1030,10 @@
   "qU9dRt": {
     "note": "Form Field label",
     "text": "Scale"
+  },
+  "qZiKXL": {
+    "note": "ExpandableInfoSection Title",
+    "text": "Convert scene"
   },
   "r0JN3A": {
     "note": "Menu Item",
@@ -1079,6 +1127,10 @@
     "note": "Enter your Matterport model id placeholder",
     "text": "Enter your Matterport model id"
   },
+  "ujFSQs": {
+    "note": "alert body text",
+    "text": "Some node conversion failed:"
+  },
   "v+Dj24": {
     "note": "hex validations messages",
     "text": "Invalid hex code"
@@ -1086,6 +1138,10 @@
   "v+tpx1": {
     "note": "Menu Item label",
     "text": "Light"
+  },
+  "v6Z7tj": {
+    "note": "Progress Bar description",
+    "text": "{convertedNumber} out of {totalNumber} converted"
   },
   "v7BBG+": {
     "note": "Error message wrong input",
@@ -1130,6 +1186,14 @@
   "x8NTqi": {
     "note": "Menu Item",
     "text": "Add empty node"
+  },
+  "xyFy7p": {
+    "note": "modal header text",
+    "text": "Convert scene"
+  },
+  "y9R3yg": {
+    "note": "Sub-Section Header",
+    "text": "Convert to entities"
   },
   "yXdV0F": {
     "note": "ExpandableInfoSection Title",


### PR DESCRIPTION
## Overview
- Resizing legend wont move widget around grid, regardless of selection state
- Widget can be selected from anywhere, not just the header area


![legendResize](https://github.com/awslabs/iot-app-kit/assets/28601414/e4b4f5f5-d5e4-4201-8174-43a72d97b724)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
