### PR TITLE
fix(dashboard): ungate csv download

### DIFF
--- a/packages/dashboard/src/components/csvDownloadButton/index.tsx
+++ b/packages/dashboard/src/components/csvDownloadButton/index.tsx
@@ -9,7 +9,7 @@ import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 
 const isQueryEmpty = (queryConfig: StyledSiteWiseQueryConfig) => {
   const query = queryConfig.query;
-  return !query?.assets.length && !query?.properties?.length && !query?.assetModels?.length;
+  return !query?.assets?.length && !query?.properties?.length && !query?.assetModels?.length;
 };
 
 export const CSVDownloadButton = ({
@@ -53,6 +53,7 @@ export const CSVDownloadButton = ({
 
   return (
     <Button
+      ariaLabel='download CSV'
       iconName='download'
       loading={isDownloading}
       variant='icon'

--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -23,7 +23,6 @@ import './tile.css';
 import { onChangeDashboardGridEnabledAction } from '~/store/actions';
 import { CSVDownloadButton } from '~/components/csvDownloadButton';
 import { StyledSiteWiseQueryConfig } from '~/customization/widgets/types';
-import { useGetConfigValue } from '@iot-app-kit/react-components';
 import { useClients } from '~/components/dashboard/clientContext';
 
 type DeletableTileActionProps = {
@@ -59,7 +58,6 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
   const [visible, setVisible] = useState(false);
   const { iotSiteWiseClient } = useClients();
   const { onDelete } = useDeleteWidgets();
-  const isCSVDownloadEnabled = useGetConfigValue('useCSVDownload');
 
   const isRemoveable = !isReadOnly && removeable;
   const headerVisible = !isReadOnly || title;
@@ -106,7 +104,7 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
             {title}
           </Box>
           <SpaceBetween size='s' direction='horizontal'>
-            {widget.type !== 'text' && isCSVDownloadEnabled && iotSiteWiseClient && (
+            {iotSiteWiseClient && widget.type !== 'text' && (
               <CSVDownloadButton
                 client={iotSiteWiseClient}
                 queryConfig={widget.properties.queryConfig as StyledSiteWiseQueryConfig}

--- a/packages/react-components/src/store/config.ts
+++ b/packages/react-components/src/store/config.ts
@@ -1,13 +1,11 @@
 import { StateCreator } from 'zustand/esm';
 
-export type Flags = 'useEcharts' | 'useCSVDownload' | 'useModelBasedQuery';
+export type Flags = 'useModelBasedQuery';
 export interface ConfigState {
   config: Record<Flags, boolean>;
 }
 export const createConfigSlice: StateCreator<ConfigState> = () => ({
   config: {
-    useEcharts: !!localStorage?.getItem('USE_ECHARTS'),
-    useCSVDownload: !!localStorage?.getItem('USE_CSV_DOWNLOAD'),
     useModelBasedQuery: !!localStorage?.getItem('USE_MODEL_BASED_QUERY'),
   },
 });


### PR DESCRIPTION
## Overview
- ungating the CSV feature 
- add aria label to CSV download button 
<img width="174" alt="image" src="https://github.com/awslabs/iot-app-kit/assets/28601414/99d18d08-f41b-479e-91de-28e9e2a75055">

example file: 
[status-timeline 2023-11-10T20 19 13.377Z.csv](https://github.com/awslabs/iot-app-kit/files/13322924/status-timeline.2023-11-10T20.19.13.377Z.csv)
[bar-chart 2023-11-10T20 19 06.910Z.csv](https://github.com/awslabs/iot-app-kit/files/13322927/bar-chart.2023-11-10T20.19.06.910Z.csv)
[xy-plot 2023-11-10T20 19 01.897Z.csv](https://github.com/awslabs/iot-app-kit/files/13322928/xy-plot.2023-11-10T20.19.01.897Z.csv)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
