### PR TITLE
feat(composer): utils to handle subModelRef component in entity

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/__tests__/__snapshots__/SubModelTree.spec.tsx.snap
@@ -15,7 +15,7 @@ Array [
     "name": "RootObject",
     "parentRef": "112",
     "properties": Object {},
-    "ref": "112#undefined",
+    "ref": "40B59050-EBAE-497F-A366-201E775341DD",
     "transform": Object {
       "position": Array [
         1,

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/index.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SubModelTree/index.tsx
@@ -5,7 +5,7 @@ import useMaterialEffect from '../../../../../hooks/useMaterialEffect';
 import { generateUUID } from '../../../../../utils/mathUtils';
 import Tree, { TreeItem } from '../../../../Tree';
 import { ISubModelRefComponent, KnownComponentType } from '../../../../../interfaces';
-import { ISceneComponentInternal, ISceneNodeInternal, useEditorState, useSceneDocument } from '../../../../../store';
+import { ISceneNodeInternal, useEditorState, useSceneDocument } from '../../../../../store';
 import { useSceneComposerId } from '../../../../../common/sceneComposerIdContext';
 import { findComponentByType } from '../../../../../utils/nodeUtils';
 
@@ -86,7 +86,7 @@ const SubModelTree: FC<SubModelTreeProps> = ({
       return;
     }
 
-    const nodeRef = `${parentRef}#${object3D.id}`;
+    const nodeRef = generateUUID();
     const subModelComponent: ISubModelRefComponent = {
       type: KnownComponentType.SubModelRef,
       parentRef,
@@ -97,7 +97,7 @@ const SubModelTree: FC<SubModelTreeProps> = ({
     const node = {
       ref: nodeRef,
       name: object3D.name,
-      components: [subModelComponent as ISceneComponentInternal],
+      components: [subModelComponent],
       parentRef,
       transform: {
         position: [object3D.position.x, object3D.position.y, object3D.position.z],

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.spec.ts
@@ -9,10 +9,11 @@ import { createTagEntityComponent } from './tagComponent';
 import { createOverlayEntityComponent } from './overlayComponent';
 import { createCameraEntityComponent } from './cameraComponent';
 import { createMotionIndicatorEntityComponent } from './motionIndicatorComponent';
-import { createModelRefComponent } from './modelRefComponent';
+import { createModelRefEntityComponent } from './modelRefComponent';
 import { createNodeEntity } from './createNodeEntity';
 import { createModelShaderEntityComponent } from './modelShaderComponent';
 import { createLightEntityComponent } from './lightComponent';
+import { createSubModelRefEntityComponent } from './subModelRefComponent';
 
 jest.mock('./nodeComponent', () => ({
   createNodeEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.node' }),
@@ -30,13 +31,16 @@ jest.mock('./motionIndicatorComponent', () => ({
   createMotionIndicatorEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.motionIndicator' }),
 }));
 jest.mock('./modelRefComponent', () => ({
-  createModelRefComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelRef' }),
+  createModelRefEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelRef' }),
 }));
 jest.mock('./modelShaderComponent', () => ({
   createModelShaderEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelShader' }),
 }));
 jest.mock('./lightComponent', () => ({
   createLightEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.light' }),
+}));
+jest.mock('./subModelRefComponent', () => ({
+  createSubModelRefEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.subModelRef' }),
 }));
 
 describe('createNodeEntity', () => {
@@ -53,8 +57,8 @@ describe('createNodeEntity', () => {
   it('should call create entity with only node component', async () => {
     await createNodeEntity(defaultNode, 'parent', 'layer');
 
-    expect(createSceneEntity).toHaveBeenCalledTimes(1);
-    expect(createSceneEntity).toHaveBeenCalledWith({
+    expect(createSceneEntity).toBeCalledTimes(1);
+    expect(createSceneEntity).toBeCalledWith({
       workspaceId: undefined,
       entityId: defaultNode.ref,
       entityName: defaultNode.name + '_' + defaultNode.ref,
@@ -64,8 +68,8 @@ describe('createNodeEntity', () => {
       },
     });
 
-    expect(createNodeEntityComponent).toHaveBeenCalledTimes(1);
-    expect(createNodeEntityComponent).toHaveBeenCalledWith(defaultNode, 'layer');
+    expect(createNodeEntityComponent).toBeCalledTimes(1);
+    expect(createNodeEntityComponent).toBeCalledWith(defaultNode, 'layer');
   });
 
   it('should call create entity to create multiple components', async () => {
@@ -76,12 +80,17 @@ describe('createNodeEntity', () => {
     const modelRef = { type: KnownComponentType.ModelRef, ref: 'modelref-ref' };
     const modelShader = { type: KnownComponentType.ModelShader, ref: 'modelShader-ref' };
     const light = { type: KnownComponentType.Light, ref: 'light-ref' };
-    const node = { ...defaultNode, components: [tag, overlay, camera, motionIndicator, modelRef, modelShader, light] };
+    const subModelRef = { type: KnownComponentType.SubModelRef, ref: 'subModelref-ref' };
+
+    const node = {
+      ...defaultNode,
+      components: [tag, overlay, camera, motionIndicator, modelRef, modelShader, light, subModelRef],
+    };
 
     await createNodeEntity(node, 'parent', 'layer');
 
-    expect(createSceneEntity).toHaveBeenCalledTimes(1);
-    expect(createSceneEntity).toHaveBeenCalledWith({
+    expect(createSceneEntity).toBeCalledTimes(1);
+    expect(createSceneEntity).toBeCalledWith({
       workspaceId: undefined,
       entityId: defaultNode.ref,
       entityName: defaultNode.name + '_' + defaultNode.ref,
@@ -95,24 +104,27 @@ describe('createNodeEntity', () => {
         ModelRef: { componentTypeId: '3d.modelRef' },
         ModelShader: { componentTypeId: '3d.modelShader' },
         Light: { componentTypeId: '3d.light' },
+        SubModelRef: { componentTypeId: '3d.subModelRef' },
       },
     });
 
-    expect(createNodeEntityComponent).toHaveBeenCalledTimes(1);
-    expect(createNodeEntityComponent).toHaveBeenCalledWith(node, 'layer');
-    expect(createTagEntityComponent).toHaveBeenCalledTimes(1);
-    expect(createTagEntityComponent).toHaveBeenCalledWith(tag);
-    expect(createOverlayEntityComponent).toHaveBeenCalledTimes(1);
-    expect(createOverlayEntityComponent).toHaveBeenCalledWith(overlay);
-    expect(createCameraEntityComponent).toHaveBeenCalledTimes(1);
-    expect(createCameraEntityComponent).toHaveBeenCalledWith(camera);
-    expect(createMotionIndicatorEntityComponent).toHaveBeenCalledTimes(1);
-    expect(createMotionIndicatorEntityComponent).toHaveBeenCalledWith(motionIndicator);
-    expect(createModelRefComponent).toHaveBeenCalledTimes(1);
-    expect(createModelRefComponent).toHaveBeenCalledWith(modelRef);
-    expect(createModelShaderEntityComponent).toHaveBeenCalledTimes(1);
-    expect(createModelShaderEntityComponent).toHaveBeenCalledWith(modelShader);
-    expect(createLightEntityComponent).toHaveBeenCalledTimes(1);
-    expect(createLightEntityComponent).toHaveBeenCalledWith(light);
+    expect(createNodeEntityComponent).toBeCalledTimes(1);
+    expect(createNodeEntityComponent).toBeCalledWith(node, 'layer');
+    expect(createTagEntityComponent).toBeCalledTimes(1);
+    expect(createTagEntityComponent).toBeCalledWith(tag);
+    expect(createOverlayEntityComponent).toBeCalledTimes(1);
+    expect(createOverlayEntityComponent).toBeCalledWith(overlay);
+    expect(createCameraEntityComponent).toBeCalledTimes(1);
+    expect(createCameraEntityComponent).toBeCalledWith(camera);
+    expect(createMotionIndicatorEntityComponent).toBeCalledTimes(1);
+    expect(createMotionIndicatorEntityComponent).toBeCalledWith(motionIndicator);
+    expect(createModelRefEntityComponent).toBeCalledTimes(1);
+    expect(createModelRefEntityComponent).toBeCalledWith(modelRef);
+    expect(createModelShaderEntityComponent).toBeCalledTimes(1);
+    expect(createModelShaderEntityComponent).toBeCalledWith(modelShader);
+    expect(createLightEntityComponent).toBeCalledTimes(1);
+    expect(createLightEntityComponent).toBeCalledWith(light);
+    expect(createSubModelRefEntityComponent).toBeCalledTimes(1);
+    expect(createSubModelRefEntityComponent).toBeCalledWith(subModelRef);
   });
 });

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
@@ -12,6 +12,7 @@ import {
   ILightComponent,
   IModelRefComponent,
   IMotionIndicatorComponent,
+  ISubModelRefComponent,
   KnownComponentType,
 } from '../../interfaces';
 import { ISceneNodeInternal } from '../../store/internalInterfaces';
@@ -21,9 +22,10 @@ import { createTagEntityComponent } from './tagComponent';
 import { createOverlayEntityComponent } from './overlayComponent';
 import { createMotionIndicatorEntityComponent } from './motionIndicatorComponent';
 import { createCameraEntityComponent } from './cameraComponent';
-import { createModelRefComponent } from './modelRefComponent';
+import { createModelRefEntityComponent } from './modelRefComponent';
 import { createModelShaderEntityComponent } from './modelShaderComponent';
 import { createLightEntityComponent } from './lightComponent';
+import { createSubModelRefEntityComponent } from './subModelRefComponent';
 
 export const createNodeEntity = async (
   node: ISceneNodeInternal,
@@ -61,13 +63,16 @@ export const createNodeEntity = async (
           comp = createCameraEntityComponent(compToBeCreated as ICameraComponent);
           break;
         case KnownComponentType.ModelRef:
-          comp = createModelRefComponent(compToBeCreated as IModelRefComponent);
+          comp = createModelRefEntityComponent(compToBeCreated as IModelRefComponent);
           break;
         case KnownComponentType.ModelShader:
           comp = createModelShaderEntityComponent(compToBeCreated as IColorOverlayComponent);
           break;
         case KnownComponentType.Light:
           comp = createLightEntityComponent(compToBeCreated as ILightComponent);
+          break;
+        case KnownComponentType.SubModelRef:
+          comp = createSubModelRefEntityComponent(compToBeCreated as ISubModelRefComponent);
           break;
 
         default:

--- a/packages/scene-composer/src/utils/entityModelUtils/modelRefComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/modelRefComponent.spec.ts
@@ -1,11 +1,15 @@
 import { componentTypeToId } from '../../common/entityModelConstants';
 import { KnownComponentType } from '../../interfaces';
 
-import { createModelRefComponent, parseModelRefComp, updateModelRefComponent } from './modelRefComponent';
+import { createModelRefEntityComponent, parseModelRefComp, updateModelRefEntityComponent } from './modelRefComponent';
 
-describe('createModelRefComponent', () => {
+describe('createModelRefEntityComponent', () => {
   it('should return expected modelRef component with uri and modelType', () => {
-    const result = createModelRefComponent({ type: KnownComponentType.ModelRef, uri: 'abc', modelType: 'modelType' });
+    const result = createModelRefEntityComponent({
+      type: KnownComponentType.ModelRef,
+      uri: 'abc',
+      modelType: 'modelType',
+    });
 
     expect(result.properties).toEqual({
       uri: {
@@ -18,7 +22,7 @@ describe('createModelRefComponent', () => {
   });
 
   it('should return expected modelRef component by setting castShadow and receiveShadow to false', () => {
-    const result = createModelRefComponent({
+    const result = createModelRefEntityComponent({
       type: KnownComponentType.ModelRef,
       uri: 'abc',
       modelType: 'modelType',
@@ -59,7 +63,7 @@ describe('createModelRefComponent', () => {
   });
 
   it('should return expected modelRef component by setting castShadow and receiveShadow to true ', () => {
-    const result = createModelRefComponent({
+    const result = createModelRefEntityComponent({
       type: KnownComponentType.ModelRef,
       uri: 'abc',
       modelType: 'modelType',
@@ -100,9 +104,11 @@ describe('createModelRefComponent', () => {
   });
 });
 
-describe('updateModelRefComponent', () => {
+describe('updateModelRefEntityComponent', () => {
   it('should update a model ref component', () => {
-    expect(updateModelRefComponent({ type: KnownComponentType.ModelRef, uri: 'abc', modelType: 'modelType' })).toEqual({
+    expect(
+      updateModelRefEntityComponent({ type: KnownComponentType.ModelRef, uri: 'abc', modelType: 'modelType' }),
+    ).toEqual({
       componentTypeId: componentTypeToId[KnownComponentType.ModelRef],
       propertyUpdates: {
         uri: {

--- a/packages/scene-composer/src/utils/entityModelUtils/modelRefComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/modelRefComponent.ts
@@ -15,7 +15,7 @@ enum ModelRefComponentProperty {
   ReceiveShadow = 'receiveShadow',
 }
 
-export const createModelRefComponent = (model: IModelRefComponent): ComponentRequest => {
+export const createModelRefEntityComponent = (model: IModelRefComponent): ComponentRequest => {
   const comp: ComponentRequest = {
     componentTypeId: componentTypeToId[KnownComponentType.ModelRef],
     properties: {
@@ -63,8 +63,8 @@ export const createModelRefComponent = (model: IModelRefComponent): ComponentReq
   return comp;
 };
 
-export const updateModelRefComponent = (model: IModelRefComponent): ComponentUpdateRequest => {
-  const request = createModelRefComponent(model);
+export const updateModelRefEntityComponent = (model: IModelRefComponent): ComponentUpdateRequest => {
+  const request = createModelRefEntityComponent(model);
   return {
     componentTypeId: request.componentTypeId,
     propertyUpdates: request.properties,

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
@@ -235,6 +235,15 @@ describe('parseNode', () => {
       },
     ],
   };
+  const subModelRefComp = {
+    componentTypeId: componentTypeToId.SubModelRef,
+    properties: [
+      {
+        propertyName: 'selector',
+        propertyValue: 'abc',
+      },
+    ],
+  };
 
   const nodeComp = {
     componentTypeId: NODE_COMPONENT_TYPE_ID,
@@ -302,7 +311,16 @@ describe('parseNode', () => {
     const result = parseNode(
       {
         ...entity,
-        components: [tagComp, overlayComp, modelRefComp, cameraComp, indicatorComp, modelShaderComp, lightComp],
+        components: [
+          tagComp,
+          overlayComp,
+          modelRefComp,
+          cameraComp,
+          indicatorComp,
+          modelShaderComp,
+          lightComp,
+          subModelRefComp,
+        ],
       },
       nodeComp,
     );
@@ -328,6 +346,9 @@ describe('parseNode', () => {
       }),
       expect.objectContaining({
         type: KnownComponentType.Light,
+      }),
+      expect.objectContaining({
+        type: KnownComponentType.SubModelRef,
       }),
     ];
     expect(result?.components).toEqual(expectedComponents);

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
@@ -19,6 +19,7 @@ import { parseCameraComp } from './cameraComponent';
 import { parseMotionIndicatorComp } from './motionIndicatorComponent';
 import { parseModelShaderComp } from './modelShaderComponent';
 import { parseLightComp } from './lightComponent';
+import { parseSubModelRefComp } from './subModelRefComponent';
 
 enum NodeComponentProperty {
   Name = 'name',
@@ -178,6 +179,13 @@ const parseNodeComponents = (components: DocumentType): ISceneComponentInternal[
         const light = parseLightComp(comp);
         if (light) {
           results.push(light);
+        }
+        break;
+      }
+      case componentTypeToId.SubModelRef: {
+        const subModelRef = parseSubModelRefComp(comp);
+        if (subModelRef) {
+          results.push(subModelRef);
         }
         break;
       }

--- a/packages/scene-composer/src/utils/entityModelUtils/subModelRefComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/subModelRefComponent.spec.ts
@@ -1,0 +1,84 @@
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { KnownComponentType } from '../../interfaces';
+
+import {
+  createSubModelRefEntityComponent,
+  parseSubModelRefComp,
+  updateSubModelRefEntityComponent,
+} from './subModelRefComponent';
+
+describe('createSubModelRefEntityComponent', () => {
+  it('should return expected subModelRef component', () => {
+    const result = createSubModelRefEntityComponent({
+      type: KnownComponentType.SubModelRef,
+      selector: 'abc',
+      parentRef: 'parent',
+    });
+    const expected = {
+      componentTypeId: componentTypeToId[KnownComponentType.SubModelRef],
+      properties: {
+        selector: {
+          value: { stringValue: 'abc' },
+        },
+        parentRef: {
+          value: { relationshipValue: { targetEntityId: 'parent' } },
+        },
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('updateSubModelRefEntityComponent', () => {
+  it('should update a sub model ref component', () => {
+    const result = updateSubModelRefEntityComponent({
+      type: KnownComponentType.SubModelRef,
+      selector: 'abc',
+      parentRef: 'parent',
+    });
+    const expected = {
+      componentTypeId: componentTypeToId[KnownComponentType.SubModelRef],
+      propertyUpdates: {
+        selector: {
+          value: { stringValue: 'abc' },
+        },
+        parentRef: {
+          value: { relationshipValue: { targetEntityId: 'parent' } },
+        },
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('parseSubModelRefComponent', () => {
+  it('should parse to expected sub model ref component', () => {
+    const result = parseSubModelRefComp({
+      componentTypeId: componentTypeToId[KnownComponentType.SubModelRef],
+      properties: [
+        {
+          propertyName: 'selector',
+          propertyValue: 'abc',
+        },
+      ],
+    });
+    const expected = {
+      ref: expect.any(String),
+      type: KnownComponentType.SubModelRef,
+      selector: 'abc',
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should return undefined when selector is not found', () => {
+    const result = parseSubModelRefComp({
+      componentTypeId: componentTypeToId[KnownComponentType.SubModelRef],
+      properties: [],
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/subModelRefComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/subModelRefComponent.ts
@@ -1,0 +1,63 @@
+import { ComponentRequest, ComponentUpdateRequest } from '@aws-sdk/client-iottwinmaker';
+import { DocumentType } from '@aws-sdk/types';
+
+import { ISubModelRefComponent, KnownComponentType } from '../../interfaces';
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { ISubModelRefComponentInternal } from '../../store';
+import { generateUUID } from '../mathUtils';
+
+export enum SubModelRefComponentProperty {
+  Selector = 'selector',
+  ParentRef = 'parentRef',
+}
+
+export const createSubModelRefEntityComponent = (subModel: ISubModelRefComponent): ComponentRequest => {
+  const comp: ComponentRequest = {
+    componentTypeId: componentTypeToId[KnownComponentType.SubModelRef],
+    properties: {
+      [SubModelRefComponentProperty.Selector]: {
+        value: {
+          stringValue: subModel.selector,
+        },
+      },
+    },
+  };
+
+  if (subModel.parentRef !== undefined) {
+    comp.properties![SubModelRefComponentProperty.ParentRef] = {
+      value: {
+        relationshipValue: {
+          targetEntityId: subModel.parentRef,
+        },
+      },
+    };
+  }
+  return comp;
+};
+
+export const updateSubModelRefEntityComponent = (model: ISubModelRefComponent): ComponentUpdateRequest => {
+  const request = createSubModelRefEntityComponent(model);
+  return {
+    componentTypeId: request.componentTypeId,
+    propertyUpdates: request.properties,
+  };
+};
+
+export const parseSubModelRefComp = (comp: DocumentType): ISubModelRefComponentInternal | undefined => {
+  const selector = comp?.['properties'].find(
+    (mp) => mp['propertyName'] === SubModelRefComponentProperty.Selector,
+  )?.propertyValue;
+
+  if (!comp?.['properties'] || selector === undefined) {
+    return undefined;
+  }
+
+  const subModelComponent: ISubModelRefComponentInternal = {
+    ref: generateUUID(),
+    type: KnownComponentType.SubModelRef,
+    selector: selector,
+    parentRef: comp['properties'].find((mp) => mp['propertyName'] === SubModelRefComponentProperty.ParentRef)
+      ?.propertyValue,
+  };
+  return subModelComponent;
+};

--- a/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
@@ -11,9 +11,10 @@ import { updateTagEntityComponent } from './tagComponent';
 import { updateOverlayEntityComponent } from './overlayComponent';
 import { updateCameraEntityComponent } from './cameraComponent';
 import { updateMotionIndicatorEntityComponent } from './motionIndicatorComponent';
-import { updateModelRefComponent } from './modelRefComponent';
+import { updateModelRefEntityComponent } from './modelRefComponent';
 import { updateModelShaderEntityComponent } from './modelShaderComponent';
 import { updateLightEntityComponent } from './lightComponent';
+import { updateSubModelRefEntityComponent } from './subModelRefComponent';
 
 jest.mock('./nodeComponent', () => ({
   updateNodeEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.node' }),
@@ -31,13 +32,16 @@ jest.mock('./motionIndicatorComponent', () => ({
   updateMotionIndicatorEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.motionIndicator' }),
 }));
 jest.mock('./modelRefComponent', () => ({
-  updateModelRefComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelRef' }),
+  updateModelRefEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelRef' }),
 }));
 jest.mock('./modelShaderComponent', () => ({
   updateModelShaderEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.modelShader' }),
 }));
 jest.mock('./lightComponent', () => ({
   updateLightEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.light' }),
+}));
+jest.mock('./subModelRefComponent', () => ({
+  updateSubModelRefEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.subModelRef' }),
 }));
 
 describe('updateEntity', () => {
@@ -54,8 +58,8 @@ describe('updateEntity', () => {
   it('should call update entity with only node component', async () => {
     await updateEntity(defaultNode);
 
-    expect(updateSceneEntity).toHaveBeenCalledTimes(1);
-    expect(updateSceneEntity).toHaveBeenCalledWith({
+    expect(updateSceneEntity).toBeCalledTimes(1);
+    expect(updateSceneEntity).toBeCalledWith({
       workspaceId: undefined,
       entityId: defaultNode.ref,
       entityName: defaultNode.name + '_' + defaultNode.ref,
@@ -64,10 +68,10 @@ describe('updateEntity', () => {
       },
     });
 
-    expect(updateNodeEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateNodeEntityComponent).toHaveBeenCalledWith(defaultNode, undefined, undefined);
-    expect(updateTagEntityComponent).not.toHaveBeenCalled();
-    expect(updateOverlayEntityComponent).not.toHaveBeenCalled();
+    expect(updateNodeEntityComponent).toBeCalledTimes(1);
+    expect(updateNodeEntityComponent).toBeCalledWith(defaultNode, undefined, undefined);
+    expect(updateTagEntityComponent).not.toBeCalled();
+    expect(updateOverlayEntityComponent).not.toBeCalled();
   });
 
   it('should call update entity to update multiple components', async () => {
@@ -78,11 +82,16 @@ describe('updateEntity', () => {
     const modelRef = { type: KnownComponentType.ModelRef, ref: 'modelref-ref' };
     const modelShader = { type: KnownComponentType.ModelShader, ref: 'modelshader-ref' };
     const light = { type: KnownComponentType.Light, ref: 'light-ref' };
+    const subModelRef = { type: KnownComponentType.SubModelRef, ref: 'subModelref-ref' };
 
-    await updateEntity(defaultNode, [tag, overlay, camera, motionIndicator, modelRef, modelShader, light], 'UPDATE');
+    await updateEntity(
+      defaultNode,
+      [tag, overlay, camera, motionIndicator, modelRef, modelShader, light, subModelRef],
+      'UPDATE',
+    );
 
-    expect(updateSceneEntity).toHaveBeenCalledTimes(1);
-    expect(updateSceneEntity).toHaveBeenCalledWith({
+    expect(updateSceneEntity).toBeCalledTimes(1);
+    expect(updateSceneEntity).toBeCalledWith({
       workspaceId: undefined,
       entityId: defaultNode.ref,
       entityName: defaultNode.name + '_' + defaultNode.ref,
@@ -95,25 +104,28 @@ describe('updateEntity', () => {
         ModelRef: { componentTypeId: '3d.modelRef' },
         ModelShader: { componentTypeId: '3d.modelShader' },
         Light: { componentTypeId: '3d.light' },
+        SubModelRef: { componentTypeId: '3d.subModelRef' },
       },
     });
 
-    expect(updateNodeEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateNodeEntityComponent).toHaveBeenCalledWith(defaultNode, undefined, 'UPDATE');
-    expect(updateTagEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateTagEntityComponent).toHaveBeenCalledWith(tag);
-    expect(updateOverlayEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateOverlayEntityComponent).toHaveBeenCalledWith(overlay);
-    expect(updateCameraEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateCameraEntityComponent).toHaveBeenCalledWith(camera);
-    expect(updateMotionIndicatorEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateMotionIndicatorEntityComponent).toHaveBeenCalledWith(motionIndicator);
-    expect(updateModelRefComponent).toHaveBeenCalledTimes(1);
-    expect(updateModelRefComponent).toHaveBeenCalledWith(modelRef);
-    expect(updateModelShaderEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateModelShaderEntityComponent).toHaveBeenCalledWith(modelShader);
-    expect(updateLightEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateLightEntityComponent).toHaveBeenCalledWith(light);
+    expect(updateNodeEntityComponent).toBeCalledTimes(1);
+    expect(updateNodeEntityComponent).toBeCalledWith(defaultNode, undefined, 'UPDATE');
+    expect(updateTagEntityComponent).toBeCalledTimes(1);
+    expect(updateTagEntityComponent).toBeCalledWith(tag);
+    expect(updateOverlayEntityComponent).toBeCalledTimes(1);
+    expect(updateOverlayEntityComponent).toBeCalledWith(overlay);
+    expect(updateCameraEntityComponent).toBeCalledTimes(1);
+    expect(updateCameraEntityComponent).toBeCalledWith(camera);
+    expect(updateMotionIndicatorEntityComponent).toBeCalledTimes(1);
+    expect(updateMotionIndicatorEntityComponent).toBeCalledWith(motionIndicator);
+    expect(updateModelRefEntityComponent).toBeCalledTimes(1);
+    expect(updateModelRefEntityComponent).toBeCalledWith(modelRef);
+    expect(updateModelShaderEntityComponent).toBeCalledTimes(1);
+    expect(updateModelShaderEntityComponent).toBeCalledWith(modelShader);
+    expect(updateLightEntityComponent).toBeCalledTimes(1);
+    expect(updateLightEntityComponent).toBeCalledWith(light);
+    expect(updateSubModelRefEntityComponent).toBeCalledTimes(1);
+    expect(updateSubModelRefEntityComponent).toBeCalledWith(subModelRef);
   });
 
   it('should call update entity to update tag component', async () => {
@@ -121,8 +133,8 @@ describe('updateEntity', () => {
 
     await updateEntity(defaultNode, [compToUpdate], 'UPDATE');
 
-    expect(updateSceneEntity).toHaveBeenCalledTimes(1);
-    expect(updateSceneEntity).toHaveBeenCalledWith({
+    expect(updateSceneEntity).toBeCalledTimes(1);
+    expect(updateSceneEntity).toBeCalledWith({
       workspaceId: undefined,
       entityId: defaultNode.ref,
       entityName: defaultNode.name + '_' + defaultNode.ref,
@@ -132,11 +144,11 @@ describe('updateEntity', () => {
       },
     });
 
-    expect(updateNodeEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateNodeEntityComponent).toHaveBeenCalledWith(defaultNode, undefined, 'UPDATE');
-    expect(updateTagEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateTagEntityComponent).toHaveBeenCalledWith(compToUpdate);
-    expect(updateOverlayEntityComponent).not.toHaveBeenCalled();
+    expect(updateNodeEntityComponent).toBeCalledTimes(1);
+    expect(updateNodeEntityComponent).toBeCalledWith(defaultNode, undefined, 'UPDATE');
+    expect(updateTagEntityComponent).toBeCalledTimes(1);
+    expect(updateTagEntityComponent).toBeCalledWith(compToUpdate);
+    expect(updateOverlayEntityComponent).not.toBeCalled();
   });
 
   it('should call update entity to update overlay component', async () => {
@@ -144,8 +156,8 @@ describe('updateEntity', () => {
 
     await updateEntity(defaultNode, [compToUpdate], 'UPDATE');
 
-    expect(updateSceneEntity).toHaveBeenCalledTimes(1);
-    expect(updateSceneEntity).toHaveBeenCalledWith({
+    expect(updateSceneEntity).toBeCalledTimes(1);
+    expect(updateSceneEntity).toBeCalledWith({
       workspaceId: undefined,
       entityId: defaultNode.ref,
       entityName: defaultNode.name + '_' + defaultNode.ref,
@@ -155,11 +167,11 @@ describe('updateEntity', () => {
       },
     });
 
-    expect(updateNodeEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateNodeEntityComponent).toHaveBeenCalledWith(defaultNode, undefined, 'UPDATE');
-    expect(updateOverlayEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateOverlayEntityComponent).toHaveBeenCalledWith(compToUpdate);
-    expect(updateTagEntityComponent).not.toHaveBeenCalled();
+    expect(updateNodeEntityComponent).toBeCalledTimes(1);
+    expect(updateNodeEntityComponent).toBeCalledWith(defaultNode, undefined, 'UPDATE');
+    expect(updateOverlayEntityComponent).toBeCalledTimes(1);
+    expect(updateOverlayEntityComponent).toBeCalledWith(compToUpdate);
+    expect(updateTagEntityComponent).not.toBeCalled();
   });
 
   it('should call update entity without entity binding component', async () => {
@@ -167,8 +179,8 @@ describe('updateEntity', () => {
 
     await updateEntity(defaultNode, [compToUpdate], 'UPDATE');
 
-    expect(updateSceneEntity).toHaveBeenCalledTimes(1);
-    expect(updateSceneEntity).toHaveBeenCalledWith({
+    expect(updateSceneEntity).toBeCalledTimes(1);
+    expect(updateSceneEntity).toBeCalledWith({
       workspaceId: undefined,
       entityId: defaultNode.ref,
       entityName: defaultNode.name + '_' + defaultNode.ref,
@@ -177,10 +189,10 @@ describe('updateEntity', () => {
       },
     });
 
-    expect(updateNodeEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateNodeEntityComponent).toHaveBeenCalledWith(defaultNode, undefined, 'UPDATE');
-    expect(updateOverlayEntityComponent).not.toHaveBeenCalled();
-    expect(updateTagEntityComponent).not.toHaveBeenCalled();
+    expect(updateNodeEntityComponent).toBeCalledTimes(1);
+    expect(updateNodeEntityComponent).toBeCalledWith(defaultNode, undefined, 'UPDATE');
+    expect(updateOverlayEntityComponent).not.toBeCalled();
+    expect(updateTagEntityComponent).not.toBeCalled();
   });
 
   it('should call update entity to delete tag component', async () => {
@@ -188,8 +200,8 @@ describe('updateEntity', () => {
 
     await updateEntity(defaultNode, [compToUpdate], 'DELETE');
 
-    expect(updateSceneEntity).toHaveBeenCalledTimes(1);
-    expect(updateSceneEntity).toHaveBeenCalledWith({
+    expect(updateSceneEntity).toBeCalledTimes(1);
+    expect(updateSceneEntity).toBeCalledWith({
       workspaceId: undefined,
       entityId: defaultNode.ref,
       entityName: defaultNode.name + '_' + defaultNode.ref,
@@ -199,9 +211,9 @@ describe('updateEntity', () => {
       },
     });
 
-    expect(updateNodeEntityComponent).toHaveBeenCalledTimes(1);
-    expect(updateNodeEntityComponent).toHaveBeenCalledWith(defaultNode, undefined, 'DELETE');
-    expect(updateOverlayEntityComponent).not.toHaveBeenCalled();
-    expect(updateTagEntityComponent).not.toHaveBeenCalled();
+    expect(updateNodeEntityComponent).toBeCalledTimes(1);
+    expect(updateNodeEntityComponent).toBeCalledWith(defaultNode, undefined, 'DELETE');
+    expect(updateOverlayEntityComponent).not.toBeCalled();
+    expect(updateTagEntityComponent).not.toBeCalled();
   });
 });

--- a/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.ts
@@ -8,6 +8,7 @@ import {
   ILightComponent,
   IModelRefComponent,
   IMotionIndicatorComponent,
+  ISubModelRefComponent,
   KnownComponentType,
 } from '../../interfaces';
 import { ISceneComponentInternal, ISceneNodeInternal } from '../../store/internalInterfaces';
@@ -16,11 +17,12 @@ import { componentTypeToId } from '../../common/entityModelConstants';
 import { updateNodeEntityComponent } from './nodeComponent';
 import { updateTagEntityComponent } from './tagComponent';
 import { updateOverlayEntityComponent } from './overlayComponent';
-import { updateModelRefComponent } from './modelRefComponent';
+import { updateModelRefEntityComponent } from './modelRefComponent';
 import { updateCameraEntityComponent } from './cameraComponent';
 import { updateMotionIndicatorEntityComponent } from './motionIndicatorComponent';
 import { updateModelShaderEntityComponent } from './modelShaderComponent';
 import { updateLightEntityComponent } from './lightComponent';
+import { updateSubModelRefEntityComponent } from './subModelRefComponent';
 
 export const updateEntity = async (
   node: ISceneNodeInternal,
@@ -57,7 +59,7 @@ export const updateEntity = async (
             comp = updateOverlayEntityComponent(compToBeUpdated as IDataOverlayComponent);
             break;
           case KnownComponentType.ModelRef:
-            comp = updateModelRefComponent(compToBeUpdated as IModelRefComponent);
+            comp = updateModelRefEntityComponent(compToBeUpdated as IModelRefComponent);
             break;
           case KnownComponentType.Camera:
             comp = updateCameraEntityComponent(compToBeUpdated as ICameraComponent);
@@ -70,6 +72,9 @@ export const updateEntity = async (
             break;
           case KnownComponentType.Light:
             comp = updateLightEntityComponent(compToBeUpdated as ILightComponent);
+            break;
+          case KnownComponentType.SubModelRef:
+            comp = updateSubModelRefEntityComponent(compToBeUpdated as ISubModelRefComponent);
             break;
 
           default:


### PR DESCRIPTION
## Overview
utils to handle subModelRef component in entity

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
