### PR TITLE
fix: better disabled states and error handling for CSV

### DIFF
--- a/packages/dashboard/src/components/csvDownloadButton/getDescribedTimeSeries.tsx
+++ b/packages/dashboard/src/components/csvDownloadButton/getDescribedTimeSeries.tsx
@@ -24,12 +24,12 @@ export const getDescribedTimeSeries = async ({
 
   try {
     const data = await client.send(command);
-    return { data, isSuccess: true };
+    return { data, isError: false };
   } catch (error) {
     console.error(`Failed to get described time series. Error: ${error}`);
     console.info('Request input:');
     console.table(params);
 
-    throw error;
+    return { data: undefined, isError: true };
   }
 };

--- a/packages/dashboard/src/components/csvDownloadButton/index.tsx
+++ b/packages/dashboard/src/components/csvDownloadButton/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Button, ButtonProps } from '@cloudscape-design/components';
 
@@ -7,6 +7,11 @@ import { StyledSiteWiseQueryConfig } from '~/customization/widgets/types';
 import { useViewportData } from '~/components/csvDownloadButton/useViewportData';
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 
+const isQueryEmpty = (queryConfig: StyledSiteWiseQueryConfig) => {
+  const query = queryConfig.query;
+  return !query?.assets.length && !query?.properties?.length && !query?.assetModels?.length;
+};
+
 const CSVDownloadButton = ({
   queryConfig,
   fileName,
@@ -14,12 +19,21 @@ const CSVDownloadButton = ({
   ...rest
 }: { queryConfig: StyledSiteWiseQueryConfig; client: IoTSiteWiseClient; fileName: string } & ButtonProps) => {
   const { fetchViewportData } = useViewportData({ queryConfig, client });
+  const [isDownloading, setIsDownloading] = useState(false);
 
   const onClickDownload = async () => {
+    setIsDownloading(true);
     const requestDateMS = Date.now();
     const requestDateString = new Date(requestDateMS).toISOString();
 
-    const data = await fetchViewportData(requestDateMS);
+    const { data, isError } = await fetchViewportData(requestDateMS);
+
+    if (isError || !data || data.length === 0) {
+      isError && console.error('Unable to download CSV data');
+      setIsDownloading(false);
+      return;
+    }
+
     const stringCSVData = unparse(data);
 
     const file = new Blob([stringCSVData], { type: 'text/csv' });
@@ -31,10 +45,22 @@ const CSVDownloadButton = ({
     document.body.appendChild(element); // required for this to work in firefox
     element.click();
     element.remove();
+    setIsDownloading(false);
   };
 
+  const isEmptyQuery = isQueryEmpty(queryConfig);
+
+  if (isEmptyQuery) return <></>;
+
   return (
-    <Button iconName='download' variant='icon' onClick={onClickDownload} data-testid='csv-download-button' {...rest} />
+    <Button
+      iconName='download'
+      loading={isDownloading}
+      variant='icon'
+      onClick={onClickDownload}
+      data-testid='csv-download-button'
+      {...rest}
+    />
   );
 };
 


### PR DESCRIPTION
## Overview
- download button is disabled when download is in progress
- if any dataStreams are in an error state, then the CSV download does not occur
- empty widget does not show download button
![image](https://github.com/awslabs/iot-app-kit/assets/28601414/625877fb-30e0-4d95-956e-a42a1f0ad323)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
