### PR TITLE
feat: draw box, corresponding with there the mouse was dragged and center align

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/dashboardEmptyState.css
+++ b/packages/dashboard/src/components/internalDashboard/dashboardEmptyState.css
@@ -1,15 +1,15 @@
 .dashboard-empty-state {
   position: fixed;
   top: 50%;
-  right: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   border: dashed;
   height: 200px;
-  margin-top: -100px;
   width: 350px;
-  margin-right: -125px;
   text-align: center;
   font-size: 16px !important;
   font-weight: 600 !important;
+  pointer-events: none;
 }
 
 .dashboard-empty-state img {


### PR DESCRIPTION
## Overview
This PR is for ticket #2137  and this includes
1. clicking and dragging on the empty state image draws the expected rectangle aligned with where the mouse was clicked and dragged
2. empty state correctly aligned center.

## Verifying Changes
[center-align.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/3616dc0e-9029-4e4f-adef-8dffa5fe5264)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
