### PR TITLE
fix(dashboard): toggle from hide to show for unmodeled datastreams

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledSection.tsx
@@ -114,7 +114,7 @@ export const StyledPropertiesAlarmsSection: FC<StyledPropertiesAlarmsSectionProp
             styledAssetQuery?.properties?.map((property) => {
               if (property.propertyAlias === propertyAlias) {
                 const visible = property.visible !== undefined ? !property.visible : false;
-                return visible ? property : { ...property, visible: false };
+                return { ...property, visible };
               } else {
                 return property;
               }


### PR DESCRIPTION
## Overview
Changed ternary operator to ensure that unmodeled data streams can be shown after being hidden.

## Verifying Changes


https://github.com/awslabs/iot-app-kit/assets/145582655/bdb56f36-b2e1-4b1a-8062-42294001e4c2


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
