### PR TITLE
feat(component): utils to handle light component in entity

### DIFF
--- a/packages/scene-composer/.eslintrc.js
+++ b/packages/scene-composer/.eslintrc.js
@@ -56,5 +56,10 @@ module.exports = {
       },
     },
   ],
-  ignorePatterns: ['src/three/GLTFLoader.js', 'src/three/tiles3d/*', 'tools/watch-build.js'],
+  ignorePatterns: [
+    'src/three/GLTFLoader.js',
+    'src/three/tiles3d/*',
+    'tools/watch-build.js',
+    'src/assets/auto-gen/icons/*',
+  ],
 };

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -46,7 +46,7 @@
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --index-template tools/index-template.js -- src/assets/icons/",
     "release": "run-s compile copy-assets",
     "copy-assets": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" dist/",
-    "lint": "eslint . --max-warnings=510",
+    "lint": "eslint . --max-warnings=484",
     "fix": "eslint --fix .",
     "test": "jest --config jest.config.ts --coverage --silent",
     "test:dev": "jest --config jest.config.ts --coverage",

--- a/packages/scene-composer/src/common/constants.ts
+++ b/packages/scene-composer/src/common/constants.ts
@@ -74,13 +74,13 @@ export const DEFAULT_CAMERA_SETTINGS = {
 };
 
 const DEFAULT_DIRECTIONAL_LIGHT_SETTINGS: Component.IDirectionalLightSettings = {
-  color: 0xffffff,
+  color: '#ffffff',
   intensity: 1,
   castShadow: true,
 };
 
 const DEFAULT_POINT_LIGHT_SETTINGS: Component.IPointLightSettings = {
-  color: 0xffffff,
+  color: '#ffffff',
   intensity: 1,
   decay: 2.0,
   distance: 0,
@@ -88,13 +88,13 @@ const DEFAULT_POINT_LIGHT_SETTINGS: Component.IPointLightSettings = {
 };
 
 const DEFAULT_AMBIENT_LIGHT_SETTINGS: Component.IAmbientLightSettings = {
-  color: 0xffffff,
+  color: '#ffffff',
   intensity: 1,
 };
 
 const DEFAULT_HEMISPHERE_LIGHT_SETTINGS: Component.IHemisphereLightSettings = {
-  color: 0xffffff,
-  groundColor: 0x333333,
+  color: '#ffffff',
+  groundColor: '#333333',
   intensity: 1,
 };
 

--- a/packages/scene-composer/src/components/panels/scene-components/LightComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/LightComponentEditor.tsx
@@ -1,29 +1,18 @@
 import React, { useContext, useEffect, useLayoutEffect, useState, useCallback } from 'react';
 import { useIntl, defineMessages } from 'react-intl';
 import { Checkbox, FormField, Select, SpaceBetween } from '@awsui/components-react';
-import { ColorRepresentation } from 'three';
 
 import useLogger from '../../../logger/react-logger/hooks/useLogger';
-import { Color, LightType } from '../../../models/SceneModels';
+import { Component, LightType } from '../../../models/SceneModels';
 import { ILightComponentInternal, useStore } from '../../../store';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { IComponentEditorProps } from '../ComponentEditor';
 import { DEFAULT_LIGHT_SETTINGS_MAP } from '../../../common/constants';
-import { decToHexString, hexStringToDec, parseFloatOrDefault } from '../../../utils/mathUtils';
+import { parseFloatOrDefault } from '../../../utils/mathUtils';
 import { NumericInput } from '../CommonPanelComponents';
 import { ColorPicker } from '../ColorPicker/ColorPicker';
-import { hexString } from '../ColorPicker/ColorPickerHelpers';
 
-type OnLightSettingsUpdatedCallback = (lightSettings: unknown) => void;
-
-export function colorToHexString(color: Color) {
-  if (typeof color === 'string') {
-    // assume the string color is css-style hex
-    return color;
-  }
-
-  return decToHexString(color);
-}
+type OnLightSettingsUpdatedCallback = (lightSettings: Component.ILightSettings) => void;
 
 function createInputForField(
   fieldName: string,
@@ -37,9 +26,9 @@ function createInputForField(
     return (
       <FormField key={index} label={intl.formatMessage({ defaultMessage: 'Color', description: 'Form Field label' })}>
         <ColorPicker
-          color={colorToHexString(lightSettings.color)}
-          onChange={(newColor: ColorRepresentation) => {
-            setLightSettings({ ...lightSettings, color: hexStringToDec(hexString(newColor)) });
+          color={lightSettings.color}
+          onChange={(newColor: string) => {
+            setLightSettings({ ...lightSettings, color: newColor });
             setDirty(true);
           }}
         />
@@ -124,9 +113,9 @@ function createInputForField(
         label={intl.formatMessage({ defaultMessage: 'Ground Color', description: 'Form Field label' })}
       >
         <ColorPicker
-          color={colorToHexString(lightSettings.groundColor)}
-          onChange={(newColor: ColorRepresentation) => {
-            setLightSettings({ ...lightSettings, groundColor: hexStringToDec(hexString(newColor)) });
+          color={lightSettings.groundColor}
+          onChange={(newColor: string) => {
+            setLightSettings({ ...lightSettings, groundColor: newColor });
             setDirty(true);
           }}
         />
@@ -135,7 +124,10 @@ function createInputForField(
   }
 }
 
-function LightSettingsEditor(props: { lightSettings: any; onSettingsUpdated: OnLightSettingsUpdatedCallback }) {
+function LightSettingsEditor(props: {
+  lightSettings: Component.ILightSettings;
+  onSettingsUpdated: OnLightSettingsUpdatedCallback;
+}) {
   const [lightSettings, setLightSettings] = useState(props.lightSettings);
   const [dirty, setDirty] = useState(false);
 
@@ -209,7 +201,7 @@ export const LightComponentEditor: React.FC<IComponentEditorProps> = ({ node, co
   }));
 
   const onLightSettingsUpdated = useCallback(
-    (lightSettings: any) => {
+    (lightSettings: Component.ILightSettings) => {
       log?.verbose('updated on light settings', lightSettings);
 
       const currentLightComponent = getSceneNodeByRef(node.ref)?.components.find(
@@ -223,7 +215,7 @@ export const LightComponentEditor: React.FC<IComponentEditorProps> = ({ node, co
 
       updateComponentInternal(node.ref, updatedLightComponent, true);
     },
-    [log, updateComponentInternal],
+    [log, updateComponentInternal, node.ref, component.ref],
   );
 
   const onLightTypeUpdated = (lightType: string) => {

--- a/packages/scene-composer/src/components/three-fiber/LightComponent/__tests__/LightComponent.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/LightComponent/__tests__/LightComponent.spec.tsx
@@ -4,7 +4,9 @@ import React from 'react';
 import { create } from 'react-test-renderer';
 
 import LightComponent from '..';
-import { LightType } from '../../../../models/SceneModels';
+import { Component, LightType } from '../../../../models/SceneModels';
+import { ISceneNodeInternal } from '../../../../store';
+import { KnownComponentType } from '../../../../interfaces';
 
 jest.mock('@react-three/fiber', () => {
   const originalModule = jest.requireActual('@react-three/fiber');
@@ -23,7 +25,7 @@ describe('LightComponent', () => {
     distance: 100,
     decay: 0.1,
     groundColor: 'white',
-  } as any;
+  } as Component.ILightSettings;
 
   [
     ['Point', LightType.Point],
@@ -35,8 +37,13 @@ describe('LightComponent', () => {
     it(`should render correctly for ${value[0]} light`, () => {
       const container = create(
         <LightComponent
-          node={{ name: 'Light' } as any}
-          component={{ ref: 'light-ref', lightType: value[1] as any, lightSettings } as any}
+          node={{ name: 'Light' } as ISceneNodeInternal}
+          component={{
+            ref: 'light-ref',
+            type: KnownComponentType.Light,
+            lightType: value[1] as LightType,
+            lightSettings,
+          }}
         />,
       );
 

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -245,7 +245,7 @@ export namespace Component {
   }
 
   interface ILightSettingsBase {
-    color: Color;
+    color: string;
     intensity: number;
   }
 
@@ -266,11 +266,17 @@ export namespace Component {
   export interface IAmbientLightSettings extends ILightSettingsBase {}
 
   export interface IHemisphereLightSettings extends ILightSettingsBase {
-    groundColor: Color;
+    groundColor: string;
   }
+
+  export type ILightSettings =
+    | IDirectionalLightSettings
+    | IAmbientLightSettings
+    | IHemisphereLightSettings
+    | IPointLightSettings;
 
   export interface Light extends IComponent {
     lightType: LightType;
-    lightSettings: IDirectionalLightSettings | IAmbientLightSettings | IHemisphereLightSettings | IPointLightSettings;
+    lightSettings: ILightSettings;
   }
 }

--- a/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
+++ b/packages/scene-composer/src/store/helpers/__tests__/serializationHelpers.spec.ts
@@ -1,7 +1,7 @@
 import SerializationHelpers, { exportsForTesting } from '../serializationHelpers';
 import { ERROR_MESSAGE_DICT, ErrorCode, ErrorLevel, IModelRefComponent, KnownComponentType } from '../../..';
 import { generateUUID } from '../../../utils/mathUtils';
-import { Component, Node } from '../../../models/SceneModels';
+import { Component, LightType, ModelType, Node } from '../../../models/SceneModels';
 import { ISceneComponentInternal, ISceneDocumentInternal, ISceneNodeInternal } from '../..';
 
 jest.mock('../../../utils/mathUtils', () => ({
@@ -20,14 +20,17 @@ describe('serializationHelpers', () => {
 
     const errorCollector = [];
     const glb = exportsForTesting.createModelRefComponent(
-      { modelType: 'GLB' } as any,
+      { modelType: 'GLB' } as Component.ModelRef,
       errorCollector,
     ) as unknown as ISceneNodeInternal;
     const gltf = exportsForTesting.createModelRefComponent(
-      { modelType: 'GLTF' } as any,
+      { modelType: 'GLTF' } as Component.ModelRef,
       errorCollector,
     ) as unknown as ISceneNodeInternal;
-    const error = exportsForTesting.createModelRefComponent({ modelType: 'OBJ' } as any, errorCollector);
+    const error = exportsForTesting.createModelRefComponent(
+      { modelType: 'OBJ' as ModelType } as Component.ModelRef,
+      errorCollector,
+    );
 
     expect(glb.ref).toEqual('test-uuid');
     expect(gltf.ref).toEqual('other-test-uuid');
@@ -91,7 +94,7 @@ describe('serializationHelpers', () => {
       type: 'Light',
       lightType: 'Ambient',
       lightSettings: {
-        color: 0xffffff,
+        color: '#ffffff',
         intensity: 1,
         volume: 'full',
       },
@@ -432,19 +435,26 @@ describe('serializationHelpers', () => {
       const component = {
         type: Component.Type.Light,
         ref: 'test-uuid',
-        lightType: 'Ambient',
+        lightType: LightType.Ambient,
         lightSettings: {
           color: 0xffffff,
           intensity: 1,
           volume: 'full',
         },
-      } as Component.Light;
+      };
+      const expected: Component.Light = {
+        ...component,
+        lightSettings: {
+          ...component.lightSettings,
+          color: '#ffffff',
+        },
+      };
 
       const node = {} as ISceneNodeInternal;
 
       const deserializedComponent = exportsForTesting.deserializeComponent(component, node, resolver, [], {});
 
-      expect(deserializedComponent).toEqual(component);
+      expect(deserializedComponent).toEqual(expected);
     });
 
     it('should create a modelShader', () => {
@@ -542,7 +552,7 @@ describe('serializationHelpers', () => {
               type: Component.Type.Light,
               lightType: 'Ambient',
               lightSettings: {
-                color: 0xffffff,
+                color: '#ffffff',
                 intensity: 1,
                 volume: 'full',
               },
@@ -756,7 +766,7 @@ describe('serializationHelpers', () => {
           type: Component.Type.Light,
           lightType: 'Ambient',
           lightSettings: {
-            color: 0xffffff,
+            color: '#ffffff',
             intensity: 1,
             volume: 'full',
           },

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.spec.ts
@@ -12,6 +12,7 @@ import { createMotionIndicatorEntityComponent } from './motionIndicatorComponent
 import { createModelRefComponent } from './modelRefComponent';
 import { createNodeEntity } from './createNodeEntity';
 import { createModelShaderEntityComponent } from './modelShaderComponent';
+import { createLightEntityComponent } from './lightComponent';
 
 jest.mock('./nodeComponent', () => ({
   createNodeEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.node' }),
@@ -33,6 +34,9 @@ jest.mock('./modelRefComponent', () => ({
 }));
 jest.mock('./modelShaderComponent', () => ({
   createModelShaderEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelShader' }),
+}));
+jest.mock('./lightComponent', () => ({
+  createLightEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.light' }),
 }));
 
 describe('createNodeEntity', () => {
@@ -71,7 +75,8 @@ describe('createNodeEntity', () => {
     const motionIndicator = { type: KnownComponentType.MotionIndicator, ref: 'indicator-ref' };
     const modelRef = { type: KnownComponentType.ModelRef, ref: 'modelref-ref' };
     const modelShader = { type: KnownComponentType.ModelShader, ref: 'modelShader-ref' };
-    const node = { ...defaultNode, components: [tag, overlay, camera, motionIndicator, modelRef, modelShader] };
+    const light = { type: KnownComponentType.Light, ref: 'light-ref' };
+    const node = { ...defaultNode, components: [tag, overlay, camera, motionIndicator, modelRef, modelShader, light] };
 
     await createNodeEntity(node, 'parent', 'layer');
 
@@ -89,6 +94,7 @@ describe('createNodeEntity', () => {
         MotionIndicator: { componentTypeId: '3d.motionIndicator' },
         ModelRef: { componentTypeId: '3d.modelRef' },
         ModelShader: { componentTypeId: '3d.modelShader' },
+        Light: { componentTypeId: '3d.light' },
       },
     });
 
@@ -106,5 +112,7 @@ describe('createNodeEntity', () => {
     expect(createModelRefComponent).toHaveBeenCalledWith(modelRef);
     expect(createModelShaderEntityComponent).toHaveBeenCalledTimes(1);
     expect(createModelShaderEntityComponent).toHaveBeenCalledWith(modelShader);
+    expect(createLightEntityComponent).toHaveBeenCalledTimes(1);
+    expect(createLightEntityComponent).toHaveBeenCalledWith(light);
   });
 });

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
@@ -9,6 +9,7 @@ import {
   ICameraComponent,
   IColorOverlayComponent,
   IDataOverlayComponent,
+  ILightComponent,
   IModelRefComponent,
   IMotionIndicatorComponent,
   KnownComponentType,
@@ -22,6 +23,7 @@ import { createMotionIndicatorEntityComponent } from './motionIndicatorComponent
 import { createCameraEntityComponent } from './cameraComponent';
 import { createModelRefComponent } from './modelRefComponent';
 import { createModelShaderEntityComponent } from './modelShaderComponent';
+import { createLightEntityComponent } from './lightComponent';
 
 export const createNodeEntity = async (
   node: ISceneNodeInternal,
@@ -63,6 +65,9 @@ export const createNodeEntity = async (
           break;
         case KnownComponentType.ModelShader:
           comp = createModelShaderEntityComponent(compToBeCreated as IColorOverlayComponent);
+          break;
+        case KnownComponentType.Light:
+          comp = createLightEntityComponent(compToBeCreated as ILightComponent);
           break;
 
         default:

--- a/packages/scene-composer/src/utils/entityModelUtils/lightComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/lightComponent.spec.ts
@@ -1,0 +1,299 @@
+import { DEFAULT_LIGHT_SETTINGS_MAP } from '../../common/constants';
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { ILightComponent, KnownComponentType } from '../../interfaces';
+import { LightType } from '../../models/SceneModels';
+
+import { createLightEntityComponent, parseLightComp, updateLightEntityComponent } from './lightComponent';
+
+const ambientLight: ILightComponent = {
+  type: KnownComponentType.Light,
+  lightType: LightType.Ambient,
+  lightSettings: DEFAULT_LIGHT_SETTINGS_MAP.Ambient,
+};
+
+const pointLight: ILightComponent = {
+  type: KnownComponentType.Light,
+  lightType: LightType.Point,
+  lightSettings: DEFAULT_LIGHT_SETTINGS_MAP.Point,
+};
+
+const directionalLight: ILightComponent = {
+  type: KnownComponentType.Light,
+  lightType: LightType.Directional,
+  lightSettings: DEFAULT_LIGHT_SETTINGS_MAP.Directional,
+};
+
+const hemisphereLight: ILightComponent = {
+  type: KnownComponentType.Light,
+  lightType: LightType.Hemisphere,
+  lightSettings: DEFAULT_LIGHT_SETTINGS_MAP.Hemisphere,
+};
+
+describe('createLightEntityComponent', () => {
+  it('should return expected ambient light component', () => {
+    expect(createLightEntityComponent(ambientLight)).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.Light],
+      properties: {
+        lightType: {
+          value: {
+            stringValue: LightType.Ambient,
+          },
+        },
+        lightSettings_color: {
+          value: {
+            stringValue: DEFAULT_LIGHT_SETTINGS_MAP.Ambient.color,
+          },
+        },
+        lightSettings_intensity: {
+          value: {
+            doubleValue: DEFAULT_LIGHT_SETTINGS_MAP.Ambient.intensity,
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected directional light component', () => {
+    expect(createLightEntityComponent(directionalLight)).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.Light],
+      properties: {
+        lightType: {
+          value: {
+            stringValue: LightType.Directional,
+          },
+        },
+        lightSettings_color: {
+          value: {
+            stringValue: DEFAULT_LIGHT_SETTINGS_MAP.Directional.color,
+          },
+        },
+        lightSettings_intensity: {
+          value: {
+            doubleValue: DEFAULT_LIGHT_SETTINGS_MAP.Directional.intensity,
+          },
+        },
+        lightSettings_castShadow: {
+          value: {
+            booleanValue: DEFAULT_LIGHT_SETTINGS_MAP.Directional.castShadow,
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected hemisphere light component', () => {
+    expect(createLightEntityComponent(hemisphereLight)).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.Light],
+      properties: {
+        lightType: {
+          value: {
+            stringValue: LightType.Hemisphere,
+          },
+        },
+        lightSettings_color: {
+          value: {
+            stringValue: DEFAULT_LIGHT_SETTINGS_MAP.Hemisphere.color,
+          },
+        },
+        lightSettings_intensity: {
+          value: {
+            doubleValue: DEFAULT_LIGHT_SETTINGS_MAP.Hemisphere.intensity,
+          },
+        },
+        lightSettings_groundColor: {
+          value: {
+            stringValue: DEFAULT_LIGHT_SETTINGS_MAP.Hemisphere.groundColor,
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected point light component', () => {
+    expect(createLightEntityComponent(pointLight)).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.Light],
+      properties: {
+        lightType: {
+          value: {
+            stringValue: LightType.Point,
+          },
+        },
+        lightSettings_color: {
+          value: {
+            stringValue: DEFAULT_LIGHT_SETTINGS_MAP.Point.color,
+          },
+        },
+        lightSettings_intensity: {
+          value: {
+            doubleValue: DEFAULT_LIGHT_SETTINGS_MAP.Point.intensity,
+          },
+        },
+        lightSettings_castShadow: {
+          value: {
+            booleanValue: DEFAULT_LIGHT_SETTINGS_MAP.Point.castShadow,
+          },
+        },
+        lightSettings_distance: {
+          value: {
+            doubleValue: DEFAULT_LIGHT_SETTINGS_MAP.Point.distance,
+          },
+        },
+        lightSettings_decay: {
+          value: {
+            doubleValue: DEFAULT_LIGHT_SETTINGS_MAP.Point.decay,
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected point light component without distance and decay settings', () => {
+    expect(
+      createLightEntityComponent({
+        ...pointLight,
+        lightSettings: { ...pointLight.lightSettings, distance: undefined, decay: undefined },
+      }),
+    ).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.Light],
+      properties: {
+        lightType: {
+          value: {
+            stringValue: LightType.Point,
+          },
+        },
+        lightSettings_color: {
+          value: {
+            stringValue: DEFAULT_LIGHT_SETTINGS_MAP.Point.color,
+          },
+        },
+        lightSettings_intensity: {
+          value: {
+            doubleValue: DEFAULT_LIGHT_SETTINGS_MAP.Point.intensity,
+          },
+        },
+        lightSettings_castShadow: {
+          value: {
+            booleanValue: DEFAULT_LIGHT_SETTINGS_MAP.Point.castShadow,
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('updateLightEntityComponent', () => {
+  it('should return expected ambient light component', () => {
+    expect(updateLightEntityComponent(ambientLight)).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.Light],
+      propertyUpdates: expect.objectContaining({
+        lightType: {
+          value: {
+            stringValue: LightType.Ambient,
+          },
+        },
+      }),
+    });
+  });
+});
+
+describe('parseLightComp', () => {
+  it('should parse to expected ambient light component', () => {
+    expect(
+      parseLightComp({
+        properties: [
+          {
+            propertyName: 'lightType',
+            propertyValue: 'Ambient',
+          },
+          {
+            propertyName: 'lightSettings_color',
+            propertyValue: DEFAULT_LIGHT_SETTINGS_MAP.Ambient.color,
+          },
+          {
+            propertyName: 'lightSettings_intensity',
+            propertyValue: DEFAULT_LIGHT_SETTINGS_MAP.Ambient.intensity,
+          },
+        ],
+      }),
+    ).toEqual({
+      ref: expect.any(String),
+      ...ambientLight,
+    });
+  });
+
+  it('should parse to expected directional light component', () => {
+    expect(
+      parseLightComp({
+        properties: [
+          {
+            propertyName: 'lightType',
+            propertyValue: 'Directional',
+          },
+          {
+            propertyName: 'lightSettings_color',
+            propertyValue: DEFAULT_LIGHT_SETTINGS_MAP.Directional.color,
+          },
+          {
+            propertyName: 'lightSettings_intensity',
+            propertyValue: DEFAULT_LIGHT_SETTINGS_MAP.Directional.intensity,
+          },
+        ],
+      }),
+    ).toEqual({
+      ref: expect.any(String),
+      ...directionalLight,
+    });
+  });
+
+  it('should parse to expected hemisphere light component', () => {
+    expect(
+      parseLightComp({
+        properties: [
+          {
+            propertyName: 'lightType',
+            propertyValue: 'Hemisphere',
+          },
+          {
+            propertyName: 'lightSettings_color',
+            propertyValue: DEFAULT_LIGHT_SETTINGS_MAP.Hemisphere.color,
+          },
+          {
+            propertyName: 'lightSettings_intensity',
+            propertyValue: DEFAULT_LIGHT_SETTINGS_MAP.Hemisphere.intensity,
+          },
+          {
+            propertyName: 'lightSettings_groundColor',
+            propertyValue: DEFAULT_LIGHT_SETTINGS_MAP.Hemisphere.groundColor,
+          },
+        ],
+      }),
+    ).toEqual({
+      ref: expect.any(String),
+      ...hemisphereLight,
+    });
+  });
+
+  it('should parse to expected point light component', () => {
+    expect(
+      parseLightComp({
+        properties: [
+          {
+            propertyName: 'lightType',
+            propertyValue: 'Point',
+          },
+          {
+            propertyName: 'lightSettings_color',
+            propertyValue: DEFAULT_LIGHT_SETTINGS_MAP.Point.color,
+          },
+          {
+            propertyName: 'lightSettings_intensity',
+            propertyValue: DEFAULT_LIGHT_SETTINGS_MAP.Point.intensity,
+          },
+        ],
+      }),
+    ).toEqual({
+      ref: expect.any(String),
+      ...pointLight,
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/lightComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/lightComponent.ts
@@ -1,0 +1,151 @@
+import { ComponentRequest, ComponentUpdateRequest } from '@aws-sdk/client-iottwinmaker';
+import { DocumentType } from '@aws-sdk/types';
+
+import { ILightComponent, KnownComponentType } from '../../interfaces';
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { ILightComponentInternal } from '../../store';
+import { generateUUID } from '../mathUtils';
+import { Component, LightType } from '../../models/SceneModels';
+import { DEFAULT_LIGHT_SETTINGS_MAP } from '../../common/constants';
+
+enum LightComponentProperty {
+  LightType = 'lightType',
+  LightSettingsColor = 'lightSettings_color',
+  LightSettingsIntensity = 'lightSettings_intensity',
+  LightSettingsCastShadow = 'lightSettings_castShadow',
+  LightSettingsDistance = 'lightSettings_distance',
+  LightSettingsDecay = 'lightSettings_decay',
+  LightSettingsGroundColor = 'lightSettings_groundColor',
+}
+
+export const createLightEntityComponent = (light: ILightComponent): ComponentRequest => {
+  const comp: ComponentRequest = {
+    componentTypeId: componentTypeToId[KnownComponentType.Light],
+    properties: {
+      [LightComponentProperty.LightType]: {
+        value: {
+          stringValue: light.lightType,
+        },
+      },
+    },
+  };
+
+  if (light.lightSettings.color !== undefined) {
+    comp.properties![LightComponentProperty.LightSettingsColor] = {
+      value: {
+        stringValue: light.lightSettings.color,
+      },
+    };
+  }
+  if (light.lightSettings.intensity !== undefined) {
+    comp.properties![LightComponentProperty.LightSettingsIntensity] = {
+      value: {
+        doubleValue: light.lightSettings.intensity,
+      },
+    };
+  }
+  if ((light.lightSettings as Component.IPointLightSettings).castShadow !== undefined) {
+    comp.properties![LightComponentProperty.LightSettingsCastShadow] = {
+      value: {
+        booleanValue: (light.lightSettings as Component.IPointLightSettings).castShadow,
+      },
+    };
+  }
+  if ((light.lightSettings as Component.IPointLightSettings).distance !== undefined) {
+    comp.properties![LightComponentProperty.LightSettingsDistance] = {
+      value: {
+        doubleValue: (light.lightSettings as Component.IPointLightSettings).distance,
+      },
+    };
+  }
+  if ((light.lightSettings as Component.IPointLightSettings).decay !== undefined) {
+    comp.properties![LightComponentProperty.LightSettingsDecay] = {
+      value: {
+        doubleValue: (light.lightSettings as Component.IPointLightSettings).decay,
+      },
+    };
+  }
+  if ((light.lightSettings as Component.IHemisphereLightSettings).groundColor !== undefined) {
+    comp.properties![LightComponentProperty.LightSettingsGroundColor] = {
+      value: {
+        stringValue: (light.lightSettings as Component.IHemisphereLightSettings).groundColor,
+      },
+    };
+  }
+
+  return comp;
+};
+
+export const updateLightEntityComponent = (light: ILightComponent): ComponentUpdateRequest => {
+  const request = createLightEntityComponent(light);
+  return {
+    componentTypeId: request.componentTypeId,
+    propertyUpdates: request.properties,
+  };
+};
+
+export const parseLightComp = (comp: DocumentType): ILightComponentInternal | undefined => {
+  if (!comp?.['properties']) {
+    return undefined;
+  }
+
+  const lightType =
+    comp['properties'].find((p) => p['propertyName'] === LightComponentProperty.LightType)?.propertyValue ??
+    LightType.Directional;
+
+  const castShadow =
+    comp['properties'].find((p) => p['propertyName'] === LightComponentProperty.LightSettingsCastShadow)
+      ?.propertyValue ?? DEFAULT_LIGHT_SETTINGS_MAP[lightType].castShadow;
+  const distance =
+    comp['properties'].find((p) => p['propertyName'] === LightComponentProperty.LightSettingsDistance)?.propertyValue ??
+    DEFAULT_LIGHT_SETTINGS_MAP[lightType].distance;
+  const decay =
+    comp['properties'].find((p) => p['propertyName'] === LightComponentProperty.LightSettingsDecay)?.propertyValue ??
+    DEFAULT_LIGHT_SETTINGS_MAP[lightType].decay;
+  const groundColor =
+    comp['properties'].find((p) => p['propertyName'] === LightComponentProperty.LightSettingsGroundColor)
+      ?.propertyValue ?? DEFAULT_LIGHT_SETTINGS_MAP[lightType].groundColor;
+
+  const lightComp: ILightComponentInternal = {
+    ref: generateUUID(),
+    type: KnownComponentType.Light,
+    lightType,
+    lightSettings: {
+      color:
+        comp['properties'].find((p) => p['propertyName'] === LightComponentProperty.LightSettingsColor)
+          ?.propertyValue ?? DEFAULT_LIGHT_SETTINGS_MAP[lightType].color,
+      intensity:
+        comp['properties'].find((p) => p['propertyName'] === LightComponentProperty.LightSettingsIntensity)
+          ?.propertyValue ?? DEFAULT_LIGHT_SETTINGS_MAP[lightType].intensity,
+    },
+  };
+
+  switch (lightType) {
+    case LightType.Directional:
+      (lightComp.lightSettings as Component.IDirectionalLightSettings) = {
+        ...lightComp.lightSettings,
+        castShadow,
+      };
+      break;
+    case LightType.Hemisphere:
+      (lightComp.lightSettings as Component.IHemisphereLightSettings) = {
+        ...lightComp.lightSettings,
+        groundColor,
+      };
+      break;
+    case LightType.Point:
+      (lightComp.lightSettings as Component.IPointLightSettings) = {
+        ...lightComp.lightSettings,
+        castShadow,
+      };
+      if (distance !== undefined) {
+        (lightComp.lightSettings as Component.IPointLightSettings).distance = distance;
+      }
+      if (decay !== undefined) {
+        (lightComp.lightSettings as Component.IPointLightSettings).decay = decay;
+      }
+      break;
+  }
+
+  return lightComp;
+};

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
@@ -218,6 +218,23 @@ describe('parseNode', () => {
     componentTypeId: componentTypeToId.ModelShader,
     properties: [],
   };
+  const lightComp = {
+    componentTypeId: componentTypeToId.Light,
+    properties: [
+      {
+        propertyName: 'lightType',
+        propertyValue: 'Ambient',
+      },
+      {
+        propertyName: 'lightSettings_color',
+        propertyValue: '#123456',
+      },
+      {
+        propertyName: 'lightSettings_intensity',
+        propertyValue: 2,
+      },
+    ],
+  };
 
   const nodeComp = {
     componentTypeId: NODE_COMPONENT_TYPE_ID,
@@ -283,7 +300,10 @@ describe('parseNode', () => {
 
   it('should parse to expected node component with components', () => {
     const result = parseNode(
-      { ...entity, components: [tagComp, overlayComp, modelRefComp, cameraComp, indicatorComp, modelShaderComp] },
+      {
+        ...entity,
+        components: [tagComp, overlayComp, modelRefComp, cameraComp, indicatorComp, modelShaderComp, lightComp],
+      },
       nodeComp,
     );
 
@@ -305,6 +325,9 @@ describe('parseNode', () => {
       }),
       expect.objectContaining({
         type: KnownComponentType.ModelShader,
+      }),
+      expect.objectContaining({
+        type: KnownComponentType.Light,
       }),
     ];
     expect(result?.components).toEqual(expectedComponents);

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
@@ -18,6 +18,7 @@ import { parseModelRefComp } from './modelRefComponent';
 import { parseCameraComp } from './cameraComponent';
 import { parseMotionIndicatorComp } from './motionIndicatorComponent';
 import { parseModelShaderComp } from './modelShaderComponent';
+import { parseLightComp } from './lightComponent';
 
 enum NodeComponentProperty {
   Name = 'name',
@@ -170,6 +171,13 @@ const parseNodeComponents = (components: DocumentType): ISceneComponentInternal[
         const modelShader = parseModelShaderComp(comp);
         if (modelShader) {
           results.push(modelShader);
+        }
+        break;
+      }
+      case componentTypeToId.Light: {
+        const light = parseLightComp(comp);
+        if (light) {
+          results.push(light);
         }
         break;
       }

--- a/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
@@ -13,6 +13,7 @@ import { updateCameraEntityComponent } from './cameraComponent';
 import { updateMotionIndicatorEntityComponent } from './motionIndicatorComponent';
 import { updateModelRefComponent } from './modelRefComponent';
 import { updateModelShaderEntityComponent } from './modelShaderComponent';
+import { updateLightEntityComponent } from './lightComponent';
 
 jest.mock('./nodeComponent', () => ({
   updateNodeEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.node' }),
@@ -34,6 +35,9 @@ jest.mock('./modelRefComponent', () => ({
 }));
 jest.mock('./modelShaderComponent', () => ({
   updateModelShaderEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelShader' }),
+}));
+jest.mock('./lightComponent', () => ({
+  updateLightEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.light' }),
 }));
 
 describe('updateEntity', () => {
@@ -73,8 +77,9 @@ describe('updateEntity', () => {
     const motionIndicator = { type: KnownComponentType.MotionIndicator, ref: 'indicator-ref' };
     const modelRef = { type: KnownComponentType.ModelRef, ref: 'modelref-ref' };
     const modelShader = { type: KnownComponentType.ModelShader, ref: 'modelshader-ref' };
+    const light = { type: KnownComponentType.Light, ref: 'light-ref' };
 
-    await updateEntity(defaultNode, [tag, overlay, camera, motionIndicator, modelRef, modelShader], 'UPDATE');
+    await updateEntity(defaultNode, [tag, overlay, camera, motionIndicator, modelRef, modelShader, light], 'UPDATE');
 
     expect(updateSceneEntity).toHaveBeenCalledTimes(1);
     expect(updateSceneEntity).toHaveBeenCalledWith({
@@ -89,6 +94,7 @@ describe('updateEntity', () => {
         MotionIndicator: { componentTypeId: '3d.motionIndicator' },
         ModelRef: { componentTypeId: '3d.modelRef' },
         ModelShader: { componentTypeId: '3d.modelShader' },
+        Light: { componentTypeId: '3d.light' },
       },
     });
 
@@ -106,6 +112,8 @@ describe('updateEntity', () => {
     expect(updateModelRefComponent).toHaveBeenCalledWith(modelRef);
     expect(updateModelShaderEntityComponent).toHaveBeenCalledTimes(1);
     expect(updateModelShaderEntityComponent).toHaveBeenCalledWith(modelShader);
+    expect(updateLightEntityComponent).toHaveBeenCalledTimes(1);
+    expect(updateLightEntityComponent).toHaveBeenCalledWith(light);
   });
 
   it('should call update entity to update tag component', async () => {

--- a/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.ts
@@ -5,6 +5,7 @@ import {
   ICameraComponent,
   IColorOverlayComponent,
   IDataOverlayComponent,
+  ILightComponent,
   IModelRefComponent,
   IMotionIndicatorComponent,
   KnownComponentType,
@@ -19,6 +20,7 @@ import { updateModelRefComponent } from './modelRefComponent';
 import { updateCameraEntityComponent } from './cameraComponent';
 import { updateMotionIndicatorEntityComponent } from './motionIndicatorComponent';
 import { updateModelShaderEntityComponent } from './modelShaderComponent';
+import { updateLightEntityComponent } from './lightComponent';
 
 export const updateEntity = async (
   node: ISceneNodeInternal,
@@ -65,6 +67,9 @@ export const updateEntity = async (
             break;
           case KnownComponentType.ModelShader:
             comp = updateModelShaderEntityComponent(compToBeUpdated as IColorOverlayComponent);
+            break;
+          case KnownComponentType.Light:
+            comp = updateLightEntityComponent(compToBeUpdated as ILightComponent);
             break;
 
           default:

--- a/packages/scene-composer/src/utils/mathUtils.spec.ts
+++ b/packages/scene-composer/src/utils/mathUtils.spec.ts
@@ -1,13 +1,15 @@
+import { Color } from '../models/SceneModels';
+
 import {
   generateUUID,
   getScaleFactor,
   humanFileSize,
   decToHexString,
-  hexStringToDec,
   parseFloatOrDefault,
   approximatelyEquals,
   EPSILON,
-} from '../../src/utils/mathUtils';
+  colorToHexString,
+} from './mathUtils';
 
 describe('generateUUID', () => {
   it('should generate unique strings', () => {
@@ -53,14 +55,12 @@ describe('decToHexString', () => {
   });
 });
 
-describe('hexStringToDec', () => {
-  it('should convert hex string to dec correctly', () => {
-    expect(hexStringToDec('#ffffff')).toBe(0xffffff);
-    expect(hexStringToDec('#00ffff')).toBe(0x00ffff);
-  });
-
-  it('should return 0xffffff if the hex string is invalid', () => {
-    expect(hexStringToDec('xyz')).toBe(0xffffff);
+describe('colorToHexString', () => {
+  it('should return correct values for color to string', () => {
+    const colorStr: Color = '#ff0000';
+    expect(colorToHexString(colorStr)).toEqual('#ff0000');
+    const colorNumber: Color = 16711680;
+    expect(colorToHexString(colorNumber)).toEqual('#ff0000');
   });
 });
 

--- a/packages/scene-composer/src/utils/mathUtils.ts
+++ b/packages/scene-composer/src/utils/mathUtils.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 
 import { DistanceUnit } from '../interfaces';
+import { Color } from '../models/SceneModels';
 
 /**
  * Format bytes as human-readable text.
@@ -50,20 +51,13 @@ export function decToHexString(dec: number) {
   return '#' + str;
 }
 
-/**
- * Convert a css-style color string to its decimal form.
- * For example: #123456 => 0x123456 => 1193046
- *
- * If the input is an invalid hex string, the 0xFFFFFF value is returned.
- *
- * @param hex css-style hex string.
- * @returns decimal number of the hex string
- */
-export function hexStringToDec(hex: string) {
-  // assume hex string is a css-style color string, like #aabbcc
-  const result = Number.parseInt(hex.substring(1), 16);
-  // return 0xFFFFFF on error;
-  return Number.isNaN(result) ? 0xffffff : result;
+export function colorToHexString(color: Color) {
+  if (typeof color === 'string') {
+    // assume the string color is css-style hex
+    return color;
+  }
+
+  return decToHexString(color);
 }
 
 export function parseFloatOrDefault(str: string, defaultValue: number) {

--- a/packages/scene-composer/tests/components/panels/scene-components/LightComponentEditor.spec.tsx
+++ b/packages/scene-composer/tests/components/panels/scene-components/LightComponentEditor.spec.tsx
@@ -4,11 +4,8 @@ import { render } from '@testing-library/react';
 import wrapper from '@awsui/components-react/test-utils/dom';
 import _ from 'lodash';
 
-import {
-  colorToHexString,
-  LightComponentEditor,
-} from '../../../../src/components/panels/scene-components/LightComponentEditor';
-import { Color, LightType } from '../../../../src/models/SceneModels';
+import { LightComponentEditor } from '../../../../src/components/panels/scene-components/LightComponentEditor';
+import { LightType } from '../../../../src/models/SceneModels';
 import { DEFAULT_LIGHT_SETTINGS_MAP } from '../../../../src/common/constants';
 import { ILightComponentInternal, useStore } from '../../../../src/store';
 
@@ -153,12 +150,5 @@ describe('LightComponentEditor', () => {
       },
       true,
     );
-  });
-
-  it('should return correct values for color to string', () => {
-    const colorStr: Color = '#ff0000';
-    expect(colorToHexString(colorStr)).toEqual('#ff0000');
-    const colorNumber: Color = 16711680;
-    expect(colorToHexString(colorNumber)).toEqual('#ff0000');
   });
 });


### PR DESCRIPTION
## Overview
Add utils to handle light component in entity, change colors to be hex string instead of string or number

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
