### PR TITLE
fix(composer): new tag style field is empty instead of info

### DIFF
--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
@@ -119,6 +119,7 @@ describe('AddObjectMenu', () => {
 
   it('should call appendSceneNode when adding a tag', () => {
     const anchorComponent: IAnchorComponent = {
+      icon: 'Info',
       type: 'Tag',
     };
 

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -3,6 +3,7 @@ import { defineMessages, MessageDescriptor, useIntl } from 'react-intl';
 import * as THREE from 'three';
 import { IconProps } from '@awsui/components-react';
 
+import { getSceneResourceDefaultValue } from '../../../../utils/sceneResourceUtils';
 import { DEFAULT_LIGHT_SETTINGS_MAP } from '../../../../common/constants';
 import {
   COMPOSER_FEATURES,
@@ -15,6 +16,7 @@ import {
   IMotionIndicatorComponent,
   ISceneNode,
   KnownComponentType,
+  SceneResourceType,
 } from '../../../../interfaces';
 import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
 import { Component, LightType, ModelType } from '../../../../models/SceneModels';
@@ -175,7 +177,9 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
   }, [selectedSceneNodeRef, selectedSceneNode]);
 
   const handleAddAnchor = useCallback(() => {
+    const type = SceneResourceType.Icon;
     const anchorComponent: IAnchorComponent = {
+      icon: getSceneResourceDefaultValue(type),
       type: 'Tag',
     };
     const node = {


### PR DESCRIPTION
## Overview
In this PR Tag style field for newly created tag adjusted  to show Info, since newly created tag uses DefaultAnchorStatus.Info icon anyway so this correctly reflect the default icon that the code default to. No point of hiding that in the UI if we wanted a different Default or new tag creation workflow that should be addressed comprehensively in code.

Before


https://github.com/awslabs/iot-app-kit/assets/20994167/af1cb83c-0e5a-422a-babf-58802052d5a3

After


https://github.com/awslabs/iot-app-kit/assets/20994167/fe47650c-d811-41c9-95de-440f1f89d1fd



## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
