### PR TITLE
feat(dashboard): gated CSV download button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24867,6 +24867,15 @@
       "version": "2019.7.0",
       "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg=="
     },
+    "node_modules/@types/papaparse": {
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.10.tgz",
+      "integrity": "sha512-mS1Fta/xJ9EDYmAvpeWzcV9Gr0cOl1ClpW7di9+wSUNDIDO55tBtyXg97O7K+Syrd9rDEmuejM2iqmJIJ1SO5g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
@@ -58596,6 +58605,7 @@
         "@types/is-hotkey": "^0.1.7",
         "@types/lodash": "^4.14.195",
         "@types/node": "^18.16.18",
+        "@types/papaparse": "^5.3.10",
         "@types/react": "^18.2.12",
         "@types/react-dom": "^18.2.5",
         "css-loader": "6.8.1",
@@ -72371,6 +72381,7 @@
         "@types/is-hotkey": "^0.1.7",
         "@types/lodash": "^4.14.195",
         "@types/node": "^18.16.18",
+        "@types/papaparse": "^5.3.10",
         "@types/react": "^18.2.12",
         "@types/react-dom": "^18.2.5",
         "aws-sdk-client-mock": "^3.0.0",
@@ -85040,6 +85051,15 @@
     "@types/offscreencanvas": {
       "version": "2019.7.0",
       "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg=="
+    },
+    "@types/papaparse": {
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.10.tgz",
+      "integrity": "sha512-mS1Fta/xJ9EDYmAvpeWzcV9Gr0cOl1ClpW7di9+wSUNDIDO55tBtyXg97O7K+Syrd9rDEmuejM2iqmJIJ1SO5g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/parse-json": {
       "version": "4.0.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -63,6 +63,7 @@
     "@types/node": "^18.16.18",
     "@types/react": "^18.2.12",
     "@types/react-dom": "^18.2.5",
+    "@types/papaparse": "^5.3.10",
     "css-loader": "6.8.1",
     "dotenv": "^16.3.1",
     "eslint-config-iot-app-kit": "9.2.0",

--- a/packages/dashboard/src/components/csvDownloadButton/index.tsx
+++ b/packages/dashboard/src/components/csvDownloadButton/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { Button, ButtonProps } from '@cloudscape-design/components';
+
+import { unparse } from 'papaparse';
+import { StyledSiteWiseQueryConfig } from '~/customization/widgets/types';
+import { useViewportData } from '~/components/csvDownloadButton/useViewportData';
+
+const CSVDownloadButton = ({
+  queryConfig,
+  fileName,
+  ...rest
+}: { queryConfig: StyledSiteWiseQueryConfig; fileName: string } & ButtonProps) => {
+  const { fetchViewportData } = useViewportData({ queryConfig });
+
+  const onClickDownload = () => {
+    const requestDateMS = Date.now();
+    const requestDateString = new Date(requestDateMS).toISOString();
+
+    const data = fetchViewportData(requestDateMS);
+    const stringCSVData = unparse(data);
+
+    const file = new Blob([stringCSVData], { type: 'text/csv' });
+
+    // create Anchor element with download attribute, click on it, and then delete it
+    const element = document.createElement('a');
+    element.href = URL.createObjectURL(file);
+    element.download = `${fileName} ${requestDateString}.csv`;
+    document.body.appendChild(element); // required for this to work in firefox
+    element.click();
+    element.remove();
+  };
+
+  return (
+    <Button iconName='download' variant='icon' onClick={onClickDownload} data-testid='custom-orange-button' {...rest} />
+  );
+};
+
+export default CSVDownloadButton;

--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -21,6 +21,9 @@ import { DashboardState } from '~/store/state';
 
 import './tile.css';
 import { onChangeDashboardGridEnabledAction } from '~/store/actions';
+import CSVDownloadButton from '~/components/csvDownloadButton';
+import { StyledSiteWiseQueryConfig } from '~/customization/widgets/types';
+import { useGetConfigValue } from '@iot-app-kit/react-components';
 
 type DeletableTileActionProps = {
   handleDelete: CancelableEventHandler<ClickDetail>;
@@ -54,6 +57,7 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
   const dispatch = useDispatch();
   const [visible, setVisible] = useState(false);
   const { onDelete } = useDeleteWidgets();
+  const isCSVDownloadEnabled = useGetConfigValue('useCSVDownload');
 
   const isRemoveable = !isReadOnly && removeable;
   const headerVisible = !isReadOnly || title;
@@ -100,6 +104,12 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
             {title}
           </Box>
           <SpaceBetween size='s' direction='horizontal'>
+            {widget.type !== 'text' && isCSVDownloadEnabled && (
+              <CSVDownloadButton
+                queryConfig={widget.properties.queryConfig as StyledSiteWiseQueryConfig}
+                fileName={`${widget.properties.title ?? widget.type}`}
+              />
+            )}
             {isRemoveable && <DeletableTileAction handleDelete={handleDelete} />}
             <ConfirmDeleteModal
               visible={visible}

--- a/packages/react-components/src/store/config.ts
+++ b/packages/react-components/src/store/config.ts
@@ -1,11 +1,12 @@
 import { StateCreator } from 'zustand/esm';
 
-export type Flags = 'useEcharts';
+export type Flags = 'useEcharts' | 'useCSVDownload';
 export interface ConfigState {
   config: Record<Flags, boolean>;
 }
 export const createConfigSlice: StateCreator<ConfigState> = () => ({
   config: {
     useEcharts: !!localStorage?.getItem('USE_ECHARTS'),
+    useCSVDownload: !!localStorage?.getItem('USE_CSV_DOWNLOAD'),
   },
 });


### PR DESCRIPTION
## Overview
- Create download button component
- Gate download button component behind `USE_CSV_DOWNLOAD` in localStorage
- Add download button to widget tile IF gate is enabled and widget is not a text widget

https://github.com/awslabs/iot-app-kit/assets/28601414/fe07cc45-fbca-465a-ad85-1e944a2a7c11

<img width="636" alt="image" src="https://github.com/awslabs/iot-app-kit/assets/28601414/2e9cd118-1946-48f6-9d86-12ae32e9c857">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
