### PR TITLE
feat: dashboard resource explorer e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46916,6 +46916,23 @@
         "node": ">=16"
       }
     },
+    "node_modules/playwright-msw": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/playwright-msw/-/playwright-msw-2.2.1.tgz",
+      "integrity": "sha512-LjT68LWqzJX8boy4KbnPp5ACLf7WDpt6RUem0tQQcQKys+45KNlluzBx8HEl1HNiCBYV/XZw1aI1aD2giKXWRg==",
+      "dev": true,
+      "dependencies": {
+        "@mswjs/cookies": "^0.2.2",
+        "strict-event-emitter": "^0.4.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.20.0",
+        "msw": ">=0.47.3"
+      }
+    },
     "node_modules/pnp-webpack-plugin": {
       "version": "1.6.4",
       "integrity": "sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==",
@@ -58583,6 +58600,7 @@
         "jest-matcher-utils": "^29.5.0",
         "lodash": "^4.17.21",
         "msw": "^1.3.1",
+        "playwright-msw": "^2.2.1",
         "postcss": "^8.4.31",
         "postcss-import": "^15.1.0",
         "postcss-url": "^10.1.3",
@@ -72247,6 +72265,7 @@
         "msw": "^1.3.1",
         "papaparse": "^5.4.1",
         "parse-duration": "^1.0.3",
+        "playwright-msw": "^2.2.1",
         "postcss": "^8.4.31",
         "postcss-import": "^15.1.0",
         "postcss-url": "^10.1.3",
@@ -100364,6 +100383,16 @@
       "version": "1.39.0",
       "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "dev": true
+    },
+    "playwright-msw": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/playwright-msw/-/playwright-msw-2.2.1.tgz",
+      "integrity": "sha512-LjT68LWqzJX8boy4KbnPp5ACLf7WDpt6RUem0tQQcQKys+45KNlluzBx8HEl1HNiCBYV/XZw1aI1aD2giKXWRg==",
+      "dev": true,
+      "requires": {
+        "@mswjs/cookies": "^0.2.2",
+        "strict-event-emitter": "^0.4.4"
+      }
     },
     "pnp-webpack-plugin": {
       "version": "1.6.4",

--- a/packages/dashboard/e2e/tests/constants.ts
+++ b/packages/dashboard/e2e/tests/constants.ts
@@ -1,0 +1,13 @@
+export const TEST_PAGE = '/iframe.html?id=dashboard-mocked-data--empty';
+export const TEST_IFRAME = '#root';
+export const COMPONENT_SELECTOR = '.dashboard';
+
+export const TOOLBAR_FRAME = '.dashboard-toolbar';
+
+export const RESOURCE_EXPLORER_FRAME = '.collapsible-panel-left';
+export const RESOURCE_EXPLORER_ICON = '[data-testid="collapsed-left-panel-icon"]';
+export const MODELED_TAB = '[data-testid="explore-modeled-tab"]';
+export const UNMODELED_TAB = '[data-testid="explore-unmodeled-tab"]';
+export const ASSET_MODEL_TAB = '[data-testid="explore-asset-model-tab"]';
+
+export const WIDGET_EMPTY_STATE_TEXT = 'Browse and select to add your asset properties in your line widget.';

--- a/packages/dashboard/e2e/tests/dashboard/dashboard.spec.ts
+++ b/packages/dashboard/e2e/tests/dashboard/dashboard.spec.ts
@@ -2,10 +2,7 @@ import { test, expect } from '@playwright/test';
 import { dragAndDrop } from '../utils/dragAndDrop';
 import { GRID_SIZE, gridUtil } from '../utils/grid';
 import { getBoundingBox } from '../utils/locator';
-
-const TEST_PAGE = '/iframe.html?id=dashboard-mocked-data--empty';
-const TEST_IFRAME = '#root';
-const COMPONENT_SELECTOR = '.dashboard';
+import { COMPONENT_SELECTOR, TEST_IFRAME, TEST_PAGE } from '../constants';
 
 test('dashboard', async ({ page }) => {
   await page.goto(TEST_PAGE);

--- a/packages/dashboard/e2e/tests/resourceExplorer/resourceExplorer.spec.ts
+++ b/packages/dashboard/e2e/tests/resourceExplorer/resourceExplorer.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '../test';
+import { gridUtil } from '../utils/grid';
+import { ASSET_MODEL_TAB, MODELED_TAB, TEST_PAGE, UNMODELED_TAB, WIDGET_EMPTY_STATE_TEXT } from '../constants';
+import { resourceExplorerUtil } from '../utils/resourceExplorer';
+
+test('can load resource explorer', async ({ page }) => {
+  await page.goto(TEST_PAGE);
+
+  const resourceExplorer = resourceExplorerUtil(page);
+
+  await resourceExplorer.open();
+
+  await expect(page.locator(MODELED_TAB)).toBeVisible();
+  await expect(page.locator(UNMODELED_TAB)).toBeVisible();
+});
+
+test('can load configure a widget with an asset model', async ({ page }) => {
+  await page.goto(TEST_PAGE);
+  await page.evaluate(() => {
+    // enable feature flag for model based query
+    window.localStorage.setItem('USE_MODEL_BASED_QUERY', 'true');
+  });
+  // need to reload the page so that local storage is applied.
+  await page.reload();
+
+  const grid = gridUtil(page);
+  const resourceExplorer = resourceExplorerUtil(page);
+
+  // add line widget
+  const location1 = await grid.cellLocation(0, 0);
+  const lineWidget = await grid.addWidget('line', () => location1);
+
+  // select line widget
+  await grid.clickWidget(lineWidget);
+
+  // check that widget is in empty state
+  await expect(page.getByText(WIDGET_EMPTY_STATE_TEXT)).toBeVisible();
+
+  // open resource explorer and tab to asset model tab
+  await resourceExplorer.open();
+  await expect(page.locator(ASSET_MODEL_TAB)).toBeVisible();
+  await resourceExplorer.tabTo('assetModel');
+
+  const { selectAssetModel, selectAsset, saveAssetModel, selectProperty, addToWidget } =
+    resourceExplorer.assetModelActions;
+  // configure asset model and default asset and select
+  await selectAssetModel('Site');
+  await selectAsset('Africa site');
+  await saveAssetModel();
+
+  // select property on asset model and add to widget
+  await selectProperty('Coordinates');
+  await addToWidget();
+
+  // check that widget is not in empty state
+  await expect(page.getByText(WIDGET_EMPTY_STATE_TEXT)).not.toBeVisible();
+  // check that property is visible in legend
+  await expect(grid.gridArea().getByText('Coordinates')).toBeVisible();
+});

--- a/packages/dashboard/e2e/tests/test.ts
+++ b/packages/dashboard/e2e/tests/test.ts
@@ -1,0 +1,18 @@
+import { test as base, expect } from '@playwright/test';
+import { rest } from 'msw';
+import type { MockServiceWorker, Config } from 'playwright-msw';
+import { createWorkerFixture } from 'playwright-msw';
+import { handlers } from '../../src/msw/handlers';
+
+const testFactory = (config?: Config) =>
+  base.extend<{
+    worker: MockServiceWorker;
+    rest: typeof rest;
+  }>({
+    worker: createWorkerFixture(handlers, config),
+    rest,
+  });
+
+const test = testFactory();
+
+export { testFactory, test, expect };

--- a/packages/dashboard/e2e/tests/utils/grid.ts
+++ b/packages/dashboard/e2e/tests/utils/grid.ts
@@ -13,6 +13,7 @@ const GridSelector = '#container';
 const WidgetSelectorMap = {
   kpi: 'add KPI widget',
   text: 'add Text widget',
+  line: 'add Line widget',
 };
 
 const SelectionAnchorMap = {
@@ -119,5 +120,11 @@ export const gridUtil = (page: Page) => {
      * @returns the user selection box.
      */
     selection: (): Locator => page.locator(SelectionSelector),
+    /**
+     * helper to get the grid area.
+     *
+     * @returns the grid area locator.
+     */
+    gridArea: (): Locator => gridArea,
   };
 };

--- a/packages/dashboard/e2e/tests/utils/resourceExplorer.ts
+++ b/packages/dashboard/e2e/tests/utils/resourceExplorer.ts
@@ -1,0 +1,92 @@
+import { Page, expect } from '@playwright/test';
+import {
+  RESOURCE_EXPLORER_ICON,
+  RESOURCE_EXPLORER_FRAME,
+  MODELED_TAB,
+  UNMODELED_TAB,
+  ASSET_MODEL_TAB,
+} from '../constants';
+
+const tabMap = {
+  modeled: MODELED_TAB,
+  unmodeled: UNMODELED_TAB,
+  assetModel: ASSET_MODEL_TAB,
+};
+type Tabs = keyof typeof tabMap;
+
+export const resourceExplorerUtil = (page: Page) => {
+  const frame = page.locator(RESOURCE_EXPLORER_FRAME);
+
+  /**
+   * asset model tab specific actions
+   */
+  const assetModelActions = {
+    /**
+     * select an asset model from the dropdown
+     *
+     * @returns void
+     */
+    selectAssetModel: async (label: string) => {
+      await frame.getByText('Select an asset model').click();
+      const searchBox = await frame.getByPlaceholder('Find an asset model');
+      await searchBox.click();
+      await searchBox.fill(label);
+      await frame.getByText(label).click();
+    },
+    /**
+     * select a default asset from the dropdown
+     *
+     * @returns void
+     */
+    selectAsset: async (label: string) => {
+      await frame.getByText('Select an asset').click();
+      await frame.getByText(label).click();
+    },
+    /**
+     * save the asset model / asset selection
+     *
+     * @returns void
+     */
+    saveAssetModel: async () => {
+      await frame.getByText('Save').click();
+    },
+    /**
+     * select an asset model property from the table
+     *
+     * @returns void
+     */
+    selectProperty: async (label: string) => {
+      await frame.getByLabel(`Select asset model property ${label}`).click();
+    },
+    /**
+     * click the add button
+     * will add the asset model configuration to the selection.
+     *
+     * @returns void
+     */
+    addToWidget: async () => {
+      await frame.getByRole('button', { name: 'Add', exact: true }).click();
+    },
+  };
+
+  return {
+    /**
+     * click the resource explorer icon to toggle it open
+     *
+     * @returns void
+     */
+    open: async () => {
+      await frame.locator(RESOURCE_EXPLORER_ICON).click();
+      await expect(page.getByText('Resource explorer')).toBeVisible();
+    },
+    /**
+     * click a tab on the resource explorer
+     *
+     * @returns void
+     */
+    tabTo: async (tab: Tabs) => {
+      await frame.locator(tabMap[tab]).click();
+    },
+    assetModelActions,
+  };
+};

--- a/packages/dashboard/e2e/tests/utils/toolbar.ts
+++ b/packages/dashboard/e2e/tests/utils/toolbar.ts
@@ -1,0 +1,12 @@
+import { Page } from '@playwright/test';
+import { TOOLBAR_FRAME } from '../constants';
+
+export const toolbarUtil = (page: Page) => {
+  const frame = page.locator(TOOLBAR_FRAME);
+
+  return {
+    saveDashboard: async () => {
+      frame.getByText('Save').click();
+    },
+  };
+};

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -74,6 +74,7 @@
     "jest-matcher-utils": "^29.5.0",
     "lodash": "^4.17.21",
     "msw": "^1.3.1",
+    "playwright-msw": "^2.2.1",
     "postcss": "^8.4.31",
     "postcss-import": "^15.1.0",
     "postcss-url": "^10.1.3",

--- a/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import Dashboard from '../../src/components/dashboard';
+import Dashboard, { DashboardProperties } from '../../src/components/dashboard';
 import { DashboardClientConfiguration } from '../../src/types';
 import { DEFAULT_REGION } from '~/msw/constants';
 import { useWorker } from '~/msw/useWorker';
@@ -25,14 +25,17 @@ const displaySettings = {
 
 const viewport = { duration: '5m' };
 
-const emptyDashboardConfiguration = {
+const emptyDashboardConfiguration: DashboardProperties = {
   clientConfiguration,
   dashboardConfiguration: {
     displaySettings,
     viewport,
     widgets: [],
   },
-  onSave: () => Promise.resolve(),
+  onSave: async (dashboard) => {
+    window.localStorage.setItem('dashboard', JSON.stringify(dashboard));
+    Promise.resolve();
+  },
 };
 
 const widgetDashboardConfiguration = {


### PR DESCRIPTION
## Overview
Add integration tests for resource explorer. In order to get mock service worker to work within playwright, a wrapper around the test method is added which utilizes the `playwright-msw` package. This package uses the same handlers as the `msw` implementation but has extra functionality to plug into playwright testing.

Tests Added:
1. basic visibility test
2. asset model happy path test for selecting an asset model and property and adding it to a xy-plot widget.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
