### PR TITLE
feat: disable add button when no widget and property selected 

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -36,6 +36,7 @@ export function ModeledDataStreamTable({
   client,
 }: ModeledDataStreamTableProps) {
   const significantDigits = useSelector((state: DashboardState) => state.significantDigits);
+  const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
 
   const [preferences, setPreferences] = useExplorerPreferences({
     defaultVisibleContent: ['name', 'latestValue'],
@@ -110,7 +111,7 @@ export function ModeledDataStreamTable({
             </Button>
             <Button
               variant='primary'
-              disabled={collectionProps.selectedItems?.length === 0}
+              disabled={collectionProps.selectedItems?.length === 0 || selectedWidgets.length === 0}
               onClick={() => {
                 onClickAddModeledDataStreams(collectionProps.selectedItems as unknown as ModeledDataStream[]);
               }}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
@@ -36,6 +36,7 @@ export function UnmodeledDataStreamTable({
   hasNextPage,
 }: UnmodeledDataStreamTableProps) {
   const significantDigits = useSelector((state: DashboardState) => state.significantDigits);
+  const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
   const [preferences, setPreferences] = useExplorerPreferences({
     defaultVisibleContent: ['propertyAlias', 'latestValue'],
     resourceName: 'unmodeled data stream',
@@ -116,7 +117,7 @@ export function UnmodeledDataStreamTable({
             </Button>
             <Button
               variant='primary'
-              disabled={collectionProps.selectedItems?.length === 0}
+              disabled={collectionProps.selectedItems?.length === 0 || selectedWidgets.length === 0}
               onClick={() => onClickAdd(collectionProps.selectedItems as unknown as UnmodeledDataStream[])}
             >
               Add


### PR DESCRIPTION
## Overview
This PR is for ticket #2115 and to disable add button if no widget and properties selected. 
1. no properties selected  -- disable both Add and Reset button
2. properties selected but no widget is selected  -- disable Add button and enable Reset button
3. both properties and widget selected -- enable both Add and Reset button

## Verifying Changes
[disable-add-button.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/2bfd4f63-cb94-4dc8-b58f-8bc6a4ad741f)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
