### PR TITLE
fix(scene): only show selected tags overlay

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
@@ -7,16 +7,7 @@ import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { applyDataBindingTemplate } from '../../../utils/dataBindingTemplateUtils';
 
 import { DataOverlayRows } from './DataOverlayRows';
-import {
-  tmAnnotationContainer,
-  tmArrow,
-  tmArrowInner,
-  tmArrowOuter,
-  tmCloseButton,
-  tmCloseButtonDiv,
-  tmContainer,
-  tmPanelContainer,
-} from './styles';
+import { tmAnnotationContainer, tmArrow, tmArrowInner, tmArrowOuter, tmContainer, tmPanelContainer } from './styles';
 
 export interface DataOverlayContainerProps {
   node: ISceneNodeInternal;
@@ -47,6 +38,8 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
   useEffect(() => {
     if (selectedSceneNodeRef === node.ref) {
       setVisible(true);
+    } else if (!isAnnotation && !componentVisible) {
+      setVisible(false);
     }
   }, [selectedSceneNodeRef, node.ref]);
 
@@ -54,7 +47,11 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
   // isPinned config can keep panel open initially.
   useEffect(() => {
     if (initialVisibilitySkipped.current) {
-      setVisible(componentVisible);
+      if (!isAnnotation && selectedSceneNodeRef === node.ref) {
+        setVisible(true);
+      } else {
+        setVisible(componentVisible);
+      }
     }
     initialVisibilitySkipped.current = true;
   }, [componentVisible]);
@@ -92,14 +89,6 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
     [selectedSceneNodeRef, node.ref, onWidgetClick],
   );
 
-  const onClickCloseButton = useCallback(
-    (e) => {
-      setVisible(false);
-      e.stopPropagation();
-    },
-    [setVisible],
-  );
-
   return visible ? (
     <>
       <div
@@ -107,13 +96,6 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
         onClick={onClickContainer}
         style={{ ...tmContainer, ...(isAnnotation ? tmAnnotationContainer : tmPanelContainer) }}
       >
-        {!isAnnotation && !componentVisible && (
-          <div style={tmCloseButtonDiv}>
-            <button style={tmCloseButton} onClick={onClickCloseButton}>
-              X
-            </button>
-          </div>
-        )}
         <DataOverlayRows component={component} />
         {subType == Component.DataOverlaySubType.OverlayPanel && (
           <div style={tmArrow}>

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
@@ -48,15 +48,6 @@ exports[`DataOverlayContainer should render with panel visible correctly when th
     style="overflow: auto; border-radius: 2px; box-shadow: 0px 1px 4px -2px rgba(0, 28, 36, 0.5); padding-top: 12px; padding-bottom: 12px; width: 210px; min-height: 2em;"
   >
     <div
-      style="float: right; margin-top: 8px; margin-right: 8px;"
-    >
-      <button
-        style="background-color: transparent; border-color: transparent; color: white;"
-      >
-        X
-      </button>
-    </div>
-    <div
       data-testid="rows"
     >
       [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[]}},{}]

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.ts
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.ts
@@ -30,16 +30,6 @@ export const tmAnnotationContainer: CSSProperties = {
   paddingLeft: '12px',
   paddingRight: '12px',
 };
-export const tmCloseButtonDiv: CSSProperties = {
-  float: 'right',
-  marginTop: '8px',
-  marginRight: '8px',
-};
-export const tmCloseButton: CSSProperties = {
-  backgroundColor: 'transparent',
-  borderColor: 'transparent',
-  color: 'white',
-};
 
 // Overlay panel arrow
 export const tmArrow: CSSProperties = {


### PR DESCRIPTION
## Overview
When using the option to not display all overlays, overlays staying open when not selected can make the screen cluttered.  We want to make overlays only visible if their tag is selected OR we're in display all mode.

## Verifying Changes

Use local storybook composer 
have a scene with 2 tags
ensure that when overlay visible setting is toggled on their both visible.
ensure that when overlay visible setting is toggled off that the overlay is only visible if the tag is selected.

https://github.com/awslabs/iot-app-kit/assets/109186219/b04eee73-d9e5-4436-941d-e6bbc5310e68

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
