### PR TITLE
feat(composer): append scene node action creates entity for dynamic scene

### DIFF
--- a/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.spec.tsx
@@ -1,20 +1,9 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import { MpSdk } from '@matterport/r3f/dist';
-import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 
 import { ISceneNodeInternal, useStore } from '../../../store';
 import { MattertagItem, TagItem } from '../../../utils/matterportTagUtils';
-import useDynamicScene from '../../../hooks/useDynamicScene';
-import { KnownSceneProperty } from '../../../interfaces';
-import { createLayer } from '../../../utils/entityModelUtils/sceneLayerUtils';
-import { LayerType, MATTERPORT_TAG_LAYER_PREFIX } from '../../../common/entityModelConstants';
-import {
-  checkIfEntityAvailable,
-  createSceneRootEntity,
-  prepareWorkspace,
-} from '../../../utils/entityModelUtils/sceneUtils';
-import { setTwinMakerSceneMetadataModule } from '../../../common/GlobalSettings';
 
 import { MatterportTagSync } from './MatterportTagSync';
 
@@ -31,9 +20,9 @@ jest.mock('../../../hooks/useMatterportObserver', () => {
   }));
 });
 
-const handleAddMatterportTagMock = jest.fn().mockResolvedValue(undefined);
-const handleUpdateMatterportTagMock = jest.fn().mockResolvedValue(undefined);
-const handleRemoveMatterportTagMock = jest.fn().mockResolvedValue(undefined);
+const handleAddMatterportTagMock = jest.fn();
+const handleUpdateMatterportTagMock = jest.fn();
+const handleRemoveMatterportTagMock = jest.fn();
 jest.mock('../../../hooks/useMatterportTags', () => {
   return jest.fn(() => ({
     handleAddMatterportTag: handleAddMatterportTagMock,
@@ -42,27 +31,13 @@ jest.mock('../../../hooks/useMatterportTags', () => {
   }));
 });
 
-jest.mock('../../../hooks/useDynamicScene', () => jest.fn());
-jest.mock('../../../utils/entityModelUtils/sceneLayerUtils', () => ({
-  createLayer: jest.fn(),
-}));
-jest.mock('../../../utils/entityModelUtils/sceneUtils', () => ({
-  createSceneRootEntity: jest.fn(),
-  prepareWorkspace: jest.fn(),
-  checkIfEntityAvailable: jest.fn(),
-}));
-
 describe('MatterportTagSync', () => {
   const getComponentRefByTypeMock = jest.fn();
   const getSceneNodeByRefMock = jest.fn();
-  const setScenePropertyMock = jest.fn();
-  const getScenePropertyMock = jest.fn();
 
   const baseState = {
     getComponentRefByType: getComponentRefByTypeMock,
     getSceneNodeByRef: getSceneNodeByRefMock,
-    setSceneProperty: setScenePropertyMock,
-    getSceneProperty: getScenePropertyMock,
   };
 
   const testInternalNode: ISceneNodeInternal = {
@@ -228,285 +203,5 @@ describe('MatterportTagSync', () => {
     expect(handleAddMatterportTagMock).toBeCalledWith({ id: 'id3', item: tag2 });
     expect(handleUpdateMatterportTagMock).toBeCalledWith({ ref: 'ref2', node: node2, item: tag3 });
     expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
-  });
-
-  describe('when dynamic scene is enabled', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      (useDynamicScene as jest.Mock).mockReturnValue(true);
-      (createLayer as jest.Mock).mockImplementation((name, _) => {
-        return Promise.resolve({ entityId: name });
-      });
-      (createSceneRootEntity as jest.Mock).mockImplementation(() => {
-        return Promise.resolve({ entityId: 'scene-root-id' });
-      });
-      (prepareWorkspace as jest.Mock).mockResolvedValue(undefined);
-
-      getScenePropertyMock.mockImplementation((p) => {
-        if (p == KnownSceneProperty.MatterportModelId) {
-          return 'matterportModelId';
-        } else if (p == KnownSceneProperty.LayerIds) {
-          return ['layer-id'];
-        } else if (p == KnownSceneProperty.SceneRootEntityId) {
-          return 'scene-root-id';
-        } else {
-          return undefined;
-        }
-      });
-
-      (checkIfEntityAvailable as jest.Mock).mockReturnValue(true);
-
-      setTwinMakerSceneMetadataModule({} as TwinMakerSceneMetadataModule);
-    });
-
-    it('should render success status', async () => {
-      useStore('default').setState(baseState);
-      const rendered = render(<MatterportTagSync />);
-
-      await act(async () => {
-        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
-      });
-
-      expect(rendered.getByTestId('sync-button-status')).toMatchSnapshot();
-    });
-
-    it('should render failure status', async () => {
-      useStore('default').setState(baseState);
-      (prepareWorkspace as jest.Mock).mockRejectedValue(new Error('prepare workspace failed'));
-
-      const rendered = render(<MatterportTagSync />);
-
-      await act(async () => {
-        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
-      });
-
-      expect(rendered.getByTestId('sync-button-status')).toMatchSnapshot();
-    });
-
-    it('should call prepareWorkspace', async () => {
-      useStore('default').setState(baseState);
-      const rendered = render(<MatterportTagSync />);
-
-      await act(async () => {
-        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
-      });
-
-      expect(prepareWorkspace as jest.Mock).toBeCalledTimes(1);
-    });
-
-    it('should create a default layer and root entity when none available', async () => {
-      getScenePropertyMock.mockImplementation((p) => {
-        if (p == KnownSceneProperty.MatterportModelId) {
-          return 'matterportModelId';
-        } else {
-          return undefined;
-        }
-      });
-      useStore('default').setState(baseState);
-      const rendered = render(<MatterportTagSync />);
-
-      await act(async () => {
-        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
-      });
-
-      expect(createLayer as jest.Mock).toBeCalledTimes(1);
-      expect(createLayer as jest.Mock).toBeCalledWith(
-        MATTERPORT_TAG_LAYER_PREFIX + 'matterportModelId',
-        LayerType.Relationship,
-      );
-      expect(createSceneRootEntity as jest.Mock).toBeCalledTimes(1);
-      expect(setScenePropertyMock).toBeCalledTimes(2);
-      expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.LayerIds, [
-        MATTERPORT_TAG_LAYER_PREFIX + 'matterportModelId',
-      ]);
-      expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneRootEntityId, 'scene-root-id');
-    });
-
-    it('should create a default layer entity when it does not exist', async () => {
-      (checkIfEntityAvailable as jest.Mock).mockImplementation((entityId) => {
-        if (entityId == 'layer-id') {
-          return Promise.resolve(false);
-        }
-        return Promise.resolve(true);
-      });
-
-      useStore('default').setState(baseState);
-      const rendered = render(<MatterportTagSync />);
-
-      await act(async () => {
-        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
-      });
-
-      expect(createLayer as jest.Mock).toBeCalledTimes(1);
-      expect(createLayer as jest.Mock).toBeCalledWith(
-        MATTERPORT_TAG_LAYER_PREFIX + 'matterportModelId',
-        LayerType.Relationship,
-      );
-      expect(createSceneRootEntity as jest.Mock).not.toBeCalled();
-      expect(setScenePropertyMock).toBeCalledTimes(1);
-      expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.LayerIds, [
-        MATTERPORT_TAG_LAYER_PREFIX + 'matterportModelId',
-      ]);
-    });
-
-    it('should create a default scene entity when it does not exist', async () => {
-      (checkIfEntityAvailable as jest.Mock).mockImplementation((entityId) => {
-        if (entityId == 'scene-root-id') {
-          return Promise.resolve(false);
-        }
-        return Promise.resolve(true);
-      });
-
-      useStore('default').setState(baseState);
-      const rendered = render(<MatterportTagSync />);
-
-      await act(async () => {
-        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
-      });
-
-      expect(createLayer as jest.Mock).not.toBeCalled();
-      expect(createSceneRootEntity as jest.Mock).toBeCalledTimes(1);
-      expect(setScenePropertyMock).toBeCalledTimes(1);
-      expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneRootEntityId, 'scene-root-id');
-    });
-
-    it('should not create the default layer and root entity when available', async () => {
-      useStore('default').setState(baseState);
-      const rendered = render(<MatterportTagSync />);
-
-      await act(async () => {
-        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
-      });
-
-      expect(createLayer as jest.Mock).not.toBeCalled();
-      expect(createSceneRootEntity as jest.Mock).not.toBeCalled();
-      expect(setScenePropertyMock).not.toBeCalled();
-    });
-
-    it('should sync mattertags by deleting id1, updating id2, and adding id3', async () => {
-      useStore('default').setState(baseState);
-
-      getComponentRefByTypeMock.mockImplementation(() => {
-        const deletableTag: Record<string, string[]> = {
-          ref1: [],
-          ref2: [],
-          'ref3:': [],
-        };
-        return deletableTag;
-      });
-
-      const node1: ISceneNodeInternal = { ...testInternalNode };
-      const node2: ISceneNodeInternal = {
-        ...testInternalNode,
-        properties: {
-          matterportId: 'id2',
-        },
-      };
-      const node3: ISceneNodeInternal = {
-        ...testInternalNode,
-        properties: {},
-      };
-
-      getSceneNodeByRefMock.mockImplementation((ref: string) => {
-        const nodeLookup = {
-          ref1: node1,
-          ref2: node2,
-          ref3: node3,
-        };
-        return nodeLookup[ref];
-      });
-
-      const matterTag2 = { ...testMattertagItem, sid: 'id2' };
-      const matterTag3 = { ...testMattertagItem, sid: 'id2' };
-      getMatterTagsMock.mockImplementation(() => {
-        const mattertags: Array<[string, MpSdk.Mattertag.ObservableMattertagData]> = [
-          ['id2', matterTag2],
-          ['id3', matterTag3],
-        ];
-        return mattertags;
-      });
-      getTagsMock.mockImplementation(() => undefined);
-      const rendered = render(<MatterportTagSync />);
-
-      await act(async () => {
-        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
-      });
-
-      expect(getComponentRefByTypeMock).toBeCalled();
-      expect(handleAddMatterportTagMock).toBeCalledWith({
-        layerId: 'layer-id',
-        sceneRootId: 'scene-root-id',
-        id: 'id3',
-        item: matterTag3,
-      });
-      expect(handleUpdateMatterportTagMock).toBeCalledWith({
-        layerId: 'layer-id',
-        sceneRootId: 'scene-root-id',
-        ref: 'ref2',
-        node: node2,
-        item: matterTag2,
-      });
-      expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
-    });
-
-    it('should sync matterport tags by deleting id1, updating id2, and adding id3', async () => {
-      useStore('default').setState(baseState);
-
-      getComponentRefByTypeMock.mockImplementation(() => {
-        const deletableTag: Record<string, string[]> = {
-          ref1: [],
-          ref2: [],
-        };
-        return deletableTag;
-      });
-
-      const node1: ISceneNodeInternal = { ...testInternalNode };
-      const node2: ISceneNodeInternal = {
-        ...testInternalNode,
-        properties: {
-          matterportId: 'id2',
-        },
-      };
-
-      getSceneNodeByRefMock.mockImplementation((ref: string) => {
-        const nodeLookup = {
-          ref1: node1,
-          ref2: node2,
-        };
-        return nodeLookup[ref];
-      });
-
-      const tag2 = { ...testTagItem, sid: 'id2' };
-      const tag3 = { ...testTagItem, sid: 'id2' };
-      getMatterTagsMock.mockImplementation(() => undefined);
-      getTagsMock.mockImplementation(() => {
-        const tags: Array<[string, MpSdk.Tag.TagData]> = [
-          ['id2', tag2],
-          ['id3', tag3],
-        ];
-        return tags;
-      });
-      const rendered = render(<MatterportTagSync />);
-
-      await act(async () => {
-        fireEvent.click(rendered.getByTestId('matterport-tag-sync-button'));
-      });
-
-      expect(getComponentRefByTypeMock).toBeCalled();
-      expect(handleAddMatterportTagMock).toBeCalledWith({
-        layerId: 'layer-id',
-        sceneRootId: 'scene-root-id',
-        id: 'id3',
-        item: tag2,
-      });
-      expect(handleUpdateMatterportTagMock).toBeCalledWith({
-        layerId: 'layer-id',
-        sceneRootId: 'scene-root-id',
-        ref: 'ref2',
-        node: node2,
-        item: tag3,
-      });
-      expect(handleRemoveMatterportTagMock).toBeCalledWith('ref1');
-    });
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/MatterportTagSync.tsx
@@ -3,21 +3,12 @@ import { useIntl } from 'react-intl';
 import { Button, Popover, StatusIndicator } from '@awsui/components-react';
 import { isEmpty } from 'lodash';
 
-import { KnownComponentType, KnownSceneProperty } from '../../../interfaces';
+import { KnownComponentType } from '../../../interfaces';
 import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
 import useLifecycleLogging from '../../../logger/react-logger/hooks/useLifecycleLogging';
 import { ISceneNodeInternal, useStore } from '../../../store';
 import useMatterportTags from '../../../hooks/useMatterportTags';
 import useMatterportObserver from '../../../hooks/useMatterportObserver';
-import { LayerType, MATTERPORT_TAG_LAYER_PREFIX } from '../../../common/entityModelConstants';
-import { createLayer } from '../../../utils/entityModelUtils/sceneLayerUtils';
-import useDynamicScene from '../../../hooks/useDynamicScene';
-import {
-  checkIfEntityAvailable,
-  createSceneRootEntity,
-  prepareWorkspace,
-} from '../../../utils/entityModelUtils/sceneUtils';
-import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { DisplayMessageCategory, IDisplayMessage } from '../../../store/internalInterfaces';
 
 export const MatterportTagSync: React.FC = () => {
@@ -29,18 +20,6 @@ export const MatterportTagSync: React.FC = () => {
   const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
   const addMessages = useStore(sceneComposerId)((state) => state.addMessages);
 
-  const matterportModelId = useStore(sceneComposerId)((state) =>
-    state.getSceneProperty<string>(KnownSceneProperty.MatterportModelId),
-  );
-  const sceneRootId = useStore(sceneComposerId)((state) =>
-    state.getSceneProperty<string>(KnownSceneProperty.SceneRootEntityId),
-  );
-  const sceneLayerIds = useStore(sceneComposerId)((state) =>
-    state.getSceneProperty<string[]>(KnownSceneProperty.LayerIds),
-  );
-  const setSceneProperty = useStore(sceneComposerId)((state) => state.setSceneProperty);
-  const dynamicSceneEnabled = useDynamicScene();
-
   const { handleAddMatterportTag, handleUpdateMatterportTag, handleRemoveMatterportTag } = useMatterportTags();
   const { mattertagObserver, tagObserver } = useMatterportObserver();
   const [syncTagStatus, setSyncTagStatus] = useState<'loading' | 'success' | 'error'>('loading');
@@ -50,29 +29,6 @@ export const MatterportTagSync: React.FC = () => {
     const errorMessages: IDisplayMessage[] = [];
 
     try {
-      const layerName = MATTERPORT_TAG_LAYER_PREFIX + matterportModelId;
-      let layerId = sceneLayerIds?.at(0);
-      let rootId = sceneRootId;
-      const sceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
-
-      if (dynamicSceneEnabled && sceneMetadataModule) {
-        // Before backend can create the new default roots, the client side code will
-        // create them temporarily here.
-        await prepareWorkspace(sceneMetadataModule);
-
-        // Create default layer and default scene root node
-        if (!layerId || isEmpty(layerId) || !(await checkIfEntityAvailable(layerId, sceneMetadataModule))) {
-          const layer = await createLayer(layerName, LayerType.Relationship);
-          layerId = layer?.entityId;
-          setSceneProperty(KnownSceneProperty.LayerIds, [layerId]);
-        }
-        if (!sceneRootId || isEmpty(sceneRootId) || !(await checkIfEntityAvailable(sceneRootId, sceneMetadataModule))) {
-          const root = await createSceneRootEntity();
-          rootId = root?.entityId;
-          setSceneProperty(KnownSceneProperty.SceneRootEntityId, rootId);
-        }
-      }
-
       const mattertags = mattertagObserver.getMattertags(); // Matterport tags v1
       const tags = tagObserver.getTags(); // Matterport tags v2
 
@@ -90,15 +46,13 @@ export const MatterportTagSync: React.FC = () => {
         for (const [key, value] of tags) {
           try {
             if (oldTagMap[key]) {
-              await handleUpdateMatterportTag({
-                layerId,
-                sceneRootId: rootId,
+              handleUpdateMatterportTag({
                 ref: oldTagMap[key].nodeRef,
                 node: oldTagMap[key].node,
                 item: value,
               });
             } else {
-              await handleAddMatterportTag({ layerId, sceneRootId: rootId, id: key, item: value });
+              handleAddMatterportTag({ id: key, item: value });
             }
           } catch (e) {
             errorMessages.push({
@@ -122,15 +76,16 @@ export const MatterportTagSync: React.FC = () => {
 
           try {
             if (oldTagMap[key]) {
-              await handleUpdateMatterportTag({
-                layerId,
-                sceneRootId: rootId,
+              handleUpdateMatterportTag({
                 ref: oldTagMap[key].nodeRef,
                 node: oldTagMap[key].node,
                 item: value,
               });
             } else {
-              await handleAddMatterportTag({ layerId, sceneRootId: rootId, id: key, item: value });
+              handleAddMatterportTag({
+                id: key,
+                item: value,
+              });
             }
           } catch (e) {
             errorMessages.push({
@@ -144,7 +99,7 @@ export const MatterportTagSync: React.FC = () => {
       }
 
       for (const key in oldTagMap) {
-        await handleRemoveMatterportTag(oldTagMap[key].nodeRef);
+        handleRemoveMatterportTag(oldTagMap[key].nodeRef);
       }
     } catch (e) {
       logger?.error(String(e));
@@ -165,10 +120,6 @@ export const MatterportTagSync: React.FC = () => {
     getSceneNodeByRef,
     mattertagObserver,
     tagObserver,
-    matterportModelId,
-    sceneLayerIds,
-    sceneRootId,
-    dynamicSceneEnabled,
     handleAddMatterportTag,
     handleUpdateMatterportTag,
     handleRemoveMatterportTag,

--- a/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/MatterportTagSync.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/MatterportTagSync.spec.tsx.snap
@@ -25,23 +25,3 @@ exports[`MatterportTagSync should render correctly 1`] = `
   </div>
 </div>
 `;
-
-exports[`MatterportTagSync when dynamic scene is enabled should render failure status 1`] = `
-<div
-  data-mocked="StatusIndicator"
-  data-testid="sync-button-status"
-  type="error"
->
-  Tags sync failed
-</div>
-`;
-
-exports[`MatterportTagSync when dynamic scene is enabled should render success status 1`] = `
-<div
-  data-mocked="StatusIndicator"
-  data-testid="sync-button-status"
-  type="success"
->
-  Tags sync successful
-</div>
-`;

--- a/packages/scene-composer/src/store/helpers/sceneDocumentHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/sceneDocumentHelpers.ts
@@ -1,4 +1,5 @@
 import ILogger from '../../logger/ILogger';
+import { RootState } from '../Store';
 import { ISceneDocumentInternal, ISceneNodeInternal } from '../internalInterfaces';
 
 import { addNodeToComponentNodeMap, deleteNodeFromComponentNodeMap } from './componentMapHelpers';
@@ -122,4 +123,28 @@ export const renderSceneNodesFromLayers = (
       removeNode(document, ref, logger);
     }
   });
+};
+
+export const appendSceneNode = (draft: RootState, node: ISceneNodeInternal, disableAutoSelect?: boolean): void => {
+  if (!draft.document) {
+    return;
+  }
+  draft.document.nodeMap[node.ref] = node;
+
+  // Update the parent node of the inserted node
+  if (!node.parentRef) {
+    draft.document!.rootNodeRefs.push(node.ref);
+  } else {
+    draft.document!.nodeMap[node.parentRef]!.childRefs.push(node.ref);
+  }
+
+  // Update componentNodeMap
+  addNodeToComponentNodeMap(draft.document.componentNodeMap, node);
+
+  // Update the selected node
+  if (!disableAutoSelect) {
+    draft.selectedSceneNodeRef = node.ref;
+  }
+
+  draft.lastOperation = 'appendSceneNodeInternal';
 };

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
@@ -23,11 +23,11 @@ import { createCameraEntityComponent } from './cameraComponent';
 import { createModelRefComponent } from './modelRefComponent';
 import { createModelShaderEntityComponent } from './modelShaderComponent';
 
-export const createNodeEntity = (
+export const createNodeEntity = async (
   node: ISceneNodeInternal,
   parentRef: string,
   layerId: string,
-): Promise<CreateEntityCommandOutput> | undefined => {
+): Promise<CreateEntityCommandOutput | undefined> => {
   const sceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
 
   const nodecomp = createNodeEntityComponent(node, layerId);

--- a/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.ts
@@ -110,7 +110,7 @@ export const parseOverlayComp = (comp: DocumentType): IDataOverlayComponentInter
         index++;
       }
       return {
-        content: decodeURI(content),
+        content: decodeURI(content ?? ''),
         rowType: r[OverlayComponentProperty.RowType],
       };
     });

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.spec.ts
@@ -12,6 +12,7 @@ import {
 import { ISceneDocumentInternal, ISceneNodeInternal, SceneNodeRuntimeProperty } from '../../store/internalInterfaces';
 import { defaultNode } from '../../../__mocks__/sceneNode';
 import { getFinalNodeTransform } from '../nodeUtils';
+import { KnownSceneProperty } from '../../interfaces';
 
 import {
   checkIfEntityAvailable,
@@ -19,6 +20,7 @@ import {
   createSceneEntityId,
   createSceneRootEntity,
   isDynamicNode,
+  isDynamicScene,
   prepareWorkspace,
   staticNodeCount,
 } from './sceneUtils';
@@ -181,6 +183,41 @@ describe('isDynamicNode', () => {
       } as ISceneNodeInternal),
     ).toEqual(false);
     expect(isDynamicNode({ properties: {} } as ISceneNodeInternal)).toEqual(false);
+  });
+});
+
+describe('isDynamicScene', () => {
+  it('should return true', () => {
+    expect(
+      isDynamicScene({
+        properties: {
+          [KnownSceneProperty.LayerIds]: ['layer'],
+          [KnownSceneProperty.SceneRootEntityId]: 'scene-root',
+        },
+      } as ISceneDocumentInternal),
+    ).toEqual(true);
+  });
+
+  it('should return false', () => {
+    expect(
+      isDynamicScene({
+        properties: {
+          [KnownSceneProperty.LayerIds]: ['layer'],
+        },
+      } as ISceneDocumentInternal),
+    ).toEqual(false);
+    expect(
+      isDynamicScene({
+        properties: {
+          [KnownSceneProperty.SceneRootEntityId]: 'scene-root',
+        },
+      } as ISceneDocumentInternal),
+    ).toEqual(false);
+    expect(
+      isDynamicScene({
+        properties: {},
+      } as ISceneDocumentInternal),
+    ).toEqual(false);
   });
 });
 

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
@@ -13,6 +13,7 @@ import { generateUUID } from '../mathUtils';
 import { ISceneDocumentInternal, ISceneNodeInternal } from '../../store';
 import { SceneNodeRuntimeProperty } from '../../store/internalInterfaces';
 import { getFinalNodeTransform } from '../nodeUtils';
+import { KnownSceneProperty } from '../../interfaces';
 
 import { createNodeEntity } from './createNodeEntity';
 
@@ -75,6 +76,13 @@ export const isDynamicNode = (node?: ISceneNodeInternal): boolean => {
   return !isEmpty(node?.properties.layerIds);
 };
 
+export const isDynamicScene = (document?: ISceneDocumentInternal): boolean => {
+  return (
+    !isEmpty(document?.properties?.[KnownSceneProperty.LayerIds]) &&
+    !isEmpty(document?.properties?.[KnownSceneProperty.SceneRootEntityId])
+  );
+};
+
 export const staticNodeCount = (nodeMap: { [key: string]: ISceneNodeInternal }): number => {
   return Object.values(nodeMap).filter((node) => !isDynamicNode(node)).length;
 };
@@ -113,7 +121,7 @@ export const convertAllNodesToEntities = ({
       };
 
       createNodeEntity(worldTransformNode, sceneRootEntityId, layerId)
-        ?.then(() => {
+        .then(() => {
           onSuccess?.(worldTransformNode);
         })
         .catch((error) => {


### PR DESCRIPTION
## Overview
- append scene node action calls create entity API for dynamic scene
- clean up entity API calls from matterport sync and have the store as the central place to make those requests

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
