### PR TITLE
fix(composer): get entityBinding in different query

### DIFF
--- a/packages/scene-composer/src/components/SceneLayers.spec.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.spec.tsx
@@ -6,6 +6,7 @@ import { useStore } from '../store';
 import { processQueries } from '../utils/entityModelUtils/processQueries';
 import { KnownSceneProperty } from '../interfaces';
 import { LAYER_DEFAULT_REFRESH_INTERVAL } from '../utils/entityModelUtils/sceneLayerUtils';
+import { DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME } from '../common/entityModelConstants';
 
 import { SceneLayers } from './SceneLayers';
 
@@ -142,7 +143,10 @@ describe('SceneLayers', () => {
 
     expect(processQueries as jest.Mock).toBeCalledTimes(1);
     expect(processQueries as jest.Mock).toBeCalledWith(
-      [expect.stringContaining("AND e.entityId = 'layer1'")],
+      [
+        expect.stringContaining("AND e.entityId = 'layer1'"),
+        expect.stringContaining(`MATCH (binding)<-[r2:${DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME}]-(entity)-[r]->(e)`),
+      ],
       expect.anything(),
     );
     expect(renderSceneNodesFromLayersMock).not.toBeCalled();

--- a/packages/scene-composer/src/components/SceneLayers.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.tsx
@@ -28,12 +28,18 @@ export const SceneLayers: React.FC = () => {
     queryFn: async () => {
       const nodes = await processQueries(
         [
+          // Get node entities in the layer
           `SELECT entity, r, e
         FROM EntityGraph 
         MATCH (entity)-[r]->(e)
-        WHERE (r.relationshipName = '${DEFAULT_LAYER_RELATIONSHIP_NAME}'
-        AND e.entityId = '${layerId}')
-        OR r.relationshipName = '${DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME}'`,
+        WHERE r.relationshipName = '${DEFAULT_LAYER_RELATIONSHIP_NAME}'
+        AND e.entityId = '${layerId}'`,
+          // Get entityBinding for the nodes in the layer
+          `SELECT entity, r2, binding
+        FROM EntityGraph 
+        MATCH (binding)<-[r2:${DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME}]-(entity)-[r]->(e)
+        WHERE r.relationshipName = '${DEFAULT_LAYER_RELATIONSHIP_NAME}'
+        AND e.entityId = '${layerId}'`,
         ],
         (node) => (node.properties.layerIds = [...(node.properties.layerIds ?? []), layerId!]),
       );

--- a/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
+++ b/packages/scene-composer/src/hooks/useMatterportTags.spec.ts
@@ -195,6 +195,23 @@ ${mattertagItem.description}`,
     );
   });
 
+  it('should update matterport mattertag node name correctly when label is empty', () => {
+    const { handleUpdateMatterportTag } = renderHook(() => useMatterportTags()).result.current;
+
+    handleUpdateMatterportTag({
+      ref: '',
+      node: { ...testInternalNode, name: 'random' },
+      item: { ...mattertagItem, label: '' },
+    });
+    expect(updateSceneNodeInternal).toBeCalledWith(
+      '',
+      expect.objectContaining({
+        name: 'random',
+      }),
+      false,
+    );
+  });
+
   it('should delete matterport mattertag or tag', () => {
     const { handleRemoveMatterportTag } = renderHook(() => useMatterportTags()).result.current;
 

--- a/packages/scene-composer/src/hooks/useMatterportTags.ts
+++ b/packages/scene-composer/src/hooks/useMatterportTags.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { Color } from 'three';
+import { isEmpty } from 'lodash';
 
 import { useSceneComposerId } from '../common/sceneComposerIdContext';
 import {
@@ -119,7 +120,7 @@ const updateTag = (
   updateSceneNode(
     ref,
     {
-      name: item.label,
+      name: isEmpty(item.label) ? node.name : item.label,
       transform: {
         position: [item.anchorPosition.x, item.anchorPosition.y, item.anchorPosition.z],
       },

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
@@ -76,7 +76,7 @@ export const createNodeEntity = async (
           break;
 
         default:
-          throw new Error('Component type not supported');
+          throw new Error(`Component type not supported: ${compToBeCreated.type}`);
       }
 
       if (comp) {


### PR DESCRIPTION
## Overview
- get entityBinding in different query and only for entities in the layer

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
