### PR TITLE
feat(scene): enable scene backgrounds

### DIFF
--- a/packages/scene-composer/src/components/WebGLCanvasManager.tsx
+++ b/packages/scene-composer/src/components/WebGLCanvasManager.tsx
@@ -27,6 +27,7 @@ import EntityGroup from './three-fiber/EntityGroup';
 import { EditorMainCamera } from './three-fiber/EditorCamera';
 import { EditorTransformControls } from './three-fiber/EditorTransformControls';
 import { SceneInfoView } from './three-fiber/SceneInfoView';
+import SceneBackground from './three-fiber/SceneBackground';
 import IntlProvider from './IntlProvider';
 import { SceneLayers } from './SceneLayers';
 
@@ -88,7 +89,12 @@ export const WebGLCanvasManager: React.FC = () => {
 
   return (
     <React.Fragment>
-      {sceneAppearanceEnabled && <Fog />}
+      {sceneAppearanceEnabled && (
+        <React.Fragment>
+          <Fog />
+          <SceneBackground />
+        </React.Fragment>
+      )}
       <EditorMainCamera />
       {environmentPreset && environmentPreset in presets && (
         <Environment preset={environmentPreset} extensions={envLoaderExtension} />

--- a/packages/scene-composer/src/components/panels/SettingsPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SettingsPanel.tsx
@@ -19,6 +19,7 @@ import { ComponentVisibilityToggle } from './scene-settings/ComponentVisibilityT
 import { OverlayPanelVisibilityToggle } from './scene-settings/OverlayPanelVisibilityToggle';
 import { ConvertSceneSettings } from './scene-settings/ConvertSceneSettings';
 import { FogSettingsEditor } from './scene-settings/FogSettingsEditor';
+import { SceneBackgroundSettingsEditor } from './scene-settings/SceneBackgroundSettingsEditor';
 export interface SettingsPanelProps {
   valueDataBindingProvider?: IValueDataBindingProvider;
 }
@@ -179,7 +180,12 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
                 expandToViewport
               />
             </FormField>
-            {sceneAppearanceEnabled && <FogSettingsEditor />}
+            {sceneAppearanceEnabled && (
+              <React.Fragment>
+                <FogSettingsEditor />
+                <SceneBackgroundSettingsEditor />
+              </React.Fragment>
+            )}
           </SpaceBetween>
         </ExpandableInfoSection>
       )}

--- a/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.spec.tsx
@@ -1,5 +1,5 @@
 import wrapper from '@awsui/components-react/test-utils/dom';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import React from 'react';
 
 import { useStore } from '../../../store';
@@ -31,12 +31,14 @@ describe('FogSettingsEditor', () => {
     const checkbox = polarisWrapper.findCheckbox();
 
     expect(checkbox).toBeDefined();
-    console.log('checkbox: ', checkbox);
+
     // click checkbox should update store
-    checkbox?.findNativeInput().click();
+    act(() => {
+      checkbox?.findNativeInput().click();
+    });
     expect(setScenePropertyMock).toBeCalledTimes(1);
     expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, {
-      colorHex: 0xcccccc,
+      color: '#cccccc',
       near: 1,
       far: 1000,
     });
@@ -44,7 +46,7 @@ describe('FogSettingsEditor', () => {
 
   it('should clear fogsettings when unchecked', async () => {
     getScenePropertyMock.mockReturnValue({
-      colorHex: 0xcccccc,
+      color: '#cccccc',
       near: 1,
       far: 1000,
     });
@@ -56,14 +58,16 @@ describe('FogSettingsEditor', () => {
     expect(checkbox).toBeDefined();
 
     // click checkbox should update store
-    checkbox?.findNativeInput().click();
+    act(() => {
+      checkbox?.findNativeInput().click();
+    });
     expect(setScenePropertyMock).toBeCalledTimes(1);
     expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, undefined);
   });
 
   it('should update fog when near changes', async () => {
     getScenePropertyMock.mockReturnValue({
-      colorHex: 0xcccccc,
+      color: '#cccccc',
       near: 1,
       far: 1000,
     });
@@ -77,9 +81,10 @@ describe('FogSettingsEditor', () => {
     nearInput!.focus();
     nearInput!.setInputValue('2');
     nearInput!.blur();
+
     expect(setScenePropertyMock).toBeCalledTimes(1);
     expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, {
-      colorHex: 0xcccccc,
+      color: '#cccccc',
       near: 2,
       far: 1000,
     });
@@ -87,7 +92,7 @@ describe('FogSettingsEditor', () => {
 
   it('should update fog when far changes', async () => {
     getScenePropertyMock.mockReturnValue({
-      colorHex: 0xcccccc,
+      color: '#cccccc',
       near: 1,
       far: 1000,
     });
@@ -103,7 +108,7 @@ describe('FogSettingsEditor', () => {
     farInput!.blur();
     expect(setScenePropertyMock).toBeCalledTimes(1);
     expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, {
-      colorHex: 0xcccccc,
+      color: '#cccccc',
       near: 1,
       far: 2000,
     });
@@ -112,18 +117,15 @@ describe('FogSettingsEditor', () => {
   it('should update fog when colors changes', async () => {
     getScenePropertyMock.mockImplementation((property: string) => {
       if (property === KnownSceneProperty.FogSettings) {
-        console.log('getting fog setting');
         return {
-          colorHex: 0xcccccc,
+          color: '#cccccc',
           near: 1,
           far: 1000,
         };
       } else if (property === KnownSceneProperty.TagCustomColors) {
-        console.log('getting custom colors setting');
         const customColors: string[] = [];
         return customColors;
       }
-      console.log('got wrong thing: ', property);
     });
     useStore('default').setState(baseState);
     const { container } = render(<FogSettingsEditor />);
@@ -138,7 +140,7 @@ describe('FogSettingsEditor', () => {
     colorInput!.blur();
     expect(setScenePropertyMock).toBeCalledTimes(2);
     expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, {
-      colorHex: 0xffffff,
+      color: '#FFFFFF',
       near: 1,
       far: 1000,
     });

--- a/packages/scene-composer/src/components/panels/scene-settings/SceneBackgroundSettingsEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/SceneBackgroundSettingsEditor.spec.tsx
@@ -1,0 +1,91 @@
+import wrapper from '@awsui/components-react/test-utils/dom';
+import { act, render } from '@testing-library/react';
+import React from 'react';
+
+import { useStore } from '../../../store';
+import { KnownSceneProperty } from '../../../interfaces';
+
+import { SceneBackgroundSettingsEditor } from './SceneBackgroundSettingsEditor';
+
+jest.mock('@awsui/components-react', () => ({
+  ...jest.requireActual('@awsui/components-react'),
+}));
+
+describe('SceneBackgroundSettingsEditor', () => {
+  const setScenePropertyMock = jest.fn();
+  const getScenePropertyMock = jest.fn();
+  const baseState = {
+    setSceneProperty: setScenePropertyMock,
+    getSceneProperty: getScenePropertyMock,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should save background when checked', async () => {
+    getScenePropertyMock.mockReturnValue(undefined);
+    useStore('default').setState(baseState);
+    const { container } = render(<SceneBackgroundSettingsEditor />);
+    const polarisWrapper = wrapper(container);
+    const checkbox = polarisWrapper.findCheckbox();
+
+    expect(checkbox).toBeDefined();
+
+    // click checkbox should update store
+    act(() => {
+      checkbox?.findNativeInput().click();
+    });
+    expect(setScenePropertyMock).toBeCalledTimes(1);
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneBackgroundSettings, {
+      color: '#cccccc',
+    });
+  });
+
+  it('should clear background when unchecked', async () => {
+    getScenePropertyMock.mockReturnValue({
+      color: '#cccccc',
+    });
+    useStore('default').setState(baseState);
+    const { container } = render(<SceneBackgroundSettingsEditor />);
+    const polarisWrapper = wrapper(container);
+    const checkbox = polarisWrapper.findCheckbox();
+
+    expect(checkbox).toBeDefined();
+
+    // click checkbox should update store
+    act(() => {
+      checkbox?.findNativeInput().click();
+    });
+    expect(setScenePropertyMock).toBeCalledTimes(1);
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneBackgroundSettings, undefined);
+  });
+
+  it('should update background when colors changes', async () => {
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.SceneBackgroundSettings) {
+        return {
+          color: '#cccccc',
+        };
+      } else if (property === KnownSceneProperty.TagCustomColors) {
+        const customColors: string[] = [];
+        return customColors;
+      }
+    });
+    useStore('default').setState(baseState);
+    const { container } = render(<SceneBackgroundSettingsEditor />);
+    const polarisWrapper = wrapper(container);
+    const colorInput = polarisWrapper.findInput('[data-testid="hexcode"]');
+
+    expect(colorInput).toBeDefined();
+
+    // click checkbox should update store
+    colorInput!.focus();
+    colorInput!.setInputValue('#FFFFFF');
+    colorInput!.blur();
+    expect(setScenePropertyMock).toBeCalledTimes(2);
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneBackgroundSettings, {
+      color: '#FFFFFF',
+    });
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-settings/SceneBackgroundSettingsEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/SceneBackgroundSettingsEditor.tsx
@@ -1,0 +1,83 @@
+import React, { useCallback, useContext, useState } from 'react';
+import { useIntl } from 'react-intl';
+import { Checkbox, SpaceBetween } from '@awsui/components-react';
+
+import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import { ISceneBackgroundSetting, KnownSceneProperty } from '../../../interfaces';
+import useLifecycleLogging from '../../../logger/react-logger/hooks/useLifecycleLogging';
+import { useStore } from '../../../store';
+import { ColorSelectorCombo } from '../scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo';
+
+export const SceneBackgroundSettingsEditor: React.FC = () => {
+  useLifecycleLogging('SceneBackgroundSettingsEditor');
+
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const intl = useIntl();
+  const setSceneProperty = useStore(sceneComposerId)(
+    (state) => state.setSceneProperty<ISceneBackgroundSetting | undefined>,
+  );
+  const backgroundSettings = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<ISceneBackgroundSetting>(KnownSceneProperty.SceneBackgroundSettings),
+  );
+
+  const [backgroundEnabled, setBackgroundEnabled] = useState(!!backgroundSettings);
+  const [internalColor, setInternalColor] = useState(backgroundSettings?.color || '#cccccc');
+  const backgroundColors = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<string[]>(KnownSceneProperty.BackgroundCustomColors, []),
+  );
+  const setBackgroundColorsSceneProperty = useStore(sceneComposerId)((state) => state.setSceneProperty<string[]>);
+
+  const onToggleBackground = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        setSceneProperty(KnownSceneProperty.SceneBackgroundSettings, {
+          color: internalColor,
+        });
+      } else {
+        setSceneProperty(KnownSceneProperty.SceneBackgroundSettings, undefined);
+      }
+      setBackgroundEnabled(checked);
+    },
+    [backgroundSettings, internalColor],
+  );
+
+  const onColorChange = useCallback(
+    (color: string) => {
+      if (color !== internalColor) {
+        setInternalColor(color);
+        if (backgroundEnabled) {
+          setSceneProperty(KnownSceneProperty.SceneBackgroundSettings, {
+            color: color,
+          });
+        }
+      }
+    },
+    [backgroundEnabled, internalColor],
+  );
+
+  return (
+    <React.Fragment>
+      <SpaceBetween size='s'>
+        <Checkbox
+          data-testid='enable-background-checkbox'
+          checked={!!backgroundSettings}
+          onChange={(e) => onToggleBackground(e.detail.checked)}
+        >
+          {intl.formatMessage({ defaultMessage: 'Enable Background', description: 'checkbox label' })}
+        </Checkbox>
+        {!!backgroundSettings && (
+          <ColorSelectorCombo
+            color={internalColor}
+            onSelectColor={(pickedColor) => onColorChange(pickedColor)}
+            onUpdateCustomColors={(chosenCustomColors) =>
+              setBackgroundColorsSceneProperty(KnownSceneProperty.BackgroundCustomColors, chosenCustomColors)
+            }
+            customColors={backgroundColors}
+            colorPickerLabel={intl.formatMessage({ defaultMessage: 'Color', description: 'Color' })}
+            customColorLabel={intl.formatMessage({ defaultMessage: 'Custom colors', description: 'Custom colors' })}
+          />
+        )}
+      </SpaceBetween>
+    </React.Fragment>
+  );
+};

--- a/packages/scene-composer/src/components/three-fiber/Fog.tsx
+++ b/packages/scene-composer/src/components/three-fiber/Fog.tsx
@@ -15,9 +15,7 @@ const Fog: FC = () => {
 
   useEffect(() => {
     scene.fog =
-      fogSettings && fogSettings.colorHex
-        ? new THREE.Fog(fogSettings.colorHex, fogSettings.near, fogSettings.far)
-        : null;
+      fogSettings && fogSettings.color ? new THREE.Fog(fogSettings.color, fogSettings.near, fogSettings.far) : null;
   }, [scene, fogSettings]);
 
   return null;

--- a/packages/scene-composer/src/components/three-fiber/SceneBackground.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/SceneBackground.spec.tsx
@@ -11,13 +11,13 @@ import { useThree } from '@react-three/fiber';
 import React from 'react';
 
 import { useStore } from '../../../src/store';
-import { IFogSettings } from '../../interfaces';
+import { ISceneBackgroundSetting } from '../../interfaces';
 
-import Fog from './Fog';
+import SceneBackground from './SceneBackground';
 
 import Mock = jest.Mock;
 
-describe('Fog', () => {
+describe('SceneBackground', () => {
   const setup = () => {
     jest.resetAllMocks();
 
@@ -28,7 +28,7 @@ describe('Fog', () => {
     setup();
   });
 
-  it(`should add fog to the scene`, () => {
+  it(`should add background color to the scene`, () => {
     const testScene = new THREE.Scene();
     const mockThreeStates = {
       scene: testScene,
@@ -38,23 +38,19 @@ describe('Fog', () => {
       return s(mockThreeStates);
     });
 
-    const fogSetting: IFogSettings = {
+    const backgroundSetting: ISceneBackgroundSetting = {
       color: '#cccccc',
-      near: 2,
-      far: 20,
     };
-    getScenePropertyMock.mockReturnValue(fogSetting);
+    getScenePropertyMock.mockReturnValue(backgroundSetting);
 
-    expect(testScene.fog).toBeNull();
-    render(<Fog />);
-    const fog = testScene.fog as THREE.Fog;
+    expect(testScene.background).toBeNull();
+    render(<SceneBackground />);
+    const background = testScene.background as THREE.Color;
 
-    expect(fog.color.getHexString()).toEqual(fogSetting.color.replace('#', ''));
-    expect(fog.near).toEqual(fogSetting.near);
-    expect(fog.far).toEqual(fogSetting.far);
+    expect(background.getHexString()).toEqual(backgroundSetting.color?.replace('#', ''));
   });
 
-  it(`should not add fog to the scene`, () => {
+  it(`should not add background to the scene`, () => {
     const testScene = new THREE.Scene();
     const mockThreeStates = {
       scene: testScene,
@@ -66,8 +62,8 @@ describe('Fog', () => {
 
     getScenePropertyMock.mockReturnValue(undefined);
 
-    expect(testScene.fog).toBeNull();
-    render(<Fog />);
-    expect(testScene.fog).toBeNull();
+    expect(testScene.background).toBeNull();
+    render(<SceneBackground />);
+    expect(testScene.background).toBeNull();
   });
 });

--- a/packages/scene-composer/src/components/three-fiber/SceneBackground.tsx
+++ b/packages/scene-composer/src/components/three-fiber/SceneBackground.tsx
@@ -1,0 +1,23 @@
+import { Color } from 'three';
+import { FC, useContext, useEffect } from 'react';
+import { useThree } from '@react-three/fiber';
+
+import { useStore } from '../../store';
+import { ISceneBackgroundSetting, KnownSceneProperty } from '../../interfaces';
+import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
+
+const SceneBackground: FC = () => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const scene = useThree((state) => state.scene);
+  const sceneBackgroundSettings = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<ISceneBackgroundSetting>(KnownSceneProperty.SceneBackgroundSettings),
+  );
+
+  useEffect(() => {
+    scene.background = sceneBackgroundSettings?.color ? new Color(sceneBackgroundSettings.color) : null;
+  }, [scene, sceneBackgroundSettings]);
+
+  return null;
+};
+
+export default SceneBackground;

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -74,6 +74,9 @@ export enum KnownSceneProperty {
   SceneRootEntityId = 'sceneRootEntityId',
   TagCustomColors = 'tagCustomColors',
   FogSettings = 'fogSettings',
+  SceneBackgroundSettings = 'sceneBackgroundSettings',
+  FogCustomColors = 'fogCustomColors',
+  BackgroundCustomColors = 'backgroundCustomColors',
 }
 
 /************************************************
@@ -144,7 +147,11 @@ export interface StyleTarget {
 }
 
 export interface IFogSettings {
-  colorHex: number;
+  color: string;
   near: number;
   far: number;
+}
+
+export interface ISceneBackgroundSetting {
+  color?: string;
 }

--- a/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
@@ -20,6 +20,7 @@ export const defaultArgs = {
     COMPOSER_FEATURES.CameraView,
     COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.Matterport,
+    COMPOSER_FEATURES.SceneAppearance,
   ]
 }
 

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -103,10 +103,6 @@
     "note": "Error message",
     "text": "Error - unable to render the scene"
   },
-  "2A8qfi": {
-    "note": "ExpandableInfoSection Title",
-    "text": "Fog Settings"
-  },
   "2F5/qR": {
     "note": "ExpandableInfoSection Title",
     "text": "Scene Settings"
@@ -622,6 +618,10 @@
   "T1kJTq": {
     "note": "label",
     "text": "Select color"
+  },
+  "TWQfaz": {
+    "note": "checkbox label",
+    "text": "Enable Background"
   },
   "TZDmnV": {
     "note": "label for when the user searches for a nonexistent animation",


### PR DESCRIPTION
## Overview
Update layout of fog settings to not require expander click and toggle color picker/distance inputs based on enable checkbox

Add scene background settings with color picker.  Does not support background textures.

https://github.com/awslabs/iot-app-kit/assets/109186219/533ea9f7-b88f-4986-9e0b-cdda28c39be4

## Verifying Changes
Use storybook to open a scene composer
visit settings
go to scene settings
use the enable fog and enable background to test setting and see the colors change in the 3d scene

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
