### PR TITLE
fix: pagination default pagesize is set to 250 and error message upda…

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/dataStreamSearch/searchQueryInput.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/dataStreamSearch/searchQueryInput.tsx
@@ -10,21 +10,21 @@ export interface SearchQueryInputProps {
 
 export function SearchQueryInput({ control }: SearchQueryInputProps) {
   const MIN_SEARCH_QUERY_LENGTH = 1;
-  const MAX_SEARCH_QUERY_LENGTH = 18;
+  const MAX_SEARCH_QUERY_LENGTH = 48;
 
   return (
     <Controller
       control={control}
       name='searchQuery'
       rules={{
-        required: 'Search query is required.',
+        required: 'Search query must be between 1 and 48 characters.',
         minLength: { value: MIN_SEARCH_QUERY_LENGTH, message: 'Search query is too short.' },
         maxLength: { value: MAX_SEARCH_QUERY_LENGTH, message: 'Search query is too long.' },
       }}
       render={({ field, fieldState }) => (
         <FormField
           label='Search query'
-          description='Enter a query to search for modeled data streams.'
+          description='Enter a query using character string or wildcard character % to search the data.'
           errorText={fieldState.error?.message}
           constraintText={`Must be between ${MIN_SEARCH_QUERY_LENGTH} and ${MAX_SEARCH_QUERY_LENGTH} characters.`}
         >

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/useExplorerPreferences.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/useExplorerPreferences.ts
@@ -2,7 +2,7 @@ import { type CollectionPreferencesProps } from '@cloudscape-design/components/c
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 
 const DEFAULT_PREFERENCES = {
-  pageSize: 10,
+  pageSize: 250,
   wrapLines: true,
   stripedRows: false,
   stickyColumns: { first: 1 },


### PR DESCRIPTION
## Overview
This PR is for ticket (only a few sub tasks are covered here) #2242  and to update  pagination default page size in Resource explorer tables and ux update
1.  Default page size is now set to 250 for all the tables in resource explorer (assets and data stream tables in modeled and data stream table in unmodeled)
2. Search query validation error message and description is updated.

## Verifying Changes
[re-ux-update.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/28dd813f-0226-4218-bc5b-ed9f2537713f)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
