### PR TITLE
fix(example): roll back unneeded package json changes

### DIFF
--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -59,7 +59,6 @@
     "rollup-plugin-node-polyfills": "^0.2.1",
     "sass": "^1.63.4",
     "typescript": "^4.8.3",
-    "vite": "^4.4.9",
-    "vite-plugin-dynamic-import": "1.5.0"
+    "vite": "^4.4.3"
   }
 }

--- a/examples/react-app/vite.config.ts
+++ b/examples/react-app/vite.config.ts
@@ -9,28 +9,6 @@ export default defineConfig(() => {
     },
     assetsInclude: ['**/*.hdr'],
     plugins: [
-        /**
-       * This plugin is required to resolve the charts-core module as they are dynamically imported
-       * when the library is loaded.
-       * See the dynamic loading code here: https://github.com/ionic-team/stencil/blob/main/src/client/client-load-module.ts#L32
-       * Unfortunately, we are using an older version of the stencil library which doesn't use the syntax vite supports to
-       * detect the dynamic imports automatically, so we need to use this plugin to explicitly tell vite to include the
-       * charts-core module otherwise their code will not be included in the build.
-       */
-      dynamicImport({
-        filter(id) {
-          // `node_modules` is exclude by default, so we need to include it explicitly
-          // https://github.com/vite-plugin/vite-plugin-dynamic-import/blob/v1.3.0/src/index.ts#L133-L135
-          if (id.includes('/node_modules/@iot-app-kit/charts-core')) {
-            console.log('dynamically import entry point', id);
-            return true;
-          }
-        },
-        onFiles(files) {
-          console.log('dynamically import files', files);
-        }
-      }),
-      // required to support the commonjs require in dev builds
       react({
         // Use React plugin in all *.jsx and *.tsx files
         include: '**/*.{jsx,tsx}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,8 +125,7 @@
         "rollup-plugin-node-polyfills": "^0.2.1",
         "sass": "^1.63.4",
         "typescript": "^4.8.3",
-        "vite": "^4.4.9",
-        "vite-plugin-dynamic-import": "1.5.0"
+        "vite": "^4.4.3"
       }
     },
     "examples/react-app/node_modules/@types/jest": {
@@ -7776,7 +7775,6 @@
     },
     "node_modules/@awsui/component-toolkit": {
       "version": "1.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@awsui/component-toolkit/-/component-toolkit-1.0.0-beta.16.tgz",
       "integrity": "sha512-7DXPsgEFcoWOHtpf2IWJW1yTL/ybf6P3+M/W2Za7GWzvW0GVo64dO02oiJXW0rMQ8Qc38LK7IAGNb//UkP05YQ==",
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1",
@@ -7785,7 +7783,6 @@
     },
     "node_modules/@awsui/components-react": {
       "version": "3.0.960",
-      "resolved": "https://registry.npmjs.org/@awsui/components-react/-/components-react-3.0.960.tgz",
       "integrity": "sha512-yEsSEdWn6gv4PYPAjNi21XYZvEAUicLPpZ+vcyLbSKLQGq+cXIm487mCbJo8WdoYKNne6v00VNSQMoRKnD7W6Q==",
       "dependencies": {
         "@awsui/collection-hooks": "^1.0.0",
@@ -7816,7 +7813,6 @@
     },
     "node_modules/@awsui/design-tokens": {
       "version": "3.0.58",
-      "resolved": "https://registry.npmjs.org/@awsui/design-tokens/-/design-tokens-3.0.58.tgz",
       "integrity": "sha512-pIvT950BRBYj1feh3eLv2Iuz4DdOX8DxtF6XaBRRn6TvGE2NdBP6/eWHgvYa95mFg1u4NUBD0Rf4dDTSEWfqRQ=="
     },
     "node_modules/@awsui/global-styles": {
@@ -9929,7 +9925,6 @@
     },
     "node_modules/@cloudscape-design/component-toolkit": {
       "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.26.tgz",
       "integrity": "sha512-nUS3iRsV5mbYzQmH8104eTJj0GotkJQxEoJjqdu4WyJvwJez4KCJCdN3YtV8anWPxMCkDiKMhvvsDcL2i9w1WA==",
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1",
@@ -9938,7 +9933,6 @@
     },
     "node_modules/@cloudscape-design/components": {
       "version": "3.0.415",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.415.tgz",
       "integrity": "sha512-QazrO1NFkOcAs57tlPpmIET1aRGjiNDpYQmCXOlGlLnGBaji/Yamc87qbGihx9d6H2NoiFoaoDkAmpI23UBCaQ==",
       "dependencies": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
@@ -14072,9 +14066,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.4.14",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.19",
@@ -14101,7 +14095,7 @@
       }
     },
     "node_modules/@matterport/r3f": {
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "SEE LICENSE IN LICENSE.md",
       "peerDependencies": {
         "@matterport/webcomponent": ">=0.1.26",
@@ -14117,7 +14111,7 @@
       }
     },
     "node_modules/@matterport/webcomponent": {
-      "version": "0.1.26",
+      "version": "0.1.35",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "lit": "^2.4.1"
@@ -14126,7 +14120,7 @@
         "matterport-assets": "bin/matterport-assets.cjs"
       },
       "peerDependencies": {
-        "three": "^0.146.0"
+        "three": "^0.151.3"
       }
     },
     "node_modules/@mdx-js/mdx": {
@@ -14350,7 +14344,6 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
       "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
       "dev": true,
       "dependencies": {
@@ -24774,7 +24767,6 @@
     },
     "node_modules/@types/lodash.throttle": {
       "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.throttle/-/lodash.throttle-4.1.7.tgz",
       "integrity": "sha512-znwGDpjCHQ4FpLLx19w4OXDqq8+OvREa05H89obtSyXyOFKL3dDjCslsmfBz0T2FU8dmf5Wx1QvogbINiGIu9g==",
       "dev": true,
       "dependencies": {
@@ -26060,7 +26052,6 @@
     },
     "node_modules/ace-builds": {
       "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.30.0.tgz",
       "integrity": "sha512-ZC+G1ozrrVCVL/KPkeU9R7TEwYeNJUYRrjnEvNhF8r2+WR2tkcCjmduL8M6D3abIdf/16ccEXHtpoRBhAnTyCw=="
     },
     "node_modules/acorn": {
@@ -30805,7 +30796,6 @@
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/detect-package-manager": {
@@ -31614,11 +31604,11 @@
       }
     },
     "node_modules/eslint-config-turbo": {
-      "version": "1.10.14",
-      "resolved": "https://registry.npmjs.org/eslint-config-turbo/-/eslint-config-turbo-1.10.14.tgz",
-      "integrity": "sha512-ZeB+IcuFXy1OICkLuAplVa0euoYbhK+bMEQd0nH9+Lns18lgZRm33mVz/iSoH9VdUzl/1ZmFmoK+RpZc+8R80A==",
+      "version": "1.10.16",
+      "resolved": "https://registry.npmjs.org/eslint-config-turbo/-/eslint-config-turbo-1.10.16.tgz",
+      "integrity": "sha512-O3NQI72bQHV7FvSC6lWj66EGx8drJJjuT1kuInn6nbMLOHdMBhSUX/8uhTAlHRQdlxZk2j9HtgFCIzSc93w42g==",
       "dependencies": {
-        "eslint-plugin-turbo": "1.10.14"
+        "eslint-plugin-turbo": "1.10.16"
       },
       "peerDependencies": {
         "eslint": ">6.6.0"
@@ -32083,8 +32073,8 @@
       }
     },
     "node_modules/eslint-plugin-turbo": {
-      "version": "1.10.14",
-      "integrity": "sha512-sBdBDnYr9AjT1g4lR3PBkZDonTrMnR4TvuGv5W0OiF7z9az1rI68yj2UHJZvjkwwcGu5mazWA1AfB0oaagpmfg==",
+      "version": "1.10.16",
+      "integrity": "sha512-ZjrR88MTN64PNGufSEcM0tf+V1xFYVbeiMeuIqr0aiABGomxFLo4DBkQ7WI4WzkZtWQSIA2sP+yxqSboEfL9MQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "dotenv": "16.0.3"
@@ -33388,7 +33378,6 @@
     },
     "node_modules/focus-lock": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.0.0.tgz",
       "integrity": "sha512-a8Ge6cdKh9za/GZR/qtigTAk7SrGore56EFcoMshClsh7FLk1zwszc/ltuMfKhx56qeuyL/jWQ4J4axou0iJ9w==",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -46551,7 +46540,6 @@
     },
     "node_modules/playwright": {
       "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
       "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
       "dev": true,
       "dependencies": {
@@ -46569,7 +46557,6 @@
     },
     "node_modules/playwright-core": {
       "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
       "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "dev": true,
       "bin": {
@@ -46624,7 +46611,6 @@
     },
     "node_modules/postcss": {
       "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
@@ -47934,7 +47920,6 @@
     },
     "node_modules/react-clientside-effect": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
       "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
       "dependencies": {
         "@babel/runtime": "^7.12.13"
@@ -48184,7 +48169,6 @@
     },
     "node_modules/react-focus-lock": {
       "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.6.tgz",
       "integrity": "sha512-B7gYnCjHNrNYwY2juS71dHbf0+UpXXojt02svxybj8N5bxceAkzPChKEncHuratjUHkIFNCn06k2qj1DRlzTug==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -53884,7 +53868,6 @@
     },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "node_modules/tippy.js": {
@@ -55239,7 +55222,6 @@
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
       "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -55271,7 +55253,6 @@
     },
     "node_modules/use-sidecar": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
       "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
       "dependencies": {
         "detect-node-es": "^1.1.0",
@@ -55521,14 +55502,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.4.3",
+      "integrity": "sha512-IMnXQXXWgLi5brBQx/4WzDxdzW0X3pjO4nqFJAuNvwKtxzAmPzFE1wszW3VDpAGQJm3RZkm/brzRdyGsnwgJIA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
-        "postcss": "^8.4.27",
-        "rollup": "^3.27.1"
+        "postcss": "^8.4.25",
+        "rollup": "^3.25.2"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -55573,42 +55553,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-plugin-dynamic-import": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dynamic-import/-/vite-plugin-dynamic-import-1.5.0.tgz",
-      "integrity": "sha512-Qp85c+AVJmLa8MLni74U4BDiWpUeFNx7NJqbGZyR2XJOU7mgW0cb7nwlAMucFyM4arEd92Nfxp4j44xPi6Fu7g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.8.2",
-        "es-module-lexer": "^1.2.1",
-        "fast-glob": "^3.2.12",
-        "magic-string": "^0.30.1"
-      }
-    },
-    "node_modules/vite-plugin-dynamic-import/node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/vite-plugin-dynamic-import/node_modules/magic-string": {
-      "version": "0.30.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
-      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm": {
@@ -57374,7 +57318,6 @@
     },
     "packages/core/node_modules/@jest/environment": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
       "dependencies": {
@@ -57389,7 +57332,6 @@
     },
     "packages/core/node_modules/@jest/fake-timers": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
       "dependencies": {
@@ -57406,7 +57348,6 @@
     },
     "packages/core/node_modules/@jest/types": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
       "dependencies": {
@@ -57423,7 +57364,6 @@
     },
     "packages/core/node_modules/@sinonjs/commons": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
       "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
       "dependencies": {
@@ -57432,7 +57372,6 @@
     },
     "packages/core/node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
       "dependencies": {
@@ -57441,7 +57380,6 @@
     },
     "packages/core/node_modules/@tootallnate/once": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true,
       "engines": {
@@ -57450,7 +57388,6 @@
     },
     "packages/core/node_modules/acorn": {
       "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "bin": {
@@ -57462,7 +57399,6 @@
     },
     "packages/core/node_modules/acorn-globals": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
       "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
       "dev": true,
       "dependencies": {
@@ -57472,7 +57408,6 @@
     },
     "packages/core/node_modules/acorn-walk": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
       "engines": {
@@ -57481,7 +57416,6 @@
     },
     "packages/core/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
@@ -57496,7 +57430,6 @@
     },
     "packages/core/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
@@ -57512,7 +57445,6 @@
     },
     "packages/core/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
@@ -57524,19 +57456,16 @@
     },
     "packages/core/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "packages/core/node_modules/cssom": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
       "dev": true
     },
     "packages/core/node_modules/data-urls": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
       "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
       "dev": true,
       "dependencies": {
@@ -57550,7 +57479,6 @@
     },
     "packages/core/node_modules/domexception": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
       "dev": true,
       "dependencies": {
@@ -57562,7 +57490,6 @@
     },
     "packages/core/node_modules/form-data": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
       "dependencies": {
@@ -57576,7 +57503,6 @@
     },
     "packages/core/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
@@ -57585,7 +57511,6 @@
     },
     "packages/core/node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
       "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
       "dev": true,
       "dependencies": {
@@ -57597,7 +57522,6 @@
     },
     "packages/core/node_modules/http-proxy-agent": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
       "dependencies": {
@@ -57611,7 +57535,6 @@
     },
     "packages/core/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "dependencies": {
@@ -57623,7 +57546,6 @@
     },
     "packages/core/node_modules/jest-environment-jsdom": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
       "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
       "dev": true,
       "dependencies": {
@@ -57650,7 +57572,6 @@
     },
     "packages/core/node_modules/jest-message-util": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
       "dependencies": {
@@ -57670,7 +57591,6 @@
     },
     "packages/core/node_modules/jest-mock": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
       "dependencies": {
@@ -57684,7 +57604,6 @@
     },
     "packages/core/node_modules/jsdom": {
       "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "dependencies": {
@@ -57729,7 +57648,6 @@
     },
     "packages/core/node_modules/saxes": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "dependencies": {
@@ -57741,7 +57659,6 @@
     },
     "packages/core/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
@@ -57753,7 +57670,6 @@
     },
     "packages/core/node_modules/tr46": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "dev": true,
       "dependencies": {
@@ -57772,7 +57688,6 @@
     },
     "packages/core/node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
       "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
       "dev": true,
       "dependencies": {
@@ -57784,7 +57699,6 @@
     },
     "packages/core/node_modules/webidl-conversions": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "engines": {
@@ -57793,7 +57707,6 @@
     },
     "packages/core/node_modules/whatwg-encoding": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
       "dev": true,
       "dependencies": {
@@ -57805,7 +57718,6 @@
     },
     "packages/core/node_modules/whatwg-mimetype": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
       "engines": {
@@ -57814,7 +57726,6 @@
     },
     "packages/core/node_modules/whatwg-url": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
       "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "dev": true,
       "dependencies": {
@@ -57827,7 +57738,6 @@
     },
     "packages/core/node_modules/xml-name-validator": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "dev": true,
       "engines": {
@@ -61099,7 +61009,6 @@
     },
     "packages/source-iotsitewise/node_modules/@jest/environment": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
       "dependencies": {
@@ -61114,7 +61023,6 @@
     },
     "packages/source-iotsitewise/node_modules/@jest/fake-timers": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
       "dependencies": {
@@ -61131,7 +61039,6 @@
     },
     "packages/source-iotsitewise/node_modules/@jest/types": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
       "dependencies": {
@@ -61148,7 +61055,6 @@
     },
     "packages/source-iotsitewise/node_modules/@sinonjs/commons": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
       "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
       "dependencies": {
@@ -61157,7 +61063,6 @@
     },
     "packages/source-iotsitewise/node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
       "dependencies": {
@@ -61166,7 +61071,6 @@
     },
     "packages/source-iotsitewise/node_modules/@tootallnate/once": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true,
       "engines": {
@@ -61175,7 +61079,6 @@
     },
     "packages/source-iotsitewise/node_modules/acorn": {
       "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "bin": {
@@ -61187,7 +61090,6 @@
     },
     "packages/source-iotsitewise/node_modules/acorn-globals": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
       "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
       "dev": true,
       "dependencies": {
@@ -61197,7 +61099,6 @@
     },
     "packages/source-iotsitewise/node_modules/acorn-walk": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
       "engines": {
@@ -61206,7 +61107,6 @@
     },
     "packages/source-iotsitewise/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
@@ -61221,7 +61121,6 @@
     },
     "packages/source-iotsitewise/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
@@ -61237,7 +61136,6 @@
     },
     "packages/source-iotsitewise/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
@@ -61249,19 +61147,16 @@
     },
     "packages/source-iotsitewise/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "packages/source-iotsitewise/node_modules/cssom": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
       "dev": true
     },
     "packages/source-iotsitewise/node_modules/data-urls": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
       "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
       "dev": true,
       "dependencies": {
@@ -61275,7 +61170,6 @@
     },
     "packages/source-iotsitewise/node_modules/domexception": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
       "dev": true,
       "dependencies": {
@@ -61287,7 +61181,6 @@
     },
     "packages/source-iotsitewise/node_modules/form-data": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
       "dependencies": {
@@ -61301,7 +61194,6 @@
     },
     "packages/source-iotsitewise/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
@@ -61310,7 +61202,6 @@
     },
     "packages/source-iotsitewise/node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
       "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
       "dev": true,
       "dependencies": {
@@ -61322,7 +61213,6 @@
     },
     "packages/source-iotsitewise/node_modules/http-proxy-agent": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
       "dependencies": {
@@ -61336,7 +61226,6 @@
     },
     "packages/source-iotsitewise/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "dependencies": {
@@ -61348,7 +61237,6 @@
     },
     "packages/source-iotsitewise/node_modules/jest-environment-jsdom": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
       "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
       "dev": true,
       "dependencies": {
@@ -61375,7 +61263,6 @@
     },
     "packages/source-iotsitewise/node_modules/jest-message-util": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
       "dependencies": {
@@ -61395,7 +61282,6 @@
     },
     "packages/source-iotsitewise/node_modules/jest-mock": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
       "dependencies": {
@@ -61409,7 +61295,6 @@
     },
     "packages/source-iotsitewise/node_modules/jsdom": {
       "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "dependencies": {
@@ -61454,7 +61339,6 @@
     },
     "packages/source-iotsitewise/node_modules/saxes": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "dependencies": {
@@ -61466,7 +61350,6 @@
     },
     "packages/source-iotsitewise/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
@@ -61478,7 +61361,6 @@
     },
     "packages/source-iotsitewise/node_modules/tr46": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "dev": true,
       "dependencies": {
@@ -61490,7 +61372,6 @@
     },
     "packages/source-iotsitewise/node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
       "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
       "dev": true,
       "dependencies": {
@@ -61502,7 +61383,6 @@
     },
     "packages/source-iotsitewise/node_modules/webidl-conversions": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "engines": {
@@ -61511,7 +61391,6 @@
     },
     "packages/source-iotsitewise/node_modules/whatwg-encoding": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
       "dev": true,
       "dependencies": {
@@ -61523,7 +61402,6 @@
     },
     "packages/source-iotsitewise/node_modules/whatwg-mimetype": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
       "engines": {
@@ -61532,7 +61410,6 @@
     },
     "packages/source-iotsitewise/node_modules/whatwg-url": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
       "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "dev": true,
       "dependencies": {
@@ -61545,7 +61422,6 @@
     },
     "packages/source-iotsitewise/node_modules/xml-name-validator": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "dev": true,
       "engines": {
@@ -61598,7 +61474,6 @@
     },
     "packages/source-iottwinmaker/node_modules/@jest/environment": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
       "dependencies": {
@@ -61613,7 +61488,6 @@
     },
     "packages/source-iottwinmaker/node_modules/@jest/fake-timers": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
       "dependencies": {
@@ -61630,7 +61504,6 @@
     },
     "packages/source-iottwinmaker/node_modules/@jest/types": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
       "dependencies": {
@@ -61647,7 +61520,6 @@
     },
     "packages/source-iottwinmaker/node_modules/@sinonjs/commons": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
       "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
       "dependencies": {
@@ -61656,7 +61528,6 @@
     },
     "packages/source-iottwinmaker/node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
       "dependencies": {
@@ -61665,7 +61536,6 @@
     },
     "packages/source-iottwinmaker/node_modules/@tootallnate/once": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true,
       "engines": {
@@ -61674,7 +61544,6 @@
     },
     "packages/source-iottwinmaker/node_modules/acorn": {
       "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "bin": {
@@ -61686,7 +61555,6 @@
     },
     "packages/source-iottwinmaker/node_modules/acorn-globals": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
       "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
       "dev": true,
       "dependencies": {
@@ -61696,7 +61564,6 @@
     },
     "packages/source-iottwinmaker/node_modules/acorn-walk": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
       "engines": {
@@ -61705,7 +61572,6 @@
     },
     "packages/source-iottwinmaker/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
@@ -61720,7 +61586,6 @@
     },
     "packages/source-iottwinmaker/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
@@ -61736,7 +61601,6 @@
     },
     "packages/source-iottwinmaker/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
@@ -61748,19 +61612,16 @@
     },
     "packages/source-iottwinmaker/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "packages/source-iottwinmaker/node_modules/cssom": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
       "dev": true
     },
     "packages/source-iottwinmaker/node_modules/data-urls": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
       "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
       "dev": true,
       "dependencies": {
@@ -61774,7 +61635,6 @@
     },
     "packages/source-iottwinmaker/node_modules/domexception": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
       "dev": true,
       "dependencies": {
@@ -61786,7 +61646,6 @@
     },
     "packages/source-iottwinmaker/node_modules/form-data": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
       "dependencies": {
@@ -61800,7 +61659,6 @@
     },
     "packages/source-iottwinmaker/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
@@ -61809,7 +61667,6 @@
     },
     "packages/source-iottwinmaker/node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
       "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
       "dev": true,
       "dependencies": {
@@ -61821,7 +61678,6 @@
     },
     "packages/source-iottwinmaker/node_modules/http-proxy-agent": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
       "dependencies": {
@@ -61835,7 +61691,6 @@
     },
     "packages/source-iottwinmaker/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "dependencies": {
@@ -61847,7 +61702,6 @@
     },
     "packages/source-iottwinmaker/node_modules/jest-environment-jsdom": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
       "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
       "dev": true,
       "dependencies": {
@@ -61874,7 +61728,6 @@
     },
     "packages/source-iottwinmaker/node_modules/jest-message-util": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
       "dependencies": {
@@ -61894,7 +61747,6 @@
     },
     "packages/source-iottwinmaker/node_modules/jest-mock": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
       "dependencies": {
@@ -61908,7 +61760,6 @@
     },
     "packages/source-iottwinmaker/node_modules/jsdom": {
       "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "dependencies": {
@@ -61953,7 +61804,6 @@
     },
     "packages/source-iottwinmaker/node_modules/saxes": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "dependencies": {
@@ -61965,7 +61815,6 @@
     },
     "packages/source-iottwinmaker/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
@@ -61977,7 +61826,6 @@
     },
     "packages/source-iottwinmaker/node_modules/tr46": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "dev": true,
       "dependencies": {
@@ -61989,7 +61837,6 @@
     },
     "packages/source-iottwinmaker/node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
       "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
       "dev": true,
       "dependencies": {
@@ -62001,7 +61848,6 @@
     },
     "packages/source-iottwinmaker/node_modules/webidl-conversions": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "engines": {
@@ -62010,7 +61856,6 @@
     },
     "packages/source-iottwinmaker/node_modules/whatwg-encoding": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
       "dev": true,
       "dependencies": {
@@ -62022,7 +61867,6 @@
     },
     "packages/source-iottwinmaker/node_modules/whatwg-mimetype": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
       "engines": {
@@ -62031,7 +61875,6 @@
     },
     "packages/source-iottwinmaker/node_modules/whatwg-url": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
       "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "dev": true,
       "dependencies": {
@@ -62044,7 +61887,6 @@
     },
     "packages/source-iottwinmaker/node_modules/xml-name-validator": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "dev": true,
       "engines": {
@@ -68291,7 +68133,6 @@
     },
     "@awsui/component-toolkit": {
       "version": "1.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@awsui/component-toolkit/-/component-toolkit-1.0.0-beta.16.tgz",
       "integrity": "sha512-7DXPsgEFcoWOHtpf2IWJW1yTL/ybf6P3+M/W2Za7GWzvW0GVo64dO02oiJXW0rMQ8Qc38LK7IAGNb//UkP05YQ==",
       "requires": {
         "@juggle/resize-observer": "^3.3.1",
@@ -68300,7 +68141,6 @@
     },
     "@awsui/components-react": {
       "version": "3.0.960",
-      "resolved": "https://registry.npmjs.org/@awsui/components-react/-/components-react-3.0.960.tgz",
       "integrity": "sha512-yEsSEdWn6gv4PYPAjNi21XYZvEAUicLPpZ+vcyLbSKLQGq+cXIm487mCbJo8WdoYKNne6v00VNSQMoRKnD7W6Q==",
       "requires": {
         "@awsui/collection-hooks": "^1.0.0",
@@ -68327,7 +68167,6 @@
     },
     "@awsui/design-tokens": {
       "version": "3.0.58",
-      "resolved": "https://registry.npmjs.org/@awsui/design-tokens/-/design-tokens-3.0.58.tgz",
       "integrity": "sha512-pIvT950BRBYj1feh3eLv2Iuz4DdOX8DxtF6XaBRRn6TvGE2NdBP6/eWHgvYa95mFg1u4NUBD0Rf4dDTSEWfqRQ=="
     },
     "@awsui/global-styles": {
@@ -69719,7 +69558,6 @@
     },
     "@cloudscape-design/component-toolkit": {
       "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.26.tgz",
       "integrity": "sha512-nUS3iRsV5mbYzQmH8104eTJj0GotkJQxEoJjqdu4WyJvwJez4KCJCdN3YtV8anWPxMCkDiKMhvvsDcL2i9w1WA==",
       "requires": {
         "@juggle/resize-observer": "^3.3.1",
@@ -69728,7 +69566,6 @@
     },
     "@cloudscape-design/components": {
       "version": "3.0.415",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.415.tgz",
       "integrity": "sha512-QazrO1NFkOcAs57tlPpmIET1aRGjiNDpYQmCXOlGlLnGBaji/Yamc87qbGihx9d6H2NoiFoaoDkAmpI23UBCaQ==",
       "requires": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
@@ -71248,7 +71085,6 @@
       "dependencies": {
         "@jest/environment": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
           "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
           "dev": true,
           "requires": {
@@ -71260,7 +71096,6 @@
         },
         "@jest/fake-timers": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
           "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
           "dev": true,
           "requires": {
@@ -71274,7 +71109,6 @@
         },
         "@jest/types": {
           "version": "29.6.3",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
           "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
           "dev": true,
           "requires": {
@@ -71288,7 +71122,6 @@
         },
         "@sinonjs/commons": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
           "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
           "dev": true,
           "requires": {
@@ -71297,7 +71130,6 @@
         },
         "@sinonjs/fake-timers": {
           "version": "10.3.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
           "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
           "dev": true,
           "requires": {
@@ -71306,19 +71138,16 @@
         },
         "@tootallnate/once": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
           "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
           "dev": true
         },
         "acorn": {
           "version": "8.10.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
           "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
           "dev": true
         },
         "acorn-globals": {
           "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
           "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
           "dev": true,
           "requires": {
@@ -71328,13 +71157,11 @@
         },
         "acorn-walk": {
           "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
           "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
           "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
@@ -71343,7 +71170,6 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
@@ -71353,7 +71179,6 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -71362,19 +71187,16 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "cssom": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
           "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
           "dev": true
         },
         "data-urls": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
           "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
           "dev": true,
           "requires": {
@@ -71385,7 +71207,6 @@
         },
         "domexception": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
           "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
           "dev": true,
           "requires": {
@@ -71394,7 +71215,6 @@
         },
         "form-data": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
           "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
           "dev": true,
           "requires": {
@@ -71405,13 +71225,11 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "html-encoding-sniffer": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
           "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
           "dev": true,
           "requires": {
@@ -71420,7 +71238,6 @@
         },
         "http-proxy-agent": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
           "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
           "dev": true,
           "requires": {
@@ -71431,7 +71248,6 @@
         },
         "iconv-lite": {
           "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "dev": true,
           "requires": {
@@ -71440,7 +71256,6 @@
         },
         "jest-environment-jsdom": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
           "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
           "dev": true,
           "requires": {
@@ -71456,7 +71271,6 @@
         },
         "jest-message-util": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
           "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
           "dev": true,
           "requires": {
@@ -71473,7 +71287,6 @@
         },
         "jest-mock": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
           "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
           "dev": true,
           "requires": {
@@ -71484,7 +71297,6 @@
         },
         "jsdom": {
           "version": "20.0.3",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
           "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
           "dev": true,
           "requires": {
@@ -71518,7 +71330,6 @@
         },
         "saxes": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
           "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
           "dev": true,
           "requires": {
@@ -71527,7 +71338,6 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -71536,7 +71346,6 @@
         },
         "tr46": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
           "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
           "dev": true,
           "requires": {
@@ -71549,7 +71358,6 @@
         },
         "w3c-xmlserializer": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
           "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
           "dev": true,
           "requires": {
@@ -71558,13 +71366,11 @@
         },
         "webidl-conversions": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
           "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
           "dev": true
         },
         "whatwg-encoding": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
           "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
           "dev": true,
           "requires": {
@@ -71573,13 +71379,11 @@
         },
         "whatwg-mimetype": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
           "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
           "dev": true
         },
         "whatwg-url": {
           "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
           "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
           "dev": true,
           "requires": {
@@ -71589,7 +71393,6 @@
         },
         "xml-name-validator": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
           "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
           "dev": true
         }
@@ -74056,7 +73859,6 @@
       "dependencies": {
         "@jest/environment": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
           "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
           "dev": true,
           "requires": {
@@ -74068,7 +73870,6 @@
         },
         "@jest/fake-timers": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
           "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
           "dev": true,
           "requires": {
@@ -74082,7 +73883,6 @@
         },
         "@jest/types": {
           "version": "29.6.3",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
           "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
           "dev": true,
           "requires": {
@@ -74096,7 +73896,6 @@
         },
         "@sinonjs/commons": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
           "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
           "dev": true,
           "requires": {
@@ -74105,7 +73904,6 @@
         },
         "@sinonjs/fake-timers": {
           "version": "10.3.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
           "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
           "dev": true,
           "requires": {
@@ -74114,19 +73912,16 @@
         },
         "@tootallnate/once": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
           "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
           "dev": true
         },
         "acorn": {
           "version": "8.10.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
           "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
           "dev": true
         },
         "acorn-globals": {
           "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
           "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
           "dev": true,
           "requires": {
@@ -74136,13 +73931,11 @@
         },
         "acorn-walk": {
           "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
           "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
           "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
@@ -74151,7 +73944,6 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
@@ -74161,7 +73953,6 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -74170,19 +73961,16 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "cssom": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
           "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
           "dev": true
         },
         "data-urls": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
           "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
           "dev": true,
           "requires": {
@@ -74193,7 +73981,6 @@
         },
         "domexception": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
           "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
           "dev": true,
           "requires": {
@@ -74202,7 +73989,6 @@
         },
         "form-data": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
           "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
           "dev": true,
           "requires": {
@@ -74213,13 +73999,11 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "html-encoding-sniffer": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
           "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
           "dev": true,
           "requires": {
@@ -74228,7 +74012,6 @@
         },
         "http-proxy-agent": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
           "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
           "dev": true,
           "requires": {
@@ -74239,7 +74022,6 @@
         },
         "iconv-lite": {
           "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "dev": true,
           "requires": {
@@ -74248,7 +74030,6 @@
         },
         "jest-environment-jsdom": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
           "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
           "dev": true,
           "requires": {
@@ -74264,7 +74045,6 @@
         },
         "jest-message-util": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
           "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
           "dev": true,
           "requires": {
@@ -74281,7 +74061,6 @@
         },
         "jest-mock": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
           "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
           "dev": true,
           "requires": {
@@ -74292,7 +74071,6 @@
         },
         "jsdom": {
           "version": "20.0.3",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
           "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
           "dev": true,
           "requires": {
@@ -74326,7 +74104,6 @@
         },
         "saxes": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
           "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
           "dev": true,
           "requires": {
@@ -74335,7 +74112,6 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -74344,7 +74120,6 @@
         },
         "tr46": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
           "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
           "dev": true,
           "requires": {
@@ -74353,7 +74128,6 @@
         },
         "w3c-xmlserializer": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
           "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
           "dev": true,
           "requires": {
@@ -74362,13 +74136,11 @@
         },
         "webidl-conversions": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
           "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
           "dev": true
         },
         "whatwg-encoding": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
           "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
           "dev": true,
           "requires": {
@@ -74377,13 +74149,11 @@
         },
         "whatwg-mimetype": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
           "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
           "dev": true
         },
         "whatwg-url": {
           "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
           "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
           "dev": true,
           "requires": {
@@ -74393,7 +74163,6 @@
         },
         "xml-name-validator": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
           "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
           "dev": true
         }
@@ -74438,7 +74207,6 @@
         },
         "@jest/environment": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
           "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
           "dev": true,
           "requires": {
@@ -74450,7 +74218,6 @@
         },
         "@jest/fake-timers": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
           "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
           "dev": true,
           "requires": {
@@ -74464,7 +74231,6 @@
         },
         "@jest/types": {
           "version": "29.6.3",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
           "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
           "dev": true,
           "requires": {
@@ -74478,7 +74244,6 @@
         },
         "@sinonjs/commons": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
           "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
           "dev": true,
           "requires": {
@@ -74487,7 +74252,6 @@
         },
         "@sinonjs/fake-timers": {
           "version": "10.3.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
           "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
           "dev": true,
           "requires": {
@@ -74496,19 +74260,16 @@
         },
         "@tootallnate/once": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
           "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
           "dev": true
         },
         "acorn": {
           "version": "8.10.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
           "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
           "dev": true
         },
         "acorn-globals": {
           "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
           "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
           "dev": true,
           "requires": {
@@ -74518,13 +74279,11 @@
         },
         "acorn-walk": {
           "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
           "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
           "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
@@ -74533,7 +74292,6 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
@@ -74543,7 +74301,6 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -74552,19 +74309,16 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "cssom": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
           "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
           "dev": true
         },
         "data-urls": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
           "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
           "dev": true,
           "requires": {
@@ -74575,7 +74329,6 @@
         },
         "domexception": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
           "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
           "dev": true,
           "requires": {
@@ -74584,7 +74337,6 @@
         },
         "form-data": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
           "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
           "dev": true,
           "requires": {
@@ -74595,13 +74347,11 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "html-encoding-sniffer": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
           "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
           "dev": true,
           "requires": {
@@ -74610,7 +74360,6 @@
         },
         "http-proxy-agent": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
           "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
           "dev": true,
           "requires": {
@@ -74621,7 +74370,6 @@
         },
         "iconv-lite": {
           "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "dev": true,
           "requires": {
@@ -74630,7 +74378,6 @@
         },
         "jest-environment-jsdom": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
           "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
           "dev": true,
           "requires": {
@@ -74646,7 +74393,6 @@
         },
         "jest-message-util": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
           "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
           "dev": true,
           "requires": {
@@ -74663,7 +74409,6 @@
         },
         "jest-mock": {
           "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
           "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
           "dev": true,
           "requires": {
@@ -74674,7 +74419,6 @@
         },
         "jsdom": {
           "version": "20.0.3",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
           "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
           "dev": true,
           "requires": {
@@ -74708,7 +74452,6 @@
         },
         "saxes": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
           "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
           "dev": true,
           "requires": {
@@ -74717,7 +74460,6 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -74726,7 +74468,6 @@
         },
         "tr46": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
           "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
           "dev": true,
           "requires": {
@@ -74735,7 +74476,6 @@
         },
         "w3c-xmlserializer": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
           "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
           "dev": true,
           "requires": {
@@ -74744,13 +74484,11 @@
         },
         "webidl-conversions": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
           "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
           "dev": true
         },
         "whatwg-encoding": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
           "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
           "dev": true,
           "requires": {
@@ -74759,13 +74497,11 @@
         },
         "whatwg-mimetype": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
           "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
           "dev": true
         },
         "whatwg-url": {
           "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
           "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
           "dev": true,
           "requires": {
@@ -74775,7 +74511,6 @@
         },
         "xml-name-validator": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
           "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
           "dev": true
         }
@@ -76526,9 +76261,8 @@
       }
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.4.14",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.19",
@@ -76554,10 +76288,10 @@
       }
     },
     "@matterport/r3f": {
-      "version": "0.2.6"
+      "version": "0.2.7"
     },
     "@matterport/webcomponent": {
-      "version": "0.1.26",
+      "version": "0.1.35",
       "requires": {
         "lit": "^2.4.1"
       }
@@ -76729,7 +76463,6 @@
     },
     "@playwright/test": {
       "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
       "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
       "dev": true,
       "requires": {
@@ -84231,7 +83964,6 @@
     },
     "@types/lodash.throttle": {
       "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.throttle/-/lodash.throttle-4.1.7.tgz",
       "integrity": "sha512-znwGDpjCHQ4FpLLx19w4OXDqq8+OvREa05H89obtSyXyOFKL3dDjCslsmfBz0T2FU8dmf5Wx1QvogbINiGIu9g==",
       "dev": true,
       "requires": {
@@ -85224,7 +84956,6 @@
     },
     "ace-builds": {
       "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.30.0.tgz",
       "integrity": "sha512-ZC+G1ozrrVCVL/KPkeU9R7TEwYeNJUYRrjnEvNhF8r2+WR2tkcCjmduL8M6D3abIdf/16ccEXHtpoRBhAnTyCw=="
     },
     "acorn": {
@@ -88624,7 +88355,6 @@
     },
     "detect-node-es": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "detect-package-manager": {
@@ -89345,11 +89075,11 @@
       "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA=="
     },
     "eslint-config-turbo": {
-      "version": "1.10.14",
-      "resolved": "https://registry.npmjs.org/eslint-config-turbo/-/eslint-config-turbo-1.10.14.tgz",
-      "integrity": "sha512-ZeB+IcuFXy1OICkLuAplVa0euoYbhK+bMEQd0nH9+Lns18lgZRm33mVz/iSoH9VdUzl/1ZmFmoK+RpZc+8R80A==",
+      "version": "1.10.16",
+      "resolved": "https://registry.npmjs.org/eslint-config-turbo/-/eslint-config-turbo-1.10.16.tgz",
+      "integrity": "sha512-O3NQI72bQHV7FvSC6lWj66EGx8drJJjuT1kuInn6nbMLOHdMBhSUX/8uhTAlHRQdlxZk2j9HtgFCIzSc93w42g==",
       "requires": {
-        "eslint-plugin-turbo": "1.10.14"
+        "eslint-plugin-turbo": "1.10.16"
       }
     },
     "eslint-import-resolver-node": {
@@ -89655,8 +89385,8 @@
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g=="
     },
     "eslint-plugin-turbo": {
-      "version": "1.10.14",
-      "integrity": "sha512-sBdBDnYr9AjT1g4lR3PBkZDonTrMnR4TvuGv5W0OiF7z9az1rI68yj2UHJZvjkwwcGu5mazWA1AfB0oaagpmfg==",
+      "version": "1.10.16",
+      "integrity": "sha512-ZjrR88MTN64PNGufSEcM0tf+V1xFYVbeiMeuIqr0aiABGomxFLo4DBkQ7WI4WzkZtWQSIA2sP+yxqSboEfL9MQ==",
       "requires": {
         "dotenv": "16.0.3"
       },
@@ -90483,7 +90213,6 @@
     },
     "focus-lock": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.0.0.tgz",
       "integrity": "sha512-a8Ge6cdKh9za/GZR/qtigTAk7SrGore56EFcoMshClsh7FLk1zwszc/ltuMfKhx56qeuyL/jWQ4J4axou0iJ9w==",
       "requires": {
         "tslib": "^2.0.3"
@@ -99582,7 +99311,6 @@
     },
     "playwright": {
       "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
       "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
       "dev": true,
       "requires": {
@@ -99592,7 +99320,6 @@
     },
     "playwright-core": {
       "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
       "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "dev": true
     },
@@ -99623,7 +99350,6 @@
     },
     "postcss": {
       "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "requires": {
@@ -100478,8 +100204,7 @@
         "rollup-plugin-node-polyfills": "^0.2.1",
         "sass": "^1.63.4",
         "typescript": "^4.8.3",
-        "vite": "^4.4.9",
-        "vite-plugin-dynamic-import": "1.5.0",
+        "vite": "^4.4.3",
         "web-vitals": "^3.4.0",
         "zustand": "^3.7.2"
       },
@@ -100607,7 +100332,6 @@
     },
     "react-clientside-effect": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
       "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
       "requires": {
         "@babel/runtime": "^7.12.13"
@@ -100763,7 +100487,6 @@
     },
     "react-focus-lock": {
       "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.6.tgz",
       "integrity": "sha512-B7gYnCjHNrNYwY2juS71dHbf0+UpXXojt02svxybj8N5bxceAkzPChKEncHuratjUHkIFNCn06k2qj1DRlzTug==",
       "requires": {
         "@babel/runtime": "^7.0.0",
@@ -104796,7 +104519,6 @@
     },
     "tinycolor2": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "tippy.js": {
@@ -105711,7 +105433,6 @@
     },
     "use-callback-ref": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
       "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
       "requires": {
         "tslib": "^2.0.0"
@@ -105727,7 +105448,6 @@
     },
     "use-sidecar": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
       "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
       "requires": {
         "detect-node-es": "^1.1.0",
@@ -105909,15 +105629,14 @@
       }
     },
     "vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.4.3",
+      "integrity": "sha512-IMnXQXXWgLi5brBQx/4WzDxdzW0X3pjO4nqFJAuNvwKtxzAmPzFE1wszW3VDpAGQJm3RZkm/brzRdyGsnwgJIA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.27",
-        "rollup": "^3.27.1"
+        "postcss": "^8.4.25",
+        "rollup": "^3.25.2"
       },
       "dependencies": {
         "@esbuild/android-arm": {
@@ -106079,35 +105798,6 @@
             "@esbuild/win32-arm64": "0.18.11",
             "@esbuild/win32-ia32": "0.18.11",
             "@esbuild/win32-x64": "0.18.11"
-          }
-        }
-      }
-    },
-    "vite-plugin-dynamic-import": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dynamic-import/-/vite-plugin-dynamic-import-1.5.0.tgz",
-      "integrity": "sha512-Qp85c+AVJmLa8MLni74U4BDiWpUeFNx7NJqbGZyR2XJOU7mgW0cb7nwlAMucFyM4arEd92Nfxp4j44xPi6Fu7g==",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.8.2",
-        "es-module-lexer": "^1.2.1",
-        "fast-glob": "^3.2.12",
-        "magic-string": "^0.30.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.11.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-          "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-          "dev": true
-        },
-        "magic-string": {
-          "version": "0.30.5",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
-          "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/sourcemap-codec": "^1.4.15"
           }
         }
       }


### PR DESCRIPTION
## Overview
Changes in package json to support stencil workaround causes breaks in some environments but stencil is no longer used in the example so we'll revert the changes.

## Verifying Changes
example still builds and run in serve mode with line chart showing properly

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
