### PR TITLE
chore(example): add line chart example

### DIFF
--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -59,6 +59,7 @@
     "rollup-plugin-node-polyfills": "^0.2.1",
     "sass": "^1.63.4",
     "typescript": "^4.8.3",
-    "vite": "^4.4.3"
+    "vite": "^4.4.9",
+    "vite-plugin-dynamic-import": "1.5.0"
   }
 }

--- a/examples/react-app/src/components/LineChart.scss
+++ b/examples/react-app/src/components/LineChart.scss
@@ -1,0 +1,5 @@
+.LineChart {
+  position: relative;
+  width: '100vw';
+  height: '100vh';
+}

--- a/examples/react-app/src/components/LineChart.tsx
+++ b/examples/react-app/src/components/LineChart.tsx
@@ -1,0 +1,44 @@
+import { FC, useMemo } from 'react';
+import { Chart } from '@iot-app-kit/react-components';
+import { useViewport } from "@iot-app-kit/react-components";
+
+import { dataSource } from '../dataSource';
+import './LineChart.scss';
+
+interface LineChartProps {
+  entityId: string,
+}
+
+const LineChart: FC<LineChartProps> = ({ entityId }) => {
+  const { viewport } = useViewport();
+
+  const queries = useMemo(() =>{
+    const rpmQuery = {
+      entityId: entityId,
+      componentName: 'MixerComponent',
+      properties: [{ propertyName: 'RPM' }],
+    }
+    const tempQuery = {
+      entityId: entityId,
+      componentName: 'MixerComponent',
+      properties: [{ propertyName: 'Temperature' }],
+    }
+    return [dataSource.query.timeSeriesData(rpmQuery), dataSource.query.timeSeriesData(tempQuery)];
+  }, [entityId, dataSource]);
+
+  return (
+    <div className='LineChart'>
+      <Chart
+        queries={queries}
+        viewport={viewport}
+        axis={{}}
+        size={{width: 800, height: 500}}
+        legend={{}}
+        defaultVisualizationType={'line'}
+        significantDigits={2}
+      />
+    </div>
+  )
+};
+
+export default LineChart;

--- a/examples/react-app/src/index.tsx
+++ b/examples/react-app/src/index.tsx
@@ -11,7 +11,7 @@ import '@cloudscape-design/global-styles/index.css';
 import '@iot-app-kit/components/styles.css';
 
 applyDensity(Density.Comfortable);
-applyMode(Mode.Dark);
+applyMode(Mode.Light);
 
 const root = createRoot(document.getElementById('root')!);
 

--- a/examples/react-app/src/pages/Home/index.tsx
+++ b/examples/react-app/src/pages/Home/index.tsx
@@ -6,6 +6,7 @@ import SceneViewer from '../../components/SceneViewer';
 import VideoPlayer from '../../components/VideoPlayer';
 import DashboardManager from '../../components/DashboardManager';
 import KnowledgeGraph from '../../components/KnowledgeGraph';
+import LineChart from '../../components/LineChart';
 
 import { Container, Header, SpaceBetween } from '@cloudscape-design/components';
 
@@ -163,6 +164,9 @@ const ScenePage = () => {
           <SpaceBetween size={'s'}>
             <Container>
               <TimeSelection />
+            </Container>
+            <Container>
+              <LineChart entityId={selectedEntityId} />
             </Container>
             <Container header={<Header>Scene</Header>}>
               <SceneViewer onSelectionChanged={onSelectionChanged} onWidgetClick={onWidgetClick} />

--- a/examples/react-app/vite.config.ts
+++ b/examples/react-app/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import dynamicImport from 'vite-plugin-dynamic-import';
 
 export default defineConfig(() => {
   return {
@@ -7,7 +8,34 @@ export default defineConfig(() => {
       outDir: 'build',
     },
     assetsInclude: ['**/*.hdr'],
-    plugins: [react()],
+    plugins: [
+        /**
+       * This plugin is required to resolve the charts-core module as they are dynamically imported
+       * when the library is loaded.
+       * See the dynamic loading code here: https://github.com/ionic-team/stencil/blob/main/src/client/client-load-module.ts#L32
+       * Unfortunately, we are using an older version of the stencil library which doesn't use the syntax vite supports to
+       * detect the dynamic imports automatically, so we need to use this plugin to explicitly tell vite to include the
+       * charts-core module otherwise their code will not be included in the build.
+       */
+      dynamicImport({
+        filter(id) {
+          // `node_modules` is exclude by default, so we need to include it explicitly
+          // https://github.com/vite-plugin/vite-plugin-dynamic-import/blob/v1.3.0/src/index.ts#L133-L135
+          if (id.includes('/node_modules/@iot-app-kit/charts-core')) {
+            console.log('dynamically import entry point', id);
+            return true;
+          }
+        },
+        onFiles(files) {
+          console.log('dynamically import files', files);
+        }
+      }),
+      // required to support the commonjs require in dev builds
+      react({
+        // Use React plugin in all *.jsx and *.tsx files
+        include: '**/*.{jsx,tsx}'
+      })
+    ],
     server: {
       port: 3000,
       host: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,8 @@
         "rollup-plugin-node-polyfills": "^0.2.1",
         "sass": "^1.63.4",
         "typescript": "^4.8.3",
-        "vite": "^4.4.3"
+        "vite": "^4.4.9",
+        "vite-plugin-dynamic-import": "1.5.0"
       }
     },
     "examples/react-app/node_modules/@types/jest": {
@@ -14071,9 +14072,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "license": "MIT"
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.19",
@@ -55520,13 +55521,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.3",
-      "integrity": "sha512-IMnXQXXWgLi5brBQx/4WzDxdzW0X3pjO4nqFJAuNvwKtxzAmPzFE1wszW3VDpAGQJm3RZkm/brzRdyGsnwgJIA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
+      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
-        "postcss": "^8.4.25",
-        "rollup": "^3.25.2"
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -55571,6 +55573,42 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-dynamic-import": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dynamic-import/-/vite-plugin-dynamic-import-1.5.0.tgz",
+      "integrity": "sha512-Qp85c+AVJmLa8MLni74U4BDiWpUeFNx7NJqbGZyR2XJOU7mgW0cb7nwlAMucFyM4arEd92Nfxp4j44xPi6Fu7g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "es-module-lexer": "^1.2.1",
+        "fast-glob": "^3.2.12",
+        "magic-string": "^0.30.1"
+      }
+    },
+    "node_modules/vite-plugin-dynamic-import/node_modules/acorn": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/vite-plugin-dynamic-import/node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm": {
@@ -76482,8 +76520,9 @@
       }
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.19",
@@ -100433,7 +100472,8 @@
         "rollup-plugin-node-polyfills": "^0.2.1",
         "sass": "^1.63.4",
         "typescript": "^4.8.3",
-        "vite": "^4.4.3",
+        "vite": "^4.4.9",
+        "vite-plugin-dynamic-import": "1.5.0",
         "web-vitals": "^3.4.0",
         "zustand": "^3.7.2"
       },
@@ -105863,14 +105903,15 @@
       }
     },
     "vite": {
-      "version": "4.4.3",
-      "integrity": "sha512-IMnXQXXWgLi5brBQx/4WzDxdzW0X3pjO4nqFJAuNvwKtxzAmPzFE1wszW3VDpAGQJm3RZkm/brzRdyGsnwgJIA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
+      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.25",
-        "rollup": "^3.25.2"
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       },
       "dependencies": {
         "@esbuild/android-arm": {
@@ -106032,6 +106073,35 @@
             "@esbuild/win32-arm64": "0.18.11",
             "@esbuild/win32-ia32": "0.18.11",
             "@esbuild/win32-x64": "0.18.11"
+          }
+        }
+      }
+    },
+    "vite-plugin-dynamic-import": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dynamic-import/-/vite-plugin-dynamic-import-1.5.0.tgz",
+      "integrity": "sha512-Qp85c+AVJmLa8MLni74U4BDiWpUeFNx7NJqbGZyR2XJOU7mgW0cb7nwlAMucFyM4arEd92Nfxp4j44xPi6Fu7g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.8.2",
+        "es-module-lexer": "^1.2.1",
+        "fast-glob": "^3.2.12",
+        "magic-string": "^0.30.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.11.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+          "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.30.5",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+          "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.15"
           }
         }
       }


### PR DESCRIPTION
## Overview
Adds line chart to the example/react-app that connects an iot-app-kit chart in line format to data in twinMaker based off the selected TwinMaker entity

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/109186219/8db641cc-e93b-4360-9304-23721af61c2b


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
