### PR TITLE
feat: disable add button when more than one widgets are selected

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -111,7 +111,7 @@ export function ModeledDataStreamTable({
             </Button>
             <Button
               variant='primary'
-              disabled={collectionProps.selectedItems?.length === 0 || selectedWidgets.length === 0}
+              disabled={collectionProps.selectedItems?.length === 0 || selectedWidgets.length !== 1}
               onClick={() => {
                 onClickAddModeledDataStreams(collectionProps.selectedItems as unknown as ModeledDataStream[]);
               }}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
@@ -117,7 +117,7 @@ export function UnmodeledDataStreamTable({
             </Button>
             <Button
               variant='primary'
-              disabled={collectionProps.selectedItems?.length === 0 || selectedWidgets.length === 0}
+              disabled={collectionProps.selectedItems?.length === 0 || selectedWidgets.length !== 1}
               onClick={() => onClickAdd(collectionProps.selectedItems as unknown as UnmodeledDataStream[])}
             >
               Add


### PR DESCRIPTION
## Overview
This PR is for ticket #2115 and to disable add button if more than 1 widgets selected.

## Verifying Changes
[disable-add-button-when-more-widgets-selected.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/ed037835-b59b-4079-a71a-e17b972f6c80)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
