### PR TITLE
feat(scene composer): fix for icon rules and save icon metadata

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneRulesPanel.tsx
@@ -1,4 +1,3 @@
-import React, { useCallback, useContext, useRef, useState } from 'react';
 import {
   AttributeEditor,
   Box,
@@ -9,6 +8,7 @@ import {
   SpaceBetween,
   Textarea,
 } from '@awsui/components-react';
+import React, { useCallback, useContext, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
@@ -95,11 +95,12 @@ export const SceneRuleMapExpandableInfoSection: React.FC<
         description: 'Aria label for remove statement button',
       })} ${statement.expression}`,
   };
+
   return (
     <ExpandableInfoSection title={ruleBasedMapId} defaultExpanded={false}>
       <AttributeEditor
         {...a11yProps}
-        onAddButtonClick={() => setNewRule({ expression: '', target: '' })}
+        onAddButtonClick={() => setNewRule({ expression: '', target: '', targetMetadata: {} })}
         onRemoveButtonClick={({ detail: { itemIndex } }) => onRemoveRule(itemIndex)}
         items={items}
         definition={[

--- a/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetIconEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetIconEditor.tsx
@@ -50,8 +50,7 @@ export const SceneRuleTargetIconEditor: React.FC<ISceneRuleTargetIconEditorProps
     [DefaultAnchorStatus.Video]: { defaultMessage: 'Video icon', description: 'Icon name label' },
     [DefaultAnchorStatus.Custom]: { defaultMessage: 'Custom icon', description: 'Icon name label' },
   });
-  const iconInfo = (customIcon ?? { prefix: 'fas', iconName: 'info' }) as IconLookup;
-
+  const iconInfo = (customIcon ?? { prefix: '', iconName: '' }) as IconLookup;
   return (
     <Grid gridDefinition={[{ colspan: 9 }, { colspan: 2 }]}>
       <Select

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -4,6 +4,8 @@
  */
 import { IValueDataBinding } from '@iot-app-kit/source-iottwinmaker';
 
+import { TargetMetadata } from '../interfaces';
+
 export type KeyValuePair = { [key: string]: unknown };
 export type UUID = string;
 export type Vector3 = [number, number, number];
@@ -37,6 +39,7 @@ export interface GeoLocation {
 export interface RuleStatement {
   expression: string;
   target: string;
+  targetMetadata?: TargetMetadata;
 }
 
 export interface RuleBasedMap {

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -1,40 +1,40 @@
 import { isNumber } from 'lodash';
 
-import DebugLogger from '../../logger/DebugLogger';
 import {
-  DEFAULT_DISTANCE_UNIT,
-  DEFAULT_CAMERA_SETTINGS,
   CURRENT_MAJOR_VERSION,
   CURRENT_MINOR_VERSION,
+  CURRENT_VERSION,
+  DEFAULT_CAMERA_SETTINGS,
+  DEFAULT_DISTANCE_UNIT,
   DEFAULT_LIGHT_SETTINGS_MAP,
   LEGACY_VERSION,
-  CURRENT_VERSION,
 } from '../../common/constants';
+import { ERROR_MESSAGE_DICT, ErrorCode, ErrorLevel, SceneComposerRuntimeError } from '../../common/errors';
 import { KnownComponentType } from '../../interfaces';
-import { generateUUID } from '../../utils/mathUtils';
-import { ErrorCode, ErrorLevel, ERROR_MESSAGE_DICT, SceneComposerRuntimeError } from '../../common/errors';
+import DebugLogger from '../../logger/DebugLogger';
 import { Component, DistanceUnit, ModelType, Node, Scene } from '../../models/SceneModels';
-import {
-  ISceneComponentInternal,
-  ISceneNodeInternal,
-  ICameraComponentInternal,
-  IRuleBasedMapInternal,
-  ISceneDocumentInternal,
-  isISceneComponentInternal,
-  ISerializationErrorDetails,
-  IDeserializationResult,
-  IModelRefComponentInternal,
-  IAnimationComponentInternal,
-  IAnchorComponentInternal,
-  ILightComponentInternal,
-  IColorOverlayComponentInternal,
-  IMotionIndicatorComponentInternal,
-  ISubModelRefComponentInternal,
-  IDataOverlayComponentInternal,
-  IEntityBindingComponentInternal,
-  SceneNodeRuntimeProperty,
-} from '../internalInterfaces';
 import { isDynamicNode } from '../../utils/entityModelUtils/sceneUtils';
+import { generateUUID } from '../../utils/mathUtils';
+import {
+  IAnchorComponentInternal,
+  IAnimationComponentInternal,
+  ICameraComponentInternal,
+  IColorOverlayComponentInternal,
+  IDataOverlayComponentInternal,
+  IDeserializationResult,
+  IEntityBindingComponentInternal,
+  ILightComponentInternal,
+  IModelRefComponentInternal,
+  IMotionIndicatorComponentInternal,
+  IRuleBasedMapInternal,
+  ISceneComponentInternal,
+  ISceneDocumentInternal,
+  ISceneNodeInternal,
+  ISerializationErrorDetails,
+  ISubModelRefComponentInternal,
+  SceneNodeRuntimeProperty,
+  isISceneComponentInternal,
+} from '../internalInterfaces';
 
 import { addComponentToComponentNodeMap } from './componentMapHelpers';
 
@@ -135,6 +135,7 @@ function createTagComponent(
     type: 'Tag',
     icon,
     chosenColor: component.chosenColor,
+    customIcon: component.customIcon,
     ruleBasedMapId,
     valueDataBinding: {
       ...(valueDataBinding || {}),
@@ -549,6 +550,7 @@ function createDocumentState(
             statements: statements.map((s) => ({
               expression: s.expression,
               target: s.target,
+              targetMetadata: s.targetMetadata,
             })),
           },
         ];
@@ -704,6 +706,7 @@ function convertRules(ruleMap: Record<string, IRuleBasedMapInternal>) {
       const statements = ruleBasedMap.statements.map((s) => ({
         expression: s.expression,
         target: s.target,
+        targetMetadata: s.targetMetadata,
       }));
       return [
         ruleId,


### PR DESCRIPTION
## Overview
* Bug fix for saving icon metadata.
* Retrieve icon info upon reload.
## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/54058998/04a2f87d-6680-4ef4-bbc2-dffe0f8f7123



### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
