### PR TITLE
fix(react-components): echarts grab on canvas update cursor and tooltip

### DIFF
--- a/packages/react-components/jest.config.ts
+++ b/packages/react-components/jest.config.ts
@@ -19,6 +19,7 @@ const config = {
   coveragePathIgnorePatterns: [
     '<rootDir>/src/components/knowledge-graph/KnowledgeGraphPanel.tsx',
     '<rootDir>/src/components/chart/trendCursor/mouseEvents/useTrendCursorsEvents.ts',
+    '<rootDir>/src/components/chart/events/useHandleChartEvents.ts',
   ],
 };
 export default config;

--- a/packages/react-components/src/components/chart/contextMenu/useContextMenu.ts
+++ b/packages/react-components/src/components/chart/contextMenu/useContextMenu.ts
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { ElementEvent } from 'echarts';
-import { KeyMap } from 'react-hotkeys';
 
 export const useContextMenu = () => {
   const [showContextMenu, setShowContextMenu] = useState(false);
@@ -10,9 +9,6 @@ export const useContextMenu = () => {
     setShowContextMenu(!showContextMenu);
     e.stop();
   };
-  const keyMap: KeyMap = {
-    commandDown: { sequence: 't', action: 'keydown' },
-    commandUp: { sequence: 't', action: 'keyup' },
-  };
-  return { handleContextMenu, showContextMenu, contextMenuPos, setShowContextMenu, keyMap };
+
+  return { handleContextMenu, showContextMenu, contextMenuPos, setShowContextMenu };
 };

--- a/packages/react-components/src/components/chart/events/useHandleChartEvents.ts
+++ b/packages/react-components/src/components/chart/events/useHandleChartEvents.ts
@@ -1,0 +1,135 @@
+import { MutableRefObject, useCallback, useEffect, useState } from 'react';
+import { EChartsOption, EChartsType } from 'echarts';
+import { KeyMap } from 'react-hotkeys';
+
+export const useHandleChartEvents = (chartRef: MutableRefObject<EChartsType | null>) => {
+  const [chartEventsOptions, setChartEventsOptions] = useState<EChartsOption>({});
+
+  const [shiftDown, setShiftDown] = useState(false);
+  const [mouseDown, setMouseDown] = useState(false);
+  const [prevIsGrabbing, setPrevIsGrabbing] = useState(false);
+
+  // When dragging on the chart, turn off tooltip and set cursor to grabbing
+  const setOnDragStart = (chart: EChartsType | null) => {
+    setChartEventsOptions({
+      tooltip: {
+        show: false,
+      },
+    });
+    chart?.getZr().setCursorStyle('grabbing');
+  };
+
+  // When dragging is done turn back on the tooltip and set cursor to grab
+  // Use when the shift key is still held down but mouse is up
+  const setOnDragEnd = (chart: EChartsType | null) => {
+    setChartEventsOptions({
+      tooltip: {
+        show: true,
+      },
+    });
+    chart?.getZr().setCursorStyle('grab');
+  };
+
+  // When shift is held down show the grab cursor by default
+  // When mouse is also held down it is a grabbing event
+  const shiftDownListener = useCallback(
+    (event?: KeyboardEvent) => {
+      if (event) {
+        setShiftDown(event.shiftKey);
+        if (mouseDown && shiftDown) {
+          setOnDragStart(chartRef.current);
+        } else if (shiftDown) {
+          chartRef.current?.getZr().setCursorStyle('grab');
+        }
+      }
+    },
+    [chartRef, mouseDown, shiftDown]
+  );
+
+  // When shift is released go back to the default cursor
+  const shiftUpListener = useCallback(
+    (event?: KeyboardEvent) => {
+      if (event?.key.toLowerCase() === 'shift') {
+        setShiftDown(false);
+        chartRef.current?.getZr().setCursorStyle('default');
+      }
+    },
+    [chartRef]
+  );
+
+  const chartEventsKeyMap: KeyMap = {
+    shiftDown: { sequence: 'shift', action: 'keydown' },
+    shiftUp: { sequence: 'shift', action: 'keyup' },
+  };
+
+  const chartEventsHandlers = {
+    shiftDown: (keyEvent?: KeyboardEvent) => shiftDownListener(keyEvent),
+    shiftUp: (keyEvent?: KeyboardEvent) => shiftUpListener(keyEvent),
+  };
+
+  // Set up event listeners for pressing shift and dragging the mouse to update
+  // the cursor and tooltip
+  useEffect(() => {
+    const chart = chartRef?.current;
+
+    // Define event handler function so that we can remove this specific behavior on re-render
+
+    // When mouse is down only update when shift is also down
+    const mouseDownEventHandler = () => {
+      setMouseDown(true);
+      if (shiftDown) {
+        setOnDragStart(chart);
+      }
+    };
+
+    chart?.getZr().on('mousedown', mouseDownEventHandler);
+
+    // When mouse is released only update when shift is also down
+    const mouseUpEventHandler = () => {
+      setMouseDown(false);
+      if (shiftDown) {
+        setOnDragEnd(chart);
+      }
+    };
+
+    chart?.getZr().on('mouseup', mouseUpEventHandler);
+
+    // Most important to update dragging events on mouse move
+    const mouseMoveEventHandler = () => {
+      const isGrabbing = mouseDown && shiftDown;
+
+      // Only update tooltip when state changed
+      let stateChanged = false;
+      if (isGrabbing !== prevIsGrabbing) {
+        setPrevIsGrabbing(isGrabbing);
+        stateChanged = true;
+      } else {
+        stateChanged = false;
+      }
+
+      // Overwrite cursor style on every move of the mouse
+      // Update tooltip only once, on grab state change
+      if (isGrabbing) {
+        chart?.getZr().setCursorStyle('grabbing');
+        if (stateChanged) {
+          setOnDragStart(chart);
+        }
+      } else if (shiftDown) {
+        chart?.getZr().setCursorStyle('grab');
+        if (stateChanged) {
+          setOnDragEnd(chart);
+        }
+      }
+    };
+
+    chart?.getZr().on('mousemove', mouseMoveEventHandler);
+
+    return () => {
+      chart?.getZr()?.off('mousemove', mouseMoveEventHandler);
+      chart?.getZr()?.off('mouseup', mouseUpEventHandler);
+      chart?.getZr()?.off('mousedown', mouseDownEventHandler);
+    };
+  }, [chartRef, shiftDown, mouseDown, prevIsGrabbing]);
+
+  return { chartEventsOptions, chartEventsKeyMap, chartEventsHandlers };
+};

--- a/packages/react-components/src/components/chart/trendCursor/mouseEvents/useTrendCursorsEvents.ts
+++ b/packages/react-components/src/components/chart/trendCursor/mouseEvents/useTrendCursorsEvents.ts
@@ -1,5 +1,4 @@
-import { MutableRefObject, useCallback, useEffect, useRef } from 'react';
-import { ECharts } from 'echarts';
+import { useCallback, useEffect, useRef } from 'react';
 import { calculateNearestTcIndex, calculateXFromTimestamp, formatCopyData } from '../calculations/calculations';
 import { v4 as uuid } from 'uuid';
 import { getNewTrendCursor } from '../getTrendCursor/getTrendCursor';
@@ -11,6 +10,7 @@ import { UseEventsProps } from '../types';
 import { onDragUpdateTrendCursor } from './handlers/drag/update';
 import { calculateTimeStamp } from '../calculations/timestamp';
 import { mouseoverHandler } from './handlers/mouseover';
+import { ElementEvent } from 'echarts';
 
 const useTrendCursorsEvents = ({
   chartRef,
@@ -29,9 +29,6 @@ const useTrendCursorsEvents = ({
   const updateTrendCursorsInSyncState = useDataStore((state) => state.updateTrendCursors);
   const deleteTrendCursorsInSyncState = useDataStore((state) => state.deleteTrendCursors);
 
-  // https://stackoverflow.com/questions/55565444/how-to-register-event-with-useeffect-hooks
-  // to avoid re-rendering of the event handler useEffect, following the pattern suggested in the above link
-  const prevRef = useRef<MutableRefObject<ECharts | null> | null>(null);
   const seriesRef = useRef(series);
   const sizeRef = useRef(size);
   const isInCursorAddModeRef = useRef(isInCursorAddMode);
@@ -119,96 +116,104 @@ const useTrendCursorsEvents = ({
   // standalone mode --> updates the local state
   useEffect(() => {
     const currentChart = chartRef.current;
-    if (prevRef.current !== chartRef) {
-      currentChart?.getZr().on('mousemove', () => mouseoverHandler(isInCursorAddModeRef.current, chartRef));
 
-      // this handles all the clicks on the chart
-      // this click would be either
-      // 1. delete a TC
-      // 2. add a TC
-      currentChart?.getZr().on('click', (e) => {
-        // index of the clicked graphic
-        const graphicIndex = graphicRef.current.findIndex(
-          (g) => g.children[TREND_CURSOR_CLOSE_GRAPHIC_INDEX].id === e?.target?.id
-        );
-        if (graphicIndex !== -1) {
-          deleteTrendCursor(graphicIndex);
-          return;
-        } else {
-          addNewTrendCursor({ posX: e.offsetX ?? 0, ignoreHotKey: false });
-        }
-      });
+    // passing the function so that we can remove this specific behavior on re-render
+    const mouseMoveEventHandler = () => mouseoverHandler(isInCursorAddModeRef.current, chartRef);
+    currentChart?.getZr().on('mousemove', mouseMoveEventHandler);
 
-      // this is the ondrag handler of the trend cursor
-      currentChart?.getZr().on('drag', (event) => {
-        // update user feedback
-        event.stop();
-        currentChart?.getZr().setCursorStyle('grabbing');
+    // this handles all the clicks on the chart
+    // this click would be either
+    // 1. delete a TC
+    // 2. add a TC
+    const clickEventHandler = (event: ElementEvent) => {
+      // index of the clicked graphic
+      const graphicIndex = graphicRef.current.findIndex(
+        (g) => g.children[TREND_CURSOR_CLOSE_GRAPHIC_INDEX].id === event?.target?.id
+      );
+      if (graphicIndex !== -1) {
+        deleteTrendCursor(graphicIndex);
+        return;
+      } else {
+        addNewTrendCursor({ posX: event.offsetX ?? 0, ignoreHotKey: false });
+      }
+    };
 
-        let graphicIndex = graphicRef.current.findIndex((g) => g.children[0].id === event.target.id);
+    currentChart?.getZr().on('click', clickEventHandler);
 
-        if (graphicIndex === -1) {
-          graphicIndex = graphicRef.current.findIndex((g) => g.children[1].id === event.target.id);
-        }
+    // this is the ondrag handler of the trend cursor
+    const dragEventHandler = (event: ElementEvent) => {
+      // update user feedback
+      event.stop();
+      currentChart?.getZr().setCursorStyle('grabbing');
 
-        const posX = (event.offsetX ?? 0) + (graphicRef.current[graphicIndex]?.dragDeltaInPixels ?? 0);
-        const timeInMs = calculateTimeStamp(posX, chartRef);
+      let graphicIndex = graphicRef.current.findIndex((g) => g.children[0].id === event.target.id);
 
-        if (isInSyncModeRef.current) {
-          updateTrendCursorsInSyncState({
-            groupId: groupId ?? '',
-            timestamp: timeInMs,
-            tcId: graphicRef.current[graphicIndex].id as string,
-          });
-        } else {
-          // update current TC
-          graphicRef.current[graphicIndex] = onDragUpdateTrendCursor({
-            graphic: graphicRef.current[graphicIndex],
-            posX,
-            timeInMs,
-            size: sizeRef.current,
-            series: seriesRef.current,
-            chartRef,
-            visualization: visualizationRef.current,
-          });
-          // update component state
-          setGraphicRef.current([...graphicRef.current]);
-        }
-      });
+      if (graphicIndex === -1) {
+        graphicIndex = graphicRef.current.findIndex((g) => g.children[1].id === event.target.id);
+      }
 
-      currentChart?.getZr().on('contextmenu', (event) => {
-        onContextMenuRef.current(event);
-      });
+      const posX = (event.offsetX ?? 0) + (graphicRef.current[graphicIndex]?.dragDeltaInPixels ?? 0);
+      const timeInMs = calculateTimeStamp(posX, chartRef);
 
-      // Calculating delta in pixels between the initial interaction point vs the position of TC line
-      // we need this to avoid snapping the TC line to the center of the point of the mouse's X
-
-      currentChart?.getZr().on('dragstart', (event) => {
-        let graphicIndex = graphicRef.current.findIndex((g) => g.children[0].id === event.target.id);
-
-        if (graphicIndex === -1) {
-          graphicIndex = graphicRef.current.findIndex((g) => g.children[1].id === event.target.id);
-        }
-
-        const dragDeltaInPixels =
-          calculateXFromTimestamp(graphicRef.current[graphicIndex].timestampInMs, chartRef) - event.offsetX;
-
-        graphicRef.current[graphicIndex] = {
-          ...graphicRef.current[graphicIndex],
-          dragDeltaInPixels,
-        };
+      if (isInSyncModeRef.current) {
+        updateTrendCursorsInSyncState({
+          groupId: groupId ?? '',
+          timestamp: timeInMs,
+          tcId: graphicRef.current[graphicIndex].id as string,
+        });
+      } else {
+        // update current TC
+        graphicRef.current[graphicIndex] = onDragUpdateTrendCursor({
+          graphic: graphicRef.current[graphicIndex],
+          posX,
+          timeInMs,
+          size: sizeRef.current,
+          series: seriesRef.current,
+          chartRef,
+          visualization: visualizationRef.current,
+        });
+        // update component state
         setGraphicRef.current([...graphicRef.current]);
-      });
-    }
+      }
+    };
 
-    prevRef.current = chartRef;
+    currentChart?.getZr().on('drag', dragEventHandler);
+
+    const contextMenuEventHandler = (event: ElementEvent) => {
+      onContextMenuRef.current(event);
+    };
+
+    currentChart?.getZr().on('contextmenu', contextMenuEventHandler);
+
+    // Calculating delta in pixels between the initial interaction point vs the position of TC line
+    // we need this to avoid snapping the TC line to the center of the point of the mouse's X
+
+    const dragStartEventHandler = (event: ElementEvent) => {
+      let graphicIndex = graphicRef.current.findIndex((g) => g.children[0].id === event.target.id);
+
+      if (graphicIndex === -1) {
+        graphicIndex = graphicRef.current.findIndex((g) => g.children[1].id === event.target.id);
+      }
+
+      const dragDeltaInPixels =
+        calculateXFromTimestamp(graphicRef.current[graphicIndex].timestampInMs, chartRef) - event.offsetX;
+
+      graphicRef.current[graphicIndex] = {
+        ...graphicRef.current[graphicIndex],
+        dragDeltaInPixels,
+      };
+      setGraphicRef.current([...graphicRef.current]);
+    };
+
+    currentChart?.getZr().on('dragstart', dragStartEventHandler);
+
     return () => {
-      currentChart?.getZr()?.off('click');
-      // passing the function so that it will NOT remove all the mouseover behaviour, namely default tooltip
-      currentChart?.getZr()?.off('mouseover', () => mouseoverHandler(isInCursorAddModeRef.current, chartRef));
-      currentChart?.getZr()?.off('drag');
-      currentChart?.getZr()?.off('contextmenu');
-      currentChart?.getZr()?.off('dragstart');
+      // passing the function so that it will NOT remove all event behaviour
+      currentChart?.getZr()?.off('click', clickEventHandler);
+      currentChart?.getZr()?.off('mouseover', mouseMoveEventHandler);
+      currentChart?.getZr()?.off('drag', dragEventHandler);
+      currentChart?.getZr()?.off('contextmenu', contextMenuEventHandler);
+      currentChart?.getZr()?.off('dragstart', dragStartEventHandler);
     };
     // ignoring because refs dont need to be in dependency array
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/react-components/src/components/chart/trendCursor/useTrendCursors.ts
+++ b/packages/react-components/src/components/chart/trendCursor/useTrendCursors.ts
@@ -11,6 +11,7 @@ import { YAXisOption } from 'echarts/types/dist/shared';
 import { YAxisLegendOption } from '../types';
 import { useHandleYMinMax } from './yMinMax/useHandleYMinMax';
 import { useHandleSeries } from './series/useHandleSeries';
+import { KeyMap } from 'react-hotkeys';
 
 const useTrendCursors = ({
   chartRef,
@@ -65,11 +66,16 @@ const useTrendCursors = ({
 
   useHandleSeries({ graphic, setGraphic, chartRef, visualization, series });
 
-  const hotKeyHandlers = {
+  const trendCursorKeyMap: KeyMap = {
+    commandDown: { sequence: 't', action: 'keydown' },
+    commandUp: { sequence: 't', action: 'keyup' },
+  };
+
+  const trendCursorHandlers = {
     commandDown: () => setIsInCursorAddMode(true),
     commandUp: () => setIsInCursorAddMode(false),
   };
-  return { onContextMenuClickHandler, hotKeyHandlers, trendCursors: graphic };
+  return { onContextMenuClickHandler, trendCursorKeyMap, trendCursorHandlers, trendCursors: graphic };
 };
 
 export default useTrendCursors;


### PR DESCRIPTION
## Overview
My previous [commit](https://github.com/awslabs/iot-app-kit/commit/a29da3a08a769137610bc37efde5605bf6b62dc2) was reverted because you could not add/edit trend cursors after changing any chart property.

This bug was fixed by removing the check for a chart ref change in the `useTrendCursorsEvents` hook. The `useEffect` setting up the event handlers were being turned off on a re-render, and not turned back on.

Added back my code with the general chart drag events with shift+click.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/87385528/1c255e75-c21c-47b2-aeee-bd1ac3d8d099




### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
