### PR TITLE
fix(react-components): toggle legend hides container

### DIFF
--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -56,10 +56,13 @@ const mapSymboleStyleToSymbol = (symbolStyle: SymbolStyles['style']): ChartStyle
     case 'pin':
     case 'none':
       return symbolStyle;
+
     default:
       return undefined;
   }
 };
+
+const emptyLegendObject = {};
 
 const useAdaptedStyleSettings = (rootStyles: LineAndScatterStyles, styledAssetQuery?: IoTSiteWiseDataStreamQuery) => {
   const depQuery = JSON.stringify(styledAssetQuery);
@@ -200,7 +203,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (widge
         thresholds={thresholds}
         significantDigits={significantDigits}
         size={size}
-        legend={legend?.visible == true ? {} : undefined}
+        legend={legend?.visible ? emptyLegendObject : undefined}
         defaultVisualizationType={mapConnectionStyleToVisualizationType(line?.connectionStyle)}
       />
     </WidgetTile>

--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -65,7 +65,7 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
 
   // Setup resize container and calculate size for echarts
   const { height, chartWidth, rightLegendWidth, onResize, minConstraints, maxConstraints, leftLegendRef } =
-    useResizeableEChart(chartRef, size);
+    useResizeableEChart(chartRef, size, options.legend);
 
   // apply group to echarts
   useGroupableEChart(chartRef, group);

--- a/packages/react-components/src/hooks/useECharts/useResizeableEChart.ts
+++ b/packages/react-components/src/hooks/useECharts/useResizeableEChart.ts
@@ -7,8 +7,12 @@ import {
 } from '../../components/chart/eChartsConstants';
 import { ResizeCallbackData } from 'react-resizable';
 import { useMeasure } from 'react-use';
+import { ChartLegend } from '../../components/chart/types';
 
-const getChartWidth = (width: number, staticWidth: number) => {
+const getChartWidth = (width: number, staticWidth: number, rightLegend?: ChartLegend) => {
+  if (!rightLegend) {
+    return width - staticWidth;
+  }
   return width * CHART_RESIZE_INITIAL_FACTOR - staticWidth;
 };
 
@@ -29,22 +33,26 @@ const getChartWidth = (width: number, staticWidth: number) => {
  */
 export const useResizeableEChart = (
   chartRef: MutableRefObject<ECharts | null>,
-  size: { width: number; height: number }
+  size: { width: number; height: number },
+  rightLegend?: ChartLegend
 ) => {
   const { width, height } = size;
   const [leftLegendRef, { width: leftLegendWidth }] = useMeasure<HTMLDivElement>();
-  const [chartWidth, setWidth] = useState(getChartWidth(width, leftLegendWidth));
-
-  const rightLegendWidth = useMemo(() => width - leftLegendWidth - chartWidth, [width, leftLegendWidth, chartWidth]);
+  const [chartWidth, setChartWidth] = useState(getChartWidth(width, leftLegendWidth));
+  const rightLegendWidth = rightLegend ? width - leftLegendWidth - chartWidth : 0;
 
   const onResize = (_event: SyntheticEvent, data: ResizeCallbackData) => {
     _event.stopPropagation();
-    setWidth(data.size.width);
+    if (!rightLegend) {
+      setChartWidth(width - leftLegendWidth);
+    } else {
+      setChartWidth(data.size.width);
+    }
   };
 
   useEffect(() => {
-    setWidth(getChartWidth(width, leftLegendWidth));
-  }, [width, leftLegendWidth]);
+    setChartWidth(getChartWidth(width, leftLegendWidth, rightLegend));
+  }, [width, leftLegendWidth, rightLegend]);
 
   useEffect(() => {
     const chart = chartRef.current;


### PR DESCRIPTION
## Overview
When the user toggles the legend property in the property panel, the legend container is also hidden now. 

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/4dadbe50-ca3b-4316-b964-6ecf15827b2e


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
