### PR TITLE
fix(scene): Enforce conditional requirement of 'viewport' when 'dataStreams' are provided

### DIFF
--- a/packages/scene-composer/src/interfaces/sceneViewer.ts
+++ b/packages/scene-composer/src/interfaces/sceneViewer.ts
@@ -52,10 +52,6 @@ export interface SceneViewerPropsShared {
    * Note: Need to provide a viewport to make it work.
    */
   queries?: TimeSeriesDataQuery[];
-  /**
-   * Specifies the time range of the dataStreams or the range to trigger the queries.
-   */
-  viewport?: Viewport;
 
   dataBindingTemplate?: IDataBindingTemplate;
 
@@ -87,6 +83,16 @@ export interface SceneViewerPropsShared {
    * When selectedDataBinding is set this is ignored in favor of focusing on the selected item.
    */
   activeCamera?: string;
+
+    // Use a conditional type to make viewport required when dataStreams are provided
+  dataStreamsCondition: {
+    dataStreams: DataStream[];
+      /**
+      * Specifies the time range of the dataStreams or the range to trigger the queries.
+      */
+    viewport: Viewport;
+  };
 }
 
-export type SceneViewerProps = SceneViewerPropsShared;
+export type SceneViewerProps = SceneViewerPropsShared['dataStreamsCondition'];
+


### PR DESCRIPTION

## Overview
To ensure data visualization consistency, this commit introduces a conditional requirement in the 'SceneViewerPropsShared' interface. Now, when 'dataStreams' are provided, 'viewport' is mandatory. This enhancement enhances code reliability and maintains data integrity.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
