### PR TITLE
fix(dashboard): update unmodeled latest value to timestamp.timeInSeconds

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/useLatestValues/latestValueMapFactory.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/useLatestValues/latestValueMapFactory.ts
@@ -33,8 +33,7 @@ export class LatestValueMapFactory {
         ...acc,
         [entry.entryId ?? '']: {
           value: Object.values(entry.assetPropertyValue?.value ?? {})[0],
-          // timestamp is cast to shed TimeInNano type
-          timestamp: entry.assetPropertyValue?.timestamp as unknown as number,
+          timestamp: entry.assetPropertyValue?.timestamp?.timeInSeconds,
         },
       }),
       {}


### PR DESCRIPTION
## Overview
"Latest value times" setting on the unmodeled data table would crash.

Updated the timestamp to use the `timeInSeconds` field.

## Verifying Changes
Checked every combination of settings for the unmodeled data table.

<img width="834" alt="Screenshot 2023-10-12 at 12 50 43 PM" src="https://github.com/awslabs/iot-app-kit/assets/87385528/fc28b5c4-ae64-419d-805e-ec490a3ebd51">

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
