### PR TITLE
fix(scene): stop scene composer from forcing dark mode on page

### DIFF
--- a/packages/scene-composer/src/components/__snapshots__/SceneComposerInternalSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/SceneComposerInternalSnap.spec.tsx.snap
@@ -1,90 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SceneComposerInternal should render a default error view when loading a bad scene content 1`] = `
-<StaticLayout
-  header={<MenuBar />}
-  leftPanel={
-    <ScenePanel
-      direction="Left"
-      panels={
-        Object {
-          "Hierarchy": <SceneHierarchyPanel />,
-          "Rules": <SceneRulesPanel />,
-          "Settings": <SettingsPanel />,
-        }
-      }
-    />
+<div
+  style={
+    Object {
+      "height": "100%",
+      "minHeight": "100%",
+      "minWidth": "100%",
+      "width": "100%",
+    }
   }
-  mainContent={
-    <React.Fragment>
-      <LogProvider
-        ErrorView={[Function]}
-        namespace="SceneLayout"
-      >
-        <FloatingToolbar
-          isViewing={false}
-        />
-        <Unknown>
-          <R3FWrapper
-            sceneLoaded={true}
-          >
-            <React.Suspense
-              fallback={
-                <Provider>
-                  <LoadingProgress />
-                </Provider>
-              }
-            >
-              <React.Fragment>
-                <WebGLCanvasManager />
-              </React.Fragment>
-            </React.Suspense>
-          </R3FWrapper>
-        </Unknown>
-      </LogProvider>
-    </React.Fragment>
-  }
-  modalContent={<MessageModal />}
-  rightPanel={
-    <ScenePanel
-      direction="Right"
-      panels={
-        Object {
-          "Inspector": <SceneNodeInspectorPanel />,
-        }
-      }
-    />
-  }
-  showModal={true}
-  topBar={<TopBar />}
-/>
-`;
-
-exports[`SceneComposerInternal should render a default error view when unknown error happens 1`] = `
-<StaticLayout
-  modalContent={
-    <Styled(MockContainer)
-      header={
-        <MockHeader
-          variant="h2"
-        >
-          Error
-        </MockHeader>
-      }
-    >
-      <MockTextContent>
-        <p>
-          failed to render
-        </p>
-      </MockTextContent>
-    </Styled(MockContainer)>
-  }
-  showModal={true}
-/>
-`;
-
-exports[`SceneComposerInternal should render both valid and invalid scene correctly 1`] = `
-<div>
+>
   <StaticLayout
     header={<MenuBar />}
     leftPanel={
@@ -142,6 +68,195 @@ exports[`SceneComposerInternal should render both valid and invalid scene correc
     showModal={true}
     topBar={<TopBar />}
   />
+</div>
+`;
+
+exports[`SceneComposerInternal should render a default error view when unknown error happens 1`] = `
+<div
+  style={
+    Object {
+      "height": "100%",
+      "minHeight": "100%",
+      "minWidth": "100%",
+      "width": "100%",
+    }
+  }
+>
+  <StaticLayout
+    modalContent={
+      <Styled(MockContainer)
+        header={
+          <MockHeader
+            variant="h2"
+          >
+            Error
+          </MockHeader>
+        }
+      >
+        <MockTextContent>
+          <p>
+            failed to render
+          </p>
+        </MockTextContent>
+      </Styled(MockContainer)>
+    }
+    showModal={true}
+  />
+</div>
+`;
+
+exports[`SceneComposerInternal should render both valid and invalid scene correctly 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "height": "100%",
+        "minHeight": "100%",
+        "minWidth": "100%",
+        "width": "100%",
+      }
+    }
+  >
+    <StaticLayout
+      header={<MenuBar />}
+      leftPanel={
+        <ScenePanel
+          direction="Left"
+          panels={
+            Object {
+              "Hierarchy": <SceneHierarchyPanel />,
+              "Rules": <SceneRulesPanel />,
+              "Settings": <SettingsPanel />,
+            }
+          }
+        />
+      }
+      mainContent={
+        <React.Fragment>
+          <LogProvider
+            ErrorView={[Function]}
+            namespace="SceneLayout"
+          >
+            <FloatingToolbar
+              isViewing={false}
+            />
+            <Unknown>
+              <R3FWrapper
+                sceneLoaded={true}
+              >
+                <React.Suspense
+                  fallback={
+                    <Provider>
+                      <LoadingProgress />
+                    </Provider>
+                  }
+                >
+                  <React.Fragment>
+                    <WebGLCanvasManager />
+                  </React.Fragment>
+                </React.Suspense>
+              </R3FWrapper>
+            </Unknown>
+          </LogProvider>
+        </React.Fragment>
+      }
+      modalContent={<MessageModal />}
+      rightPanel={
+        <ScenePanel
+          direction="Right"
+          panels={
+            Object {
+              "Inspector": <SceneNodeInspectorPanel />,
+            }
+          }
+        />
+      }
+      showModal={true}
+      topBar={<TopBar />}
+    />
+  </div>
+  <div
+    style={
+      Object {
+        "height": "100%",
+        "minHeight": "100%",
+        "minWidth": "100%",
+        "width": "100%",
+      }
+    }
+  >
+    <StaticLayout
+      header={<MenuBar />}
+      leftPanel={
+        <ScenePanel
+          direction="Left"
+          panels={
+            Object {
+              "Hierarchy": <SceneHierarchyPanel />,
+              "Rules": <SceneRulesPanel />,
+              "Settings": <SettingsPanel />,
+            }
+          }
+        />
+      }
+      mainContent={
+        <React.Fragment>
+          <LogProvider
+            ErrorView={[Function]}
+            namespace="SceneLayout"
+          >
+            <FloatingToolbar
+              isViewing={false}
+            />
+            <Unknown>
+              <R3FWrapper
+                sceneLoaded={true}
+              >
+                <React.Suspense
+                  fallback={
+                    <Provider>
+                      <LoadingProgress />
+                    </Provider>
+                  }
+                >
+                  <React.Fragment>
+                    <WebGLCanvasManager />
+                  </React.Fragment>
+                </React.Suspense>
+              </R3FWrapper>
+            </Unknown>
+          </LogProvider>
+        </React.Fragment>
+      }
+      modalContent={<MessageModal />}
+      rightPanel={
+        <ScenePanel
+          direction="Right"
+          panels={
+            Object {
+              "Inspector": <SceneNodeInspectorPanel />,
+            }
+          }
+        />
+      }
+      showModal={false}
+      topBar={<TopBar />}
+    />
+  </div>
+</div>
+`;
+
+exports[`SceneComposerInternal should render correctly with a valid scene in editing mode 1`] = `
+<div
+  style={
+    Object {
+      "height": "100%",
+      "minHeight": "100%",
+      "minWidth": "100%",
+      "width": "100%",
+    }
+  }
+>
   <StaticLayout
     header={<MenuBar />}
     leftPanel={
@@ -202,460 +317,477 @@ exports[`SceneComposerInternal should render both valid and invalid scene correc
 </div>
 `;
 
-exports[`SceneComposerInternal should render correctly with a valid scene in editing mode 1`] = `
-<StaticLayout
-  header={<MenuBar />}
-  leftPanel={
-    <ScenePanel
-      direction="Left"
-      panels={
-        Object {
-          "Hierarchy": <SceneHierarchyPanel />,
-          "Rules": <SceneRulesPanel />,
-          "Settings": <SettingsPanel />,
-        }
-      }
-    />
-  }
-  mainContent={
-    <React.Fragment>
-      <LogProvider
-        ErrorView={[Function]}
-        namespace="SceneLayout"
-      >
-        <FloatingToolbar
-          isViewing={false}
-        />
-        <Unknown>
-          <R3FWrapper
-            sceneLoaded={true}
-          >
-            <React.Suspense
-              fallback={
-                <Provider>
-                  <LoadingProgress />
-                </Provider>
-              }
-            >
-              <React.Fragment>
-                <WebGLCanvasManager />
-              </React.Fragment>
-            </React.Suspense>
-          </R3FWrapper>
-        </Unknown>
-      </LogProvider>
-    </React.Fragment>
-  }
-  modalContent={<MessageModal />}
-  rightPanel={
-    <ScenePanel
-      direction="Right"
-      panels={
-        Object {
-          "Inspector": <SceneNodeInspectorPanel />,
-        }
-      }
-    />
-  }
-  showModal={false}
-  topBar={<TopBar />}
-/>
-`;
-
 exports[`SceneComposerInternal should render correctly with an empty scene in editing mode 1`] = `
-<StaticLayout
-  header={<MenuBar />}
-  leftPanel={
-    <ScenePanel
-      direction="Left"
-      panels={
-        Object {
-          "Hierarchy": <SceneHierarchyPanel />,
-          "Rules": <SceneRulesPanel />,
-          "Settings": <SettingsPanel />,
+<div
+  style={
+    Object {
+      "height": "100%",
+      "minHeight": "100%",
+      "minWidth": "100%",
+      "width": "100%",
+    }
+  }
+>
+  <StaticLayout
+    header={<MenuBar />}
+    leftPanel={
+      <ScenePanel
+        direction="Left"
+        panels={
+          Object {
+            "Hierarchy": <SceneHierarchyPanel />,
+            "Rules": <SceneRulesPanel />,
+            "Settings": <SettingsPanel />,
+          }
         }
-      }
-    />
-  }
-  mainContent={
-    <React.Fragment>
-      <LogProvider
-        ErrorView={[Function]}
-        namespace="SceneLayout"
-      >
-        <FloatingToolbar
-          isViewing={false}
-        />
-        <Unknown>
-          <R3FWrapper>
-            <React.Suspense
-              fallback={
-                <Provider>
-                  <LoadingProgress />
-                </Provider>
-              }
-            />
-          </R3FWrapper>
-        </Unknown>
-      </LogProvider>
-    </React.Fragment>
-  }
-  modalContent={<MessageModal />}
-  rightPanel={
-    <ScenePanel
-      direction="Right"
-      panels={
-        Object {
-          "Inspector": <SceneNodeInspectorPanel />,
+      />
+    }
+    mainContent={
+      <React.Fragment>
+        <LogProvider
+          ErrorView={[Function]}
+          namespace="SceneLayout"
+        >
+          <FloatingToolbar
+            isViewing={false}
+          />
+          <Unknown>
+            <R3FWrapper>
+              <React.Suspense
+                fallback={
+                  <Provider>
+                    <LoadingProgress />
+                  </Provider>
+                }
+              />
+            </R3FWrapper>
+          </Unknown>
+        </LogProvider>
+      </React.Fragment>
+    }
+    modalContent={<MessageModal />}
+    rightPanel={
+      <ScenePanel
+        direction="Right"
+        panels={
+          Object {
+            "Inspector": <SceneNodeInspectorPanel />,
+          }
         }
-      }
-    />
-  }
-  showModal={false}
-  topBar={<TopBar />}
-/>
+      />
+    }
+    showModal={false}
+    topBar={<TopBar />}
+  />
+</div>
 `;
 
 exports[`SceneComposerInternal should render correctly with an empty scene in viewing mode 1`] = `
-<StaticLayout
-  header={false}
-  leftPanel={
-    <ScenePanel
-      collapse={true}
-      direction="Left"
-      panels={
-        Object {
-          "Hierarchy": <SceneHierarchyPanel />,
-          "Settings": <SettingsPanel />,
+<div
+  style={
+    Object {
+      "height": "100%",
+      "minHeight": "100%",
+      "minWidth": "100%",
+      "width": "100%",
+    }
+  }
+>
+  <StaticLayout
+    header={false}
+    leftPanel={
+      <ScenePanel
+        collapse={true}
+        direction="Left"
+        panels={
+          Object {
+            "Hierarchy": <SceneHierarchyPanel />,
+            "Settings": <SettingsPanel />,
+          }
         }
-      }
-    />
-  }
-  mainContent={
-    <React.Fragment>
-      <LogProvider
-        ErrorView={[Function]}
-        namespace="SceneLayout"
-      >
-        <FloatingToolbar
-          isViewing={true}
-        />
-        <Unknown>
-          <R3FWrapper>
-            <React.Suspense
-              fallback={
-                <Provider>
-                  <LoadingProgress />
-                </Provider>
-              }
-            />
-          </R3FWrapper>
-        </Unknown>
-      </LogProvider>
-    </React.Fragment>
-  }
-  modalContent={<MessageModal />}
-  rightPanel={false}
-  showModal={false}
-  topBar={<TopBar />}
-/>
+      />
+    }
+    mainContent={
+      <React.Fragment>
+        <LogProvider
+          ErrorView={[Function]}
+          namespace="SceneLayout"
+        >
+          <FloatingToolbar
+            isViewing={true}
+          />
+          <Unknown>
+            <R3FWrapper>
+              <React.Suspense
+                fallback={
+                  <Provider>
+                    <LoadingProgress />
+                  </Provider>
+                }
+              />
+            </R3FWrapper>
+          </Unknown>
+        </LogProvider>
+      </React.Fragment>
+    }
+    modalContent={<MessageModal />}
+    rightPanel={false}
+    showModal={false}
+    topBar={<TopBar />}
+  />
+</div>
 `;
 
 exports[`SceneComposerInternal should render error when major version is newer 1`] = `
-<StaticLayout
-  header={<MenuBar />}
-  leftPanel={
-    <ScenePanel
-      direction="Left"
-      panels={
-        Object {
-          "Hierarchy": <SceneHierarchyPanel />,
-          "Rules": <SceneRulesPanel />,
-          "Settings": <SettingsPanel />,
-        }
-      }
-    />
+<div
+  style={
+    Object {
+      "height": "100%",
+      "minHeight": "100%",
+      "minWidth": "100%",
+      "width": "100%",
+    }
   }
-  mainContent={
-    <React.Fragment>
-      <LogProvider
-        ErrorView={[Function]}
-        namespace="SceneLayout"
-      >
-        <FloatingToolbar
-          isViewing={false}
-        />
-        <Unknown>
-          <R3FWrapper
-            sceneLoaded={true}
-          >
-            <React.Suspense
-              fallback={
-                <Provider>
-                  <LoadingProgress />
-                </Provider>
-              }
+>
+  <StaticLayout
+    header={<MenuBar />}
+    leftPanel={
+      <ScenePanel
+        direction="Left"
+        panels={
+          Object {
+            "Hierarchy": <SceneHierarchyPanel />,
+            "Rules": <SceneRulesPanel />,
+            "Settings": <SettingsPanel />,
+          }
+        }
+      />
+    }
+    mainContent={
+      <React.Fragment>
+        <LogProvider
+          ErrorView={[Function]}
+          namespace="SceneLayout"
+        >
+          <FloatingToolbar
+            isViewing={false}
+          />
+          <Unknown>
+            <R3FWrapper
+              sceneLoaded={true}
             >
-              <React.Fragment>
-                <WebGLCanvasManager />
-              </React.Fragment>
-            </React.Suspense>
-          </R3FWrapper>
-        </Unknown>
-      </LogProvider>
-    </React.Fragment>
-  }
-  modalContent={<MessageModal />}
-  rightPanel={
-    <ScenePanel
-      direction="Right"
-      panels={
-        Object {
-          "Inspector": <SceneNodeInspectorPanel />,
+              <React.Suspense
+                fallback={
+                  <Provider>
+                    <LoadingProgress />
+                  </Provider>
+                }
+              >
+                <React.Fragment>
+                  <WebGLCanvasManager />
+                </React.Fragment>
+              </React.Suspense>
+            </R3FWrapper>
+          </Unknown>
+        </LogProvider>
+      </React.Fragment>
+    }
+    modalContent={<MessageModal />}
+    rightPanel={
+      <ScenePanel
+        direction="Right"
+        panels={
+          Object {
+            "Inspector": <SceneNodeInspectorPanel />,
+          }
         }
-      }
-    />
-  }
-  showModal={true}
-  topBar={<TopBar />}
-/>
+      />
+    }
+    showModal={true}
+    topBar={<TopBar />}
+  />
+</div>
 `;
 
 exports[`SceneComposerInternal should render error when specVersion is invalid 1`] = `
-<StaticLayout
-  header={<MenuBar />}
-  leftPanel={
-    <ScenePanel
-      direction="Left"
-      panels={
-        Object {
-          "Hierarchy": <SceneHierarchyPanel />,
-          "Rules": <SceneRulesPanel />,
-          "Settings": <SettingsPanel />,
-        }
-      }
-    />
+<div
+  style={
+    Object {
+      "height": "100%",
+      "minHeight": "100%",
+      "minWidth": "100%",
+      "width": "100%",
+    }
   }
-  mainContent={
-    <React.Fragment>
-      <LogProvider
-        ErrorView={[Function]}
-        namespace="SceneLayout"
-      >
-        <FloatingToolbar
-          isViewing={false}
-        />
-        <Unknown>
-          <R3FWrapper
-            sceneLoaded={true}
-          >
-            <React.Suspense
-              fallback={
-                <Provider>
-                  <LoadingProgress />
-                </Provider>
-              }
+>
+  <StaticLayout
+    header={<MenuBar />}
+    leftPanel={
+      <ScenePanel
+        direction="Left"
+        panels={
+          Object {
+            "Hierarchy": <SceneHierarchyPanel />,
+            "Rules": <SceneRulesPanel />,
+            "Settings": <SettingsPanel />,
+          }
+        }
+      />
+    }
+    mainContent={
+      <React.Fragment>
+        <LogProvider
+          ErrorView={[Function]}
+          namespace="SceneLayout"
+        >
+          <FloatingToolbar
+            isViewing={false}
+          />
+          <Unknown>
+            <R3FWrapper
+              sceneLoaded={true}
             >
-              <React.Fragment>
-                <WebGLCanvasManager />
-              </React.Fragment>
-            </React.Suspense>
-          </R3FWrapper>
-        </Unknown>
-      </LogProvider>
-    </React.Fragment>
-  }
-  modalContent={<MessageModal />}
-  rightPanel={
-    <ScenePanel
-      direction="Right"
-      panels={
-        Object {
-          "Inspector": <SceneNodeInspectorPanel />,
+              <React.Suspense
+                fallback={
+                  <Provider>
+                    <LoadingProgress />
+                  </Provider>
+                }
+              >
+                <React.Fragment>
+                  <WebGLCanvasManager />
+                </React.Fragment>
+              </React.Suspense>
+            </R3FWrapper>
+          </Unknown>
+        </LogProvider>
+      </React.Fragment>
+    }
+    modalContent={<MessageModal />}
+    rightPanel={
+      <ScenePanel
+        direction="Right"
+        panels={
+          Object {
+            "Inspector": <SceneNodeInspectorPanel />,
+          }
         }
-      }
-    />
-  }
-  showModal={true}
-  topBar={<TopBar />}
-/>
+      />
+    }
+    showModal={true}
+    topBar={<TopBar />}
+  />
+</div>
 `;
 
 exports[`SceneComposerInternal should render warning when minor version is newer 1`] = `
-<StaticLayout
-  header={<MenuBar />}
-  leftPanel={
-    <ScenePanel
-      direction="Left"
-      panels={
-        Object {
-          "Hierarchy": <SceneHierarchyPanel />,
-          "Rules": <SceneRulesPanel />,
-          "Settings": <SettingsPanel />,
-        }
-      }
-    />
+<div
+  style={
+    Object {
+      "height": "100%",
+      "minHeight": "100%",
+      "minWidth": "100%",
+      "width": "100%",
+    }
   }
-  mainContent={
-    <React.Fragment>
-      <LogProvider
-        ErrorView={[Function]}
-        namespace="SceneLayout"
-      >
-        <FloatingToolbar
-          isViewing={false}
-        />
-        <Unknown>
-          <R3FWrapper
-            sceneLoaded={true}
-          >
-            <React.Suspense
-              fallback={
-                <Provider>
-                  <LoadingProgress />
-                </Provider>
-              }
+>
+  <StaticLayout
+    header={<MenuBar />}
+    leftPanel={
+      <ScenePanel
+        direction="Left"
+        panels={
+          Object {
+            "Hierarchy": <SceneHierarchyPanel />,
+            "Rules": <SceneRulesPanel />,
+            "Settings": <SettingsPanel />,
+          }
+        }
+      />
+    }
+    mainContent={
+      <React.Fragment>
+        <LogProvider
+          ErrorView={[Function]}
+          namespace="SceneLayout"
+        >
+          <FloatingToolbar
+            isViewing={false}
+          />
+          <Unknown>
+            <R3FWrapper
+              sceneLoaded={true}
             >
-              <React.Fragment>
-                <WebGLCanvasManager />
-              </React.Fragment>
-            </React.Suspense>
-          </R3FWrapper>
-        </Unknown>
-      </LogProvider>
-    </React.Fragment>
-  }
-  modalContent={<MessageModal />}
-  rightPanel={
-    <ScenePanel
-      direction="Right"
-      panels={
-        Object {
-          "Inspector": <SceneNodeInspectorPanel />,
+              <React.Suspense
+                fallback={
+                  <Provider>
+                    <LoadingProgress />
+                  </Provider>
+                }
+              >
+                <React.Fragment>
+                  <WebGLCanvasManager />
+                </React.Fragment>
+              </React.Suspense>
+            </R3FWrapper>
+          </Unknown>
+        </LogProvider>
+      </React.Fragment>
+    }
+    modalContent={<MessageModal />}
+    rightPanel={
+      <ScenePanel
+        direction="Right"
+        panels={
+          Object {
+            "Inspector": <SceneNodeInspectorPanel />,
+          }
         }
-      }
-    />
-  }
-  showModal={true}
-  topBar={<TopBar />}
-/>
+      />
+    }
+    showModal={true}
+    topBar={<TopBar />}
+  />
+</div>
 `;
 
 exports[`SceneComposerInternal should support rendering multiple valid scenes 1`] = `
 <div>
-  <StaticLayout
-    header={<MenuBar />}
-    leftPanel={
-      <ScenePanel
-        direction="Left"
-        panels={
-          Object {
-            "Hierarchy": <SceneHierarchyPanel />,
-            "Rules": <SceneRulesPanel />,
-            "Settings": <SettingsPanel />,
-          }
-        }
-      />
+  <div
+    style={
+      Object {
+        "height": "100%",
+        "minHeight": "100%",
+        "minWidth": "100%",
+        "width": "100%",
+      }
     }
-    mainContent={
-      <React.Fragment>
-        <LogProvider
-          ErrorView={[Function]}
-          namespace="SceneLayout"
-        >
-          <FloatingToolbar
-            isViewing={false}
-          />
-          <Unknown>
-            <R3FWrapper
-              sceneLoaded={true}
-            >
-              <React.Suspense
-                fallback={
-                  <Provider>
-                    <LoadingProgress />
-                  </Provider>
-                }
+  >
+    <StaticLayout
+      header={<MenuBar />}
+      leftPanel={
+        <ScenePanel
+          direction="Left"
+          panels={
+            Object {
+              "Hierarchy": <SceneHierarchyPanel />,
+              "Rules": <SceneRulesPanel />,
+              "Settings": <SettingsPanel />,
+            }
+          }
+        />
+      }
+      mainContent={
+        <React.Fragment>
+          <LogProvider
+            ErrorView={[Function]}
+            namespace="SceneLayout"
+          >
+            <FloatingToolbar
+              isViewing={false}
+            />
+            <Unknown>
+              <R3FWrapper
+                sceneLoaded={true}
               >
-                <React.Fragment>
-                  <WebGLCanvasManager />
-                </React.Fragment>
-              </React.Suspense>
-            </R3FWrapper>
-          </Unknown>
-        </LogProvider>
-      </React.Fragment>
-    }
-    modalContent={<MessageModal />}
-    rightPanel={
-      <ScenePanel
-        direction="Right"
-        panels={
-          Object {
-            "Inspector": <SceneNodeInspectorPanel />,
+                <React.Suspense
+                  fallback={
+                    <Provider>
+                      <LoadingProgress />
+                    </Provider>
+                  }
+                >
+                  <React.Fragment>
+                    <WebGLCanvasManager />
+                  </React.Fragment>
+                </React.Suspense>
+              </R3FWrapper>
+            </Unknown>
+          </LogProvider>
+        </React.Fragment>
+      }
+      modalContent={<MessageModal />}
+      rightPanel={
+        <ScenePanel
+          direction="Right"
+          panels={
+            Object {
+              "Inspector": <SceneNodeInspectorPanel />,
+            }
           }
-        }
-      />
+        />
+      }
+      showModal={false}
+      topBar={<TopBar />}
+    />
+  </div>
+  <div
+    style={
+      Object {
+        "height": "100%",
+        "minHeight": "100%",
+        "minWidth": "100%",
+        "width": "100%",
+      }
     }
-    showModal={false}
-    topBar={<TopBar />}
-  />
-  <StaticLayout
-    header={<MenuBar />}
-    leftPanel={
-      <ScenePanel
-        direction="Left"
-        panels={
-          Object {
-            "Hierarchy": <SceneHierarchyPanel />,
-            "Rules": <SceneRulesPanel />,
-            "Settings": <SettingsPanel />,
+  >
+    <StaticLayout
+      header={<MenuBar />}
+      leftPanel={
+        <ScenePanel
+          direction="Left"
+          panels={
+            Object {
+              "Hierarchy": <SceneHierarchyPanel />,
+              "Rules": <SceneRulesPanel />,
+              "Settings": <SettingsPanel />,
+            }
           }
-        }
-      />
-    }
-    mainContent={
-      <React.Fragment>
-        <LogProvider
-          ErrorView={[Function]}
-          namespace="SceneLayout"
-        >
-          <FloatingToolbar
-            isViewing={false}
-          />
-          <Unknown>
-            <R3FWrapper
-              sceneLoaded={true}
-            >
-              <React.Suspense
-                fallback={
-                  <Provider>
-                    <LoadingProgress />
-                  </Provider>
-                }
+        />
+      }
+      mainContent={
+        <React.Fragment>
+          <LogProvider
+            ErrorView={[Function]}
+            namespace="SceneLayout"
+          >
+            <FloatingToolbar
+              isViewing={false}
+            />
+            <Unknown>
+              <R3FWrapper
+                sceneLoaded={true}
               >
-                <React.Fragment>
-                  <WebGLCanvasManager />
-                </React.Fragment>
-              </React.Suspense>
-            </R3FWrapper>
-          </Unknown>
-        </LogProvider>
-      </React.Fragment>
-    }
-    modalContent={<MessageModal />}
-    rightPanel={
-      <ScenePanel
-        direction="Right"
-        panels={
-          Object {
-            "Inspector": <SceneNodeInspectorPanel />,
+                <React.Suspense
+                  fallback={
+                    <Provider>
+                      <LoadingProgress />
+                    </Provider>
+                  }
+                >
+                  <React.Fragment>
+                    <WebGLCanvasManager />
+                  </React.Fragment>
+                </React.Suspense>
+              </R3FWrapper>
+            </Unknown>
+          </LogProvider>
+        </React.Fragment>
+      }
+      modalContent={<MessageModal />}
+      rightPanel={
+        <ScenePanel
+          direction="Right"
+          panels={
+            Object {
+              "Inspector": <SceneNodeInspectorPanel />,
+            }
           }
-        }
-      />
-    }
-    showModal={false}
-    topBar={<TopBar />}
-  />
+        />
+      }
+      showModal={false}
+      topBar={<TopBar />}
+    />
+  </div>
 </div>
 `;

--- a/packages/scene-composer/src/hooks/useAwsLightDarkModes.spec.tsx
+++ b/packages/scene-composer/src/hooks/useAwsLightDarkModes.spec.tsx
@@ -1,0 +1,30 @@
+import React, { createRef } from 'react';
+import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+const applyModeMock = jest.fn();
+jest.mock('@awsui/global-styles', () => ({
+  applyMode: applyModeMock,
+  Mode: jest.requireActual('@awsui/global-styles').Mode,
+}));
+import { Mode } from '@awsui/global-styles';
+
+import useAwsLightDarkModes from './useAwsLightDarkModes';
+
+describe('useAwsLightDarkModes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should apply light mode', () => {
+    const divRef = createRef<HTMLDivElement>();
+    render(<div ref={divRef}></div>);
+    renderHook(() => useAwsLightDarkModes(divRef, Mode.Light));
+    expect(applyModeMock).toBeCalledWith(Mode.Light, divRef.current);
+  });
+  it('should apply dark mode', () => {
+    const divRef = createRef<HTMLDivElement>();
+    render(<div ref={divRef}></div>);
+    renderHook(() => useAwsLightDarkModes(divRef, Mode.Dark));
+    expect(applyModeMock).toBeCalledWith(Mode.Dark, divRef.current);
+  });
+});

--- a/packages/scene-composer/src/hooks/useAwsLightDarkModes.ts
+++ b/packages/scene-composer/src/hooks/useAwsLightDarkModes.ts
@@ -1,0 +1,12 @@
+import { MutableRefObject, useEffect } from 'react';
+import { applyMode, Mode } from '@awsui/global-styles';
+
+const useAwsLightDarkModes = (ref: MutableRefObject<HTMLDivElement | null>, mode: Mode): void => {
+  useEffect(() => {
+    if (ref.current) {
+      applyMode(mode, ref.current);
+    }
+  }, [ref.current, mode]);
+};
+
+export default useAwsLightDarkModes;

--- a/packages/scene-composer/src/hooks/useOverwriteRaycaster.ts
+++ b/packages/scene-composer/src/hooks/useOverwriteRaycaster.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { computeMikkTSpaceTangents } from 'three/examples/jsm/utils/BufferGeometryUtils';
 
 const useOverwriteRaycaster: (
   object: THREE.Object3D | undefined,


### PR DESCRIPTION
## Overview
Currently the scene viewer only support dark mode, and it forces it's mode on the whole page including other cloudscape packages.
![lightModeNoFix](https://github.com/awslabs/iot-app-kit/assets/109186219/8711ceed-18f2-4129-b130-4ae6949d4c6e)

## Verifying Changes
Build example/react-examples but change the src/index.tsx line 14 to applyMode(Mode.Light) then start the server.
The page when visited should have the dark mode scene composer, but the rest of the page in light mode.
![lightModeWithFix](https://github.com/awslabs/iot-app-kit/assets/109186219/f075f50f-7ffe-4085-b9e1-037c952e4090)

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
