### PR TITLE
fix(composer): custom tag rendered slightly off the center

### DIFF
--- a/packages/scene-composer/src/assets/anchors/IconSvgs.tsx
+++ b/packages/scene-composer/src/assets/anchors/IconSvgs.tsx
@@ -66,10 +66,10 @@ export const SelectedIconSvgString = `
 
 export const CustomIconSvgString = `
   <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 52 52' width='256' height='256'>
-    <g fill='none' fillRule='evenodd' transform='translate(2 2)'>
-      <ellipse cx='26' cy='26' rx='21' ry='21' stroke='${colors.customBlue}' stroke-width='2' />
-      <circle cx='26' cy='26' r='16' fill='${colors.customBlue}'/>
-      <g transform='translate(26,26) scale(0.03) translate(${iconWidth}, ${iconHeight})' fill=''>
+    <g fill='none' fillRule='evenodd' transform='translate(1 1)'>
+      <ellipse cx='25' cy='25' rx='21' ry='21' stroke='${colors.customBlue}' stroke-width='2' />
+      <circle cx='25' cy='25' r='16' fill='${colors.customBlue}'/>
+      <g transform='translate(25,25) scale(0.03) translate(${iconWidth}, ${iconHeight})' fill=''>
         <path d='M22 80a48 48 0 1 1 96 0A48 48 0 1 1 48 80zM 224c0-17.7 14.3-32 32-32H96c17.7 0 32 14.3 32 32V448h32c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H64V256H32c-17.7 0-32-14.3-32-32z' fill=''/>
       </g>
     </g>


### PR DESCRIPTION
## Overview
Fix for when custom tags is chosen from the Tag Style drop down menu it rendered slightly off center.

Before


https://github.com/awslabs/iot-app-kit/assets/20994167/eeb05058-a06f-4774-8a91-22f1645d9707


After

https://github.com/awslabs/iot-app-kit/assets/20994167/fa9a1081-1acf-461b-99c1-f84dacbda68d



## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
