### PR TITLE
fix: synchronize intervals when new intervals are created

### DIFF
--- a/packages/core/src/data-module/request-scheduler/requestScheduler.spec.ts
+++ b/packages/core/src/data-module/request-scheduler/requestScheduler.spec.ts
@@ -149,3 +149,36 @@ it('does not reset intervals when document visibility changes but the document i
 
   expect(cb).not.toHaveBeenCalled();
 });
+
+it('synchronizes intervals when a new interval is created', () => {
+  const scheduler = new RequestScheduler();
+  const id1 = 'id1';
+  const id2 = 'id2';
+  const cb1 = jest.fn();
+  const cb2 = jest.fn();
+
+  scheduler.create({
+    id: id1,
+    cb: cb1,
+    refreshRate: SECOND_IN_MS,
+  });
+
+  jest.advanceTimersByTime(SECOND_IN_MS);
+  expect(cb1).toHaveBeenCalledTimes(1);
+
+  cb1.mockClear();
+
+  scheduler.create({
+    id: id2,
+    cb: cb2,
+    refreshRate: SECOND_IN_MS,
+  });
+
+  jest.advanceTimersByTime(SECOND_IN_MS);
+  expect(cb1).toHaveBeenCalledTimes(1);
+  expect(cb2).toHaveBeenCalledTimes(1);
+
+  jest.advanceTimersByTime(SECOND_IN_MS);
+  expect(cb1).toHaveBeenCalledTimes(2);
+  expect(cb2).toHaveBeenCalledTimes(2);
+});


### PR DESCRIPTION
## Overview
When new intervals are created, it's possible for them to be out of sync. With the SiteWise data source, this leads to a failure to batch requests efficiently and could cause API throttling to occur.

This change synchronizes intervals each time a new interval is created.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
