### PR TITLE
build(dashboard): updating story book config to avoid bootstrap when dependency's file change

### DIFF
--- a/packages/dashboard/.storybook/main.js
+++ b/packages/dashboard/.storybook/main.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const path = require('path');
 
 module.exports = {
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -25,5 +26,9 @@ module.exports = {
   webpackFinal: async (config) => {
     config.resolve.plugins = [new TsconfigPathsPlugin()];
     return config;
-  }
+  },
+  alias: {
+    '@iot-app-kit/react-components': path.resolve(__dirname, '../../react-components/dist/esm/index.js'),
+    '@iot-app-kit/core': path.resolve(__dirname, '../../core/dist/es/index.js'),
+  },
 };


### PR DESCRIPTION
## Overview
Provide an explanation of what the change is

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
