### PR TITLE
feat(scene-composer): support tag occlusion

### DIFF
--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
@@ -168,7 +168,8 @@ export function AsyncLoadedAnchorWidget({
     ];
 
     const isAlwaysVisible =
-      (node.properties.alwaysVisible === undefined ? true : node.properties.alwaysVisible) === true;
+      (node.properties.alwaysVisible === undefined ? !tagSettings.enableOcclusion : node.properties.alwaysVisible) ===
+      true;
     const iconStrings = [
       SelectedIconSvgString,
       InfoIconSvgString,
@@ -192,7 +193,14 @@ export function AsyncLoadedAnchorWidget({
       }
       return svgIconToWidgetSprite(iconString, iconStyle, iconStyle, isAlwaysVisible, !autoRescale);
     });
-  }, [autoRescale, CustomIconSvgString, visualRuleCustomColor, visualCustomIcon, newCustomIcon]);
+  }, [
+    autoRescale,
+    CustomIconSvgString,
+    visualRuleCustomColor,
+    visualCustomIcon,
+    newCustomIcon,
+    tagSettings.enableOcclusion,
+  ]);
 
   const isAnchor = (nodeRef?: string) => {
     const node = getSceneNodeByRef(nodeRef);

--- a/packages/scene-composer/src/common/constants.ts
+++ b/packages/scene-composer/src/common/constants.ts
@@ -131,6 +131,7 @@ export const DRACO_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.4.
 export const DEFAULT_TAG_GLOBAL_SETTINGS: ITagSettings = {
   autoRescale: false,
   scale: 1,
+  enableOcclusion: false,
 };
 
 export const DEFAULT_OVERLAY_GLOBAL_SETTINGS: IOverlaySettings = {

--- a/packages/scene-composer/src/components/panels/scene-settings/OverlayPanelVisibilityToggle.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/OverlayPanelVisibilityToggle.tsx
@@ -82,8 +82,8 @@ export const OverlayPanelVisibilityToggle: React.FC = () => {
       <Toggle
         disabled={!hasOverlayPanel}
         checked={!!documentSettings.overlayPanelVisible}
-        onChange={() => {
-          updateSettings(!documentSettings.overlayPanelVisible);
+        onChange={(event) => {
+          updateSettings(event.detail.checked);
         }}
       >
         {formatMessage({ description: 'Toggle label', defaultMessage: 'Always on' })}

--- a/packages/scene-composer/src/components/panels/scene-settings/SceneTagSettingsEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/SceneTagSettingsEditor.spec.tsx
@@ -31,6 +31,7 @@ describe('SceneTagSettingsEditor', () => {
     isViewing: isViewingMock,
     noHistoryStates: {
       ...useStore('default').getState().noHistoryStates,
+      tagSettings: DEFAULT_TAG_GLOBAL_SETTINGS,
       setTagSettings: setTagSettingsMock,
     },
   };
@@ -224,6 +225,58 @@ describe('SceneTagSettingsEditor', () => {
     expect(setTagSettingsMock).toBeCalledWith({
       ...DEFAULT_TAG_GLOBAL_SETTINGS,
       scale: 3,
+    });
+  });
+
+  describe('Show tag through objects - enableOcclusion', () => {
+    it('should update view option with document settings', () => {
+      useStore('default').setState(baseState);
+      render(<SceneTagSettingsEditor />);
+
+      expect(baseState.noHistoryStates.tagSettings?.enableOcclusion).toBeFalsy();
+    });
+
+    it('should update tag settings when toggled', () => {
+      useStore('default').setState(baseState);
+      const { container } = render(<SceneTagSettingsEditor />);
+      const polarisWrapper = wrapper(container);
+      const toggle = polarisWrapper.findToggle();
+
+      expect(toggle).not.toBeNull();
+      expect(baseState.noHistoryStates.tagSettings?.enableOcclusion).toBeFalsy();
+
+      act(() => {
+        toggle!.findNativeInput().click();
+      });
+
+      expect(setScenePropertyMock).toBeCalledTimes(1);
+      expect(setTagSettingsMock).toBeCalledTimes(1);
+      expect(setTagSettingsMock).toBeCalledWith({
+        ...DEFAULT_TAG_GLOBAL_SETTINGS,
+        enableOcclusion: true,
+      });
+    });
+
+    it('should not update scene property when toggled in viewing mode', () => {
+      useStore('default').setState(baseState);
+      isViewingMock.mockReturnValue(true);
+      const { container } = render(<SceneTagSettingsEditor />);
+      const polarisWrapper = wrapper(container);
+      const toggle = polarisWrapper.findToggle();
+
+      expect(toggle).not.toBeNull();
+      expect(baseState.noHistoryStates.tagSettings?.enableOcclusion).toBeFalsy();
+
+      act(() => {
+        toggle!.findNativeInput().click();
+      });
+
+      expect(setScenePropertyMock).not.toBeCalled();
+      expect(setTagSettingsMock).toBeCalledTimes(1);
+      expect(setTagSettingsMock).toBeCalledWith({
+        ...DEFAULT_TAG_GLOBAL_SETTINGS,
+        enableOcclusion: true,
+      });
     });
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-settings/SceneTagSettingsEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/SceneTagSettingsEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { Checkbox, FormField, Grid, Input } from '@awsui/components-react';
+import { Checkbox, FormField, Grid, Input, SpaceBetween, Toggle } from '@awsui/components-react';
 
 import useLifecycleLogging from '../../../logger/react-logger/hooks/useLifecycleLogging';
 import { useStore, useViewOptionState } from '../../../store';
@@ -96,45 +96,55 @@ export const SceneTagSettingsEditor: React.FC = () => {
 
   return (
     <React.Fragment>
-      <FormField label={intl.formatMessage({ defaultMessage: 'Scale', description: 'Form Field label' })}>
-        <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-          <Input
-            value={String(internalScale)}
-            type='number'
-            onFocus={() => setFocusInput(true)}
-            onBlur={onInputBlur}
-            onChange={onInputChange}
-          />
-          <Checkbox
-            checked={tagSettings.autoRescale}
-            onChange={(e) => updateSettings({ autoRescale: e.detail.checked })}
-          >
-            {intl.formatMessage({ defaultMessage: 'Fixed scaling', description: 'checkbox label' })}
-          </Checkbox>
-        </Grid>
+      <SpaceBetween size='s'>
+        <FormField label={intl.formatMessage({ defaultMessage: 'Scale', description: 'Form Field label' })}>
+          <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+            <Input
+              value={String(internalScale)}
+              type='number'
+              onFocus={() => setFocusInput(true)}
+              onBlur={onInputBlur}
+              onChange={onInputChange}
+            />
+            <Checkbox
+              checked={tagSettings.autoRescale}
+              onChange={(e) => updateSettings({ autoRescale: e.detail.checked })}
+            >
+              {intl.formatMessage({ defaultMessage: 'Fixed scaling', description: 'checkbox label' })}
+            </Checkbox>
+          </Grid>
 
-        {(focusInput || focusSlider) && (
-          <Slider
-            value={internalScale}
-            step={0.1}
-            min='0'
-            max='10'
-            onFocus={() => {
-              setFocusSlider(true);
-            }}
-            onBlur={() => {
-              setFocusSlider(false);
-            }}
-            onMouseUp={() => {
-              setDraggingSlider(false);
-            }}
-            onMouseDown={() => {
-              setDraggingSlider(true);
-            }}
-            onChange={onSliderChange}
-          />
-        )}
-      </FormField>
+          {(focusInput || focusSlider) && (
+            <Slider
+              value={internalScale}
+              step={0.1}
+              min='0'
+              max='10'
+              onFocus={() => {
+                setFocusSlider(true);
+              }}
+              onBlur={() => {
+                setFocusSlider(false);
+              }}
+              onMouseUp={() => {
+                setDraggingSlider(false);
+              }}
+              onMouseDown={() => {
+                setDraggingSlider(true);
+              }}
+              onChange={onSliderChange}
+            />
+          )}
+        </FormField>
+        <Toggle
+          checked={!tagSettings.enableOcclusion}
+          onChange={(event) => {
+            updateSettings({ enableOcclusion: !event.detail.checked });
+          }}
+        >
+          {intl.formatMessage({ description: 'Toggle label', defaultMessage: 'Show tag through objects' })}
+        </Toggle>
+      </SpaceBetween>
     </React.Fragment>
   );
 };

--- a/packages/scene-composer/src/interfaces/componentSettings.ts
+++ b/packages/scene-composer/src/interfaces/componentSettings.ts
@@ -3,6 +3,7 @@ import { KnownComponentType } from './components';
 export interface ITagSettings {
   scale: number;
   autoRescale: boolean;
+  enableOcclusion: boolean;
 }
 
 export interface IOverlaySettings {

--- a/packages/scene-composer/src/store/slices/ViewOptionStateSlice.spec.ts
+++ b/packages/scene-composer/src/store/slices/ViewOptionStateSlice.spec.ts
@@ -90,11 +90,16 @@ describe('createViewOptionStateSlice', () => {
     const set = jest.fn((callback) => callback(draft));
 
     const { setTagSettings } = createViewOptionStateSlice(set);
-    setTagSettings({ scale: 3.3, autoRescale: true });
+    setTagSettings({
+      scale: 3.3,
+      autoRescale: true,
+      enableOcclusion: false,
+    });
 
     expect(draft.lastOperation!).toEqual('setTagSettings');
     expect((draft.noHistoryStates.tagSettings as ITagSettings).scale).toEqual(3.3);
     expect((draft.noHistoryStates.tagSettings as ITagSettings).autoRescale).toBeTruthy();
+    expect((draft.noHistoryStates.tagSettings as ITagSettings).enableOcclusion).toBeFalsy();
   });
 
   it('should be able to set viewport', () => {

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -127,6 +127,10 @@
     "note": "Menu Item",
     "text": "Add tag"
   },
+  "3KmpMx": {
+    "note": "Toggle label",
+    "text": "Show tag through objects"
+  },
   "3fXLy/": {
     "note": "Menu label",
     "text": "Translate"


### PR DESCRIPTION
## Overview
Issue: Tags clutter the UI when they are always visible through other Meshes

This is especially an issue when you are in immersive mode, like Matterport. Because tags are always rendered closer to the camera than any meshes, large sites with lots of tags become very difficult to navigate in immersive mode.

Fix: Provided an option to show/hide tags through objects in the Scene Tag Settings.

Default behabior:
<img width="1457" alt="ShowTagThroughObjects-Default" src="https://github.com/awslabs/iot-app-kit/assets/43108986/f1c1ad88-3e4b-4963-bebc-e1ff4421de21">

Tag Occlusion Enabled:
<img width="1453" alt="ShowTagThroughObjects-Disabled" src="https://github.com/awslabs/iot-app-kit/assets/43108986/d3b00cba-1f2b-45c8-b079-0be05e408781">

Screen recording:
https://github.com/awslabs/iot-app-kit/assets/43108986/9c2c4cf3-9ce5-49d2-b808-263aa24797b0



## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
