### PR TITLE
fix(scene composer): restoring dark mode in stotybook

### DIFF
--- a/packages/scene-composer/.storybook/main.js
+++ b/packages/scene-composer/.storybook/main.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { fromIni } = require('@aws-sdk/credential-providers');
 module.exports = {
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/preset-scss'],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/preset-scss', 'storybook-dark-mode'],
   staticDirs: [
     '../dist',
     '../public',


### PR DESCRIPTION
## Overview
Restoring dark mode in storybook for scene composer 

https://github.com/awslabs/iot-app-kit/assets/6610619/0589dd8f-8d8c-450e-81fb-3491cb7b3155



## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
