### PR TITLE
feat: add line style thickness per property

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/components/lineStyleDropdown.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/components/lineStyleDropdown.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { FC } from 'react';
+import { FormField, Select } from '@cloudscape-design/components';
+
+const defaultLineStyleOption = { label: 'Solid', value: 'solid' };
+const lineStyleOptions = [
+  defaultLineStyleOption,
+  { label: 'Dashed', value: 'dashed' },
+  { label: 'Dotted', value: 'dotted' },
+] as const;
+
+type LineStyleDropdownProps = {
+  disabled?: boolean;
+  lineStyle?: string;
+  updatelineStyle: (lineStyle: string) => void;
+};
+
+export const LineStyleDropdown: FC<LineStyleDropdownProps> = ({ disabled = false, lineStyle, updatelineStyle }) => {
+  return (
+    <FormField label='Style'>
+      <Select
+        disabled={disabled}
+        selectedOption={
+          // Find the line style option that matches the currently selected line style
+          lineStyleOptions.find(({ value }) => value === lineStyle) ?? null
+        }
+        onChange={({ detail }) =>
+          // Update the line style with the selected option value
+          updatelineStyle(detail.selectedOption.value ?? defaultLineStyleOption.value)
+        }
+        options={lineStyleOptions} // List of line style options
+      />
+    </FormField>
+  );
+};

--- a/packages/dashboard/src/customization/propertiesSections/components/lineThicknessDropdown.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/components/lineThicknessDropdown.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import type { FC } from 'react';
+
+import { FormField, Select } from '@cloudscape-design/components';
+
+const defaultLineThicknessOption = { label: 'Normal', value: '2' };
+const lineThicknessOptions = [
+  { label: 'Thin', value: '1' },
+  defaultLineThicknessOption,
+  { label: 'Thick', value: '5' },
+] as const;
+
+type LineThicknessDropdownProps = {
+  disabled?: boolean;
+  lineThickness?: string;
+  updateLineThickness: (lineStyle: string) => void;
+};
+
+export const LineThicknessDropdown: FC<LineThicknessDropdownProps> = ({
+  disabled = false,
+  lineThickness,
+  updateLineThickness,
+}) => {
+  return (
+    <FormField label='Thickness'>
+      <Select
+        disabled={disabled}
+        selectedOption={lineThicknessOptions.find(({ value }) => value === lineThickness) ?? defaultLineThicknessOption}
+        options={lineThicknessOptions}
+        onChange={({ detail }) => {
+          updateLineThickness(detail.selectedOption.value ?? defaultLineThicknessOption.value);
+        }}
+      />
+    </FormField>
+  );
+};

--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/lineStyleSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/lineStyleSection.tsx
@@ -1,31 +1,36 @@
-import ExpandableSection from '@cloudscape-design/components/expandable-section';
-import FormField from '@cloudscape-design/components/form-field';
-import Select from '@cloudscape-design/components/select';
-import type { FC } from 'react';
 import React from 'react';
+import type { FC } from 'react';
 
-const defaultLineStyleOption = { label: 'Solid', value: 'solid' };
-const lineStyleOptions = [
-  defaultLineStyleOption,
-  { label: 'Dashed', value: 'dashed' },
-  { label: 'Dotted', value: 'dotted' },
-] as const;
+import ExpandableSection from '@cloudscape-design/components/expandable-section';
+
+import { LineStyleDropdown } from '../components/lineStyleDropdown';
+import { LineThicknessDropdown } from '../components/lineThicknessDropdown';
+import { SpaceBetween } from '@cloudscape-design/components';
 
 type LineStyleSectionOptions = {
-  lineStyle: string | undefined;
+  lineStyle?: string;
+  lineThickness?: number;
   updatelineStyle: (lineStyle: string) => void;
+  updateLineThickness: (lineThickness: number) => void;
 };
 
-export const LineStyleSection: FC<LineStyleSectionOptions> = ({ lineStyle, updatelineStyle }) => {
+export const LineStyleSection: FC<LineStyleSectionOptions> = ({
+  lineStyle,
+  lineThickness,
+  updatelineStyle,
+  updateLineThickness,
+}) => {
   return (
     <ExpandableSection headerText='Line style' defaultExpanded>
-      <FormField label='Style'>
-        <Select
-          selectedOption={lineStyleOptions.find(({ value }) => value === lineStyle) ?? null}
-          onChange={({ detail }) => updatelineStyle(detail.selectedOption.value ?? defaultLineStyleOption.value)}
-          options={lineStyleOptions}
+      <SpaceBetween size='m'>
+        <LineStyleDropdown lineStyle={lineStyle} updatelineStyle={updatelineStyle} />
+        <LineThicknessDropdown
+          lineThickness={lineThickness?.toString() ?? '2'}
+          updateLineThickness={(thickness: string) => {
+            updateLineThickness(parseInt(thickness));
+          }}
         />
-      </FormField>
+      </SpaceBetween>
     </ExpandableSection>
   );
 };

--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
@@ -55,6 +55,17 @@ const RenderLineAndScatterStyleSettingsSection = ({
     })
   );
 
+  const [lineThicknessMaybe, updateLineThickness] = useProperty(
+    (properties) => properties.line?.thickness,
+    (properties, updatedLineThickness) => ({
+      ...properties,
+      line: {
+        ...properties.line,
+        thickness: updatedLineThickness,
+      },
+    })
+  );
+
   const [dataPointStyleMaybe, updateDataPointStyle] = useProperty(
     (properties) => properties.symbol?.style,
     (properties, updatedDataPointStyle) => ({
@@ -156,6 +167,7 @@ const RenderLineAndScatterStyleSettingsSection = ({
   const connectionStyle = maybeWithDefault(undefined, connectionStyleMaybe);
   const title = maybeWithDefault(undefined, titleMaybe);
   const lineStyle = maybeWithDefault(undefined, lineStyleMaybe);
+  const lineThickness = maybeWithDefault(undefined, lineThicknessMaybe);
   const dataPointStyle = maybeWithDefault(undefined, dataPointStyleMaybe);
   const axis = maybeWithDefault(undefined, axisMaybe);
   const legendVisible = maybeWithDefault(true, legendVisibleMaybe) ?? true;
@@ -177,7 +189,11 @@ const RenderLineAndScatterStyleSettingsSection = ({
       <TitleSection title={title} updateTitle={updateTitle} />
       <LineStyleSection
         lineStyle={lineStyle}
+        lineThickness={lineThickness}
         updatelineStyle={(style) => updateLineStyle(style as LineStyles['style'])}
+        updateLineThickness={(thickness) => {
+          updateLineThickness(thickness as LineStyles['thickness']);
+        }}
       />
       <DataPointStyleSection
         dataPointStyle={dataPointStyle}

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -98,7 +98,7 @@ const mapStyledAssetPropertyToChartStyleSettings = (
     symbolColor: styles.symbol?.color,
     symbolSize: styles.symbol?.size,
     lineStyle: styles.line?.style ?? line?.style,
-    lineThickness: styles.line?.thickness,
+    lineThickness: styles.line?.thickness ?? line?.thickness,
     yAxis: styles.yAxis?.visible ? styles.yAxis : undefined,
     significantDigits: styles.significantDigits,
   };


### PR DESCRIPTION
## Overview
This PR is for ticket: #2029 

made changes as requested and now we can able to customize the line style and thickness per property.

## Verifying Changes


https://github.com/awslabs/iot-app-kit/assets/139960352/60564465-9f17-4285-848f-a26c5529b8f4



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
