### PR TITLE
fix(react-components): echarts grab on canvas update cursor and tooltip

### DIFF
--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -27,6 +27,7 @@ import { DEFAULT_CHART_VISUALIZATION } from './eChartsConstants';
 import { useDataZoom } from './hooks/useDataZoom';
 import { useViewport } from '../../hooks/useViewport';
 import { getXAxis } from './utils/getXAxis';
+import { useHandleChartEvents } from './hooks/useHandleChartEvents';
 
 /**
  * Developer Notes:
@@ -117,14 +118,24 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
   // determine the set option settings
   const settings = useChartSetOptionSettings(dataStreams);
 
-  //handle dataZoom updates, which are dependent on user events and viewportInMS changes
+  // handle dataZoom updates, which are dependent on user events and viewportInMS changes
   useDataZoom(chartRef, viewportInMs);
+
+  // handle chart event updates
+  const eventOptions = useHandleChartEvents(chartRef);
+
+  const toolTipOptions = {
+    ...convertedOptions.tooltip,
+    ...eventOptions.tooltip,
+  };
 
   // set all the options on the echarts instance
   useEChartOptions(
     chartRef,
     {
       ...convertedOptions,
+      ...eventOptions,
+      tooltip: toolTipOptions,
       series,
       yAxis,
       xAxis,

--- a/packages/react-components/src/components/chart/hooks/useHandleChartEvents.ts
+++ b/packages/react-components/src/components/chart/hooks/useHandleChartEvents.ts
@@ -1,0 +1,113 @@
+import { MutableRefObject, useEffect, useState } from 'react';
+import { EChartsOption, EChartsType } from 'echarts';
+
+export const useHandleChartEvents = (chartRef: MutableRefObject<EChartsType | null>) => {
+  const [optionState, setOptionState] = useState<EChartsOption>({});
+
+  // When dragging on the chart, turn off tooltip and set cursor to grabbing
+  const setOnDragStart = (chart: EChartsType | null) => {
+    setOptionState({
+      tooltip: {
+        show: false,
+      },
+    });
+    chart?.getZr().setCursorStyle('grabbing');
+  };
+
+  // When dragging is done turn back on the tooltip and set cursor to grab
+  // Use when the shift key is still held down but mouse is up
+  const setOnDragEnd = (chart: EChartsType | null) => {
+    setOptionState({
+      tooltip: {
+        show: true,
+      },
+    });
+    chart?.getZr().setCursorStyle('grab');
+  };
+
+  // Set up event listeners for pressing shift and dragging the mouse to update
+  // the cursor and tooltip
+  useEffect(() => {
+    const chart = chartRef?.current;
+
+    let shiftDown = false;
+    let mouseDown = false;
+    let prevIsGrabbing = false;
+
+    // When shift is held down show the grab cursor by default
+    // When mouse is also held down it is a grabbing event
+    const shiftDownListener = (event: KeyboardEvent) => {
+      shiftDown = event.shiftKey;
+      if (mouseDown && shiftDown) {
+        setOnDragStart(chart);
+      } else if (shiftDown) {
+        chart?.getZr().setCursorStyle('grab');
+      }
+    };
+
+    // When shift is released go back to the default cursor
+    const shiftUpListener = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === 'shift') {
+        shiftDown = false;
+        chart?.getZr().setCursorStyle('default');
+      }
+    };
+
+    window.addEventListener('keydown', shiftDownListener);
+    window.addEventListener('keyup', shiftUpListener);
+
+    // When mouse is down only update when shift is also down
+    chart?.getZr().on('mousedown', () => {
+      mouseDown = true;
+      if (shiftDown) {
+        setOnDragStart(chart);
+      }
+    });
+
+    // When mouse is released only update when shift is also down
+    chart?.getZr().on('mouseup', () => {
+      mouseDown = false;
+      if (shiftDown) {
+        setOnDragEnd(chart);
+      }
+    });
+
+    // Most important to update dragging events on mouse move
+    chart?.getZr().on('mousemove', () => {
+      const isGrabbing = mouseDown && shiftDown;
+
+      // Only update tooltip when state changed
+      let stateChanged = false;
+      if (isGrabbing !== prevIsGrabbing) {
+        prevIsGrabbing = isGrabbing;
+        stateChanged = true;
+      } else {
+        stateChanged = false;
+      }
+
+      // Overwrite cursor style on every move of the mouse
+      // Update tooltip only once, on grab state change
+      if (isGrabbing) {
+        chart?.getZr().setCursorStyle('grabbing');
+        if (stateChanged) {
+          setOnDragStart(chart);
+        }
+      } else if (shiftDown) {
+        chart?.getZr().setCursorStyle('grab');
+        if (stateChanged) {
+          setOnDragEnd(chart);
+        }
+      }
+    });
+
+    return () => {
+      window.removeEventListener('keydown', shiftDownListener);
+      window.removeEventListener('keyup', shiftUpListener);
+      chart?.getZr()?.off('mousemove');
+      chart?.getZr()?.off('mouseup');
+      chart?.getZr()?.off('mousedown');
+    };
+  }, [chartRef]);
+
+  return optionState;
+};

--- a/packages/react-components/src/components/chart/hooks/useTrendCursorsEvents.ts
+++ b/packages/react-components/src/components/chart/hooks/useTrendCursorsEvents.ts
@@ -146,7 +146,7 @@ const useTrendCursorsEvents = ({
         if (event.target.id.toString().startsWith('line')) {
           // update user feedback
           event.stop();
-          currentChart?.getZr().setCursorStyle('grab');
+          currentChart?.getZr().setCursorStyle('grabbing');
 
           const graphicIndex = graphicRef.current.findIndex((g) => g.children[0].id === event.target.id);
           const timeInMs = calculateTimeStamp(event.offsetX ?? 0, chartRef);


### PR DESCRIPTION
## Overview
* Change cursor to open hand when holding shift while over chart area
* When clicking to pan, change to "grab" hand
* Tooltip is hidden while there is an active gesture

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/87385528/f9158635-23f5-45a4-ac22-63a27e261c72

1. Always show the "grab" cursor when shift is held down over the chart canvas
2. Always show the "grabbing" cursor when shift and the mouse is held down over the chart canvas, turn off the tooltip, and drag the canvas left to right
3. Don't show any change in cursor when the mouse is held down
4. Cannot drag on the edges of the canvas, but there is no way to avoid changing the cursor since the event is within the entire canvas


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
