### PR TITLE
feat: added widget text in the widget panel #2036

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -30,7 +30,6 @@
 
 .dashboard .dashboard-toolbar,
 .dashboard .dashboard-toolbar-read-only {
-  border-bottom: var(--border-width-toolbar) solid var(--colors-light-grey);
   background-color: var(--colors-white);
 }
 

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -3,7 +3,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { WebglContext, TrendCursorSync, TimeSync, TimeSelection } from '@iot-app-kit/react-components';
 import Box from '@cloudscape-design/components/box';
 import SpaceBetween from '@cloudscape-design/components/space-between';
-import { colorBackgroundCellShaded } from '@cloudscape-design/design-tokens';
+import {
+  colorBackgroundCellShaded,
+  colorBorderDividerDefault,
+  spaceScaledXxxs,
+} from '@cloudscape-design/design-tokens';
 
 import { selectedRect } from '~/util/select';
 
@@ -203,6 +207,10 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({ onSave, edit
     hasSelectedWidgets: selectedWidgets.length > 0,
   };
 
+  const dashboardToolbarBottomBorder = {
+    borderBottom: `solid ${spaceScaledXxxs} ${colorBorderDividerDefault}`,
+  };
+
   if (iotSiteWiseClient == null || iotTwinMakerClient == null) {
     return null;
   }
@@ -210,7 +218,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({ onSave, edit
   const EditComponent = (
     <div className='dashboard' style={userSelect}>
       <CustomDragLayer onDrag={(isDragging) => setUserSelect(isDragging ? disabledUserSelect : defaultUserSelect)} />
-      <div className='dashboard-toolbar'>
+      <div style={dashboardToolbarBottomBorder} className='dashboard-toolbar'>
         <Box float='left' padding='xs'>
           <ComponentPalette />
         </Box>
@@ -253,7 +261,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({ onSave, edit
   );
   const ReadOnlyComponent = (
     <div className='dashboard'>
-      <div className='dashboard-toolbar-read-only'>
+      <div style={dashboardToolbarBottomBorder} className='dashboard-toolbar-read-only'>
         <Box float='right' padding='s'>
           <SpaceBetween size='s' direction='horizontal'>
             <TimeSelection />

--- a/packages/dashboard/src/components/palette/index.css
+++ b/packages/dashboard/src/components/palette/index.css
@@ -1,0 +1,5 @@
+.widget-panel {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}

--- a/packages/dashboard/src/components/palette/index.tsx
+++ b/packages/dashboard/src/components/palette/index.tsx
@@ -1,20 +1,42 @@
 import React, { memo } from 'react';
 import SpaceBetween from '@cloudscape-design/components/space-between';
-import { spaceFieldHorizontal } from '@cloudscape-design/design-tokens';
+import {
+  colorBorderDividerDefault,
+  colorTextBodyDefault,
+  spaceFieldHorizontal,
+  spaceScaledS,
+  spaceScaledXxxs,
+  spaceStaticXxl,
+} from '@cloudscape-design/design-tokens';
 import {
   ComponentLibraryComponentMap,
   ComponentLibraryComponentOrdering,
 } from '~/customization/componentLibraryComponentMap';
 import PaletteComponent from './component';
+import './index.css';
 
 /* added left padding as per UX and top padding for positioning Icons Vertically centre */
 const palettePadding = {
   padding: `${spaceFieldHorizontal} ${0} ${0} ${spaceFieldHorizontal}`,
 };
 
+const widgetFont = {
+  color: colorTextBodyDefault,
+};
+
+const divider = {
+  borderLeft: `solid ${spaceScaledXxxs} ${colorBorderDividerDefault}`,
+  height: spaceStaticXxl,
+  margin: `0 ${spaceScaledS}`,
+};
+
+const Divider = () => <div style={divider} />;
+
 const Palette = () => {
   return (
-    <div style={palettePadding}>
+    <div className='widget-panel' style={palettePadding}>
+      <h4 style={widgetFont}>Widgets</h4>
+      <Divider />
       <SpaceBetween size='xxxs' direction='horizontal'>
         {ComponentLibraryComponentOrdering.map((widgetType) => {
           const [name, iconComponent] = ComponentLibraryComponentMap[widgetType];

--- a/packages/dashboard/src/styles/variables.css
+++ b/packages/dashboard/src/styles/variables.css
@@ -31,7 +31,6 @@
   --spacing-component-palette-icon: 8px;
   --border-width-button: 2px;
   --border-width-context-menu-section: 0.5px;
-  --border-width-toolbar: 2px;
   --size-text-button-icon: 30px;
   --size-context-menu-min-width: 200px;
   --size-text-link-edit-menu-min-width: 200px;


### PR DESCRIPTION

![image](https://github.com/awslabs/iot-app-kit/assets/81667589/aa901818-2557-45ad-82b7-9a2216a077e5)


Issue: https://github.com/awslabs/iot-app-kit/issues/2036

Description: Added "Widgets" text with horizontal divider to the Widget library panel on the dashboard.

Changes in the CR:
-> Added "Widgets" header with grey-900 font color and a right divider of 2px.
->Added bottom border, 2px grey-200