### PR TITLE
chore(fix-dependency): cloudscape version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "dependencies": {
         "@cloudscape-design/collection-hooks": "1.0.22",
-        "@cloudscape-design/component-toolkit": "1.0.0-beta.27",
+        "@cloudscape-design/component-toolkit": "1.0.0-beta.26",
         "@cloudscape-design/components": "3.0.415",
         "@cloudscape-design/design-tokens": "3.0.15",
         "@cloudscape-design/global-styles": "1.0.12"
@@ -9927,9 +9927,9 @@
       }
     },
     "node_modules/@cloudscape-design/component-toolkit": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.27.tgz",
-      "integrity": "sha512-quKhlNQjGw/+VAF8V938I/gCkmrRpfDJ1xAlsjYfTtipOUvCIYnZ5813OAwx+hGVHCFr+0pDSYR9+kAVGJGGRg==",
+      "version": "1.0.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.26.tgz",
+      "integrity": "sha512-nUS3iRsV5mbYzQmH8104eTJj0GotkJQxEoJjqdu4WyJvwJez4KCJCdN3YtV8anWPxMCkDiKMhvvsDcL2i9w1WA==",
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1",
         "tslib": "^2.3.1"
@@ -69677,9 +69677,9 @@
       "integrity": "sha512-U5n438CmBuh+FdpREHYlViX/qCU7WcChBJ2gDAeWllNYEtb4/jwtQ2SITuipAZ9QONahkBCQX9JQNKzDfPnPEA=="
     },
     "@cloudscape-design/component-toolkit": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.27.tgz",
-      "integrity": "sha512-quKhlNQjGw/+VAF8V938I/gCkmrRpfDJ1xAlsjYfTtipOUvCIYnZ5813OAwx+hGVHCFr+0pDSYR9+kAVGJGGRg==",
+      "version": "1.0.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.26.tgz",
+      "integrity": "sha512-nUS3iRsV5mbYzQmH8104eTJj0GotkJQxEoJjqdu4WyJvwJez4KCJCdN3YtV8anWPxMCkDiKMhvvsDcL2i9w1WA==",
       "requires": {
         "@juggle/resize-observer": "^3.3.1",
         "tslib": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@cloudscape-design/component-toolkit": "1.0.0-beta.27",
+    "@cloudscape-design/component-toolkit": "1.0.0-beta.26",
     "@cloudscape-design/collection-hooks": "1.0.22",
     "@cloudscape-design/components": "3.0.415",
     "@cloudscape-design/design-tokens": "3.0.15",


### PR DESCRIPTION
## Overview
Updated the version of `@cloudscape-design/component-toolkit` package to fix the build failure

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
