### PR TITLE
fix(dashboard): bugfix for barchart positioning

### DIFF
--- a/packages/dashboard/src/customization/widgets/barChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/component.tsx
@@ -28,7 +28,12 @@ const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
   } = widget.properties;
 
   const queries = useQueries(queryConfig.query);
-  const key = createWidgetRenderKey(widget.id);
+  /**
+   * Adding query config to force re-render when adding or removing a datastream
+   * This is required to fix a positioning bug when adding the first datastream
+   * also a bug where removing the last datastream does not actually remove the bars.
+   */
+  const key = createWidgetRenderKey(widget.id) + JSON.stringify(queryConfig.query);
   const aggregation = getAggregation(widget);
   const significantDigits = widgetSignificantDigits ?? dashboardSignificantDigits;
   // there may be better ways to fix this, i.e. not have -44 and let the chart container  take its parent height,


### PR DESCRIPTION
## Overview
The barchart has two bugs:
1. when adding a datastream to the chart, the position of the bars are not aligned with the axis.
2. when removing the last datastream from the chart, the datastream continues to render.

Before:
![bar-chart-bug](https://github.com/awslabs/iot-app-kit/assets/107281089/5e95bc61-1cbb-424e-b6df-13e128354a75)

After:
![bar-chart-bugfix](https://github.com/awslabs/iot-app-kit/assets/107281089/ee209bc4-7824-4223-90bf-cc4c2ffa0628)


To fix these, a key based on the query is added to the bar chart so that we force a rerender when the query changes.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
