### PR TITLE
feat: added delete option for empty widget #2139

### DIFF
--- a/packages/dashboard/src/customization/widgets/components/no-chart-data.spec.tsx
+++ b/packages/dashboard/src/customization/widgets/components/no-chart-data.spec.tsx
@@ -1,15 +1,82 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { act, render, screen } from '@testing-library/react';
 import NoChartData from './no-chart-data';
+import { default as lineSvgDark } from '../lineScatterChart/line-dark.svg';
+import WidgetTile from '~/components/widgets/tile/tile';
+import { configureDashboardStore } from '~/store';
+import { MOCK_LINE_CHART_WIDGET, MOCK_TEXT_WIDGET } from '../../../../testing/mocks';
+import StyledTextArea from '../text/styledText/textArea';
 
 describe('NoChartData', () => {
-  it('renders the component with the correct icon and empty state text', () => {
-    const icon = 'path/to/icon.png';
-    const emptyStateText = 'No chart data available';
+  it('renders the correct icon and empty state widget with delete option', () => {
+    const store = configureDashboardStore({
+      dashboardConfiguration: {
+        widgets: [MOCK_LINE_CHART_WIDGET],
+      },
+    });
+    const { getByText, getByAltText, getByTitle } = render(
+      <Provider store={store}>
+        <WidgetTile widget={MOCK_LINE_CHART_WIDGET} removeable>
+          <NoChartData
+            icon={lineSvgDark}
+            emptyStateText='Browse and select to add your asset properties in your line widget.'
+          />
+        </WidgetTile>
+        ;
+      </Provider>
+    );
 
-    const { getByAltText, getByText } = render(<NoChartData icon={icon} emptyStateText={emptyStateText} />);
+    const icon = getByAltText('empty widget icon');
+    const emptyStateText = getByText('Browse and select to add your asset properties in your line widget.');
+    const deleteButton = getByTitle('delete widget');
 
-    expect(getByAltText('empty widget icon')).toBeInTheDocument();
-    expect(getByText('No chart data available')).toBeInTheDocument();
+    expect(icon).toBeInTheDocument();
+    expect(emptyStateText).toBeInTheDocument();
+    expect(deleteButton).toBeInTheDocument();
+
+    act(() => {
+      deleteButton?.click();
+    });
+
+    const deleteBtn = screen.getByText('Delete');
+    expect(deleteBtn).toBeInTheDocument();
+    act(() => {
+      deleteBtn?.click();
+    });
+    expect(store.getState().dashboardConfiguration.widgets).toEqual([]);
+  });
+
+  it('renders the correct text widget with delete option', () => {
+    const store = configureDashboardStore({
+      dashboardConfiguration: {
+        widgets: [MOCK_TEXT_WIDGET],
+      },
+    });
+    const { getByText, getByTitle } = render(
+      <Provider store={store}>
+        <WidgetTile widget={MOCK_TEXT_WIDGET} removeable>
+          <StyledTextArea {...MOCK_TEXT_WIDGET} handleSetEdit={() => {}} />
+        </WidgetTile>
+        ;
+      </Provider>
+    );
+
+    const textValue = getByText('text content');
+    const deleteButton = getByTitle('delete widget');
+
+    expect(textValue).toBeInTheDocument();
+    expect(deleteButton).toBeInTheDocument();
+
+    act(() => {
+      deleteButton?.click();
+    });
+
+    const deleteBtn = screen.getByText('Delete');
+    expect(deleteBtn).toBeInTheDocument();
+    act(() => {
+      deleteBtn?.click();
+    });
+    expect(store.getState().dashboardConfiguration.widgets).toEqual([]);
   });
 });

--- a/packages/dashboard/src/customization/widgets/components/no-chart-data.tsx
+++ b/packages/dashboard/src/customization/widgets/components/no-chart-data.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 
 import { Box, SpaceBetween } from '@cloudscape-design/components';
-import {
-  borderRadiusContainer,
-  colorBorderDividerDefault,
-  colorTextLayoutToggle,
-  spaceStaticXxxs,
-} from '@cloudscape-design/design-tokens';
+import { colorTextLayoutToggle } from '@cloudscape-design/design-tokens';
 
 import './no-chart-data.css';
 
@@ -23,8 +18,6 @@ const NoChartData = ({ icon, emptyStateText }: NoChartDataProps) => {
       className='no-chart-data-empty-state'
       style={{
         backgroundColor: colorTextLayoutToggle,
-        border: `${spaceStaticXxxs} solid ${colorBorderDividerDefault}`,
-        borderRadius: borderRadiusContainer,
       }}
     >
       <Box textAlign='center'>

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -184,10 +184,12 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (widge
   const isEmptyWidget = queries.length === 0;
   if (isEmptyWidget) {
     return (
-      <NoChartData
-        icon={lineSvgDark}
-        emptyStateText='Browse and select to add your asset properties in your line widget.'
-      />
+      <WidgetTile widget={widget} removeable>
+        <NoChartData
+          icon={lineSvgDark}
+          emptyStateText='Browse and select to add your asset properties in your line widget.'
+        />
+      </WidgetTile>
     );
   }
 

--- a/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
+++ b/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
@@ -33,10 +33,12 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (widget) =
   const isEmptyWidget = queries.length === 0;
   if (isEmptyWidget) {
     return (
-      <NoChartData
-        icon={timelineSvgDark}
-        emptyStateText='Browse and select to add your asset properties in your line widget.'
-      />
+      <WidgetTile widget={widget} removeable>
+        <NoChartData
+          icon={timelineSvgDark}
+          emptyStateText='Browse and select to add your asset properties in your line widget.'
+        />
+      </WidgetTile>
     );
   }
 

--- a/packages/dashboard/src/customization/widgets/status/component.tsx
+++ b/packages/dashboard/src/customization/widgets/status/component.tsx
@@ -11,6 +11,7 @@ import { isDefined } from '~/util/isDefined';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
 import { getAggregation } from '../utils/widgetAggregationUtils';
 import './component.css';
+import WidgetTile from '~/components/widgets/tile/tile';
 
 const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
   const { viewport } = useViewport();
@@ -35,7 +36,11 @@ const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
   const aggregation = getAggregation(widget);
 
   if (shouldShowEmptyState) {
-    return <StatusWidgetEmptyStateComponent />;
+    return (
+      <WidgetTile widget={widget} removeable>
+        <StatusWidgetEmptyStateComponent />
+      </WidgetTile>
+    );
   }
 
   const settings = pickBy(

--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -16,6 +16,7 @@ import { DEFAULT_PREFERENCES, collectionPreferencesProps, PROPERTY_FILTERING } f
 import { TABLE_OVERFLOW_HEIGHT, TABLE_WIDGET_MAX_HEIGHT } from '../constants';
 import { onUpdateWidgetsAction } from '~/store/actions';
 import { useTableItems } from './useTableItems';
+import WidgetTile from '~/components/widgets/tile/tile';
 
 export const DEFAULT_TABLE_COLUMN_DEFINITIONS: TableColumnDefinition[] = [
   {
@@ -70,40 +71,42 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
   };
 
   return (
-    <div
-      data-testid='table-widget-component'
-      onMouseDown={handleMouseDown}
-      style={{
-        maxHeight: chartSize.height > TABLE_WIDGET_MAX_HEIGHT ? `${TABLE_WIDGET_MAX_HEIGHT}px` : chartSize.height,
-        overflow: chartSize.height > TABLE_OVERFLOW_HEIGHT ? 'auto' : 'scroll',
-      }}
-    >
-      <Table
-        resizableColumns
-        key={key}
-        queries={queries}
-        viewport={viewport}
-        columnDefinitions={DEFAULT_TABLE_COLUMN_DEFINITIONS}
-        items={items}
-        thresholds={thresholds}
-        significantDigits={significantDigits}
-        sortingDisabled
-        stickyHeader
-        pageSize={widget.properties.pageSize ?? DEFAULT_PREFERENCES.pageSize}
-        paginationEnabled
-        empty={<EmptyTableComponent />}
-        preferences={
-          !readOnly && (
-            <CollectionPreferences
-              {...collectionPreferencesProps}
-              preferences={{ pageSize: widget.properties.pageSize ?? DEFAULT_PREFERENCES.pageSize }}
-              onConfirm={({ detail }) => setPreferences(detail)}
-            />
-          )
-        }
-        propertyFiltering={PROPERTY_FILTERING}
-      />
-    </div>
+    <WidgetTile widget={widget} removeable>
+      <div
+        data-testid='table-widget-component'
+        onMouseDown={handleMouseDown}
+        style={{
+          maxHeight: chartSize.height > TABLE_WIDGET_MAX_HEIGHT ? `${TABLE_WIDGET_MAX_HEIGHT}px` : chartSize.height,
+          overflow: chartSize.height > TABLE_OVERFLOW_HEIGHT ? 'auto' : 'scroll',
+        }}
+      >
+        <Table
+          resizableColumns
+          key={key}
+          queries={queries}
+          viewport={viewport}
+          columnDefinitions={DEFAULT_TABLE_COLUMN_DEFINITIONS}
+          items={items}
+          thresholds={thresholds}
+          significantDigits={significantDigits}
+          sortingDisabled
+          stickyHeader
+          pageSize={widget.properties.pageSize ?? DEFAULT_PREFERENCES.pageSize}
+          paginationEnabled
+          empty={<EmptyTableComponent />}
+          preferences={
+            !readOnly && (
+              <CollectionPreferences
+                {...collectionPreferencesProps}
+                preferences={{ pageSize: widget.properties.pageSize ?? DEFAULT_PREFERENCES.pageSize }}
+                onConfirm={({ detail }) => setPreferences(detail)}
+              />
+            )
+          }
+          propertyFiltering={PROPERTY_FILTERING}
+        />
+      </div>
+    </WidgetTile>
   );
 };
 

--- a/packages/dashboard/src/customization/widgets/text/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/text/plugin.tsx
@@ -3,11 +3,16 @@ import TextWidgetComponent from './component';
 import TextIcon from './icon';
 import type { DashboardPlugin } from '~/customization/api';
 import type { TextWidget } from '../types';
+import WidgetTile from '~/components/widgets/tile/tile';
 
 export const textPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
     registerWidget<TextWidget>('text', {
-      render: (widget) => <TextWidgetComponent {...widget} />,
+      render: (widget) => (
+        <WidgetTile widget={widget} removeable>
+          <TextWidgetComponent {...widget} />
+        </WidgetTile>
+      ),
       componentLibrary: {
         name: 'Text',
         icon: TextIcon,


### PR DESCRIPTION
## Overview
add the delete option (clicking the "X" button in the top right) for empty widget. this pr includes
1.  delete option for line, status, Timeline and KPI widgets in empty state
2. delete option for table and text widgets in both scenarios (empty and with data)

new changes
[delete-empty-widgets.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/f599469a-771d-4ecf-9856-d011ad375c7e)



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
