### PR TITLE
feat(scene): add fog settings to scene

### DIFF
--- a/packages/scene-composer/src/components/WebGLCanvasManager.tsx
+++ b/packages/scene-composer/src/components/WebGLCanvasManager.tsx
@@ -6,7 +6,7 @@ import { ThreeEvent, useThree } from '@react-three/fiber';
 import { MatterportModel } from '@matterport/r3f/dist';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-import { KnownSceneProperty } from '../interfaces';
+import { KnownSceneProperty, COMPOSER_FEATURES } from '../interfaces';
 import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLogging';
 import { useEditorState, useSceneDocument, useStore } from '../store';
 import { sceneComposerIdContext } from '../common/sceneComposerIdContext';
@@ -21,6 +21,7 @@ import useMatterportViewer from '../hooks/useMatterportViewer';
 import useDynamicScene from '../hooks/useDynamicScene';
 
 import Environment, { presets } from './three-fiber/Environment';
+import Fog from './three-fiber/Fog';
 import { StatsWindow } from './three-fiber/StatsWindow';
 import EntityGroup from './three-fiber/EntityGroup';
 import { EditorMainCamera } from './three-fiber/EditorCamera';
@@ -42,6 +43,7 @@ export const WebGLCanvasManager: React.FC = () => {
 
   const sceneComposerId = useContext(sceneComposerIdContext);
   const { isEditing, addingWidget, setAddingWidget } = useEditorState(sceneComposerId);
+  const sceneAppearanceEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.SceneAppearance];
   const { enableMatterportViewer } = useMatterportViewer();
   const { document, getSceneNodeByRef, getSceneProperty } = useSceneDocument(sceneComposerId);
   const appendSceneNode = useStore(sceneComposerId)((state) => state.appendSceneNode);
@@ -86,6 +88,7 @@ export const WebGLCanvasManager: React.FC = () => {
 
   return (
     <React.Fragment>
+      {sceneAppearanceEnabled && <Fog />}
       <EditorMainCamera />
       {environmentPreset && environmentPreset in presets && (
         <Environment preset={environmentPreset} extensions={envLoaderExtension} />

--- a/packages/scene-composer/src/components/panels/SettingsPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SettingsPanel.tsx
@@ -18,7 +18,7 @@ import { MatterportIntegration, SceneDataBindingTemplateEditor, SceneTagSettings
 import { ComponentVisibilityToggle } from './scene-settings/ComponentVisibilityToggle';
 import { OverlayPanelVisibilityToggle } from './scene-settings/OverlayPanelVisibilityToggle';
 import { ConvertSceneSettings } from './scene-settings/ConvertSceneSettings';
-
+import { FogSettingsEditor } from './scene-settings/FogSettingsEditor';
 export interface SettingsPanelProps {
   valueDataBindingProvider?: IValueDataBindingProvider;
 }
@@ -35,6 +35,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
   const tagResizeEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagResize];
   const matterportEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Matterport];
   const overlayEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Overlay];
+  const sceneAppearanceEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.SceneAppearance];
   const dynamicSceneEnabled = useDynamicScene();
 
   const selectedEnvPreset = useStore(sceneComposerId)((state) =>
@@ -178,6 +179,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
                 expandToViewport
               />
             </FormField>
+            {sceneAppearanceEnabled && <FogSettingsEditor />}
           </SpaceBetween>
         </ExpandableInfoSection>
       )}

--- a/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.spec.tsx
@@ -1,0 +1,146 @@
+import wrapper from '@awsui/components-react/test-utils/dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { useStore } from '../../../store';
+import { KnownSceneProperty } from '../../../interfaces';
+
+import { FogSettingsEditor } from './FogSettingsEditor';
+
+jest.mock('@awsui/components-react', () => ({
+  ...jest.requireActual('@awsui/components-react'),
+}));
+
+describe('FogSettingsEditor', () => {
+  const setScenePropertyMock = jest.fn();
+  const getScenePropertyMock = jest.fn();
+  const baseState = {
+    setSceneProperty: setScenePropertyMock,
+    getSceneProperty: getScenePropertyMock,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should save fogsettings when checked', async () => {
+    getScenePropertyMock.mockReturnValue(undefined);
+    useStore('default').setState(baseState);
+    const { container } = render(<FogSettingsEditor />);
+    const polarisWrapper = wrapper(container);
+    const checkbox = polarisWrapper.findCheckbox();
+
+    expect(checkbox).toBeDefined();
+    console.log('checkbox: ', checkbox);
+    // click checkbox should update store
+    checkbox?.findNativeInput().click();
+    expect(setScenePropertyMock).toBeCalledTimes(1);
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, {
+      colorHex: 0xcccccc,
+      near: 1,
+      far: 1000,
+    });
+  });
+
+  it('should clear fogsettings when unchecked', async () => {
+    getScenePropertyMock.mockReturnValue({
+      colorHex: 0xcccccc,
+      near: 1,
+      far: 1000,
+    });
+    useStore('default').setState(baseState);
+    const { container } = render(<FogSettingsEditor />);
+    const polarisWrapper = wrapper(container);
+    const checkbox = polarisWrapper.findCheckbox();
+
+    expect(checkbox).toBeDefined();
+
+    // click checkbox should update store
+    checkbox?.findNativeInput().click();
+    expect(setScenePropertyMock).toBeCalledTimes(1);
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, undefined);
+  });
+
+  it('should update fog when near changes', async () => {
+    getScenePropertyMock.mockReturnValue({
+      colorHex: 0xcccccc,
+      near: 1,
+      far: 1000,
+    });
+    useStore('default').setState(baseState);
+    const { container } = render(<FogSettingsEditor />);
+    const polarisWrapper = wrapper(container);
+    const nearInput = polarisWrapper.findInput('[data-testid="fog-near-input"]');
+
+    expect(nearInput).toBeDefined();
+
+    nearInput!.focus();
+    nearInput!.setInputValue('2');
+    nearInput!.blur();
+    expect(setScenePropertyMock).toBeCalledTimes(1);
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, {
+      colorHex: 0xcccccc,
+      near: 2,
+      far: 1000,
+    });
+  });
+
+  it('should update fog when far changes', async () => {
+    getScenePropertyMock.mockReturnValue({
+      colorHex: 0xcccccc,
+      near: 1,
+      far: 1000,
+    });
+    useStore('default').setState(baseState);
+    const { container } = render(<FogSettingsEditor />);
+    const polarisWrapper = wrapper(container);
+    const farInput = polarisWrapper.findInput('[data-testid="fog-far-input"]');
+
+    expect(farInput).toBeDefined();
+
+    farInput!.focus();
+    farInput!.setInputValue('2000');
+    farInput!.blur();
+    expect(setScenePropertyMock).toBeCalledTimes(1);
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, {
+      colorHex: 0xcccccc,
+      near: 1,
+      far: 2000,
+    });
+  });
+
+  it('should update fog when colors changes', async () => {
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.FogSettings) {
+        console.log('getting fog setting');
+        return {
+          colorHex: 0xcccccc,
+          near: 1,
+          far: 1000,
+        };
+      } else if (property === KnownSceneProperty.TagCustomColors) {
+        console.log('getting custom colors setting');
+        const customColors: string[] = [];
+        return customColors;
+      }
+      console.log('got wrong thing: ', property);
+    });
+    useStore('default').setState(baseState);
+    const { container } = render(<FogSettingsEditor />);
+    const polarisWrapper = wrapper(container);
+    const colorInput = polarisWrapper.findInput('[data-testid="hexcode"]');
+
+    expect(colorInput).toBeDefined();
+
+    // click checkbox should update store
+    colorInput!.focus();
+    colorInput!.setInputValue('#FFFFFF');
+    colorInput!.blur();
+    expect(setScenePropertyMock).toBeCalledTimes(2);
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, {
+      colorHex: 0xffffff,
+      near: 1,
+      far: 1000,
+    });
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.tsx
@@ -1,0 +1,147 @@
+import React, { useCallback, useContext, useState } from 'react';
+import { useIntl } from 'react-intl';
+import { Checkbox, FormField, Input, SpaceBetween } from '@awsui/components-react';
+
+import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import { IFogSettings, KnownSceneProperty } from '../../../interfaces';
+import useLifecycleLogging from '../../../logger/react-logger/hooks/useLifecycleLogging';
+import { useStore } from '../../../store';
+import { ColorSelectorCombo } from '../scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo';
+import { ExpandableInfoSection } from '../CommonPanelComponents';
+
+export const FogSettingsEditor: React.FC = () => {
+  useLifecycleLogging('FogSettingsEditor');
+
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const intl = useIntl();
+  const setSceneProperty = useStore(sceneComposerId)((state) => state.setSceneProperty<IFogSettings | undefined>);
+  const fogSettings = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<IFogSettings>(KnownSceneProperty.FogSettings),
+  );
+
+  const [fogEnabled, setFogEnabled] = useState(!!fogSettings);
+  const [internalColor, setInternalColor] = useState(fogSettings?.colorHex || 0xcccccc);
+  const [internalNearDistance, setInternalNearDistance] = useState(fogSettings?.near || 1);
+  const [internalFarDistance, setInternalFarDistance] = useState(fogSettings?.far || 1000);
+
+  const tagStyleColors = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<string[]>(KnownSceneProperty.TagCustomColors, []),
+  );
+  const setTagColorsSceneProperty = useStore(sceneComposerId)((state) => state.setSceneProperty<string[]>);
+
+  const onToggleFog = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        setSceneProperty(KnownSceneProperty.FogSettings, {
+          colorHex: internalColor,
+          near: internalNearDistance,
+          far: internalFarDistance,
+        });
+      } else {
+        setSceneProperty(KnownSceneProperty.FogSettings, undefined);
+      }
+      setFogEnabled(checked);
+    },
+    [fogSettings, internalColor, internalNearDistance, internalFarDistance],
+  );
+
+  const onInputBlur = useCallback(() => {
+    if (fogEnabled && (fogSettings?.near !== internalNearDistance || fogSettings?.far !== internalFarDistance)) {
+      setSceneProperty(KnownSceneProperty.FogSettings, {
+        colorHex: internalColor,
+        near: internalNearDistance,
+        far: internalFarDistance,
+      });
+    }
+  }, [fogEnabled, internalColor, internalNearDistance, internalFarDistance]);
+
+  const onColorChange = useCallback(
+    (color: string) => {
+      const hex = parseInt(color.replace(/^#/, ''), 16);
+      if (hex !== internalColor) {
+        setInternalColor(hex);
+        if (fogEnabled) {
+          setSceneProperty(KnownSceneProperty.FogSettings, {
+            colorHex: hex,
+            near: internalNearDistance,
+            far: internalFarDistance,
+          });
+        }
+      }
+    },
+    [fogEnabled, internalColor, internalNearDistance, internalFarDistance],
+  );
+
+  const onNearChange = useCallback(
+    (event) => {
+      const value = Number(event.detail.value);
+      if (value !== internalNearDistance) {
+        setInternalNearDistance(value);
+      }
+    },
+    [internalNearDistance],
+  );
+
+  const onFarChange = useCallback(
+    (event) => {
+      const value = Number(event.detail.value);
+      if (value !== internalFarDistance) {
+        setInternalFarDistance(value);
+      }
+    },
+    [internalFarDistance],
+  );
+
+  return (
+    <React.Fragment>
+      <ExpandableInfoSection
+        title={intl.formatMessage({ description: 'ExpandableInfoSection Title', defaultMessage: 'Fog Settings' })}
+        defaultExpanded={false}
+      >
+        <SpaceBetween size='s'>
+          <Checkbox
+            data-testid='enable-fog-checkbox'
+            checked={!!fogSettings}
+            onChange={(e) => onToggleFog(e.detail.checked)}
+          >
+            {intl.formatMessage({ defaultMessage: 'Enable Fog', description: 'checkbox label' })}
+          </Checkbox>
+          <ColorSelectorCombo
+            color={`#${internalColor?.toString(16).padStart(6, '0')}`}
+            onSelectColor={(pickedColor) => onColorChange(pickedColor)}
+            onUpdateCustomColors={(chosenCustomColors) =>
+              setTagColorsSceneProperty(KnownSceneProperty.TagCustomColors, chosenCustomColors)
+            }
+            customColors={tagStyleColors}
+            colorPickerLabel={intl.formatMessage({ defaultMessage: 'Color', description: 'Color' })}
+            customColorLabel={intl.formatMessage({ defaultMessage: 'Custom colors', description: 'Custom colors' })}
+          />
+          <FormField label={intl.formatMessage({ defaultMessage: 'Near Distance', description: 'Form Field label' })}>
+            <Input
+              data-testid='fog-near-input'
+              value={String(internalNearDistance)}
+              type='number'
+              onBlur={onInputBlur}
+              onChange={onNearChange}
+              onKeyDown={(e) => {
+                if (e.detail.key === 'Enter') onInputBlur();
+              }}
+            />
+          </FormField>
+          <FormField label={intl.formatMessage({ defaultMessage: 'Far Distance', description: 'Form Field label' })}>
+            <Input
+              data-testid='fog-far-input'
+              value={String(internalFarDistance)}
+              type='number'
+              onBlur={onInputBlur}
+              onChange={onFarChange}
+              onKeyDown={(e) => {
+                if (e.detail.key === 'Enter') onInputBlur();
+              }}
+            />
+          </FormField>
+        </SpaceBetween>
+      </ExpandableInfoSection>
+    </React.Fragment>
+  );
+};

--- a/packages/scene-composer/src/components/three-fiber/Fog.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/Fog.spec.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react';
+import * as THREE from 'three';
+jest.doMock('@react-three/fiber', () => ({
+  useThree: jest.fn(),
+}));
+const getScenePropertyMock = jest.fn();
+const baseState = {
+  getSceneProperty: getScenePropertyMock,
+};
+import { useThree } from '@react-three/fiber';
+import React from 'react';
+
+import { useStore } from '../../../src/store';
+import { IFogSettings } from '../../interfaces';
+
+import Fog from './Fog';
+
+import Mock = jest.Mock;
+
+describe('Fog', () => {
+  const setup = () => {
+    jest.resetAllMocks();
+
+    useStore('default').setState(baseState);
+  };
+
+  beforeEach(() => {
+    setup();
+  });
+
+  it(`should add fog to the scene`, () => {
+    const testScene = new THREE.Scene();
+    const mockThreeStates = {
+      scene: testScene,
+    };
+    const useThreeMock = useThree as Mock;
+    useThreeMock.mockImplementation((s) => {
+      return s(mockThreeStates);
+    });
+
+    const fogSetting: IFogSettings = {
+      colorHex: 0xcccccc,
+      near: 2,
+      far: 20,
+    };
+    getScenePropertyMock.mockReturnValue(fogSetting);
+
+    expect(testScene.fog).toBeNull();
+    render(<Fog />);
+    const fog = testScene.fog as THREE.Fog;
+
+    expect(fog.color.getHex()).toEqual(fogSetting.colorHex);
+    expect(fog.near).toEqual(fogSetting.near);
+    expect(fog.far).toEqual(fogSetting.far);
+  });
+
+  it(`should not add fog to the scene`, () => {
+    const testScene = new THREE.Scene();
+    const mockThreeStates = {
+      scene: testScene,
+    };
+    const useThreeMock = useThree as Mock;
+    useThreeMock.mockImplementation((s) => {
+      return s(mockThreeStates);
+    });
+
+    getScenePropertyMock.mockReturnValue(undefined);
+
+    expect(testScene.fog).toBeNull();
+    render(<Fog />);
+    expect(testScene.fog).toBeNull();
+  });
+});

--- a/packages/scene-composer/src/components/three-fiber/Fog.tsx
+++ b/packages/scene-composer/src/components/three-fiber/Fog.tsx
@@ -1,0 +1,26 @@
+import * as THREE from 'three';
+import { FC, useContext, useEffect } from 'react';
+import { useThree } from '@react-three/fiber';
+
+import { useStore } from '../../store';
+import { IFogSettings, KnownSceneProperty } from '../../interfaces';
+import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
+
+const Fog: FC = () => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const scene = useThree((state) => state.scene);
+  const fogSettings = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<IFogSettings>(KnownSceneProperty.FogSettings),
+  );
+
+  useEffect(() => {
+    scene.fog =
+      fogSettings && fogSettings.colorHex
+        ? new THREE.Fog(fogSettings.colorHex, fogSettings.near, fogSettings.far)
+        : null;
+  }, [scene, fogSettings]);
+
+  return null;
+};
+
+export default Fog;

--- a/packages/scene-composer/src/interfaces/feature.ts
+++ b/packages/scene-composer/src/interfaces/feature.ts
@@ -19,6 +19,7 @@ export enum COMPOSER_FEATURES {
   Animations = 'Animations',
   DynamicScene = 'DynamicScene',
   FirstPerson = 'FirstPerson',
+  SceneAppearance = 'SceneAppearance',
 
   // Deprecated features (to be removed)
   EnvironmentModel = 'EnvironmentModel',

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -73,6 +73,7 @@ export enum KnownSceneProperty {
   LayerIds = 'layerIds',
   SceneRootEntityId = 'sceneRootEntityId',
   TagCustomColors = 'tagCustomColors',
+  FogSettings = 'fogSettings',
 }
 
 /************************************************
@@ -140,4 +141,10 @@ export interface MeshStyle {
 export interface StyleTarget {
   dataBindingContext: unknown;
   style: MeshStyle;
+}
+
+export interface IFogSettings {
+  colorHex: number;
+  near: number;
+  far: number;
 }

--- a/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
@@ -24,6 +24,7 @@ export const defaultArgs = {
     COMPOSER_FEATURES.Matterport,
     COMPOSER_FEATURES.TagStyle,
     COMPOSER_FEATURES.AutoQuery,
+    COMPOSER_FEATURES.SceneAppearance,
   ],
 };
 

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -103,6 +103,10 @@
     "note": "Error message",
     "text": "Error - unable to render the scene"
   },
+  "2A8qfi": {
+    "note": "ExpandableInfoSection Title",
+    "text": "Fog Settings"
+  },
   "2F5/qR": {
     "note": "ExpandableInfoSection Title",
     "text": "Scene Settings"
@@ -259,6 +263,10 @@
     "note": "label",
     "text": "Select speed"
   },
+  "9yVMfn": {
+    "note": "Form Field label",
+    "text": "Far Distance"
+  },
   "A/Q8OL": {
     "note": "Status indicator label",
     "text": "Camera view saved"
@@ -318,6 +326,10 @@
   "Bzw++H": {
     "note": "label for the remove animation button",
     "text": "remove"
+  },
+  "C11Rim": {
+    "note": "Form Field label",
+    "text": "Near Distance"
   },
   "C9z9wU": {
     "note": "Abbreviation for green",
@@ -498,6 +510,10 @@
   "NXP1Hm": {
     "note": "Form field errorText",
     "text": "FOV cannot be less than 10"
+  },
+  "NZvDHt": {
+    "note": "checkbox label",
+    "text": "Enable Fog"
   },
   "Nj6Ob1": {
     "note": "Select Color type option",


### PR DESCRIPTION
## Overview
Adds a feature flag 'SceneAppearance' that adds an option for a Fog setting in the Scene Composer setting tab.

https://github.com/awslabs/iot-app-kit/assets/109186219/43537422-19a9-4bcb-a795-a55d88d5bc5e


## Verifying Changes

Storybook
Scene Composer - Local Scene
Open Settings Tab
Expand Scene Settings
Expand Fog Settings
Use color picker, near, far, and enable check box to toggle fog settings.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
