### PR TITLE
fix(react-components): correct failing viewport adapter tests

### DIFF
--- a/packages/react-components/src/components/time-sync/viewportAdapter.spec.ts
+++ b/packages/react-components/src/components/time-sync/viewportAdapter.spec.ts
@@ -152,7 +152,9 @@ describe('getViewportStartOnBackwardRelative', () => {
       type: 'relative',
     });
 
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(300000);
+    const result = currentDate.getTime() - newDate.getTime();
+    expect(result).toBeGreaterThanOrEqual(299999);
+    expect(result).toBeLessThanOrEqual(300000);
 
     currentDate = new Date();
     newDate = getViewportStartOnBackwardRelative({
@@ -193,6 +195,13 @@ describe('getViewportStartOnBackwardRelative', () => {
       unit: 'month',
       type: 'relative',
     });
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(2592000000);
+
+    if ([0, 1, 3, 5, 6, 7, 8, 10].includes(currentDate.getMonth())) {
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(2678400000); //previous month is 31 days
+    } else if (currentDate.getMonth() === 2) {
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(2419200000 || 2505600000); //previous month is february
+    } else {
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(2592000000); //previous month is 30 days
+    }
   });
 });


### PR DESCRIPTION
## Overview
Fixes for the viewport adapter tests that check for previous month to see how many milliseconds the viewport changes by

## Verifying Changes

Should pass all unit tests.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
