### PR TITLE
fix(scene): add overlay close button back

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayContainer.tsx
@@ -7,7 +7,16 @@ import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { applyDataBindingTemplate } from '../../../utils/dataBindingTemplateUtils';
 
 import { DataOverlayRows } from './DataOverlayRows';
-import { tmAnnotationContainer, tmArrow, tmArrowInner, tmArrowOuter, tmContainer, tmPanelContainer } from './styles';
+import {
+  tmAnnotationContainer,
+  tmArrow,
+  tmArrowInner,
+  tmArrowOuter,
+  tmCloseButton,
+  tmCloseButtonDiv,
+  tmContainer,
+  tmPanelContainer,
+} from './styles';
 
 export interface DataOverlayContainerProps {
   node: ISceneNodeInternal;
@@ -89,6 +98,14 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
     [selectedSceneNodeRef, node.ref, onWidgetClick],
   );
 
+  const onClickCloseButton = useCallback(
+    (e) => {
+      setVisible(false);
+      e.stopPropagation();
+    },
+    [setVisible],
+  );
+
   return visible ? (
     <>
       <div
@@ -96,6 +113,13 @@ export const DataOverlayContainer = ({ component, node }: DataOverlayContainerPr
         onClick={onClickContainer}
         style={{ ...tmContainer, ...(isAnnotation ? tmAnnotationContainer : tmPanelContainer) }}
       >
+        {!isAnnotation && !componentVisible && (
+          <div style={tmCloseButtonDiv}>
+            <button style={tmCloseButton} onClick={onClickCloseButton}>
+              X
+            </button>
+          </div>
+        )}
         <DataOverlayRows component={component} />
         {subType == Component.DataOverlaySubType.OverlayPanel && (
           <div style={tmArrow}>

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayContainerSnap.spec.tsx.snap
@@ -48,6 +48,15 @@ exports[`DataOverlayContainer should render with panel visible correctly when th
     style="overflow: auto; border-radius: 2px; box-shadow: 0px 1px 4px -2px rgba(0, 28, 36, 0.5); padding-top: 12px; padding-bottom: 12px; width: 210px; min-height: 2em;"
   >
     <div
+      style="float: right; margin-top: 8px; margin-right: 8px;"
+    >
+      <button
+        style="background-color: transparent; border-color: transparent; color: white;"
+      >
+        X
+      </button>
+    </div>
+    <div
       data-testid="rows"
     >
       [{"component":{"ref":"comp-ref","type":"DataOverlay","subType":"OverlayPanel","dataRows":[{"rowType":"Markdown","content":"content"}],"valueDataBindings":[]}},{}]

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.ts
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/styles.ts
@@ -30,6 +30,16 @@ export const tmAnnotationContainer: CSSProperties = {
   paddingLeft: '12px',
   paddingRight: '12px',
 };
+export const tmCloseButtonDiv: CSSProperties = {
+  float: 'right',
+  marginTop: '8px',
+  marginRight: '8px',
+};
+export const tmCloseButton: CSSProperties = {
+  backgroundColor: 'transparent',
+  borderColor: 'transparent',
+  color: 'white',
+};
 
 // Overlay panel arrow
 export const tmArrow: CSSProperties = {


### PR DESCRIPTION
## Overview
Adds the overlay close button back to handles hiding an overlay even though the tag is still selected.

## Verifying Changes
run storybook
select a tag with an overlay
see the X mark and click it to close the overlay

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
