### PR TITLE
fix: dashboard mock service worker lifecycle

### DIFF
--- a/packages/dashboard/src/msw/useWorker.ts
+++ b/packages/dashboard/src/msw/useWorker.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { worker } from './browser';
+
+export const useWorker = () => {
+  useEffect(() => {
+    worker.start();
+
+    return () => {
+      worker.stop();
+    };
+  }, []);
+};

--- a/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
@@ -4,10 +4,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 import Dashboard from '../../src/components/dashboard';
 import { DashboardClientConfiguration } from '../../src/types';
 import { DEFAULT_REGION } from '~/msw/constants';
-import { worker } from '~/msw/browser';
-
-// Start mocked service worker for iot client calls
-worker.start();
+import { useWorker } from '~/msw/useWorker';
 
 /**
  * Data is mocked by the service worker started above.
@@ -65,6 +62,13 @@ export default {
   parameters: {
     layout: 'fullscreen',
   },
+  // Applies to all stories under Mocked data
+  decorators: [
+    (Story) => {
+      useWorker();
+      return <Story />;
+    },
+  ],
 } as ComponentMeta<typeof Dashboard>;
 
 export const Empty: ComponentStory<typeof Dashboard> = () => <Dashboard {...emptyDashboardConfiguration} />;


### PR DESCRIPTION
## Overview
Fix for mock service worker lifecycle in storybook. Adds a decorator to the Mocked data story which will start and stop the service worker on story mount / unmount. This way, the service worker will not be running for any other story.

_Note: if switching between mocked / connected stories, you will need to refresh the page as react query caches all calls in memory, and there is no access to the client at the Storybook story level._

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
