### PR TITLE
fix(scene): ensure the selected overlay is always the one at front

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
@@ -32,7 +32,7 @@ export const DataOverlayComponent = ({ node, component }: DataOverlayComponentPr
     }
   };
 
-  // enforces a zIndex on the outer div of HTML to push the selected overlay to the front before other overlays
+  // enforces a zIndex on outer div of r3f HTML to push the selected overlay to the front before other overlays
   useEffect(() => {
     if (htmlRef.current?.parentElement) {
       htmlRef.current.parentElement.style.zIndex = node.ref == selectedSceneNodeRef ? '999' : '1';

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayComponentSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/__tests__/__snapshots__/DataOverlayComponentSnap.spec.tsx.snap
@@ -9,6 +9,7 @@ exports[`DataOverlayComponent should render the component correctly 1`] = `
       class="tm-html-wrapper"
       data-mocked="Html"
       style="top: -14px; transform: translate3d(-50%,-100%,0);"
+      zindexrange="[]"
     >
       <div
         data-testid="container"


### PR DESCRIPTION
## Overview
Currently when all overlays are visible the user can't control which is in front without trying to manage the camera. We'd like the selected overlay to always be the one in front

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/109186219/6233cb22-0702-4678-b887-1a51d4bbb593

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
