### PR TITLE
feat: format latest value time in resource explorer table

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/createModeledDataStreamColumnDefinitions.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/createModeledDataStreamColumnDefinitions.ts
@@ -1,6 +1,7 @@
 import { isNumeric, round } from '@iot-app-kit/core-util';
 import { type TableProps } from '@cloudscape-design/components/table';
 import type { ModeledDataStream } from '../types';
+import { getFormattedDateTimeFromEpoch } from '~/components/util/dateTimeUtil';
 
 export function createModeledDataStreamColumnDefinitions(
   significantDigits: number
@@ -30,9 +31,9 @@ export function createModeledDataStreamColumnDefinitions(
       header: 'Latest value time',
       cell: ({ latestValueTime }) => {
         if (latestValueTime && isNumeric(latestValueTime)) {
-          return round(latestValueTime, significantDigits);
+          return getFormattedDateTimeFromEpoch(round(latestValueTime, significantDigits));
         }
-        return latestValueTime;
+        return getFormattedDateTimeFromEpoch(latestValueTime);
       },
       sortingField: 'latestValueTime',
     },

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
@@ -18,6 +18,7 @@ import { useExplorerPreferences } from '../../useExplorerPreferences';
 import { SUPPORTED_PAGE_SIZES } from '../../constants';
 import { useLatestValues } from '../../useLatestValues';
 import { DashboardState } from '~/store/state';
+import { getFormattedDateTimeFromEpoch } from '~/components/util/dateTimeUtil';
 
 export interface UnmodeledDataStreamTableProps {
   onClickAdd: (unmodeledDataStreams: UnmodeledDataStream[]) => void;
@@ -147,9 +148,9 @@ export function UnmodeledDataStreamTable({
           header: 'Latest value time',
           cell: ({ latestValueTime }) => {
             if (latestValueTime && isNumeric(latestValueTime)) {
-              return round(latestValueTime, significantDigits);
+              return getFormattedDateTimeFromEpoch(round(latestValueTime, significantDigits));
             }
-            return latestValueTime;
+            return getFormattedDateTimeFromEpoch(latestValueTime);
           },
           sortingField: 'latestValueTime',
         },

--- a/packages/dashboard/src/components/util/dateTimeUtil.spec.tsx
+++ b/packages/dashboard/src/components/util/dateTimeUtil.spec.tsx
@@ -1,6 +1,12 @@
-import { getFormattedDateTime } from './dateTimeUtil';
+import { getFormattedDateTime, getFormattedDateTimeFromEpoch } from './dateTimeUtil';
 
 it('should format the Date to full Date and Time value', () => {
   const rawDate = new Date(1665583620000 + new Date().getTimezoneOffset() * 60000);
   expect(getFormattedDateTime(rawDate)).toEqual(`10/12/22 14:07:00`);
+});
+
+it('should format the epoch seconds to Date and Time value', () => {
+  const rawDate = 1698641538;
+  const time = new Date(rawDate * 1000).toTimeString().split(' ')[0];
+  expect(getFormattedDateTimeFromEpoch(rawDate)).toEqual(`10/30/23 ${time}`);
 });

--- a/packages/dashboard/src/components/util/dateTimeUtil.tsx
+++ b/packages/dashboard/src/components/util/dateTimeUtil.tsx
@@ -1,7 +1,17 @@
 // Format Date object to get date and time to display MM/DD/YY HH:MM:SS format
-export const getFormattedDateTime = (rawDate: Date) => {
+const formatDateTime = (rawDate: Date) => {
   const date = rawDate.getMonth() + 1 + '/' + rawDate.getDate() + '/' + rawDate.getFullYear().toString().slice(-2);
   const time = rawDate.toTimeString().split(' ')[0];
   const dateTime = date + ' ' + time;
   return dateTime;
+};
+
+export const getFormattedDateTime = (rawDate: Date) => {
+  return formatDateTime(rawDate);
+};
+
+export const getFormattedDateTimeFromEpoch = (epochSeconds: number | undefined) => {
+  if (!epochSeconds) return '';
+  const rawDate = new Date(epochSeconds * 1000);
+  return formatDateTime(rawDate);
 };


### PR DESCRIPTION
## Overview
This PR is to format latest value time values in the resource explorer table to MM/DD/YY HH:MM:SS format. This is related to ticket #2140 

## Verifying Changes
Modeled data stream table
![image](https://github.com/awslabs/iot-app-kit/assets/142866907/1d28622e-3e1a-4ba6-a103-a66f1e84e222)

Unmodeled data stream table
![image](https://github.com/awslabs/iot-app-kit/assets/142866907/43b992c8-7310-4b81-bdf4-50813c24c1c3)



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
