### PR TITLE
fix: broken tooltip imports

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
@@ -21,7 +21,7 @@ import {
   StatusEyeHidden,
   StatusEyeVisible,
 } from '~/customization/propertiesSections/propertiesAndAlarmsSettings/icons';
-import { Tooltip } from '@iot-app-kit/react-components/src';
+import { Tooltip } from '@iot-app-kit/react-components';
 import { LineStyleDropdown } from '../components/lineStyleDropdown';
 import { LineThicknessDropdown } from '../components/lineThicknessDropdown';
 

--- a/packages/react-components/src/components/chart/trendCursor/calculations/viewport.ts
+++ b/packages/react-components/src/components/chart/trendCursor/calculations/viewport.ts
@@ -1,4 +1,4 @@
-import { DurationViewport, Viewport } from '@iot-app-kit/core/src';
+import { DurationViewport, Viewport } from '@iot-app-kit/core';
 import { parseDuration } from '../../../../utils/time';
 
 export const isDurationViewport = (viewport: Viewport): viewport is DurationViewport =>


### PR DESCRIPTION
## Overview
Provide an explanation of what the change is

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
