### PR TITLE
revert: reverting fix(dashboard): remove hide/show from dashboard definition and config panel

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/handleDeleteAssetModelProperty.ts
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/handleDeleteAssetModelProperty.ts
@@ -30,3 +30,39 @@ export const handleDeleteAssetModelProperty = (
     ),
   };
 };
+
+//handles hide/show in AssetModelProperty
+
+export const handleToggleHideAssetModelProperty = (
+  { assetModels = [] }: StyledAssetQuery,
+  { assetModelId, propertyId }: { assetModelId: string; propertyId: string }
+) => {
+  return assetModels
+    .map((assetModel) => {
+      if (assetModel.assetModelId !== assetModelId) return assetModel;
+      const { properties } = assetModel;
+      return {
+        ...assetModel,
+        properties: properties.map((property) => {
+          if (property.propertyId === propertyId) {
+            const visible = property.visible !== undefined ? !property.visible : false;
+            return { ...property, visible };
+          } else {
+            return property;
+          }
+        }),
+      };
+    })
+    .filter((assetModel) => assetModel.properties.length > 0);
+};
+
+export const handleHideAssetModelProperty = (
+  siteWiseAssetQuery: StyledAssetQuery,
+  { assetModelId, propertyId }: { assetModelId: string; propertyId: string }
+): StyledAssetQuery => {
+  if (!siteWiseAssetQuery) return siteWiseAssetQuery;
+  return {
+    ...siteWiseAssetQuery,
+    assetModels: handleToggleHideAssetModelProperty(siteWiseAssetQuery, { assetModelId, propertyId }),
+  };
+};

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
@@ -11,12 +11,17 @@ import {
   Input,
 } from '@cloudscape-design/components';
 import { spaceStaticXxs } from '@cloudscape-design/design-tokens';
+import { ClickDetail, NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 
 import ColorPicker from '../shared/colorPicker';
 import { LineStyles, StyledAssetPropertyQuery, YAxisOptions } from '~/customization/widgets/types';
 import { getPropertyDisplay } from './getPropertyDisplay';
 import type { AssetSummary } from '~/hooks/useAssetDescriptionQueries';
-import { Tooltip } from '@iot-app-kit/react-components/src';
+import {
+  StatusEyeHidden,
+  StatusEyeVisible,
+} from '~/customization/propertiesSections/propertiesAndAlarmsSettings/icons';
+import { Tooltip } from '@iot-app-kit/react-components';
 import { LineStyleDropdown } from '../components/lineStyleDropdown';
 import { LineThicknessDropdown } from '../components/lineThicknessDropdown';
 
@@ -160,21 +165,40 @@ export type StyledPropertyComponentProps = {
   updateStyle: (newStyles: object) => void;
   assetSummary: AssetSummary;
   property: StyledAssetPropertyQuery;
+  onHideAssetQuery: () => void;
   onDeleteAssetQuery?: () => void;
   colorable: boolean;
+  isPropertyVisible: boolean;
 };
 
 export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
   assetSummary,
   property,
   updateStyle,
+  onHideAssetQuery,
   onDeleteAssetQuery,
   colorable,
+  isPropertyVisible,
 }) => {
   const { display, label } = getPropertyDisplay(property.propertyId, assetSummary);
-
+  const [onMouseOver, setOnMouseOver] = useState(false);
+  const isAssetQueryVisible = !onMouseOver ? isPropertyVisible : !isPropertyVisible;
+  const propertyVisibilityIcon = isAssetQueryVisible ? StatusEyeVisible : StatusEyeHidden;
   const labelRef = useRef<HTMLDivElement | null>(null);
   const [isNameTruncated, setIsNameTruncated] = useState(false);
+
+  const onToggleAssetQuery: NonCancelableEventHandler<ClickDetail> = (e) => {
+    e.stopPropagation();
+    onHideAssetQuery();
+  };
+
+  const handleMouseEnter = () => {
+    setOnMouseOver(true);
+  };
+
+  const handleMouseLeave = () => {
+    setOnMouseOver(false);
+  };
 
   const resetStyles = (styleToReset: object) => {
     updateStyle(styleToReset); // as we add more sections, reset style values here
@@ -196,6 +220,11 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
           {label}
         </div>
       </Tooltip>
+      <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        <Tooltip content={onMouseOver && isPropertyVisible ? 'hide' : 'unhide'} position='top'>
+          <Button onClick={onToggleAssetQuery} variant='icon' iconSvg={propertyVisibilityIcon} />
+        </Tooltip>
+      </div>
 
       <Button onClick={onDeleteAssetQuery} variant='icon' iconName='remove' />
     </SpaceBetween>

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledSection.tsx
@@ -9,7 +9,7 @@ import { StyledPropertiesAlarmsSectionProps } from './sectionTypes';
 import { defaultOnDeleteQuery } from './onDeleteProperty';
 import { StyledAssetQuery } from '~/customization/widgets/types';
 import { useAssetModel } from '~/hooks/useAssetModel/useAssetModel';
-import { handleDeleteAssetModelProperty } from './handleDeleteAssetModelProperty';
+import { handleDeleteAssetModelProperty, handleHideAssetModelProperty } from './handleDeleteAssetModelProperty';
 
 const NoComponents = () => <Box variant='p'>No properties or alarms found</Box>;
 
@@ -109,6 +109,51 @@ export const StyledPropertiesAlarmsSection: FC<StyledPropertiesAlarmsSectionProp
 
       updateSiteWiseAssetQuery(newQuery);
     };
+    const onHideAssetQuery = (updatedAssetId: string, updatedPropertyId: string) => {
+      const newQuery = {
+        ...styledAssetQuery,
+        assets:
+          styledAssetQuery?.assets?.map((asset) => {
+            if (asset.assetId === updatedAssetId) {
+              return {
+                ...asset,
+                properties: asset.properties.map((property) => {
+                  if (property.propertyId === updatedPropertyId) {
+                    const visible = property.visible !== undefined ? !property.visible : false;
+                    return { ...property, visible };
+                  } else {
+                    return property;
+                  }
+                }),
+              };
+            } else {
+              return asset;
+            }
+          }) ?? [],
+      };
+
+      updateSiteWiseAssetQuery(newQuery);
+    };
+
+    const onHidePropertyAliasQuery = (propertyAlias: string) => {
+      const newQuery = {
+        ...styledAssetQuery,
+        assets: styledAssetQuery?.assets || [],
+        properties:
+          (styledAssetQuery &&
+            styledAssetQuery?.properties?.map((property) => {
+              if (property.propertyAlias === propertyAlias) {
+                const visible = property.visible !== undefined ? !property.visible : false;
+                return { ...property, visible };
+              } else {
+                return property;
+              }
+            })) ??
+          [],
+      };
+
+      updateSiteWiseAssetQuery(newQuery);
+    };
 
     const modeled =
       styledAssetQuery?.assets?.flatMap(({ assetId, properties }) =>
@@ -128,6 +173,8 @@ export const StyledPropertiesAlarmsSection: FC<StyledPropertiesAlarmsSectionProp
                 updateSiteWiseAssetQuery,
               })}
               colorable={colorable}
+              onHideAssetQuery={() => onHideAssetQuery(assetId, property.propertyId)}
+              isPropertyVisible={property.visible ?? true}
             />
           ) : null
         )
@@ -150,6 +197,10 @@ export const StyledPropertiesAlarmsSection: FC<StyledPropertiesAlarmsSectionProp
               updateSiteWiseAssetQuery,
             })}
             colorable={colorable}
+            onHideAssetQuery={() => {
+              onHidePropertyAliasQuery(property.propertyAlias);
+            }}
+            isPropertyVisible={property.visible ?? true}
           />
         );
       }) ?? [];
@@ -194,6 +245,15 @@ export const StyledPropertiesAlarmsSection: FC<StyledPropertiesAlarmsSectionProp
                 )
               }
               colorable={colorable}
+              isPropertyVisible={property.visible ?? true}
+              onHideAssetQuery={() => {
+                updateSiteWiseAssetQuery(
+                  handleHideAssetModelProperty(styledAssetQuery, {
+                    assetModelId,
+                    propertyId: property.propertyId,
+                  }) as StyledAssetQuery
+                );
+              }}
             />
           );
         })

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -66,6 +66,7 @@ export type LineAndScatterStyles = {
   line?: LineStyles;
   aggregationType?: AggregateType;
   resolution?: string;
+  visible?: boolean; // defaults to true
 };
 export type LineStyles = {
   connectionStyle?: 'none' | 'linear' | 'curve' | 'step-start' | 'step-middle' | 'step-end';


### PR DESCRIPTION
## Overview
Reverted #2212. We do not have the hide/show from legend feature complete so we will be adding back hide/show in config panel till that is complete for release. Also added a hide/show functionality for the model centric visualization workflow. 

## Verifying Changes


https://github.com/awslabs/iot-app-kit/assets/145582655/7265fef8-b145-4196-b6fc-73f0febc462f




## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
