### PR TITLE
feat(composer): support tag custom icon in entity

### DIFF
--- a/packages/scene-composer/src/utils/entityModelUtils/motionIndicatorComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/motionIndicatorComponent.spec.ts
@@ -61,7 +61,7 @@ describe('createMotionIndicatorEntityComponent', () => {
     });
 
     expect(result.properties!['config_defaultSpeed']).toEqual({
-      value: { integerValue: 11 },
+      value: { doubleValue: 11 },
     });
   });
 

--- a/packages/scene-composer/src/utils/entityModelUtils/motionIndicatorComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/motionIndicatorComponent.ts
@@ -81,7 +81,7 @@ export const createMotionIndicatorEntityComponent = (indicator: IMotionIndicator
   if (indicator.config.defaultSpeed !== undefined) {
     comp.properties![MotionIndicatorComponentProperty.ConfigDefaultSpeed] = {
       value: {
-        integerValue: indicator.config.defaultSpeed,
+        doubleValue: indicator.config.defaultSpeed,
       },
     };
   }

--- a/packages/scene-composer/src/utils/entityModelUtils/tagComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/tagComponent.spec.ts
@@ -85,6 +85,22 @@ describe('createTagEntityComponent', () => {
     });
   });
 
+  it('should return expected tag component with custom icon', () => {
+    const result = createTagEntityComponent({
+      type: KnownComponentType.Tag,
+      customIcon: { prefix: 'prefix', iconName: 'name' },
+    });
+
+    expect(result.properties).toEqual({
+      customIcon_prefix: {
+        value: { stringValue: 'prefix' },
+      },
+      customIcon_iconName: {
+        value: { stringValue: 'name' },
+      },
+    });
+  });
+
   it('should return expected tag component with styleBinding with rule id', () => {
     const result = createTagEntityComponent({ type: KnownComponentType.Tag, ruleBasedMapId: 'rule-id' });
 
@@ -238,6 +254,38 @@ describe('parseTagComp', () => {
     });
 
     expect(result?.chosenColor).toEqual('red');
+  });
+
+  it('should parse to expected tag component with custom icon', () => {
+    const result = parseTagComp({
+      componentTypeId: componentTypeToId[KnownComponentType.Tag],
+      properties: [
+        {
+          propertyName: 'customIcon_prefix',
+          propertyValue: 'prefix',
+        },
+        {
+          propertyName: 'customIcon_iconName',
+          propertyValue: 'name',
+        },
+      ],
+    });
+
+    expect(result?.customIcon).toEqual({ prefix: 'prefix', iconName: 'name' });
+  });
+
+  it('should parse to expected tag component without custom icon when icon prefix is missing', () => {
+    const result = parseTagComp({
+      componentTypeId: componentTypeToId[KnownComponentType.Tag],
+      properties: [
+        {
+          propertyName: 'customIcon_iconName',
+          propertyValue: 'name',
+        },
+      ],
+    });
+
+    expect(result?.customIcon).toBeUndefined();
   });
 
   it('should parse to expected tag component with styleBinding with rule id', () => {

--- a/packages/scene-composer/src/utils/entityModelUtils/tagComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/tagComponent.ts
@@ -14,6 +14,8 @@ enum TagComponentProperty {
   NavLinkParams = 'navLink_params',
   Offset = 'offset',
   ChosenColor = 'chosenColor',
+  CustomIconName = 'customIcon_iconName',
+  CustomIconPrefix = 'customIcon_prefix',
   RuleBasedMapId = 'ruleBasedMapId',
   StyleBinding = 'styleBinding',
 }
@@ -64,6 +66,20 @@ export const createTagEntityComponent = (tag: IAnchorComponent): ComponentReques
       },
     };
   }
+  if (tag.customIcon?.iconName) {
+    comp.properties![TagComponentProperty.CustomIconName] = {
+      value: {
+        stringValue: tag.customIcon.iconName,
+      },
+    };
+  }
+  if (tag.customIcon?.prefix) {
+    comp.properties![TagComponentProperty.CustomIconPrefix] = {
+      value: {
+        stringValue: tag.customIcon.prefix,
+      },
+    };
+  }
   if (tag.ruleBasedMapId || tag.valueDataBinding?.dataBindingContext) {
     const map = createDataBindingMap(tag.valueDataBinding);
     if (tag.ruleBasedMapId) {
@@ -96,6 +112,14 @@ export const parseTagComp = (comp: DocumentType): IAnchorComponentInternal | und
   const binding = comp['properties'].find(
     (p) => p['propertyName'] === TagComponentProperty.StyleBinding,
   )?.propertyValue;
+
+  const customIconName = comp['properties'].find(
+    (p) => p['propertyName'] === TagComponentProperty.CustomIconName,
+  )?.propertyValue;
+  const customIconPrefix = comp['properties'].find(
+    (p) => p['propertyName'] === TagComponentProperty.CustomIconPrefix,
+  )?.propertyValue;
+
   const tagComp: IAnchorComponentInternal = {
     ref: generateUUID(),
     type: KnownComponentType.Tag,
@@ -107,6 +131,13 @@ export const parseTagComp = (comp: DocumentType): IAnchorComponentInternal | und
       params: comp['properties'].find((p) => p['propertyName'] === TagComponentProperty.NavLinkParams)?.propertyValue,
     },
     chosenColor: comp['properties'].find((p) => p['propertyName'] === TagComponentProperty.ChosenColor)?.propertyValue,
+    customIcon:
+      customIconName && customIconPrefix
+        ? {
+            iconName: customIconName,
+            prefix: customIconPrefix,
+          }
+        : undefined,
     ruleBasedMapId: !binding ? undefined : binding[TagComponentProperty.RuleBasedMapId],
     valueDataBinding: parseDataBinding(binding),
   };


### PR DESCRIPTION
## Overview
- Save and parse tag custom icon fields in entities
- change motion indicator default speed value to be double instead of integer

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
