### PR TITLE
revert: filter query on asset models

### DIFF
--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -173,6 +173,17 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (widge
           };
         })
         .filter((asset) => asset.properties.length > 0) ?? [],
+    assetModels:
+      query?.assetModels
+        ?.map((assetModel) => {
+          const { assetModelId, assetIds, properties } = assetModel;
+          return {
+            assetModelId,
+            assetIds,
+            properties: properties.filter((p) => p.visible ?? true),
+          };
+        })
+        .filter((assetModel) => assetModel.properties.length > 0) ?? [],
   };
 
   const queries = useQueries(filteredQuery);


### PR DESCRIPTION
## Overview
Update the filter query in the line-scatter component to also filter on if the assetModel has no properties. This affects the state of the widget if all properties are hidden when using model centric viz. 

Refer to #2251 for full revert.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/8f952212-1802-41ad-a4c0-c36ca1698fab

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
