### PR TITLE
fix: cloudscape dependency resolution failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       ],
       "dependencies": {
         "@cloudscape-design/collection-hooks": "1.0.22",
+        "@cloudscape-design/component-toolkit": "1.0.0-beta.27",
         "@cloudscape-design/components": "3.0.415",
         "@cloudscape-design/design-tokens": "3.0.15",
         "@cloudscape-design/global-styles": "1.0.12"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@cloudscape-design/component-toolkit": "1.0.0-beta.27",
     "@cloudscape-design/collection-hooks": "1.0.22",
     "@cloudscape-design/components": "3.0.415",
     "@cloudscape-design/design-tokens": "3.0.15",


### PR DESCRIPTION
## Overview
This change fixes an dependency resolution issue with a recent upgrade of `@awsui/components-react`.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
