### PR TITLE
fix(composer): floating toolbar orientation dependent on screen size

### DIFF
--- a/packages/scene-composer/src/components/panels/ComponentEditMenu.spec.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditMenu.spec.tsx
@@ -70,7 +70,7 @@ describe('ComponentEditMenu', () => {
       fireEvent.pointerUp(addBindingButton);
     });
 
-    expect(getByTestId('edit-component').childNodes[2].childNodes.length).toEqual(2);
+    expect(getByTestId('edit-component').childNodes[2].childNodes[0].childNodes.length).toEqual(2);
     expect(updateComponentInternal).toBeCalledTimes(1);
     expect(updateComponentInternal).toBeCalledWith(nodeRef, {
       ...component,
@@ -94,7 +94,7 @@ describe('ComponentEditMenu', () => {
       fireEvent.pointerUp(removeOverlayButton);
     });
 
-    expect(getByTestId('edit-component').childNodes[2].childNodes.length).toEqual(2);
+    expect(getByTestId('edit-component').childNodes[2].childNodes[0].childNodes.length).toEqual(2);
     expect(removeComponent).toBeCalledTimes(1);
     expect(removeComponent).toBeCalledWith(nodeRef, component.ref);
     expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);

--- a/packages/scene-composer/src/components/toolbars/common/ItemContainer.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/common/ItemContainer.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 
 import { setFeatureConfig } from '../../../common/GlobalSettings';
 import { COMPOSER_FEATURES } from '../../../interfaces';
@@ -62,15 +63,33 @@ describe('ItemContainer', () => {
 
   it('should render selected item properly with custom menuHeight', () => {
     const { container, getByTestId } = render(
-      <ItemContainer item={{ ...baseItem, isSelected: true }} type='action-select' menuHeight='100px' />,
+      <ItemContainer
+        item={{ ...baseItem, isSelected: true }}
+        type='action-select'
+        menuHeight='100px'
+        isVertical={true}
+      />,
     );
     const item = getByTestId(baseItem.uuid);
     expect(item.getAttribute('height')).toEqual('100px');
     expect(container).toMatchSnapshot();
   });
 
+  it('should render properly when horizontal', async () => {
+    let container: HTMLElement | undefined;
+    await act(async () => {
+      const rendered = render(
+        <ItemContainer item={{ ...baseItem }} type='action-select' onItemClick={onClick} isVertical={false} />,
+      );
+      container = rendered.container;
+    });
+    expect(container).toMatchSnapshot();
+  });
+
   it('should render properly and trigger onClick when clicking on item', () => {
-    const { container } = render(<ItemContainer item={baseItem} type='action-select' onItemClick={onClick} />);
+    const { container } = render(
+      <ItemContainer item={baseItem} type='action-select' onItemClick={onClick} isVertical={true} />,
+    );
     expect(container).toMatchSnapshot();
 
     fireEvent.pointerUp(screen.getByTestId(baseItem.uuid));
@@ -80,7 +99,9 @@ describe('ItemContainer', () => {
   });
 
   it('should render properly and trigger onClick when clicking on sub item', () => {
-    const { container } = render(<ItemContainer item={itemWithSubItems} type='action-select' onItemClick={onClick} />);
+    const { container } = render(
+      <ItemContainer item={itemWithSubItems} type='action-select' onItemClick={onClick} isVertical={true} />,
+    );
     expect(container).toMatchSnapshot();
 
     fireEvent.pointerUp(screen.getByTestId('item5-uuid'));
@@ -91,7 +112,13 @@ describe('ItemContainer', () => {
 
   it('should trigger onKeyDown when keyboard navigating on sub item', () => {
     render(
-      <ItemContainer item={itemWithSubItems} type='action-select' onItemKeyDown={onKeyDown} onItemClick={onClick} />,
+      <ItemContainer
+        item={itemWithSubItems}
+        type='action-select'
+        onItemKeyDown={onKeyDown}
+        onItemClick={onClick}
+        isVertical={true}
+      />,
     );
 
     fireEvent.keyDown(screen.getByTestId('item5-uuid'), { key: 'Enter' });
@@ -102,7 +129,13 @@ describe('ItemContainer', () => {
 
   it('should not trigger onKeyDown if item is disabled', () => {
     render(
-      <ItemContainer item={itemWithSubItems} type='action-select' onItemKeyDown={onKeyDown} onItemClick={onClick} />,
+      <ItemContainer
+        item={itemWithSubItems}
+        type='action-select'
+        onItemKeyDown={onKeyDown}
+        onItemClick={onClick}
+        isVertical={true}
+      />,
     );
 
     fireEvent.keyDown(screen.getByTestId('item6-uuid'), { key: 'Enter' });
@@ -111,7 +144,11 @@ describe('ItemContainer', () => {
 
   it('should not render when feature is not enabled', () => {
     const { container } = render(
-      <ItemContainer item={{ ...baseItem, feature: { name: COMPOSER_FEATURES.FOR_TESTS } }} type='action-select' />,
+      <ItemContainer
+        item={{ ...baseItem, feature: { name: COMPOSER_FEATURES.FOR_TESTS } }}
+        type='action-select'
+        isVertical={true}
+      />,
     );
     expect(container).toMatchInlineSnapshot('<div />');
   });
@@ -120,7 +157,11 @@ describe('ItemContainer', () => {
     setFeatureConfig({ [COMPOSER_FEATURES.FOR_TESTS]: true });
 
     const { container } = render(
-      <ItemContainer item={{ ...baseItem, feature: { name: COMPOSER_FEATURES.FOR_TESTS } }} type='action-select' />,
+      <ItemContainer
+        item={{ ...baseItem, feature: { name: COMPOSER_FEATURES.FOR_TESTS } }}
+        type='action-select'
+        isVertical={true}
+      />,
     );
     expect(container).toMatchSnapshot();
   });

--- a/packages/scene-composer/src/components/toolbars/common/ItemContainer.tsx
+++ b/packages/scene-composer/src/components/toolbars/common/ItemContainer.tsx
@@ -27,6 +27,7 @@ interface ToolbarItemContainerProps {
   orientation?: ToolbarItemOrientation;
   onItemClick?: (item: ToolbarItemOptions) => void;
   disableSelectedStyle?: boolean;
+  isVertical?: boolean;
 }
 
 // Solves forwardRef with props and eslint issue. Explictly setting the props type (twice) silences eslint
@@ -46,6 +47,7 @@ export const ItemContainer = React.forwardRef<HTMLDivElement, ToolbarItemContain
       onItemClick,
       type,
       disableSelectedStyle,
+      isVertical,
     }: ToolbarItemContainerProps,
     ref,
   ) => {
@@ -123,6 +125,7 @@ export const ItemContainer = React.forwardRef<HTMLDivElement, ToolbarItemContain
         ref={ref}
         onKeyDown={keyDown}
         tabIndex={0}
+        isVertical={isVertical !== false}
       >
         {item.icon && (
           <ToolbarItemIcon>
@@ -159,6 +162,7 @@ export const ItemContainer = React.forwardRef<HTMLDivElement, ToolbarItemContain
                   onItemKeyDown={onItemKeyDown}
                   item={subItem}
                   type={type}
+                  isVertical={isVertical}
                 />
               );
             })}

--- a/packages/scene-composer/src/components/toolbars/common/ToolbarItem.tsx
+++ b/packages/scene-composer/src/components/toolbars/common/ToolbarItem.tsx
@@ -6,15 +6,26 @@ import { ItemContainer } from './ItemContainer';
 import { CornerAdornment, ToolbarItemMenu } from './styledComponents';
 import { ToolbarItemOptions, ToolbarItemOrientation, ToolbarItemType, ToolbarMenuPosition } from './types';
 
+interface MenuItemsContainterProps {
+  maxHeight?: string;
+  children: React.ReactNode;
+}
+
+const MenuItemsContainter = ({ maxHeight, children }: MenuItemsContainterProps) => {
+  return <div style={{ overflowY: 'auto', maxHeight: maxHeight }}>{children}</div>;
+};
+
 interface ToolbarItemProps<T extends ToolbarItemOptions> {
   items: T[];
   type: ToolbarItemType;
   initialSelectedItem?: T;
   onSelect?: (item: T) => void;
   orientation?: ToolbarItemOrientation;
+  isVertical?: boolean;
   menuPosition?: ToolbarMenuPosition;
   // Only used by the first root menu item
   menuHeight?: string;
+  maxMenuContainerHeight?: number | undefined;
 }
 
 export function ToolbarItem<T extends ToolbarItemOptions>({
@@ -25,6 +36,8 @@ export function ToolbarItem<T extends ToolbarItemOptions>({
   type,
   menuPosition = 'right',
   menuHeight,
+  maxMenuContainerHeight,
+  isVertical,
 }: ToolbarItemProps<T>) {
   const [selectedItem, setSelectedItem] = useState(initialSelectedItem ?? items[0]);
   const [showMenu, setShowMenu] = useState<boolean>();
@@ -160,12 +173,15 @@ export function ToolbarItem<T extends ToolbarItemOptions>({
       type={type}
       disableSelectedStyle
       ref={itemContainerRef}
+      isVertical={isVertical}
     >
       {type !== 'button' && menuItemComponents && (
         <Fragment>
           <CornerAdornment>{CornerTriangleSvg}</CornerAdornment>
           <ToolbarItemMenu isOpen={showMenu} orientation={orientation} position={menuPosition}>
-            {menuItemComponents}
+            <MenuItemsContainter maxHeight={maxMenuContainerHeight ? `${maxMenuContainerHeight}px` : undefined}>
+              {menuItemComponents}
+            </MenuItemsContainter>
           </ToolbarItemMenu>
         </Fragment>
       )}

--- a/packages/scene-composer/src/components/toolbars/common/__snapshots__/ItemContainer.spec.tsx.snap
+++ b/packages/scene-composer/src/components/toolbars/common/__snapshots__/ItemContainer.spec.tsx.snap
@@ -20,7 +20,6 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
-  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -34,6 +33,7 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
 
 .c0:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 <div>
@@ -72,7 +72,6 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
-  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -86,6 +85,7 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
 
 .c0:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c7 {
@@ -107,7 +107,6 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
-  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
@@ -118,6 +117,7 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
 
 .c7:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c8 {
@@ -139,7 +139,6 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
-  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
@@ -149,6 +148,7 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
 
 .c8:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c1 {
@@ -371,6 +371,51 @@ exports[`ItemContainer should render properly and trigger onClick when clicking 
 </div>
 `;
 
+exports[`ItemContainer should render properly when horizontal 1`] = `
+.c0 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  min-width: 40px;
+  height: 40px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  pointer-events: initial;
+  border-left: 1px solid colorBorderDividerDefault;
+}
+
+.c0:hover {
+  background-color: colorBackgroundDropdownItemHover;
+}
+
+.c0:first-of-type {
+  border-top: 0;
+  border-left: 0;
+}
+
+<div>
+  <div
+    class="c0"
+    data-testid="item1-uuid"
+    tabindex="0"
+  />
+</div>
+`;
+
 exports[`ItemContainer should render selected item properly with custom menuHeight 1`] = `
 .c0 {
   -webkit-flex: none;
@@ -391,7 +436,6 @@ exports[`ItemContainer should render selected item properly with custom menuHeig
   justify-content: flex-start;
   min-width: 40px;
   height: 100px;
-  max-height: 100px;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
@@ -402,6 +446,7 @@ exports[`ItemContainer should render selected item properly with custom menuHeig
 
 .c0:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 <div>
@@ -434,7 +479,6 @@ exports[`ItemContainer should render when feature is enabled 1`] = `
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
-  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -448,6 +492,7 @@ exports[`ItemContainer should render when feature is enabled 1`] = `
 
 .c0:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 <div>

--- a/packages/scene-composer/src/components/toolbars/common/styledComponents.ts
+++ b/packages/scene-composer/src/components/toolbars/common/styledComponents.ts
@@ -39,8 +39,10 @@ export const Icon = styled(PolarisIcon)<ToolbarItemIconProps>`
   transform: ${({ scale = 1, isMirrored }) => isMirrored && css`scaleX(${-scale});`};
 `;
 
+export const TOOLBAR_ITEM_CONTAINER_HEIGHT = 40;
+
 export const ToolbarItemContainer = styled.div<
-  Pick<ToolbarItemOptions, 'isDisabled' | 'isSelected'> & { height?: string }
+  Pick<ToolbarItemOptions, 'isDisabled' | 'isSelected'> & { height?: string; isVertical?: boolean }
 >`
   flex: none;
   position: relative;
@@ -48,13 +50,13 @@ export const ToolbarItemContainer = styled.div<
   align-items: center;
   justify-content: flex-start;
   min-width: 40px;
-  height: ${({ height }) => height || '40px'};
-  max-height: ${({ height }) => height || '10vh'};
+  height: ${({ height }) => height || `${TOOLBAR_ITEM_CONTAINER_HEIGHT}px`};
   text-decoration: none;
   cursor: ${({ isDisabled, isSelected }) => (isDisabled || isSelected ? 'default' : 'pointer')};
   pointer-events: ${({ isDisabled, isSelected }) => (isDisabled || isSelected ? 'none' : 'initial')};
   background-color: ${({ isSelected }) => (isSelected ? colorBackgroundItemSelected : undefined)};
-  border-top: ${ITEM_DIVIDER_WIDTH}px solid ${colorBorderDividerDefault};
+  border-top: ${({ isVertical }) => (isVertical ? `${ITEM_DIVIDER_WIDTH}px solid ${colorBorderDividerDefault}` : '')};
+  border-left: ${({ isVertical }) => (!isVertical ? `${ITEM_DIVIDER_WIDTH}px solid ${colorBorderDividerDefault}` : '')};
 
   &:hover {
     background-color: ${({ isDisabled, isSelected }) => !isDisabled && !isSelected && colorBackgroundDropdownItemHover};
@@ -62,17 +64,23 @@ export const ToolbarItemContainer = styled.div<
 
   &:first-of-type {
     border-top: 0;
+    border-left: 0;
   }
 `;
 
-export const ToolbarItemGroup = styled.div`
+export const ToolbarItemGroup = styled.div<{
+  isVertical: boolean;
+}>`
   position: relative;
   display: flex;
-  flex-direction: column;
-  border-top: ${GROUP_DIVIDER_WIDTH}px solid ${colorBorderDividerDefault};
+  flex-direction: ${({ isVertical }) => (isVertical ? 'column' : 'row')};
+  border-top: ${({ isVertical }) => (isVertical ? `${GROUP_DIVIDER_WIDTH}px solid ${colorBorderDividerDefault}` : '')};
+  border-left: ${({ isVertical }) =>
+    !isVertical ? `${GROUP_DIVIDER_WIDTH}px solid ${colorBorderDividerDefault}` : ''};
 
   &:first-of-type {
     border-top: 0;
+    border-left: 0;
   }
 `;
 

--- a/packages/scene-composer/src/components/toolbars/common/types.ts
+++ b/packages/scene-composer/src/components/toolbars/common/types.ts
@@ -28,4 +28,9 @@ export type ToolbarItemType = 'button' | 'action-select' | 'mode-select';
 
 export type ToolbarItemOrientation = 'horizontal' | 'vertical';
 
+export enum ToolbarOrientation {
+  Horizontal = 'horizontal',
+  Vertical = 'vertical',
+}
+
 export type ToolbarMenuPosition = 'right' | 'bottom-left' | 'bottom-right';

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
@@ -25,8 +25,9 @@ import {
   setFeatureConfig,
   setMetricRecorder,
 } from '../../../..';
-import { Component, LightType } from '../../../../models/SceneModels';
+import { CameraType, Component, LightType } from '../../../../models/SceneModels';
 import { createNodeWithTransform } from '../../../../utils/nodeUtils';
+import { ToolbarOrientation } from '../../common/types';
 /* eslint-enable */
 
 jest.mock('../../../../../src/utils/pathUtils', () => ({
@@ -70,7 +71,7 @@ describe('AddObjectMenu', () => {
       lightSettings: DEFAULT_LIGHT_SETTINGS_MAP[LightType.Directional],
     };
 
-    render(<AddObjectMenu />);
+    render(<AddObjectMenu canvasHeight={null} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-object-light');
     fireEvent.pointerUp(sut);
     expect(appendSceneNode).toBeCalledWith({
@@ -84,7 +85,7 @@ describe('AddObjectMenu', () => {
 
   it('should call appendSceneNode when adding a camera', () => {
     const cameraComponent: ICameraComponent = {
-      cameraType: 'Perspective',
+      cameraType: CameraType.Perspective,
       type: 'Camera',
       fov: DEFAULT_CAMERA_OPTIONS.fov,
       far: DEFAULT_CAMERA_OPTIONS.far,
@@ -107,7 +108,7 @@ describe('AddObjectMenu', () => {
 
     (createNodeWithTransform as jest.Mock).mockReturnValue(node);
 
-    render(<AddObjectMenu />);
+    render(<AddObjectMenu canvasHeight={null} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-object-view-camera');
     fireEvent.pointerUp(sut);
 
@@ -121,7 +122,7 @@ describe('AddObjectMenu', () => {
       type: 'Tag',
     };
 
-    render(<AddObjectMenu />);
+    render(<AddObjectMenu canvasHeight={null} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-object-tag');
     fireEvent.pointerUp(sut);
     expect(appendSceneNode).toBeCalledWith({
@@ -134,7 +135,7 @@ describe('AddObjectMenu', () => {
   });
 
   it('should call appendSceneNode when adding an empty node', () => {
-    render(<AddObjectMenu />);
+    render(<AddObjectMenu canvasHeight={null} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-object-empty');
     fireEvent.pointerUp(sut);
     expect(appendSceneNode).toBeCalledWith({
@@ -153,7 +154,7 @@ describe('AddObjectMenu', () => {
     };
     showAssetBrowserCallback.mockImplementationOnce((callback) => callback(null, 'modelUri'));
 
-    render(<AddObjectMenu />);
+    render(<AddObjectMenu canvasHeight={null} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-object-model');
     fireEvent.pointerUp(sut);
     expect(appendSceneNode).toBeCalledWith({
@@ -173,7 +174,7 @@ describe('AddObjectMenu', () => {
     };
     showAssetBrowserCallback.mockImplementationOnce((callback) => callback(null, 'modelUri'));
 
-    render(<AddObjectMenu />);
+    render(<AddObjectMenu canvasHeight={null} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-environment-model');
     fireEvent.pointerUp(sut);
     expect(appendSceneNode).toBeCalledWith({
@@ -191,7 +192,7 @@ describe('AddObjectMenu', () => {
       type: 'ModelShader',
     };
 
-    render(<AddObjectMenu />);
+    render(<AddObjectMenu canvasHeight={null} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-effect-model-shader');
     fireEvent.pointerUp(sut);
     expect(addComponentInternal).toBeCalledWith(selectedSceneNodeRef, colorOverlayComponent);
@@ -210,7 +211,7 @@ describe('AddObjectMenu', () => {
       },
     };
 
-    render(<AddObjectMenu />);
+    render(<AddObjectMenu canvasHeight={null} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-object-motion-indicator');
     fireEvent.pointerUp(sut);
     expect(appendSceneNode).toBeCalledWith({
@@ -225,7 +226,7 @@ describe('AddObjectMenu', () => {
   it('should not see add overlay item when feature is not enabled', () => {
     setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: false });
 
-    render(<AddObjectMenu />);
+    render(<AddObjectMenu canvasHeight={null} toolbarOrientation={ToolbarOrientation.Vertical} />);
 
     expect(screen.queryByTestId('add-overlay-menu')).toBeNull();
   });
@@ -244,7 +245,7 @@ describe('AddObjectMenu', () => {
       ],
     };
 
-    render(<AddObjectMenu />);
+    render(<AddObjectMenu canvasHeight={null} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-object-annotation');
     fireEvent.pointerUp(sut);
     expect(setAddingWidget).toBeCalledWith({

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -21,11 +21,13 @@ import { Component, LightType, ModelType } from '../../../../models/SceneModels'
 import { IColorOverlayComponentInternal, ISceneNodeInternal, useEditorState, useStore } from '../../../../store';
 import { extractFileNameExtFromUrl, parseS3BucketFromArn } from '../../../../utils/pathUtils';
 import { ToolbarItem } from '../../common/ToolbarItem';
-import { ToolbarItemOptionRaw, ToolbarItemOptions } from '../../common/types';
+import { ToolbarItemOptionRaw, ToolbarItemOptions, ToolbarOrientation } from '../../common/types';
 import { getGlobalSettings } from '../../../../common/GlobalSettings';
 import useActiveCamera from '../../../../hooks/useActiveCamera';
 import useMatterportViewer from '../../../../hooks/useMatterportViewer';
 import { createNodeWithTransform, findComponentByType, isEnvironmentNode } from '../../../../utils/nodeUtils';
+import { FLOATING_TOOLBAR_VERTICAL_ORIENTATION_BUFFER } from '../FloatingToolbar';
+import { TOOLBAR_ITEM_CONTAINER_HEIGHT } from '../../common/styledComponents';
 
 // Note: ObjectType String is used to record metric. DO NOT change existing ids unless it's necessary.
 enum ObjectTypes {
@@ -70,7 +72,12 @@ const textStrings = defineMessages({
   [ObjectTypes.Annotation]: { defaultMessage: 'Add annotation', description: 'Menu Item' },
 });
 
-export const AddObjectMenu = (): JSX.Element => {
+interface AddObjectMenuProps {
+  canvasHeight: number | undefined;
+  toolbarOrientation: ToolbarOrientation;
+}
+
+export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMenuProps): JSX.Element => {
   const sceneComposerId = useContext(sceneComposerIdContext);
   const addComponentInternal = useStore(sceneComposerId)((state) => state.addComponentInternal);
   const appendSceneNode = useStore(sceneComposerId)((state) => state.appendSceneNode);
@@ -389,6 +396,13 @@ export const AddObjectMenu = (): JSX.Element => {
 
         getGlobalSettings().metricRecorder?.recordClick(uuid);
       }}
+      maxMenuContainerHeight={
+        canvasHeight
+          ? canvasHeight - FLOATING_TOOLBAR_VERTICAL_ORIENTATION_BUFFER - TOOLBAR_ITEM_CONTAINER_HEIGHT
+          : undefined
+      }
+      isVertical={toolbarOrientation === ToolbarOrientation.Vertical}
+      menuPosition={toolbarOrientation === ToolbarOrientation.Vertical ? 'right' : 'bottom-left'}
     />
   );
 };

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/HistoryItemGroup.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/HistoryItemGroup.spec.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { create, act } from 'react-test-renderer';
+import { render } from '@testing-library/react';
 
 import useDynamicScene from '../../../../hooks/useDynamicScene';
 import { createUndoStore } from '../../../../store/middlewares';
 import { useStore } from '../../../../store';
+import { ToolbarOrientation } from '../../common/types';
 
 import { HistoryItemGroup } from './HistoryItemGroup';
 
@@ -25,7 +27,7 @@ describe('HistoryItemGroup', () => {
     undoStore.setState({ prevStates: [{}] });
     let container;
     act(() => {
-      container = create(<HistoryItemGroup />);
+      container = create(<HistoryItemGroup toolbarOrientation={ToolbarOrientation.Vertical} />);
     });
     expect(container).toMatchSnapshot();
   });
@@ -38,7 +40,7 @@ describe('HistoryItemGroup', () => {
     undoStore.setState({ prevStates: [{}] });
     let container;
     act(() => {
-      container = create(<HistoryItemGroup />);
+      container = create(<HistoryItemGroup toolbarOrientation={ToolbarOrientation.Vertical} />);
     });
     expect(container).toMatchSnapshot();
   });
@@ -50,7 +52,7 @@ describe('HistoryItemGroup', () => {
     undoStore.setState({ futureStates: [{}] });
     let container;
     act(() => {
-      container = create(<HistoryItemGroup />);
+      container = create(<HistoryItemGroup toolbarOrientation={ToolbarOrientation.Vertical} />);
     });
     expect(container).toMatchSnapshot();
   });
@@ -63,8 +65,18 @@ describe('HistoryItemGroup', () => {
     undoStore.setState({ futureStates: [{}] });
     let container;
     act(() => {
-      container = create(<HistoryItemGroup />);
+      container = create(<HistoryItemGroup toolbarOrientation={ToolbarOrientation.Vertical} />);
     });
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should correctly render horizontally', async () => {
+    let container: HTMLElement | undefined;
+    await act(async () => {
+      const rendered = render(<HistoryItemGroup toolbarOrientation={ToolbarOrientation.Horizontal} />);
+      container = rendered.container;
+    });
+
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/HistoryItemGroup.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/HistoryItemGroup.tsx
@@ -7,8 +7,13 @@ import { UndoStoreState } from '../../../../store/middlewares';
 import { ToolbarItem } from '../../common/ToolbarItem';
 import { ToolbarItemGroup } from '../../common/styledComponents';
 import useDynamicScene from '../../../../hooks/useDynamicScene';
+import { ToolbarOrientation } from '../../common/types';
 
-export function HistoryItemGroup() {
+interface HistoryItemGroupProps {
+  toolbarOrientation: ToolbarOrientation;
+}
+
+export function HistoryItemGroup({ toolbarOrientation }: HistoryItemGroupProps) {
   const sceneComposerId = useContext(sceneComposerIdContext);
   const [redo, undo] = useStore(sceneComposerId)((state) => [state.redo, state.undo]);
   const undoStore = useStore(sceneComposerId)((state) => state.undoStore);
@@ -25,7 +30,7 @@ export function HistoryItemGroup() {
   }, [undoStore]);
 
   return (
-    <ToolbarItemGroup>
+    <ToolbarItemGroup isVertical={toolbarOrientation === ToolbarOrientation.Vertical}>
       <ToolbarItem
         items={[
           {

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import { useStore } from '../../../../store';
+import { ToolbarOrientation } from '../../common/types';
 
 import { ObjectItemGroup } from '.';
 
@@ -23,7 +24,7 @@ describe('ObjectItemGroup', () => {
   });
 
   it('should call removeSceneNode when clicking delete with a selected node', () => {
-    render(<ObjectItemGroup />);
+    render(<ObjectItemGroup canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('delete');
     fireEvent.pointerUp(sut);
     expect(removeSceneNode).toBeCalledWith(selectedSceneNodeRef);
@@ -33,14 +34,14 @@ describe('ObjectItemGroup', () => {
     useStore('default').setState({
       selectedSceneNodeRef: undefined,
     });
-    render(<ObjectItemGroup />);
+    render(<ObjectItemGroup canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('delete');
     fireEvent.pointerUp(sut);
     expect(removeSceneNode).not.toBeCalled();
   });
 
   it('should call setTransformControlMode when clicking rotate', () => {
-    render(<ObjectItemGroup />);
+    render(<ObjectItemGroup canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('transform-rotate');
     fireEvent.pointerUp(sut);
     expect(setTransformControlMode).toBeCalledWith('rotate');

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.tsx
@@ -6,9 +6,10 @@ import { KnownComponentType, TransformControlMode } from '../../../../interfaces
 import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
 import { useEditorState, useSceneDocument } from '../../../../store';
 import { ToolbarItem } from '../../common/ToolbarItem';
-import { ToolbarItemGroup } from '../../common/styledComponents';
-import { ToolbarItemOptions } from '../../common/types';
+import { TOOLBAR_ITEM_CONTAINER_HEIGHT, ToolbarItemGroup } from '../../common/styledComponents';
+import { ToolbarItemOptions, ToolbarOrientation } from '../../common/types';
 import { findComponentByType } from '../../../../utils/nodeUtils';
+import { FLOATING_TOOLBAR_VERTICAL_ORIENTATION_BUFFER } from '../FloatingToolbar';
 
 enum TransformTypes {
   Translate = 'transform-translate',
@@ -28,7 +29,12 @@ const textStrings = defineMessages({
   [TransformTypes.Scale]: { defaultMessage: 'Scale object', description: 'Menu Item' },
 });
 
-export function ObjectItemGroup() {
+interface ObjectItemGroupProps {
+  canvasHeight: number | undefined;
+  toolbarOrientation: ToolbarOrientation;
+}
+
+export function ObjectItemGroup({ toolbarOrientation, canvasHeight }: ObjectItemGroupProps) {
   const sceneComposerId = useContext(sceneComposerIdContext);
   const intl = useIntl();
   const { selectedSceneNodeRef, transformControlMode, setTransformControlMode } = useEditorState(sceneComposerId);
@@ -80,7 +86,7 @@ export function ObjectItemGroup() {
   }, [intl, isTagComponent, isOverlayComponent, transformControlMode]);
 
   return (
-    <ToolbarItemGroup>
+    <ToolbarItemGroup isVertical={toolbarOrientation === ToolbarOrientation.Vertical}>
       <ToolbarItem
         items={[
           {
@@ -96,12 +102,20 @@ export function ObjectItemGroup() {
             removeSceneNode(selectedSceneNodeRef);
           }
         }}
+        isVertical={toolbarOrientation === ToolbarOrientation.Vertical}
       />
       <ToolbarItem
         items={translatedItems}
         type='mode-select'
         initialSelectedItem={initialSelectedItem}
         onSelect={(selectedItem) => setTransformControlMode(selectedItem.mode)}
+        maxMenuContainerHeight={
+          canvasHeight
+            ? canvasHeight - FLOATING_TOOLBAR_VERTICAL_ORIENTATION_BUFFER - TOOLBAR_ITEM_CONTAINER_HEIGHT
+            : undefined
+        }
+        isVertical={toolbarOrientation === ToolbarOrientation.Vertical}
+        menuPosition={toolbarOrientation === ToolbarOrientation.Vertical ? 'right' : 'bottom-right'}
       />
     </ToolbarItemGroup>
   );

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroupSnap.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroupSnap.spec.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { act } from 'react-test-renderer';
 
 import { useStore } from '../../../../store';
 import { KnownComponentType } from '../../../../interfaces';
+import { ToolbarOrientation } from '../../common/types';
 
 import { ObjectItemGroup } from '.';
 
@@ -36,7 +38,9 @@ describe('ObjectItemGroupSnap', () => {
 
   it('should render with disabled rotate and scale when Tag is selected', () => {
     getSceneNodeByRef.mockReturnValue({ components: [{ type: KnownComponentType.Tag }] });
-    const { container, queryAllByText } = render(<ObjectItemGroup />);
+    const { container, queryAllByText } = render(
+      <ObjectItemGroup canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />,
+    );
 
     expect(queryAllByText('"isDisabled":true', { exact: false }).length).toBe(1);
     expect(container).toMatchSnapshot();
@@ -44,9 +48,23 @@ describe('ObjectItemGroupSnap', () => {
 
   it('should render with disabled rotate and scale when Overlay is selected', () => {
     getSceneNodeByRef.mockReturnValue({ components: [{ type: KnownComponentType.DataOverlay }] });
-    const { container, queryAllByText } = render(<ObjectItemGroup />);
+    const { container, queryAllByText } = render(
+      <ObjectItemGroup canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />,
+    );
 
     expect(queryAllByText('"isDisabled":true', { exact: false }).length).toBe(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should correctly render horizontally', async () => {
+    let container: HTMLElement | undefined;
+    await act(async () => {
+      const rendered = render(
+        <ObjectItemGroup canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Horizontal} />,
+      );
+      container = rendered.container;
+    });
+
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/SceneItemGroup.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/SceneItemGroup.tsx
@@ -7,9 +7,10 @@ import { getGlobalSettings } from '../../../../common/GlobalSettings';
 import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
 import { useStore } from '../../../../store';
 import { ToolbarItem } from '../../common/ToolbarItem';
-import { ToolbarItemGroup } from '../../common/styledComponents';
-import { ToolbarItemOptions } from '../../common/types';
+import { TOOLBAR_ITEM_CONTAINER_HEIGHT, ToolbarItemGroup } from '../../common/styledComponents';
+import { ToolbarItemOptions, ToolbarOrientation } from '../../common/types';
 import useMatterportViewer from '../../../../hooks/useMatterportViewer';
+import { FLOATING_TOOLBAR_VERTICAL_ORIENTATION_BUFFER } from '../FloatingToolbar';
 
 import { AddObjectMenu } from './AddObjectMenu';
 
@@ -76,9 +77,15 @@ const cameraControlItems = (
 
 export interface SceneItemGroupProps {
   isViewing?: boolean;
+  toolbarOrientation: ToolbarOrientation;
+  canvasHeight: number | undefined;
 }
 
-export function SceneItemGroup({ isViewing = false }: SceneItemGroupProps): JSX.Element {
+export function SceneItemGroup({
+  isViewing = false,
+  toolbarOrientation,
+  canvasHeight,
+}: SceneItemGroupProps): JSX.Element {
   const sceneComposerId = useContext(sceneComposerIdContext);
   const cameraControlsType = useStore(sceneComposerId)((state) => state.cameraControlsType);
   const setCameraControlsType = useStore(sceneComposerId)((state) => state.setCameraControlsType);
@@ -100,14 +107,21 @@ export function SceneItemGroup({ isViewing = false }: SceneItemGroupProps): JSX.
   }, [cameraControlsType, firstPersonOn]);
 
   return (
-    <ToolbarItemGroup>
-      {!isViewing && <AddObjectMenu />}
+    <ToolbarItemGroup isVertical={toolbarOrientation === ToolbarOrientation.Vertical}>
+      {!isViewing && <AddObjectMenu canvasHeight={canvasHeight} toolbarOrientation={toolbarOrientation} />}
       {!enableMatterportViewer && (
         <ToolbarItem
           items={items}
           initialSelectedItem={initialSelectedItem}
           type='mode-select'
           onSelect={(selectedItem) => setCameraControlsType(selectedItem.mode)}
+          isVertical={toolbarOrientation === ToolbarOrientation.Vertical}
+          menuPosition={toolbarOrientation === ToolbarOrientation.Vertical ? 'right' : 'bottom-left'}
+          maxMenuContainerHeight={
+            canvasHeight
+              ? canvasHeight - FLOATING_TOOLBAR_VERTICAL_ORIENTATION_BUFFER - TOOLBAR_ITEM_CONTAINER_HEIGHT
+              : undefined
+          }
         />
       )}
     </ToolbarItemGroup>

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/__snapshots__/HistoryItemGroup.spec.tsx.snap
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/__snapshots__/HistoryItemGroup.spec.tsx.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HistoryItemGroup should correctly render horizontally 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  border-left: 3px solid colorBorderDividerDefault;
+}
+
+.c0:first-of-type {
+  border-top: 0;
+  border-left: 0;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <toolbaritem
+      items="[object Object]"
+      type="button"
+    />
+    <toolbaritem
+      items="[object Object]"
+      type="button"
+    />
+  </div>
+</div>
+`;
+
 exports[`HistoryItemGroup should render correctly with redo disabled 1`] = `
 .c0 {
   position: relative;
@@ -15,6 +49,7 @@ exports[`HistoryItemGroup should render correctly with redo disabled 1`] = `
 
 .c0:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 <div
@@ -71,6 +106,7 @@ exports[`HistoryItemGroup should render correctly with redo enabled 1`] = `
 
 .c0:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 <div
@@ -127,6 +163,7 @@ exports[`HistoryItemGroup should render correctly with undo disabled 1`] = `
 
 .c0:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 <div
@@ -183,6 +220,7 @@ exports[`HistoryItemGroup should render correctly with undo enabled 1`] = `
 
 .c0:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 <div

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/__snapshots__/ObjectItemGroupSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/__snapshots__/ObjectItemGroupSnap.spec.tsx.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ObjectItemGroupSnap should correctly render horizontally 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  border-left: 3px solid colorBorderDividerDefault;
+}
+
+.c0:first-of-type {
+  border-top: 0;
+  border-left: 0;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      data-testid="ToolbarItem"
+    >
+      [{"items":[{"label":"Delete","icon":{"svg":"DeleteSvg"},"uuid":"delete","isDisabled":false}],"type":"button","isVertical":false},{}]
+    </div>
+    <div
+      data-testid="ToolbarItem"
+    >
+      [{"items":[{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"},{"icon":{"scale":1.06,"svg":"RotateIconSvg"},"uuid":"transform-rotate","mode":"rotate","isDisabled":true,"isSelected":false,"label":"Rotate","text":"Rotate object"},{"icon":{"scale":1.06,"svg":"ScaleIconSvg"},"uuid":"transform-scale","mode":"scale","isDisabled":true,"isSelected":false,"label":"Scale","text":"Scale object"}],"type":"mode-select","initialSelectedItem":{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"},"isVertical":false,"menuPosition":"bottom-right"},{}]
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ObjectItemGroupSnap should render with disabled rotate and scale when Overlay is selected 1`] = `
 .c0 {
   position: relative;
@@ -15,6 +51,7 @@ exports[`ObjectItemGroupSnap should render with disabled rotate and scale when O
 
 .c0:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 <div>
@@ -24,12 +61,12 @@ exports[`ObjectItemGroupSnap should render with disabled rotate and scale when O
     <div
       data-testid="ToolbarItem"
     >
-      [{"items":[{"label":"Delete","icon":{"svg":"DeleteSvg"},"uuid":"delete","isDisabled":false}],"type":"button"},{}]
+      [{"items":[{"label":"Delete","icon":{"svg":"DeleteSvg"},"uuid":"delete","isDisabled":false}],"type":"button","isVertical":true},{}]
     </div>
     <div
       data-testid="ToolbarItem"
     >
-      [{"items":[{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"},{"icon":{"scale":1.06,"svg":"RotateIconSvg"},"uuid":"transform-rotate","mode":"rotate","isDisabled":true,"isSelected":false,"label":"Rotate","text":"Rotate object"},{"icon":{"scale":1.06,"svg":"ScaleIconSvg"},"uuid":"transform-scale","mode":"scale","isDisabled":true,"isSelected":false,"label":"Scale","text":"Scale object"}],"type":"mode-select","initialSelectedItem":{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"}},{}]
+      [{"items":[{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"},{"icon":{"scale":1.06,"svg":"RotateIconSvg"},"uuid":"transform-rotate","mode":"rotate","isDisabled":true,"isSelected":false,"label":"Rotate","text":"Rotate object"},{"icon":{"scale":1.06,"svg":"ScaleIconSvg"},"uuid":"transform-scale","mode":"scale","isDisabled":true,"isSelected":false,"label":"Scale","text":"Scale object"}],"type":"mode-select","initialSelectedItem":{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"},"isVertical":true,"menuPosition":"right"},{}]
     </div>
   </div>
 </div>
@@ -50,6 +87,7 @@ exports[`ObjectItemGroupSnap should render with disabled rotate and scale when T
 
 .c0:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 <div>
@@ -59,12 +97,12 @@ exports[`ObjectItemGroupSnap should render with disabled rotate and scale when T
     <div
       data-testid="ToolbarItem"
     >
-      [{"items":[{"label":"Delete","icon":{"svg":"DeleteSvg"},"uuid":"delete","isDisabled":false}],"type":"button"},{}]
+      [{"items":[{"label":"Delete","icon":{"svg":"DeleteSvg"},"uuid":"delete","isDisabled":false}],"type":"button","isVertical":true},{}]
     </div>
     <div
       data-testid="ToolbarItem"
     >
-      [{"items":[{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"},{"icon":{"scale":1.06,"svg":"RotateIconSvg"},"uuid":"transform-rotate","mode":"rotate","isDisabled":true,"isSelected":false,"label":"Rotate","text":"Rotate object"},{"icon":{"scale":1.06,"svg":"ScaleIconSvg"},"uuid":"transform-scale","mode":"scale","isDisabled":true,"isSelected":false,"label":"Scale","text":"Scale object"}],"type":"mode-select","initialSelectedItem":{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"}},{}]
+      [{"items":[{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"},{"icon":{"scale":1.06,"svg":"RotateIconSvg"},"uuid":"transform-rotate","mode":"rotate","isDisabled":true,"isSelected":false,"label":"Rotate","text":"Rotate object"},{"icon":{"scale":1.06,"svg":"ScaleIconSvg"},"uuid":"transform-scale","mode":"scale","isDisabled":true,"isSelected":false,"label":"Scale","text":"Scale object"}],"type":"mode-select","initialSelectedItem":{"icon":{"scale":1.06,"svg":"TranslateIconSvg"},"uuid":"transform-translate","mode":"translate","isSelected":true,"label":"Translate","text":"Translate object"},"isVertical":true,"menuPosition":"right"},{}]
     </div>
   </div>
 </div>

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
@@ -84,7 +84,7 @@ const R3FWrapper = (props: { matterportConfig?: MatterportConfig; children?: Rea
       </ContextBridge>
     </MatterportViewer>
   ) : (
-    <UnselectableCanvas shadows dpr={window.devicePixelRatio}>
+    <UnselectableCanvas shadows dpr={window.devicePixelRatio} id='tm-scene-unselectable-canvas'>
       <ContextBridge>
         <Suspense fallback={null}>{children}</Suspense>
       </ContextBridge>

--- a/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
+++ b/packages/scene-composer/src/layouts/SceneLayout/__snapshots__/SceneLayout.spec.tsx.snap
@@ -1331,7 +1331,6 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
-  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -1345,6 +1344,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
 
 .c8:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c13 {
@@ -1366,7 +1366,6 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
-  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
@@ -1377,6 +1376,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
 
 .c13:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c7 {
@@ -1393,6 +1393,7 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
 
 .c7:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c9 {
@@ -1588,122 +1589,131 @@ exports[`SceneLayout should render correctly in Viewing mode 1`] = `
                   className="c12"
                 >
                   <div
-                    className="c13"
-                    data-testid="camera-controls-orbit"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onPointerDown={[Function]}
-                    onPointerEnter={[Function]}
-                    onPointerLeave={[Function]}
-                    onPointerUp={[Function]}
-                    tabIndex={0}
+                    style={
+                      Object {
+                        "maxHeight": undefined,
+                        "overflowY": "auto",
+                      }
+                    }
                   >
                     <div
-                      className="c9"
+                      className="c13"
+                      data-testid="camera-controls-orbit"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onPointerDown={[Function]}
+                      onPointerEnter={[Function]}
+                      onPointerLeave={[Function]}
+                      onPointerUp={[Function]}
+                      tabIndex={0}
                     >
-                      <span
-                        aria-label="Orbit"
-                        role="img"
-                        title="Orbit"
+                      <div
+                        className="c9"
                       >
-                        <div
-                          className="c10"
-                          data-mocked="Icon"
-                          scale={1.04}
-                          variant="normal"
+                        <span
+                          aria-label="Orbit"
+                          role="img"
+                          title="Orbit"
                         >
-                          <div>
-                            <span>
-                              <svg
-                                height={16}
-                                width={16}
-                              >
-                                <g
-                                  fill="none"
+                          <div
+                            className="c10"
+                            data-mocked="Icon"
+                            scale={1.04}
+                            variant="normal"
+                          >
+                            <div>
+                              <span>
+                                <svg
+                                  height={16}
+                                  width={16}
+                                >
+                                  <g
+                                    fill="none"
+                                  >
+                                    <path
+                                      d="M10.5 8.23c0 4.06-1.14 7.33-2.5 7.33s-2.5-3.35-2.5-7.5S6.62.56 8 .56c1 0 1.87 1.79 2.27 4.35"
+                                      stroke="currentColor"
+                                    />
+                                    <path
+                                      d="m9.23 8.61 1.21-2.18 1.28 2.14z"
+                                      fill="currentColor"
+                                    />
+                                    <path
+                                      d="M7.84 10.56C3.77 10.54.5 9.43.5 8.06s3.36-2.5 7.5-2.5c4.14 0 7.5 1.12 7.5 2.5 0 1-1.78 1.88-4.35 2.27"
+                                      stroke="currentColor"
+                                    />
+                                    <path
+                                      d="m7.46 9.29 2.17 1.22-2.14 1.27z"
+                                      fill="currentColor"
+                                    />
+                                  </g>
+                                </svg>
+                              </span>
+                            </div>
+                          </div>
+                        </span>
+                      </div>
+                      <div
+                        className="c14"
+                        color="inherit"
+                        data-mocked="Box"
+                        leftPadding={0}
+                        variant="small"
+                      >
+                        3D Orbit
+                      </div>
+                    </div>
+                    <div
+                      className="c8"
+                      data-testid="camera-controls-pan"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onPointerDown={[Function]}
+                      onPointerEnter={[Function]}
+                      onPointerLeave={[Function]}
+                      onPointerUp={[Function]}
+                      tabIndex={0}
+                    >
+                      <div
+                        className="c9"
+                      >
+                        <span
+                          aria-label="Pan"
+                          role="img"
+                          title="Pan"
+                        >
+                          <div
+                            className="c10"
+                            data-mocked="Icon"
+                            scale={1.04}
+                            variant="normal"
+                          >
+                            <div>
+                              <span>
+                                <svg
+                                  height={14}
+                                  width={14}
                                 >
                                   <path
-                                    d="M10.5 8.23c0 4.06-1.14 7.33-2.5 7.33s-2.5-3.35-2.5-7.5S6.62.56 8 .56c1 0 1.87 1.79 2.27 4.35"
+                                    d="M9.15 1.5a1 1 0 0 1 2 0m-4 0a1 1 0 1 1 2 0m2 2a1 1 0 0 1 2 0v5.9a4.1 4.1 0 0 1-4.1 4.1h-2A4.1 4.1 0 0 1 3.92 12l-2.8-3.34a1.21 1.21 0 0 1 .39-1.84 1.2 1.2 0 0 1 1.19.06l1.42.91h1V2.5a1 1 0 1 1 2 0m4.02 4.28.01-5.28m-2 5.28V1.5m-2 5.28V1.5"
+                                    fill="none"
                                     stroke="currentColor"
                                   />
-                                  <path
-                                    d="m9.23 8.61 1.21-2.18 1.28 2.14z"
-                                    fill="currentColor"
-                                  />
-                                  <path
-                                    d="M7.84 10.56C3.77 10.54.5 9.43.5 8.06s3.36-2.5 7.5-2.5c4.14 0 7.5 1.12 7.5 2.5 0 1-1.78 1.88-4.35 2.27"
-                                    stroke="currentColor"
-                                  />
-                                  <path
-                                    d="m7.46 9.29 2.17 1.22-2.14 1.27z"
-                                    fill="currentColor"
-                                  />
-                                </g>
-                              </svg>
-                            </span>
+                                </svg>
+                              </span>
+                            </div>
                           </div>
-                        </div>
-                      </span>
-                    </div>
-                    <div
-                      className="c14"
-                      color="inherit"
-                      data-mocked="Box"
-                      leftPadding={0}
-                      variant="small"
-                    >
-                      3D Orbit
-                    </div>
-                  </div>
-                  <div
-                    className="c8"
-                    data-testid="camera-controls-pan"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onPointerDown={[Function]}
-                    onPointerEnter={[Function]}
-                    onPointerLeave={[Function]}
-                    onPointerUp={[Function]}
-                    tabIndex={0}
-                  >
-                    <div
-                      className="c9"
-                    >
-                      <span
-                        aria-label="Pan"
-                        role="img"
-                        title="Pan"
+                        </span>
+                      </div>
+                      <div
+                        className="c14"
+                        color="inherit"
+                        data-mocked="Box"
+                        leftPadding={0}
+                        variant="small"
                       >
-                        <div
-                          className="c10"
-                          data-mocked="Icon"
-                          scale={1.04}
-                          variant="normal"
-                        >
-                          <div>
-                            <span>
-                              <svg
-                                height={14}
-                                width={14}
-                              >
-                                <path
-                                  d="M9.15 1.5a1 1 0 0 1 2 0m-4 0a1 1 0 1 1 2 0m2 2a1 1 0 0 1 2 0v5.9a4.1 4.1 0 0 1-4.1 4.1h-2A4.1 4.1 0 0 1 3.92 12l-2.8-3.34a1.21 1.21 0 0 1 .39-1.84 1.2 1.2 0 0 1 1.19.06l1.42.91h1V2.5a1 1 0 1 1 2 0m4.02 4.28.01-5.28m-2 5.28V1.5m-2 5.28V1.5"
-                                  fill="none"
-                                  stroke="currentColor"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </div>
-                      </span>
-                    </div>
-                    <div
-                      className="c14"
-                      color="inherit"
-                      data-mocked="Box"
-                      leftPadding={0}
-                      variant="small"
-                    >
-                      3D Pan
+                        3D Pan
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1871,7 +1881,6 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
-  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -1885,6 +1894,7 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
 
 .c10:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c15 {
@@ -1906,7 +1916,6 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
   justify-content: flex-start;
   min-width: 40px;
   height: 40px;
-  max-height: 10vh;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: default;
@@ -1917,6 +1926,7 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
 
 .c15:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c9 {
@@ -1933,6 +1943,7 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
 
 .c9:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c11 {
@@ -2168,122 +2179,131 @@ exports[`SceneLayout should render correctly in Viewing mode with modal 1`] = `
                   className="c14"
                 >
                   <div
-                    className="c15"
-                    data-testid="camera-controls-orbit"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onPointerDown={[Function]}
-                    onPointerEnter={[Function]}
-                    onPointerLeave={[Function]}
-                    onPointerUp={[Function]}
-                    tabIndex={0}
+                    style={
+                      Object {
+                        "maxHeight": undefined,
+                        "overflowY": "auto",
+                      }
+                    }
                   >
                     <div
-                      className="c11"
+                      className="c15"
+                      data-testid="camera-controls-orbit"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onPointerDown={[Function]}
+                      onPointerEnter={[Function]}
+                      onPointerLeave={[Function]}
+                      onPointerUp={[Function]}
+                      tabIndex={0}
                     >
-                      <span
-                        aria-label="Orbit"
-                        role="img"
-                        title="Orbit"
+                      <div
+                        className="c11"
                       >
-                        <div
-                          className="c12"
-                          data-mocked="Icon"
-                          scale={1.04}
-                          variant="normal"
+                        <span
+                          aria-label="Orbit"
+                          role="img"
+                          title="Orbit"
                         >
-                          <div>
-                            <span>
-                              <svg
-                                height={16}
-                                width={16}
-                              >
-                                <g
-                                  fill="none"
+                          <div
+                            className="c12"
+                            data-mocked="Icon"
+                            scale={1.04}
+                            variant="normal"
+                          >
+                            <div>
+                              <span>
+                                <svg
+                                  height={16}
+                                  width={16}
+                                >
+                                  <g
+                                    fill="none"
+                                  >
+                                    <path
+                                      d="M10.5 8.23c0 4.06-1.14 7.33-2.5 7.33s-2.5-3.35-2.5-7.5S6.62.56 8 .56c1 0 1.87 1.79 2.27 4.35"
+                                      stroke="currentColor"
+                                    />
+                                    <path
+                                      d="m9.23 8.61 1.21-2.18 1.28 2.14z"
+                                      fill="currentColor"
+                                    />
+                                    <path
+                                      d="M7.84 10.56C3.77 10.54.5 9.43.5 8.06s3.36-2.5 7.5-2.5c4.14 0 7.5 1.12 7.5 2.5 0 1-1.78 1.88-4.35 2.27"
+                                      stroke="currentColor"
+                                    />
+                                    <path
+                                      d="m7.46 9.29 2.17 1.22-2.14 1.27z"
+                                      fill="currentColor"
+                                    />
+                                  </g>
+                                </svg>
+                              </span>
+                            </div>
+                          </div>
+                        </span>
+                      </div>
+                      <div
+                        className="c16"
+                        color="inherit"
+                        data-mocked="Box"
+                        leftPadding={0}
+                        variant="small"
+                      >
+                        3D Orbit
+                      </div>
+                    </div>
+                    <div
+                      className="c10"
+                      data-testid="camera-controls-pan"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onPointerDown={[Function]}
+                      onPointerEnter={[Function]}
+                      onPointerLeave={[Function]}
+                      onPointerUp={[Function]}
+                      tabIndex={0}
+                    >
+                      <div
+                        className="c11"
+                      >
+                        <span
+                          aria-label="Pan"
+                          role="img"
+                          title="Pan"
+                        >
+                          <div
+                            className="c12"
+                            data-mocked="Icon"
+                            scale={1.04}
+                            variant="normal"
+                          >
+                            <div>
+                              <span>
+                                <svg
+                                  height={14}
+                                  width={14}
                                 >
                                   <path
-                                    d="M10.5 8.23c0 4.06-1.14 7.33-2.5 7.33s-2.5-3.35-2.5-7.5S6.62.56 8 .56c1 0 1.87 1.79 2.27 4.35"
+                                    d="M9.15 1.5a1 1 0 0 1 2 0m-4 0a1 1 0 1 1 2 0m2 2a1 1 0 0 1 2 0v5.9a4.1 4.1 0 0 1-4.1 4.1h-2A4.1 4.1 0 0 1 3.92 12l-2.8-3.34a1.21 1.21 0 0 1 .39-1.84 1.2 1.2 0 0 1 1.19.06l1.42.91h1V2.5a1 1 0 1 1 2 0m4.02 4.28.01-5.28m-2 5.28V1.5m-2 5.28V1.5"
+                                    fill="none"
                                     stroke="currentColor"
                                   />
-                                  <path
-                                    d="m9.23 8.61 1.21-2.18 1.28 2.14z"
-                                    fill="currentColor"
-                                  />
-                                  <path
-                                    d="M7.84 10.56C3.77 10.54.5 9.43.5 8.06s3.36-2.5 7.5-2.5c4.14 0 7.5 1.12 7.5 2.5 0 1-1.78 1.88-4.35 2.27"
-                                    stroke="currentColor"
-                                  />
-                                  <path
-                                    d="m7.46 9.29 2.17 1.22-2.14 1.27z"
-                                    fill="currentColor"
-                                  />
-                                </g>
-                              </svg>
-                            </span>
+                                </svg>
+                              </span>
+                            </div>
                           </div>
-                        </div>
-                      </span>
-                    </div>
-                    <div
-                      className="c16"
-                      color="inherit"
-                      data-mocked="Box"
-                      leftPadding={0}
-                      variant="small"
-                    >
-                      3D Orbit
-                    </div>
-                  </div>
-                  <div
-                    className="c10"
-                    data-testid="camera-controls-pan"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onPointerDown={[Function]}
-                    onPointerEnter={[Function]}
-                    onPointerLeave={[Function]}
-                    onPointerUp={[Function]}
-                    tabIndex={0}
-                  >
-                    <div
-                      className="c11"
-                    >
-                      <span
-                        aria-label="Pan"
-                        role="img"
-                        title="Pan"
+                        </span>
+                      </div>
+                      <div
+                        className="c16"
+                        color="inherit"
+                        data-mocked="Box"
+                        leftPadding={0}
+                        variant="small"
                       >
-                        <div
-                          className="c12"
-                          data-mocked="Icon"
-                          scale={1.04}
-                          variant="normal"
-                        >
-                          <div>
-                            <span>
-                              <svg
-                                height={14}
-                                width={14}
-                              >
-                                <path
-                                  d="M9.15 1.5a1 1 0 0 1 2 0m-4 0a1 1 0 1 1 2 0m2 2a1 1 0 0 1 2 0v5.9a4.1 4.1 0 0 1-4.1 4.1h-2A4.1 4.1 0 0 1 3.92 12l-2.8-3.34a1.21 1.21 0 0 1 .39-1.84 1.2 1.2 0 0 1 1.19.06l1.42.91h1V2.5a1 1 0 1 1 2 0m4.02 4.28.01-5.28m-2 5.28V1.5m-2 5.28V1.5"
-                                  fill="none"
-                                  stroke="currentColor"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </div>
-                      </span>
-                    </div>
-                    <div
-                      className="c16"
-                      color="inherit"
-                      data-mocked="Box"
-                      leftPadding={0}
-                      variant="small"
-                    >
-                      3D Pan
+                        3D Pan
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/packages/scene-composer/tests/components/toolbars/floatingToolbar/FloatingToolbar.spec.tsx
+++ b/packages/scene-composer/tests/components/toolbars/floatingToolbar/FloatingToolbar.spec.tsx
@@ -1,11 +1,14 @@
 /* eslint-disable import/first,import/order */
 import React from 'react';
 import { create } from 'react-test-renderer';
+import { render } from '@testing-library/react';
 
 import { AddObjectMenu } from '../../../../src/components/toolbars/floatingToolbar/items/AddObjectMenu';
 
 import { FloatingToolbar } from '../../../../src/components/toolbars';
 import { useStore } from '../../../../src/store';
+import { ToolbarOrientation } from '../../../../src/components/toolbars/common/types';
+import { act } from 'react-dom/test-utils';
 
 jest.mock('../../../../src/components/toolbars/floatingToolbar/items', () => ({
   HistoryItemGroup: 'HistoryItemGroup',
@@ -26,13 +29,26 @@ describe('FloatingToolbar', () => {
   });
 
   it('should render correctly', () => {
-    const container = create(<FloatingToolbar enableDefaultItems={true} additionalMenuItems={<AddObjectMenu />} />);
+    const container = create(
+      <FloatingToolbar
+        enableDefaultItems={true}
+        additionalMenuItems={
+          <AddObjectMenu canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />
+        }
+      />,
+    );
     expect(container).toMatchSnapshot();
   });
 
   it('should render correctly in view mode', () => {
     const container = create(
-      <FloatingToolbar isViewing={true} enableDefaultItems={true} additionalMenuItems={<AddObjectMenu />} />,
+      <FloatingToolbar
+        isViewing={true}
+        enableDefaultItems={true}
+        additionalMenuItems={
+          <AddObjectMenu canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />
+        }
+      />,
     );
     expect(container).toMatchSnapshot();
   });
@@ -42,6 +58,36 @@ describe('FloatingToolbar', () => {
       addingWidget: {},
     } as any);
     const container = create(<FloatingToolbar enableDefaultItems={true} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should display the toolbar vertically if the canvas is big', async () => {
+    const mockCanvas = document.createElement('canvas');
+    mockCanvas.setAttribute('id', 'tm-scene-unselectable-canvas');
+    Object.defineProperty(mockCanvas, 'clientHeight', { configurable: true, value: '1000' });
+    jest.spyOn(document, 'getElementById').mockReturnValue(mockCanvas);
+
+    let container: HTMLElement | undefined;
+    await act(async () => {
+      const rendered = render(<FloatingToolbar enableDefaultItems={true} />);
+      container = rendered.container;
+    });
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should display the toolbar horiontally if the canvas is small', async () => {
+    const mockCanvas = document.createElement('canvas');
+    mockCanvas.setAttribute('id', 'tm-scene-unselectable-canvas');
+    Object.defineProperty(mockCanvas, 'clientHeight', { configurable: true, value: '1' });
+    jest.spyOn(document, 'getElementById').mockReturnValue(mockCanvas);
+
+    let container: HTMLElement | undefined;
+    await act(async () => {
+      const rendered = render(<FloatingToolbar enableDefaultItems={true} />);
+      container = rendered.container;
+    });
+
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/scene-composer/tests/components/toolbars/floatingToolbar/__snapshots__/FloatingToolbar.spec.tsx.snap
+++ b/packages/scene-composer/tests/components/toolbars/floatingToolbar/__snapshots__/FloatingToolbar.spec.tsx.snap
@@ -1,5 +1,125 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FloatingToolbar should display the toolbar horiontally if the canvas is small 1`] = `
+.c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  border-left: 3px solid colorBorderDividerDefault;
+}
+
+.c1:first-of-type {
+  border-top: 0;
+  border-left: 0;
+}
+
+.c0 {
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 999;
+  background-color: colorBackgroundDropdownItemDefault;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <historyitemgroup
+        toolbarorientation="horizontal"
+      />
+      <sceneitemgroup
+        canvasheight="1"
+        toolbarorientation="horizontal"
+      />
+      <objectitemgroup
+        canvasheight="1"
+        toolbarorientation="horizontal"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FloatingToolbar should display the toolbar vertically if the canvas is big 1`] = `
+.c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-top: 3px solid colorBorderDividerDefault;
+}
+
+.c1:first-of-type {
+  border-top: 0;
+  border-left: 0;
+}
+
+.c0 {
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 999;
+  background-color: colorBackgroundDropdownItemDefault;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <historyitemgroup
+        toolbarorientation="vertical"
+      />
+      <sceneitemgroup
+        canvasheight="1000"
+        toolbarorientation="vertical"
+      />
+      <objectitemgroup
+        canvasheight="1000"
+        toolbarorientation="vertical"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`FloatingToolbar should render correctly 1`] = `
 .c1 {
   position: relative;
@@ -15,6 +135,7 @@ exports[`FloatingToolbar should render correctly 1`] = `
 
 .c1:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c0 {
@@ -42,13 +163,20 @@ exports[`FloatingToolbar should render correctly 1`] = `
   <div
     className="c1"
   >
-    <HistoryItemGroup />
+    <HistoryItemGroup
+      toolbarOrientation="vertical"
+    />
     <SceneItemGroup
       isViewing={false}
+      toolbarOrientation="vertical"
     />
-    <ObjectItemGroup />
+    <ObjectItemGroup
+      toolbarOrientation="vertical"
+    />
   </div>
-  <AddObjectMenu />
+  <AddObjectMenu
+    toolbarOrientation="vertical"
+  />
 </div>
 `;
 
@@ -67,6 +195,7 @@ exports[`FloatingToolbar should render correctly in view mode 1`] = `
 
 .c1:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c0 {
@@ -96,9 +225,12 @@ exports[`FloatingToolbar should render correctly in view mode 1`] = `
   >
     <SceneItemGroup
       isViewing={true}
+      toolbarOrientation="vertical"
     />
   </div>
-  <AddObjectMenu />
+  <AddObjectMenu
+    toolbarOrientation="vertical"
+  />
 </div>
 `;
 
@@ -117,6 +249,7 @@ exports[`FloatingToolbar should render correctly when addingWidget 1`] = `
 
 .c1:first-of-type {
   border-top: 0;
+  border-left: 0;
 }
 
 .c0 {

--- a/packages/scene-composer/tests/components/toolbars/floatingToolbar/items/SceneItemGroup.spec.tsx
+++ b/packages/scene-composer/tests/components/toolbars/floatingToolbar/items/SceneItemGroup.spec.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 
 import { SceneItemGroup } from '../../../../../src/components/toolbars/floatingToolbar/items';
 import { useStore } from '../../../../../src/store';
+import { ToolbarOrientation } from '../../../../../src/components/toolbars/common/types';
 
 describe('SceneItemGroup', () => {
   const cameraControlsType = 'orbit';
@@ -18,7 +19,7 @@ describe('SceneItemGroup', () => {
   });
 
   it('should call setCameraControlsType when clicking pan', () => {
-    render(<SceneItemGroup />);
+    render(<SceneItemGroup toolbarOrientation={ToolbarOrientation.Vertical} canvasHeight={null} />);
     const sut = screen.getByTestId('camera-controls-pan');
     fireEvent.pointerUp(sut);
     expect(setCameraControlsType).toBeCalledWith('pan');


### PR DESCRIPTION
## Overview
This change flips the floating toolbar from vertical to horizontal when the screen size gets too small. Per a11y guidelines, all content has to be accessible to users at 1) 320px wide by 255px high and 2) 640px wide by 256px high at 200% zoom. 

Before pic (shows 640px wide by 256px high at 200% zoom):
![Screenshot 2023-09-27 at 11 48 23 AM](https://github.com/awslabs/iot-app-kit/assets/143754227/b80f81c2-cb17-4bbf-81d1-c3be6f42967d)

After video:

https://github.com/awslabs/iot-app-kit/assets/143754227/25e1ac87-4bb4-4170-821c-ef5d1decf283


## Verifying Changes
Added some unit tests, and updated many others.
I have tested manually in storybook and in console. I have not tested in grafana, and I'm not sure how. Is this necessary for this change?

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
