### PR TITLE
feat: handle long properties names in config pane

### DIFF
--- a/packages/dashboard/src/components/tooltip/constants.ts
+++ b/packages/dashboard/src/components/tooltip/constants.ts
@@ -1,0 +1,5 @@
+export const MAX_TOOLTIP_WIDTH = 390;
+
+export const WRAPPED_TOOLTIP_WIDTH = 410;
+
+export const TOP_TOOLTIP_MARGIN = '-100';

--- a/packages/dashboard/src/components/tooltip/tooltip.css
+++ b/packages/dashboard/src/components/tooltip/tooltip.css
@@ -5,9 +5,9 @@
 
 .tooltip-text {
   position: absolute;
-  white-space: nowrap;
   visibility: hidden;
-  z-index: 9999;
+  z-index: 99;
+  text-align: center;
 }
 
 .tooltip-container:hover .tooltip-text {
@@ -15,8 +15,8 @@
 }
 
 .top {
-  bottom: 30%;
-  left: 35%;
+  bottom: -30%;
+  left: 40%;
   transform: translateX(-50%) translateY(-100%);
 }
 

--- a/packages/dashboard/src/components/tooltip/tooltip.tsx
+++ b/packages/dashboard/src/components/tooltip/tooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import './tooltip.css';
 import {
   colorBackgroundHomeHeader,
@@ -8,6 +8,7 @@ import {
   spaceStaticXs,
   spaceStaticXxxs,
 } from '@cloudscape-design/design-tokens';
+import { MAX_TOOLTIP_WIDTH, TOP_TOOLTIP_MARGIN, WRAPPED_TOOLTIP_WIDTH } from './constants';
 
 const Tooltip = ({
   content,
@@ -18,6 +19,8 @@ const Tooltip = ({
   position: 'top' | 'bottom' | 'left' | 'right';
   children: React.ReactNode;
 }) => {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [isContentWrapped, setIsContentWrapped] = useState(false);
   const tooltipStyle = {
     fontSize: spaceScaledM,
     color: colorBackgroundHomeHeader,
@@ -25,14 +28,40 @@ const Tooltip = ({
     padding: spaceStaticS,
     borderRadius: spaceStaticXs,
     border: `${spaceStaticXxxs} solid ${colorBackgroundHomeHeader}`,
+    maxWidth: `${MAX_TOOLTIP_WIDTH}px`,
+    ...(isContentWrapped && { width: `${MAX_TOOLTIP_WIDTH}px`, bottom: `${TOP_TOOLTIP_MARGIN}%` }),
+  };
+
+  const handleMouseEnter = () => {
+    if (contentRef.current) {
+      setIsContentWrapped(contentRef.current.clientWidth > WRAPPED_TOOLTIP_WIDTH);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    setIsContentWrapped(false);
+  };
+
+  const handleOnClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
   };
 
   return (
-    <div className='tooltip-container'>
+    <div className='tooltip-container' onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       {children}
-      <div className={`tooltip-text ${position}`} style={tooltipStyle}>
-        {content}
-      </div>
+      {content && (
+        <span
+          className={`tooltip-text ${position}`}
+          style={{
+            ...tooltipStyle,
+            whiteSpace: !isContentWrapped ? 'nowrap' : 'pre-wrap',
+          }}
+          ref={contentRef}
+          onClick={handleOnClick}
+        >
+          {content}
+        </span>
+      )}
     </div>
   );
 };

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.css
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.css
@@ -13,47 +13,10 @@
   align-items: center;
 }
 
-.property-display-toggle {
-  position: relative;
-}
-
-.property-display-toggle .tooltiptext {
-  position: absolute;
-  border-style: solid;
-  text-align: center;
-  z-index: 9;
-  visibility: hidden;
-  transform: translateX(-50%);
-  min-width: 60px;
-  left: 50%;
-  bottom: 100%;
-}
-
-.property-display-toggle .tooltiptext::before,
-.property-display-toggle .tooltiptext::after {
-  content: "";
-  position: absolute;
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  left: 50%;
-  right: 50%;
-  margin: auto;
-  margin-left: -10px;
-  top: 100%;
-}
-
-.property-display-toggle .tooltiptext::before {
-  border-top: 11px solid #9ba7b6;
-  margin-bottom: 5px;
-}
-
-.property-display-toggle .tooltiptext::after {
-  border-top: 10px solid var(--colors-white);
-  margin-top: -2px;
-  z-index: 1;
-}
-
-.property-display-toggle:hover .tooltiptext {
-  visibility: visible;
-  display: block;
+.property-display-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: normal;
+  width: 288px;
 }


### PR DESCRIPTION
## Overview
This PR is to improve the handling of long property names within the dashboards configuration panels "property" section. this includes,
1.  long names are truncated and added ellipses
2. tooltip for the truncated names
3. fixed width for the property Name 
4. No tooltip if full name is showing

## Verifying Changes
![image](https://github.com/awslabs/iot-app-kit/assets/142866907/a630e8f2-d09f-4f82-9da0-a890f0193a7c)
![image](https://github.com/awslabs/iot-app-kit/assets/142866907/47b1a57a-f385-4316-9b99-4cdcb5299001)



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
