### PR TITLE
feat(component): allow disable/enable layer auto refresh

### DIFF
--- a/packages/scene-composer/src/components/SceneLayers.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.tsx
@@ -14,6 +14,9 @@ import {
 export const SceneLayers: React.FC = () => {
   const sceneComposerId = useContext(sceneComposerIdContext);
   const isViewing = useStore(sceneComposerId)((state) => state.isViewing());
+  const autoUpdateInterval = useStore(sceneComposerId)(
+    (state) => state.getSceneProperty(KnownSceneProperty.LayerDefaultRefreshInterval) as number,
+  );
 
   const renderSceneNodesFromLayers = useStore(sceneComposerId)((state) => state.renderSceneNodesFromLayers);
   const layerIds = useStore(sceneComposerId)((state) => state.getSceneProperty<string[]>(KnownSceneProperty.LayerIds));
@@ -37,8 +40,9 @@ export const SceneLayers: React.FC = () => {
       return nodes;
     },
     refetchInterval: (_, query) => {
-      return !query.state.error && isViewing ? 10 * 1000 : 0;
+      return !query.state.error && isViewing ? autoUpdateInterval : 0;
     },
+    refetchOnWindowFocus: false,
   });
 
   useEffect(() => {

--- a/packages/scene-composer/src/components/panels/scene-settings/ConvertSceneSettings.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/ConvertSceneSettings.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useContext } from 'react';
 import { useIntl } from 'react-intl';
-import { Box, Button } from '@awsui/components-react';
+import { Box, Button, Checkbox, CheckboxProps, NonCancelableCustomEvent } from '@awsui/components-react';
 
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { staticNodeCount } from '../../../utils/entityModelUtils/sceneUtils';
 import { useStore } from '../../../store';
+import { KnownSceneProperty } from '../../../interfaces';
+import { LAYER_DEFAULT_REFRESH_INTERVAL } from '../../../utils/entityModelUtils/sceneLayerUtils';
 
 export const ConvertSceneSettings: React.FC = () => {
   const sceneComposerId = useContext(sceneComposerIdContext);
@@ -12,10 +14,24 @@ export const ConvertSceneSettings: React.FC = () => {
   const document = useStore(sceneComposerId)((state) => state.document);
 
   const setConvertSceneModalVisibility = useStore(sceneComposerId)((state) => state.setConvertSceneModalVisibility);
+  const autoUpdateOn = useStore(sceneComposerId)(
+    (state) => (state.getSceneProperty(KnownSceneProperty.LayerDefaultRefreshInterval) as number) > 0,
+  );
+  const setSceneProperty = useStore(sceneComposerId)((state) => state.setSceneProperty);
 
   const convertScene = useCallback(() => {
     setConvertSceneModalVisibility(true);
   }, [setConvertSceneModalVisibility]);
+
+  const setAutoUpdate = useCallback(
+    (e: NonCancelableCustomEvent<CheckboxProps.ChangeDetail>) => {
+      setSceneProperty(
+        KnownSceneProperty.LayerDefaultRefreshInterval,
+        e.detail.checked ? LAYER_DEFAULT_REFRESH_INTERVAL : 0,
+      );
+    },
+    [setSceneProperty],
+  );
 
   return (
     <>
@@ -32,6 +48,14 @@ export const ConvertSceneSettings: React.FC = () => {
       <Button data-testid='convert-button' onClick={convertScene} disabled={staticNodeCount(document.nodeMap) === 0}>
         {formatMessage({ description: 'Button text', defaultMessage: 'Convert scene' })}
       </Button>
+
+      {/* Temporary checkbox to enable/disable auto refresh layer before full Layer UX is ready */}
+      <Box variant='p' fontWeight='bold' margin={{ bottom: 'xxs', top: 's' }}>
+        {formatMessage({ description: 'Sub-Section Header', defaultMessage: 'Refresh cycle' })}
+      </Box>
+      <Checkbox data-testid='auto-update-checkbox' checked={autoUpdateOn} onChange={setAutoUpdate}>
+        {formatMessage({ description: 'checkbox label', defaultMessage: 'Auto update (every 30s)' })}
+      </Checkbox>
     </>
   );
 };

--- a/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/ConvertSceneSettings.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-settings/__snapshots__/ConvertSceneSettings.spec.tsx.snap
@@ -24,6 +24,20 @@ exports[`ConvertSceneSettings should render correctly with convert button disabl
   >
     Convert scene
   </div>
+  <div
+    data-mocked="Box"
+    font-weight="bold"
+    margin="{\\"bottom\\":\\"xxs\\",\\"top\\":\\"s\\"}"
+    variant="p"
+  >
+    Refresh cycle
+  </div>
+  <div
+    data-mocked="Checkbox"
+    data-testid="auto-update-checkbox"
+  >
+    Auto update (every 30s)
+  </div>
 </div>
 `;
 
@@ -49,6 +63,20 @@ exports[`ConvertSceneSettings should render correctly with convert button enable
     data-testid="convert-button"
   >
     Convert scene
+  </div>
+  <div
+    data-mocked="Box"
+    font-weight="bold"
+    margin="{\\"bottom\\":\\"xxs\\",\\"top\\":\\"s\\"}"
+    variant="p"
+  >
+    Refresh cycle
+  </div>
+  <div
+    data-mocked="Checkbox"
+    data-testid="auto-update-checkbox"
+  >
+    Auto update (every 30s)
   </div>
 </div>
 `;

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -77,6 +77,7 @@ export enum KnownSceneProperty {
   SceneBackgroundSettings = 'sceneBackgroundSettings',
   FogCustomColors = 'fogCustomColors',
   BackgroundCustomColors = 'backgroundCustomColors',
+  LayerDefaultRefreshInterval = 'layerDefaultRefreshInterval',
 }
 
 /************************************************

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneLayerUtils.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneLayerUtils.ts
@@ -18,6 +18,8 @@ import {
 import { getGlobalSettings } from '../../common/GlobalSettings';
 import { generateUUID } from '../mathUtils';
 
+export const LAYER_DEFAULT_REFRESH_INTERVAL = 30 * 1000;
+
 export const createLayerId = (layerName: string): string => {
   return `LAYER_${layerName}_${generateUUID()}`;
 };

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -83,6 +83,10 @@
     "note": "Abbreviation for blue",
     "text": "B"
   },
+  "1ZqGeQ": {
+    "note": "checkbox label",
+    "text": "Auto update (every 30s)"
+  },
   "1cVQu5": {
     "note": "label for an input component selecting number of arrows",
     "text": "# of arrows"
@@ -554,6 +558,10 @@
   "PT1lRG": {
     "note": "Scene Resource types in a dropdown menu",
     "text": "Opacity"
+  },
+  "PUKBon": {
+    "note": "Sub-Section Header",
+    "text": "Refresh cycle"
   },
   "PiJTq0": {
     "note": "remove rule Button Text",


### PR DESCRIPTION
## Overview
allow disable/enable layer auto refresh from settings. This is a temporary change before full layer UX is implemented.
<img width="269" alt="auto-refresh-config" src="https://github.com/awslabs/iot-app-kit/assets/9315598/bcc7196c-484a-4f2c-87c6-494f0289d783">

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
