### PR TITLE
fix(scene-composer): add scroll bar to show all tag icons by default

### DIFF
--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPicker.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPicker.tsx
@@ -27,11 +27,10 @@ export const IconPicker = ({
   });
   const [showPicker, setShowPicker] = useState<boolean>(false);
   const iconsPerPage = 8; // Number of icons per page
-  const defaultRows = 3; // Number of rows to display by default
   const icons: IconDefinition[] = Object.values(fas); // Array of all Font Awesome Solid icons
   const totalPages = Math.ceil(icons.length / iconsPerPage); // Calculate the total number of pages
   const [currentPage] = useState<number>(1);
-  const [numRows, setNumRows] = useState(defaultRows);
+  const [numRows, setNumRows] = useState(totalPages);
   const generateRandomString = Math.random().toString(16).slice(2);
   const [randomDomId] = useState<string>(generateRandomString);
   // Calculate the starting and ending index of icons for the current page
@@ -62,6 +61,12 @@ export const IconPicker = ({
       document.removeEventListener('click', handleOutsideClick);
     };
   }, [showPicker, handleOutsideClick]);
+
+  useEffect(() => {
+    if (filteringText)
+      setNumRows(0); //This will confine the popover to show only search results when user starts typing
+    else setNumRows(totalPages); // restore default when no text in search field.
+  }, [filteringText]);
 
   const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
     const { scrollTop, clientHeight, scrollHeight } = event.currentTarget;

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPickerUtils/IconPickerStyles.ts
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPickerUtils/IconPickerStyles.ts
@@ -6,6 +6,7 @@ export const tmIconPickerPopover: CSSProperties = {
   zIndex: 1,
   top: '100%',
   left: '80%',
+  width: '170%', //this to not allow the container to shrink when search results are less than 8 and keep the min width equal to the width for 8 icons which is the chosen # of icons per row.
   transform: 'translateX(-40%)',
   background: colorBackgroundHomeHeader,
   borderRadius: '25px',


### PR DESCRIPTION
## Overview
Tag icons picker by default showed only 3 rows and customer expressed the need to see all icons and scroll through them to pick instead of relying on search by icon names.


https://github.com/awslabs/iot-app-kit/assets/20994167/153da175-3a2a-4fe8-ba1e-9f24bfbe9d65



## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
