### PR TITLE
fix: restrict @iot-app-kit imports

### DIFF
--- a/configuration/eslint-config/index.js
+++ b/configuration/eslint-config/index.js
@@ -48,6 +48,12 @@ module.exports = {
     'react/jsx-uses-react': 'error',
     'react/jsx-uses-vars': 'error',
     'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never' }],
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": ["@iot-app-kit/**/src"]
+      }
+    ],
   },
   overrides: [
     {

--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -11,6 +11,8 @@ import { DashboardWidgetsConfiguration } from '~/types';
 import { initialState } from '~/store/state';
 
 import { AppKitConfig } from '@iot-app-kit/react-components';
+// FIXME: Export DEFAULT_APP_KIT_CONFIG from @iot-app-kit/react-components
+// eslint-disable-next-line no-restricted-imports
 import { DEFAULT_APP_KIT_CONFIG } from '@iot-app-kit/react-components/src/components/iot-app-kit-config/defaultValues';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 

--- a/packages/dashboard/src/components/palette/index.test.tsx
+++ b/packages/dashboard/src/components/palette/index.test.tsx
@@ -14,6 +14,8 @@ import type { DashboardState } from '../../store/state';
 import type { RecursivePartial } from '~/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AppKitConfig } from '@iot-app-kit/react-components';
+// FIXME: Export DEFAULT_APP_KIT_CONFIG from @iot-app-kit/react-components
+// eslint-disable-next-line no-restricted-imports
 import { DEFAULT_APP_KIT_CONFIG } from '@iot-app-kit/react-components/src/components/iot-app-kit-config/defaultValues';
 
 const testQueryClient = new QueryClient({

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { FormField, Select, SelectProps } from '@cloudscape-design/components';
 import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
+// FIXME: Export ThresholdStyleType from @iot-app-kit/react-components
+// eslint-disable-next-line no-restricted-imports
 import { ThresholdStyleType } from '@iot-app-kit/react-components/src/components/chart/types';
 
 export type ThresholdStyleSettingsProps = {

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
@@ -16,6 +16,8 @@ import { ComparisonOperators } from './comparisonOperators';
 import { AnnotationsSettings } from './annotations';
 import { CancelableEventHandler, ClickDetail } from '@cloudscape-design/components/internal/events';
 import { ThresholdStyleSettings, convertOptionToThresholdStyle, styledOptions } from './thresholdStyle';
+// FIXME: Export ThresholdStyleType from @iot-app-kit/react-components
+// eslint-disable-next-line no-restricted-imports
 import { ThresholdStyleType } from '@iot-app-kit/react-components/src/components/chart/types';
 
 const ThresholdsExpandableSection: React.FC<React.PropsWithChildren<{ title: string }>> = ({ children, title }) => (

--- a/packages/dashboard/src/customization/settings.ts
+++ b/packages/dashboard/src/customization/settings.ts
@@ -1,4 +1,6 @@
 import type { Threshold } from '@iot-app-kit/core';
+// FIXME: Export ThresholdStyleType from @iot-app-kit/react-components
+// eslint-disable-next-line no-restricted-imports
 import { ThresholdStyleType } from '@iot-app-kit/react-components/src/components/chart/types';
 
 export type SimpleFontSettings = {

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -2,6 +2,9 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Chart, useViewport } from '@iot-app-kit/react-components';
+// FIXME: Export ChartOptions from @iot-app-kit/react-components
+// FIXME: Export ChartStyleSettingsOptions from @iot-app-kit/react-components
+// eslint-disable-next-line no-restricted-imports
 import { ChartOptions, ChartStyleSettingsOptions } from '@iot-app-kit/react-components/src/components/chart/types';
 
 import type { DashboardState } from '~/store/state';

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -6,7 +6,7 @@ import type {
 } from '@iot-app-kit/source-iotsitewise';
 import type { DashboardWidget } from '~/types';
 import type { AxisSettings, ComplexFontSettings, SimpleFontSettings, ThresholdWithId } from '../settings';
-import type { TableColumnDefinition, TableItem } from '@iot-app-kit/react-components/src';
+import type { TableColumnDefinition, TableItem } from '@iot-app-kit/react-components';
 import { AggregateType } from '@aws-sdk/client-iotsitewise';
 
 export type QueryConfig<S, T> = {

--- a/packages/source-iotsitewise/src/asset-modules/mocks.ts
+++ b/packages/source-iotsitewise/src/asset-modules/mocks.ts
@@ -7,7 +7,7 @@ import type {
   SiteWiseAssetSessionInterface,
 } from './sitewise/types';
 import type { AssetPropertyValue, AssetSummary, DescribeAssetModelResponse } from '@aws-sdk/client-iotsitewise';
-import type { ErrorDetails } from '@iot-app-kit/core/src/common/types';
+import type { ErrorDetails } from '@iot-app-kit/core';
 
 export class MockSiteWiseAssetsReplayData {
   public models: Map<string, DescribeAssetModelResponse> = new Map<string, DescribeAssetModelResponse>();

--- a/packages/source-iotsitewise/src/asset-modules/sitewise/session.ts
+++ b/packages/source-iotsitewise/src/asset-modules/sitewise/session.ts
@@ -10,7 +10,7 @@ import type {
   SiteWiseAssetSessionInterface,
 } from './types';
 import type { AssetSummary, DescribeAssetModelResponse, AssetPropertyValue } from '@aws-sdk/client-iotsitewise';
-import type { ErrorDetails } from '@iot-app-kit/core/src/common/types';
+import type { ErrorDetails } from '@iot-app-kit/core';
 
 export class SiteWiseAssetSession implements SiteWiseAssetSessionInterface {
   private processor: RequestProcessor;

--- a/packages/source-iotsitewise/src/asset-modules/sitewise/types.ts
+++ b/packages/source-iotsitewise/src/asset-modules/sitewise/types.ts
@@ -14,7 +14,7 @@ import type {
   ListAssociatedAssetsCommandInput,
   ListAssociatedAssetsCommandOutput,
 } from '@aws-sdk/client-iotsitewise';
-import type { ErrorDetails } from '@iot-app-kit/core/src/common/types';
+import type { ErrorDetails } from '@iot-app-kit/core';
 
 export type SiteWiseAssetDataSource = {
   describeAsset: (input: DescribeAssetCommandInput) => Promise<DescribeAssetCommandOutput>;


### PR DESCRIPTION
## Overview
This change prevents absolute imports being used between `@iot-app-kit` imports. Without this change, these invalid imports can make it to library consumers before being caught and fail consumer builds.

https://github.com/awslabs/iot-app-kit/pull/2183 is one such example where we retroactively needed to fix the issue after releasing a broken version of `iot-app-kit`.

Imports of types and imports within tests do not cause consumer builds to fail, yet we should prevent all usage of restricted imports to be on the safe side and prevent the coupling of packages through referencing directory structure with absolute imports. Imports of this category were either fixed, when a package export was readily available, or ignored with a FIXME, when the package export was not available.

This PR is pointed to main so that the issue may be immediately resolved without delay.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
