### PR TITLE
fix(scene composer): show correct Icon field for tags with Custom Style

### DIFF
--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPicker.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/IconPicker/IconPicker.tsx
@@ -68,6 +68,13 @@ export const IconPicker = ({
     else setNumRows(totalPages); // restore default when no text in search field.
   }, [filteringText]);
 
+  useEffect(() => {
+    setIcon({
+      prefix: selectedIcon.prefix as IconPrefix,
+      iconName: selectedIcon.iconName as IconName,
+    });
+  }, [selectedIcon]);
+
   const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
     const { scrollTop, clientHeight, scrollHeight } = event.currentTarget;
     if (scrollTop + clientHeight === scrollHeight && numRows < totalPages) {


### PR DESCRIPTION
## Overview
This PR provide a fix for Icon field is not showing the correct value for the tags with custom style. It keeps showing the icon used for the first selected tag on scene load or of the one for which user has configured the icon most recently.

Before


https://github.com/awslabs/iot-app-kit/assets/20994167/1a49db25-28e7-46c6-a370-3aa2a744fc8f

After 


https://github.com/awslabs/iot-app-kit/assets/20994167/9f852fb5-f7b3-4cf1-b829-a0c26d35a5ec



## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
