### PR TITLE
fix(scene-composer): restore the grid line colors

### DIFF
--- a/packages/scene-composer/src/components/WebGLCanvasManager.tsx
+++ b/packages/scene-composer/src/components/WebGLCanvasManager.tsx
@@ -122,10 +122,10 @@ export const WebGLCanvasManager: React.FC = () => {
             <gridHelper
               ref={gridHelperRef}
               args={[
-                1000 /* size */, 500 /* grid# */,
-                // TODO: Restore custom colors for grid center lind
-                // new THREE.Color('#d5dbdb') /* center line color */,
-                // new THREE.Color(hexColorFromDesignToken(awsui.colorTextInputPlaceholder)) /* grid color */,
+                1000 /* size */,
+                500 /* grid# */,
+                hexColorFromDesignToken(awsui.colorTextInputPlaceholder) /* center line color */,
+                hexColorFromDesignToken(awsui.colorTextInputDisabled) /* grid color */,
               ]}
             />
             <mesh


### PR DESCRIPTION
## Overview
Restore the grid line colors which were removed due to the scene flickering issue.
Made sure that the flickering issue is not observed after restoring the grid line colors.

Before:

https://github.com/awslabs/iot-app-kit/assets/43108986/18c1b132-ea07-4b5b-9742-f6c9ff3d1c69

After:

https://github.com/awslabs/iot-app-kit/assets/43108986/28fce331-0eb0-4ac6-86bb-9d8d67d1bb78

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
