### PR TITLE
fix: pasting at the edge of dashboard should paste widget within the …

### DIFF
--- a/packages/dashboard/src/store/actions/pasteWidgets/index.spec.ts
+++ b/packages/dashboard/src/store/actions/pasteWidgets/index.spec.ts
@@ -202,3 +202,61 @@ it('selects the widgets that are pasted', () => {
     ])
   );
 });
+
+it('pastes a widget at right edge location', () => {
+  expect(
+    pasteWidgets(
+      setupDashboardState([MOCK_KPI_WIDGET], [MOCK_KPI_WIDGET]),
+      onPasteWidgetsAction({
+        position: { x: 1000, y: 1000 },
+      })
+    ).dashboardConfiguration.widgets
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: MOCK_KPI_WIDGET.type,
+        x: MOCK_KPI_WIDGET.x,
+        y: MOCK_KPI_WIDGET.y,
+      }),
+      expect.objectContaining({
+        type: MOCK_KPI_WIDGET.type,
+        x: 92,
+        y: 95,
+      }),
+    ])
+  );
+});
+
+it('pastes multiple widgets at right edge location', () => {
+  expect(
+    pasteWidgets(
+      setupDashboardState([MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET], [MOCK_KPI_WIDGET, MOCK_LINE_CHART_WIDGET]),
+      onPasteWidgetsAction({
+        position: { x: 1000, y: 1000 },
+      })
+    ).dashboardConfiguration.widgets
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: MOCK_KPI_WIDGET.type,
+        x: MOCK_KPI_WIDGET.x,
+        y: MOCK_KPI_WIDGET.y,
+      }),
+      expect.objectContaining({
+        type: MOCK_LINE_CHART_WIDGET.type,
+        x: MOCK_LINE_CHART_WIDGET.x,
+        y: MOCK_LINE_CHART_WIDGET.y,
+      }),
+      expect.objectContaining({
+        type: MOCK_KPI_WIDGET.type,
+        x: 90,
+        y: 93,
+      }),
+      expect.objectContaining({
+        type: MOCK_LINE_CHART_WIDGET.type,
+        x: 92,
+        y: 95,
+      }),
+    ])
+  );
+});

--- a/packages/dashboard/src/store/actions/pasteWidgets/index.ts
+++ b/packages/dashboard/src/store/actions/pasteWidgets/index.ts
@@ -1,8 +1,7 @@
-import first from 'lodash/first';
-import sortBy from 'lodash/sortBy';
+import { minBy, max } from 'lodash';
 import { v4 } from 'uuid';
 import type { Action } from 'redux';
-import type { Position } from '~/types';
+import type { Position, DashboardWidget } from '~/types';
 import type { DashboardState } from '../../state';
 
 type PasteWidgetsActionPayload = {
@@ -23,9 +22,15 @@ export const pasteWidgets = (state: DashboardState, action: PasteWidgetsAction):
 
   const cellSize = state.grid.cellSize;
   const copyGroup = state.copiedWidgets;
+  const gridWidth = state.grid.width;
+  const gridHeight = state.grid.height;
   let pasteCounter = state.pasteCounter + 1;
 
   let offset: Position = {
+    x: 0,
+    y: 0,
+  };
+  const correctionOffset: Position = {
     x: 0,
     y: 0,
   };
@@ -37,18 +42,50 @@ export const pasteWidgets = (state: DashboardState, action: PasteWidgetsAction):
       y: position && Math.floor(position.y / cellSize),
     };
 
-    const widgetToCompare = first(sortBy(copyGroup, ['x', 'y']));
+    // getting widgets group's left most cell value
+    const leftmostWidget: DashboardWidget = minBy(copyGroup, 'x') || copyGroup[0];
+    const groupLeftX = leftmostWidget.x;
+
+    // getting widgets group's top most cell value
+    const topmostWidget: DashboardWidget = minBy(copyGroup, 'y') || copyGroup[0];
+    const groupTopY = topmostWidget.y;
+
+    // getting widgets group's right most cell value
+    const widgetsRightPos = copyGroup.map((widget) => {
+      return widget.x + widget.width;
+    });
+    const groupRightX = max(widgetsRightPos) || gridWidth;
+
+    // getting widgets group's bottom most cell value
+    const widgetsBottomPos = copyGroup.map((widget) => {
+      return widget.y + widget.height;
+    });
+    const groupBottomY = max(widgetsBottomPos) || gridHeight;
+
+    // calculating widgets group's width & height
+    const groupWidth = groupRightX - groupLeftX;
+    const groupHeight = groupBottomY - groupTopY;
+
+    // setting offset postion
     offset = {
-      x: cellPosition.x - (widgetToCompare?.x ?? 0),
-      y: cellPosition.y - (widgetToCompare?.y ?? 0),
+      x: cellPosition.x - groupLeftX,
+      y: cellPosition.y - groupTopY,
     };
+
+    // setting correction offset position if widgets group's width or height is going off the grid
+    if (cellPosition.x + groupWidth > gridWidth) {
+      correctionOffset.x = cellPosition.x + groupWidth - gridWidth;
+    }
+    if (cellPosition.y + groupHeight > gridHeight) {
+      correctionOffset.y = cellPosition.y + groupHeight - gridHeight;
+    }
   }
 
   const widgetsToPaste = copyGroup.map((widget) => ({
     ...widget,
     id: v4(),
-    x: offset.x + widget.x + pasteCounter,
-    y: offset.y + widget.y + pasteCounter,
+    x: offset.x + widget.x + pasteCounter - correctionOffset.x,
+    y: offset.y + widget.y + pasteCounter - correctionOffset.y,
   }));
 
   return {


### PR DESCRIPTION
Issue: https://github.com/awslabs/iot-app-kit/issues/2141

Fix:
-> User pasting widgets at the edge of the dashboard should keep widget within the grid, it won't go off the grid.
-> Added test cases to check the above scenario.

Verification:
[Edge-Pasting.webm](https://github.com/awslabs/iot-app-kit/assets/81667589/689a91b9-847d-498c-9285-1166c787447e)
