### PR TITLE
feat(scene): add ground plane button

### DIFF
--- a/packages/scene-composer/src/common/entityModelConstants.ts
+++ b/packages/scene-composer/src/common/entityModelConstants.ts
@@ -17,6 +17,7 @@ export const componentTypeToId: Record<KnownComponentType, string> = {
   Light: `${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.light`,
   Camera: `${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.camera`,
   EntityBinding: NODE_COMPONENT_TYPE_ID, // EntityBinding is saved at node component
+  PlaneGeometry: `test.${SCENE_COMPONENT_TYPE_ID_PREFIX}.component.planegeometry`, //Remove .test with GA
 };
 export const DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME = 'isVisualOf';
 export const DEFAULT_PARENT_RELATIONSHIP_NAME = 'isChildOf';

--- a/packages/scene-composer/src/components/WebGLCanvasManager.tsx
+++ b/packages/scene-composer/src/components/WebGLCanvasManager.tsx
@@ -142,7 +142,7 @@ export const WebGLCanvasManager: React.FC = () => {
               renderOrder={enableMatterportViewer ? 1 : undefined}
             >
               <planeGeometry args={[1000, 1000]} />
-              <meshBasicMaterial colorWrite={false} />
+              <meshBasicMaterial transparent={true} opacity={0} />
             </mesh>
             {enableMatterportViewer && <MatterportModel onClick={onClick} />}
           </React.Fragment>

--- a/packages/scene-composer/src/components/panels/ComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditor.spec.tsx
@@ -46,6 +46,12 @@ jest.mock('./scene-components/EntityBindingComponentEditor', () => ({
   ),
 }));
 
+jest.mock('./scene-components/PlaneGeometryComponentEditor', () => ({
+  PlaneGeometryComponentEditor: (props) => (
+    <div data-mocked='PlaneGeometryComponentEditor'>{JSON.stringify(props)}</div>
+  ),
+}));
+
 describe('ComponentEditor renders correct component', () => {
   it('render DefaultComponentEditor correctly', async () => {
     const { container } = render(

--- a/packages/scene-composer/src/components/panels/ComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/ComponentEditor.tsx
@@ -15,7 +15,7 @@ import CameraComponentEditor from './scene-components/CameraComponentEditor';
 import { DataOverlayComponentEditor } from './scene-components/DataOverlayComponentEditor';
 import { EntityBindingComponentEditor } from './scene-components/EntityBindingComponentEditor';
 import { AnimationComponentEditor } from './scene-components/AnimationComponentEditor';
-
+import { PlaneGeometryComponentEditor } from './scene-components/PlaneGeometryComponentEditor';
 export interface IComponentEditorProps {
   node: ISceneNodeInternal;
   component: ISceneComponentInternal;
@@ -61,6 +61,8 @@ export const ComponentEditor: React.FC<IComponentEditorProps> = ({ node, compone
       return <EntityBindingComponentEditor node={node} component={component as IEntityBindingComponentInternal} />;
     case KnownComponentType.Animation:
       return <AnimationComponentEditor node={node} component={component as IAnimationComponentInternal} />;
+    case KnownComponentType.PlaneGeometry:
+      return <PlaneGeometryComponentEditor node={node} component={component} />;
     default:
       return <DefaultComponentEditor node={node} component={component} />;
   }

--- a/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneNodeInspectorPanel.tsx
@@ -81,6 +81,10 @@ export const SceneNodeInspectorPanel: React.FC = () => {
       defaultMessage: 'Animation',
       description: 'Expandable Section title',
     },
+    [KnownComponentType.PlaneGeometry]: {
+      defaultMessage: 'Plane Geometry',
+      description: 'Expandable Section title',
+    },
   });
 
   log?.verbose('render inspect panel with selected scene node ', selectedSceneNodeRef, selectedSceneNode);

--- a/packages/scene-composer/src/components/panels/__snapshots__/ComponentEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__snapshots__/ComponentEditor.spec.tsx.snap
@@ -109,6 +109,16 @@ exports[`ComponentEditor renders correct component should render the "MotionIndi
 </div>
 `;
 
+exports[`ComponentEditor renders correct component should render the "PlaneGeometry" editor correctly 1`] = `
+<div>
+  <div
+    data-mocked="PlaneGeometryComponentEditor"
+  >
+    {"node":{},"component":{"ref":"refId","type":"PlaneGeometry"}}
+  </div>
+</div>
+`;
+
 exports[`ComponentEditor renders correct component should render the "SubModelRef" editor correctly 1`] = `
 <div>
   <div

--- a/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditor.spec.tsx
@@ -1,0 +1,109 @@
+import wrapper from '@awsui/components-react/test-utils/dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { IPlaneGeometryComponentInternal, useStore } from '../../../store';
+import { KnownComponentType } from '../../../interfaces';
+import { mockNode, mockComponent } from '../../../../tests/components/panels/scene-components/MockComponents';
+
+import { PlaneGeometryComponentEditor } from './PlaneGeometryComponentEditor';
+
+jest.mock('@awsui/components-react', () => ({
+  ...jest.requireActual('@awsui/components-react'),
+}));
+
+describe('PlaneGeometryComponentEditor', () => {
+  const component: IPlaneGeometryComponentInternal = {
+    ...mockComponent,
+    type: KnownComponentType.PlaneGeometry,
+    width: 10,
+    height: 20,
+  };
+
+  const componentWithColor: IPlaneGeometryComponentInternal = {
+    ...mockComponent,
+    type: KnownComponentType.PlaneGeometry,
+    width: 10,
+    height: 20,
+    color: '#abcdef',
+  };
+
+  const updateComponentInternalFn = jest.fn();
+
+  const baseState = {
+    updateComponentInternal: updateComponentInternalFn,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should update width when width changes', async () => {
+    useStore('default').setState(baseState);
+    const { container } = render(
+      <PlaneGeometryComponentEditor node={{ ...mockNode, components: [component] }} component={component} />,
+    );
+    const polarisWrapper = wrapper(container);
+    const widthInput = polarisWrapper.findInput('[data-testid="plane-width-input"]');
+
+    expect(widthInput).toBeDefined();
+
+    widthInput!.focus();
+    widthInput!.setInputValue('2');
+    widthInput!.blur();
+
+    expect(updateComponentInternalFn).toBeCalledTimes(1);
+    expect(updateComponentInternalFn).toBeCalledWith(
+      mockNode.ref,
+      { ...component, ref: component.ref, width: 2, height: component.height },
+      true,
+    );
+  });
+
+  it('should update height when height changes', async () => {
+    useStore('default').setState(baseState);
+    const { container } = render(
+      <PlaneGeometryComponentEditor node={{ ...mockNode, components: [component] }} component={component} />,
+    );
+    const polarisWrapper = wrapper(container);
+    const heightInput = polarisWrapper.findInput('[data-testid="plane-height-input"]');
+
+    expect(heightInput).toBeDefined();
+
+    heightInput!.focus();
+    heightInput!.setInputValue('2');
+    heightInput!.blur();
+
+    expect(updateComponentInternalFn).toBeCalledTimes(1);
+    expect(updateComponentInternalFn).toBeCalledWith(
+      mockNode.ref,
+      { ...component, ref: component.ref, width: component.width, height: 2 },
+      true,
+    );
+  });
+
+  it('should update background when colors changes', async () => {
+    useStore('default').setState(baseState);
+    const { container } = render(
+      <PlaneGeometryComponentEditor
+        node={{ ...mockNode, components: [componentWithColor] }}
+        component={componentWithColor}
+      />,
+    );
+    const polarisWrapper = wrapper(container);
+    const colorInput = polarisWrapper.findInput('[data-testid="hexcode"]');
+
+    expect(colorInput).toBeDefined();
+
+    // click checkbox should update store
+    colorInput!.focus();
+    colorInput!.setInputValue('#FFFFFF');
+    colorInput!.blur();
+    expect(updateComponentInternalFn).toBeCalledTimes(1);
+    expect(updateComponentInternalFn).toBeCalledWith(
+      mockNode.ref,
+      { ...component, ref: component.ref, width: component.width, height: component.height, color: '#FFFFFF' },
+      true,
+    );
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditor.tsx
@@ -1,0 +1,113 @@
+import React, { useCallback, useContext, useState } from 'react';
+import { FormField, Input, SpaceBetween } from '@awsui/components-react';
+import { useIntl } from 'react-intl';
+
+import { IComponentEditorProps } from '../ComponentEditor';
+import { KnownSceneProperty } from '../../../interfaces';
+import { IPlaneGeometryComponentInternal, ISceneComponentInternal, useStore } from '../../../store';
+import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import { ColorSelectorCombo } from '../scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo';
+
+export type IPlaneGeometryComponentEditorProps = IComponentEditorProps;
+
+export const PlaneGeometryComponentEditor: React.FC<IPlaneGeometryComponentEditorProps> = ({
+  node,
+  component,
+}: IPlaneGeometryComponentEditorProps) => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const updateComponentInternal = useStore(sceneComposerId)((state) => state.updateComponentInternal);
+  const planeGeometryComponent = component as IPlaneGeometryComponentInternal;
+  const intl = useIntl();
+
+  const geometryColors = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<string[]>(KnownSceneProperty.GeometryCustomColors, []),
+  );
+  const setGeometryColorsSceneProperty = useStore(sceneComposerId)((state) => state.setSceneProperty<string[]>);
+
+  const [internalWidth, setInternalWidth] = useState(planeGeometryComponent.width);
+  const [internalHeight, setInternalHeight] = useState(planeGeometryComponent.height);
+  const [internalColor, setInternalColor] = useState(planeGeometryComponent.color || '#cccccc');
+
+  const onUpdateCallback = useCallback(
+    (componentPartial: IPlaneGeometryComponentInternal, replace?: boolean) => {
+      const componentPartialWithRef: ISceneComponentInternal = { ...componentPartial, ref: component.ref };
+      updateComponentInternal(node.ref, componentPartialWithRef, replace);
+    },
+    [node.ref, component.ref],
+  );
+
+  const onColorChange = useCallback(
+    (color: string) => {
+      if (color !== internalColor) {
+        setInternalColor(color);
+        const updatedComponent = { ...planeGeometryComponent, color };
+        onUpdateCallback(updatedComponent, true);
+      }
+    },
+    [internalColor, planeGeometryComponent],
+  );
+
+  const onInputBlur = useCallback(() => {
+    const updatedComponent = { ...planeGeometryComponent, width: internalWidth, height: internalHeight };
+    onUpdateCallback(updatedComponent, true);
+  }, [planeGeometryComponent, internalWidth, internalHeight]);
+
+  const onWidthChange = useCallback(
+    (event) => {
+      const value = Number(event.detail.value);
+      if (value !== internalWidth) {
+        setInternalWidth(value);
+      }
+    },
+    [internalWidth],
+  );
+
+  const onHeightChange = useCallback(
+    (event) => {
+      const value = Number(event.detail.value);
+      if (value !== internalHeight) {
+        setInternalHeight(value);
+      }
+    },
+    [internalHeight],
+  );
+
+  return (
+    <SpaceBetween size='s'>
+      <FormField label={intl.formatMessage({ defaultMessage: 'Width', description: 'Form Field label' })}>
+        <Input
+          data-testid='plane-width-input'
+          value={String(internalWidth)}
+          type='number'
+          onBlur={onInputBlur}
+          onChange={onWidthChange}
+          onKeyDown={(e) => {
+            if (e.detail.key === 'Enter') onInputBlur();
+          }}
+        />
+      </FormField>
+      <FormField label={intl.formatMessage({ defaultMessage: 'Height', description: 'Form Field label' })}>
+        <Input
+          data-testid='plane-height-input'
+          value={String(internalHeight)}
+          type='number'
+          onBlur={onInputBlur}
+          onChange={onHeightChange}
+          onKeyDown={(e) => {
+            if (e.detail.key === 'Enter') onInputBlur();
+          }}
+        />
+      </FormField>
+      <ColorSelectorCombo
+        color={internalColor}
+        onSelectColor={(pickedColor) => onColorChange(pickedColor)}
+        onUpdateCustomColors={(chosenCustomColors) =>
+          setGeometryColorsSceneProperty(KnownSceneProperty.GeometryCustomColors, chosenCustomColors)
+        }
+        customColors={geometryColors}
+        colorPickerLabel={intl.formatMessage({ defaultMessage: 'Color', description: 'Color' })}
+        customColorLabel={intl.formatMessage({ defaultMessage: 'Custom colors', description: 'Custom colors' })}
+      />
+    </SpaceBetween>
+  );
+};

--- a/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditorSnap.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditorSnap.spec.tsx
@@ -1,0 +1,62 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { IPlaneGeometryComponentInternal, useStore } from '../../../store';
+import { KnownComponentType } from '../../../interfaces';
+import { mockNode, mockComponent } from '../../../../tests/components/panels/scene-components/MockComponents';
+
+import { PlaneGeometryComponentEditor } from './PlaneGeometryComponentEditor';
+
+jest.mock('../scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo', () => {
+  return {
+    ColorSelectorCombo: (...props: []) => <div id='ColorSelectorCombo'>{JSON.stringify(props)}</div>,
+  };
+});
+
+describe('PlaneGeometryComponentEditor', () => {
+  const component: IPlaneGeometryComponentInternal = {
+    ...mockComponent,
+    type: KnownComponentType.PlaneGeometry,
+    width: 10,
+    height: 20,
+  };
+
+  const componentWithColor: IPlaneGeometryComponentInternal = {
+    ...mockComponent,
+    type: KnownComponentType.PlaneGeometry,
+    width: 10,
+    height: 20,
+    color: '#abcdef',
+  };
+
+  const updateComponentInternalFn = jest.fn();
+
+  const baseState = {
+    updateComponentInternal: updateComponentInternalFn,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render correctly', () => {
+    useStore('default').setState(baseState);
+
+    const { container } = render(
+      <PlaneGeometryComponentEditor node={{ ...mockNode, components: [component] }} component={component} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render correctly with color', () => {
+    useStore('default').setState(baseState);
+
+    const { container } = render(
+      <PlaneGeometryComponentEditor
+        node={{ ...mockNode, components: [componentWithColor] }}
+        component={componentWithColor}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/PlaneGeometryComponentEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/PlaneGeometryComponentEditorSnap.spec.tsx.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PlaneGeometryComponentEditor should render correctly 1`] = `
+<div>
+  <div
+    data-mocked="SpaceBetween"
+  >
+    <div
+      data-mocked="FormField"
+      label="Width"
+    >
+      <div
+        data-mocked="Input"
+        data-testid="plane-width-input"
+        type="number"
+        value="10"
+      />
+    </div>
+    <div
+      data-mocked="FormField"
+      label="Height"
+    >
+      <div
+        data-mocked="Input"
+        data-testid="plane-height-input"
+        type="number"
+        value="20"
+      />
+    </div>
+    <div
+      id="ColorSelectorCombo"
+    >
+      [{"color":"#cccccc","customColors":[],"colorPickerLabel":"Color","customColorLabel":"Custom colors"},{}]
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PlaneGeometryComponentEditor should render correctly with color 1`] = `
+<div>
+  <div
+    data-mocked="SpaceBetween"
+  >
+    <div
+      data-mocked="FormField"
+      label="Width"
+    >
+      <div
+        data-mocked="Input"
+        data-testid="plane-width-input"
+        type="number"
+        value="10"
+      />
+    </div>
+    <div
+      data-mocked="FormField"
+      label="Height"
+    >
+      <div
+        data-mocked="Input"
+        data-testid="plane-height-input"
+        type="number"
+        value="20"
+      />
+    </div>
+    <div
+      id="ColorSelectorCombo"
+    >
+      [{"color":"#abcdef","customColors":[],"colorPickerLabel":"Color","customColorLabel":"Custom colors"},{}]
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayComponent.tsx
@@ -35,7 +35,7 @@ export const DataOverlayComponent = ({ node, component }: DataOverlayComponentPr
   // enforces a zIndex on outer div of r3f HTML to push the selected overlay to the front before other overlays
   useEffect(() => {
     if (htmlRef.current?.parentElement) {
-      htmlRef.current.parentElement.style.zIndex = node.ref == selectedSceneNodeRef ? '999' : '1';
+      htmlRef.current.parentElement.style.zIndex = node.ref === selectedSceneNodeRef ? '999' : '1';
     }
   }, [selectedSceneNodeRef, node]);
 

--- a/packages/scene-composer/src/components/three-fiber/EntityGroup/ComponentGroup.tsx
+++ b/packages/scene-composer/src/components/three-fiber/EntityGroup/ComponentGroup.tsx
@@ -24,6 +24,8 @@ import ColorOverlayComponent from '../ColorOverlayComponent';
 import SubModelComponent from '../SubModelComponent';
 import DataOverlayComponent from '../DataOverlayComponent';
 import AnimationComponent from '../AnimationComponent/AnimationComponent';
+import PlaneGeometryComponent from '../ModelGeometryComponents/PlaneGeometryComponent';
+import { IPlaneGeometryComponentInternal } from '../../../store/internalInterfaces';
 
 interface ComponentViewProps {
   component: ISceneComponentInternal;
@@ -56,6 +58,8 @@ const ComponentView = ({ component, node }: ComponentViewProps) => {
       return <AnimationComponent node={node} component={component as IAnimationComponentInternal} />;
     case KnownComponentType.DataOverlay:
       return <DataOverlayComponent node={node} component={component as IDataOverlayComponentInternal} />;
+    case KnownComponentType.PlaneGeometry:
+      return <PlaneGeometryComponent node={node} component={component as IPlaneGeometryComponentInternal} />;
     default:
       return <Fragment key={component.ref}></Fragment>;
   }

--- a/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.spec.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { KnownComponentType } from '../../../interfaces';
+import { IPlaneGeometryComponentInternal } from '../../../store';
+import { mockNode, mockComponent } from '../../../../tests/components/panels/scene-components/MockComponents';
+
+import PlaneGeometryComponent from './PlaneGeometryComponent';
+
+jest.doMock('../../../utils/objectThreeUtils', () => {
+  return {
+    acceleratedRaycasting: jest.fn(),
+  };
+});
+
+const handleAddWidgetMock = jest.fn();
+jest.doMock('../../../hooks/useAddWidget', () => {
+  return {
+    handleAddWidget: handleAddWidgetMock,
+  };
+});
+
+describe('PlaneGeometryComponent', () => {
+  const component: IPlaneGeometryComponentInternal = {
+    ...mockComponent,
+    type: KnownComponentType.PlaneGeometry,
+    width: 10,
+    height: 20,
+  };
+
+  const componentWithColor: IPlaneGeometryComponentInternal = {
+    ...mockComponent,
+    type: KnownComponentType.PlaneGeometry,
+    width: 10,
+    height: 20,
+    color: '#abcdef',
+  };
+
+  const setup = () => {
+    jest.resetAllMocks();
+  };
+
+  beforeEach(() => {
+    setup();
+  });
+
+  it(`should render`, async () => {
+    const { container } = render(<PlaneGeometryComponent component={component} node={mockNode} />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it(`should render with predefined color`, () => {
+    const { container } = render(<PlaneGeometryComponent component={componentWithColor} node={mockNode} />);
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.tsx
@@ -1,0 +1,50 @@
+import * as THREE from 'three';
+import React, { useRef, useEffect } from 'react';
+import { ThreeEvent } from '@react-three/fiber';
+import { Plane } from '@react-three/drei';
+
+import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
+import useAddWidget from '../../../hooks/useAddWidget';
+import { IPlaneGeometryComponentInternal, ISceneNodeInternal, useEditorState } from '../../../store';
+import { acceleratedRaycasting, getComponentGroupName } from '../../../utils/objectThreeUtils';
+
+interface PlaneGeometryComponentProps {
+  node: ISceneNodeInternal;
+  component: IPlaneGeometryComponentInternal;
+}
+
+const PlaneGeometryComponent: React.FC<PlaneGeometryComponentProps> = ({
+  component,
+  node,
+}: PlaneGeometryComponentProps) => {
+  const meshRef = useRef<THREE.Mesh | null>(null);
+  const sceneComposerId = useSceneComposerId();
+  const { isEditing, addingWidget } = useEditorState(sceneComposerId);
+  const { handleAddWidget } = useAddWidget();
+  const MAX_CLICK_DISTANCE = 2;
+
+  const onClick = (e: ThreeEvent<MouseEvent>) => {
+    console.log('click triggered, ', e);
+    if (e.delta <= MAX_CLICK_DISTANCE) {
+      if (isEditing() && addingWidget) {
+        handleAddWidget(e);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (meshRef.current) {
+      acceleratedRaycasting(meshRef.current);
+    }
+  }, [meshRef.current]);
+
+  return (
+    <group name={getComponentGroupName(node.ref, 'PLANE_GEOMETRY')}>
+      <Plane args={[component.width, component.height]} ref={meshRef} onClick={onClick}>
+        <meshBasicMaterial color={component.color ? component.color : '#CCCCCC'} side={THREE.DoubleSide} />
+      </Plane>
+    </group>
+  );
+};
+
+export default PlaneGeometryComponent;

--- a/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/__snapshots__/PlaneGeometryComponent.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/__snapshots__/PlaneGeometryComponent.spec.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PlaneGeometryComponent should render 1`] = `
+<div>
+  <group
+    name="PLANE_GEOMETRY_COMPONENT_nodeRef"
+  >
+    <div
+      args="[10,20]"
+      data-mocked="Plane"
+    >
+      <meshbasicmaterial
+        color="#CCCCCC"
+        side="2"
+      />
+    </div>
+  </group>
+</div>
+`;
+
+exports[`PlaneGeometryComponent should render with predefined color 1`] = `
+<div>
+  <group
+    name="PLANE_GEOMETRY_COMPONENT_nodeRef"
+  >
+    <div
+      args="[10,20]"
+      data-mocked="Plane"
+    >
+      <meshbasicmaterial
+        color="#abcdef"
+        side="2"
+      />
+    </div>
+  </group>
+</div>
+`;

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -16,6 +16,7 @@ import {
   ISceneNode,
   KnownComponentType,
   SceneResourceType,
+  IPlaneGeometryComponent,
 } from '../../../../interfaces';
 import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
 import { Component, LightType, ModelType } from '../../../../models/SceneModels';
@@ -43,6 +44,7 @@ enum ObjectTypes {
   Light = 'add-object-light',
   ViewCamera = 'add-object-view-camera',
   Annotation = 'add-object-annotation',
+  GroundPlane = 'add-object-ground-plane',
 }
 
 type AddObjectMenuItem = ToolbarItemOptions & {
@@ -60,6 +62,7 @@ const labelStrings: { [key in ObjectTypes]: MessageDescriptor } = defineMessages
   [ObjectTypes.MotionIndicator]: { defaultMessage: 'Motion indicator', description: 'Menu Item label' },
   [ObjectTypes.ViewCamera]: { defaultMessage: 'Camera', description: 'Menu Item label' },
   [ObjectTypes.Annotation]: { defaultMessage: 'Annotation', description: 'Menu Item label' },
+  [ObjectTypes.GroundPlane]: { defaultMessage: 'Ground Plane', description: 'Menu Item label' },
 });
 
 const textStrings = defineMessages({
@@ -72,6 +75,7 @@ const textStrings = defineMessages({
   [ObjectTypes.MotionIndicator]: { defaultMessage: 'Add motion indicator', description: 'Menu Item' },
   [ObjectTypes.ViewCamera]: { defaultMessage: 'Add camera from current view', description: 'Menu Item' },
   [ObjectTypes.Annotation]: { defaultMessage: 'Add annotation', description: 'Menu Item' },
+  [ObjectTypes.GroundPlane]: { defaultMessage: 'Add ground plane', description: 'Menu Item' },
 });
 
 interface AddObjectMenuProps {
@@ -164,6 +168,10 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
         },
         {
           uuid: ObjectTypes.MotionIndicator,
+        },
+        {
+          uuid: ObjectTypes.GroundPlane,
+          feature: { name: COMPOSER_FEATURES.SceneAppearance },
         },
       ].map(mapToMenuItem),
     [
@@ -306,6 +314,27 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
     }
   };
 
+  const handleAddGroundPlane = () => {
+    const planeComponent: IPlaneGeometryComponent = {
+      type: 'PlaneGeometry',
+      width: 1000,
+      height: 1000,
+      color: 'green',
+    };
+    const node = {
+      name: 'Ground Plane',
+      components: [planeComponent],
+      parentRef: undefined, //force to root
+    } as unknown as ISceneNodeInternal;
+    const newNode = createNodeWithTransform(
+      node,
+      new THREE.Vector3(0, -0.001, 0), //position
+      new THREE.Euler(Math.PI / 2, 0, 0), //rotation on X 90 degrees to place in X-Z plane instead of X-Y plane
+      new THREE.Vector3(1, 1, 1), //scale
+    );
+    appendSceneNode(newNode);
+  };
+
   const handleAddMotionIndicator = () => {
     const motionIndicatorComponent: IMotionIndicatorComponent = {
       type: 'MotionIndicator',
@@ -391,6 +420,9 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
             break;
           case ObjectTypes.Annotation:
             handleAddOverlay(Component.DataOverlaySubType.TextAnnotation);
+            break;
+          case ObjectTypes.GroundPlane:
+            handleAddGroundPlane();
             break;
         }
 

--- a/packages/scene-composer/src/hooks/useAddWidget.spec.tsx
+++ b/packages/scene-composer/src/hooks/useAddWidget.spec.tsx
@@ -1,0 +1,167 @@
+import * as THREE from 'three';
+import { renderHook } from '@testing-library/react-hooks';
+import { ThreeEvent } from '@react-three/fiber';
+
+import { AddingWidgetInfo, KnownComponentType } from '../interfaces';
+import { ISceneNodeInternal, ISubModelRefComponentInternal, useStore } from '../../src/store';
+
+import useAddWidget from './useAddWidget';
+
+const appendSceneNodeMock = jest.fn();
+const getSceneNodeByRefMock = jest.fn();
+const setAddingWidgetMock = jest.fn();
+
+const baseState = {
+  appendSceneNode: appendSceneNodeMock,
+  getSceneNodeByRef: getSceneNodeByRefMock,
+  setAddingWidget: setAddingWidgetMock,
+};
+
+describe('useOverwriteRaycaster', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle a click on object with no parent', () => {
+    const node: ISceneNodeInternal = {
+      ref: 'nodeRef',
+      name: 'nodeName',
+      transform: { position: [0, 0, 0], rotation: [0, 0, 0], scale: [0, 0, 0] },
+      transformConstraint: { snapToFloor: false },
+      components: [],
+      childRefs: [],
+      properties: { hiddenWhileImmersive: true },
+    };
+    const addingWidget: AddingWidgetInfo = {
+      node: node,
+    };
+    useStore('default').setState({
+      ...baseState,
+      addingWidget: addingWidget,
+      cursorLookAt: new THREE.Vector3(),
+    });
+
+    const { handleAddWidget } = renderHook(() => useAddWidget()).result.current;
+
+    const object = new THREE.Object3D();
+    const point = new THREE.Vector3();
+    const e: ThreeEvent<MouseEvent> = {
+      ...new MouseEvent('mocked'),
+      eventObject: object,
+      intersections: [
+        {
+          point: point,
+          distance: 0,
+          eventObject: object,
+          object: object,
+        },
+      ],
+      unprojectedPoint: new THREE.Vector3(),
+      pointer: new THREE.Vector2(),
+      delta: 1,
+      ray: new THREE.Ray(),
+      camera: new THREE.PerspectiveCamera(),
+      stopPropagation: () => {},
+      nativeEvent: new MouseEvent('mocked'),
+      stopped: false,
+      distance: 0,
+      point: point,
+      object: object,
+    };
+    handleAddWidget(e);
+
+    expect(setAddingWidgetMock).toBeCalled();
+    expect(appendSceneNodeMock).toHaveBeenCalledWith({
+      ...addingWidget.node,
+      parentRef: undefined,
+      transform: {
+        position: point.toArray(),
+        rotation: [0, 0, 0],
+        scale: [1, 1, 1],
+      },
+    });
+  });
+
+  it('should handle a click on object with parents', () => {
+    const node: ISceneNodeInternal = {
+      ref: 'nodeRef',
+      name: 'nodeName',
+      transform: { position: [0, 0, 0], rotation: [0, 0, 0], scale: [0, 0, 0] },
+      transformConstraint: { snapToFloor: false },
+      components: [],
+      childRefs: [],
+      properties: { hiddenWhileImmersive: true },
+    };
+    const addingWidget: AddingWidgetInfo = {
+      node: node,
+    };
+    const subModelComponent: ISubModelRefComponentInternal = {
+      ref: 'subRef',
+      type: KnownComponentType.SubModelRef,
+      selector: 'selector',
+    };
+
+    const parentNode: ISceneNodeInternal = {
+      ref: 'parentNodeRef',
+      name: 'parentNodeName',
+      transform: { position: [0, 0, 0], rotation: [0, 0, 0], scale: [0, 0, 0] },
+      transformConstraint: { snapToFloor: false },
+      components: [subModelComponent],
+      childRefs: [],
+      properties: { hiddenWhileImmersive: true },
+    };
+    getSceneNodeByRefMock.mockReturnValue(parentNode);
+    useStore('default').setState({
+      ...baseState,
+      addingWidget: addingWidget,
+      cursorLookAt: new THREE.Vector3(),
+    });
+
+    const { handleAddWidget } = renderHook(() => useAddWidget()).result.current;
+
+    const object = new THREE.Object3D();
+    object.userData.nodeRef = 'ref1';
+
+    const parent3D = new THREE.Object3D();
+    object.parent = parent3D;
+    parent3D.userData.componentTypes = [KnownComponentType.ModelRef];
+    parent3D.userData.nodeRef = 'parentRef1';
+
+    const point = new THREE.Vector3();
+    const e: ThreeEvent<MouseEvent> = {
+      ...new MouseEvent('mocked'),
+      eventObject: object,
+      intersections: [
+        {
+          point: point,
+          distance: 0,
+          eventObject: object,
+          object: object,
+        },
+      ],
+      unprojectedPoint: new THREE.Vector3(),
+      pointer: new THREE.Vector2(),
+      delta: 1,
+      ray: new THREE.Ray(),
+      camera: new THREE.PerspectiveCamera(),
+      stopPropagation: () => {},
+      nativeEvent: new MouseEvent('mocked'),
+      stopped: false,
+      distance: 0,
+      point: point,
+      object: object,
+    };
+    handleAddWidget(e);
+
+    expect(setAddingWidgetMock).toBeCalled();
+    expect(appendSceneNodeMock).toHaveBeenCalledWith({
+      ...addingWidget.node,
+      parentRef: object.userData.nodeRef,
+      transform: {
+        position: parent3D?.worldToLocal(point.clone()).toArray(),
+        rotation: [0, 0, 0],
+        scale: [1, 1, 1],
+      },
+    });
+  });
+});

--- a/packages/scene-composer/src/hooks/useAddWidget.tsx
+++ b/packages/scene-composer/src/hooks/useAddWidget.tsx
@@ -1,0 +1,54 @@
+import { ThreeEvent } from '@react-three/fiber';
+import { useCallback } from 'react';
+
+import { useSceneComposerId } from '../common/sceneComposerIdContext';
+import { KnownComponentType } from '../interfaces';
+import { useEditorState, useStore } from '../store';
+import {
+  createNodeWithPositionAndNormal,
+  findComponentByType,
+  findNearestViableParentAncestorNodeRef,
+} from '../utils/nodeUtils';
+import { getIntersectionTransform } from '../utils/raycastUtils';
+
+const useAddWidget: () => {
+  handleAddWidget: (e: ThreeEvent<MouseEvent>) => void;
+} = () => {
+  const sceneComposerId = useSceneComposerId();
+  const { addingWidget, setAddingWidget, cursorLookAt } = useEditorState(sceneComposerId);
+  const { getSceneNodeByRef } = useStore(sceneComposerId)((state) => state);
+  const appendSceneNode = useStore(sceneComposerId)((state) => state.appendSceneNode);
+
+  const handleAddWidget = useCallback(
+    (e: ThreeEvent<MouseEvent>) => {
+      if (addingWidget) {
+        const hierarchicalParent = findNearestViableParentAncestorNodeRef(e.eventObject);
+        const hierarchicalParentNode = getSceneNodeByRef(hierarchicalParent?.userData.nodeRef);
+        let physicalParent = hierarchicalParent;
+        if (findComponentByType(hierarchicalParentNode, KnownComponentType.SubModelRef)) {
+          while (physicalParent) {
+            if (physicalParent.userData.componentTypes?.includes(KnownComponentType.ModelRef)) break;
+            physicalParent = physicalParent.parent as THREE.Object3D<Event>;
+          }
+        }
+        const { position } = getIntersectionTransform(e.intersections[0]);
+        const newWidgetNode = createNodeWithPositionAndNormal(
+          addingWidget,
+          position,
+          cursorLookAt,
+          physicalParent,
+          hierarchicalParent?.userData.nodeRef,
+        );
+
+        setAddingWidget(undefined);
+        appendSceneNode(newWidgetNode);
+        e.stopPropagation();
+      }
+    },
+    [addingWidget, cursorLookAt, setAddingWidget, getSceneNodeByRef, appendSceneNode],
+  );
+
+  return { handleAddWidget };
+};
+
+export default useAddWidget;

--- a/packages/scene-composer/src/interfaces/components.ts
+++ b/packages/scene-composer/src/interfaces/components.ts
@@ -18,6 +18,7 @@ export enum KnownComponentType {
   MotionIndicator = 'MotionIndicator',
   DataOverlay = 'DataOverlay',
   EntityBinding = 'EntityBinding',
+  PlaneGeometry = 'PlaneGeometry',
 }
 
 export interface ISceneComponent {
@@ -145,3 +146,5 @@ export interface IMotionIndicatorComponent extends ISceneComponent, SceneModels.
 export interface IDataOverlayComponent extends ISceneComponent, SceneModels.Component.DataOverlay {}
 
 export interface IEntityBindingComponent extends ISceneComponent, SceneModels.Component.EntityBindingComponent {}
+
+export interface IPlaneGeometryComponent extends ISceneComponent, SceneModels.Component.Plane {}

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -78,6 +78,7 @@ export enum KnownSceneProperty {
   FogCustomColors = 'fogCustomColors',
   BackgroundCustomColors = 'backgroundCustomColors',
   LayerDefaultRefreshInterval = 'layerDefaultRefreshInterval',
+  GeometryCustomColors = 'geometryCustomColors',
 }
 
 /************************************************

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -123,6 +123,7 @@ export namespace Component {
     MotionIndicator = 'MotionIndicator',
     DataOverlay = 'DataOverlay',
     EntityBinding = 'EntityBinding',
+    PlaneGeometry = 'PlaneGeometry',
   }
 
   export interface IComponent {
@@ -277,5 +278,11 @@ export namespace Component {
   export interface Light extends IComponent {
     lightType: LightType;
     lightSettings: ILightSettings;
+  }
+
+  export interface Plane extends IComponent {
+    width: number;
+    height: number;
+    color?: string;
   }
 }

--- a/packages/scene-composer/src/store/Store.ts
+++ b/packages/scene-composer/src/store/Store.ts
@@ -24,6 +24,7 @@ import {
   IMotionIndicatorComponentInternal,
   IDataOverlayComponentInternal,
   IEntityBindingComponentInternal,
+  IPlaneGeometryComponentInternal,
 } from './internalInterfaces';
 
 export type {
@@ -42,6 +43,7 @@ export type {
   IMotionIndicatorComponentInternal,
   IDataOverlayComponentInternal,
   IEntityBindingComponentInternal,
+  IPlaneGeometryComponentInternal,
 };
 
 export interface ISharedState {

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -34,6 +34,7 @@ import {
   ISubModelRefComponentInternal,
   SceneNodeRuntimeProperty,
   isISceneComponentInternal,
+  IPlaneGeometryComponentInternal,
 } from '../internalInterfaces';
 
 import { addComponentToComponentNodeMap } from './componentMapHelpers';
@@ -216,6 +217,10 @@ function createDataOverlayComponent(
   return Object.assign({}, { ref: generateUUID() }, { ...component });
 }
 
+function createPlaneGeometryComponent(component: Component.Plane): IPlaneGeometryComponentInternal | undefined {
+  return Object.assign({}, { ref: generateUUID() }, { ...component });
+}
+
 function createEntityBindingComponent(
   component: Component.EntityBindingComponent,
 ): IEntityBindingComponentInternal | undefined {
@@ -268,6 +273,9 @@ function deserializeComponent(
     }
     case Component.Type.EntityBinding: {
       return createEntityBindingComponent(component as Component.EntityBindingComponent);
+    }
+    case Component.Type.PlaneGeometry: {
+      return createPlaneGeometryComponent(component as Component.Plane);
     }
     default: {
       LOG.warn(`component not supported type[${component.type}]. It will be ignored.`);
@@ -779,6 +787,7 @@ export const exportsForTesting = {
   createDataOverlayComponent,
   createEntityBindingComponent,
   createAnimationRefComponent,
+  createPlaneGeometryComponent,
   deserializeComponent,
   parseSceneContent,
   createSceneNodeInternal,

--- a/packages/scene-composer/src/store/internalInterfaces.ts
+++ b/packages/scene-composer/src/store/internalInterfaces.ts
@@ -25,6 +25,7 @@ import {
   ISubModelRefComponent,
   IDataOverlayComponent,
   IEntityBindingComponent,
+  IPlaneGeometryComponent,
 } from '../interfaces';
 import { MapControls as MapControlsImpl, OrbitControls as OrbitControlsImpl } from '../three/OrbitControls';
 import { PointerLockControls as PointerLockControlsImpl } from '../three/PointerLockControls';
@@ -132,6 +133,8 @@ export type IMotionIndicatorComponentInternal = ISceneComponentInternal & IMotio
 export type IDataOverlayComponentInternal = ISceneComponentInternal & IDataOverlayComponent;
 
 export type IEntityBindingComponentInternal = IDataBoundSceneComponentInternal & IEntityBindingComponent;
+
+export type IPlaneGeometryComponentInternal = ISceneComponentInternal & IPlaneGeometryComponent;
 
 /******************************************************************************
  * Type magic...

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.spec.ts
@@ -14,6 +14,7 @@ import { createNodeEntity } from './createNodeEntity';
 import { createModelShaderEntityComponent } from './modelShaderComponent';
 import { createLightEntityComponent } from './lightComponent';
 import { createSubModelRefEntityComponent } from './subModelRefComponent';
+import { createPlaneGeometryEntityComponent } from './planeGeometryComponent';
 
 jest.mock('./nodeComponent', () => ({
   createNodeEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.node' }),
@@ -41,6 +42,9 @@ jest.mock('./lightComponent', () => ({
 }));
 jest.mock('./subModelRefComponent', () => ({
   createSubModelRefEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.subModelRef' }),
+}));
+jest.mock('./planeGeometryComponent', () => ({
+  createPlaneGeometryEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.planeGeometry' }),
 }));
 
 describe('createNodeEntity', () => {
@@ -81,10 +85,11 @@ describe('createNodeEntity', () => {
     const modelShader = { type: KnownComponentType.ModelShader, ref: 'modelShader-ref' };
     const light = { type: KnownComponentType.Light, ref: 'light-ref' };
     const subModelRef = { type: KnownComponentType.SubModelRef, ref: 'subModelref-ref' };
+    const planeGeometry = { type: KnownComponentType.PlaneGeometry, ref: 'planeGeometry-ref' };
 
     const node = {
       ...defaultNode,
-      components: [tag, overlay, camera, motionIndicator, modelRef, modelShader, light, subModelRef],
+      components: [tag, overlay, camera, motionIndicator, modelRef, modelShader, light, subModelRef, planeGeometry],
     };
 
     await createNodeEntity(node, 'parent', 'layer');
@@ -105,6 +110,7 @@ describe('createNodeEntity', () => {
         ModelShader: { componentTypeId: '3d.modelShader' },
         Light: { componentTypeId: '3d.light' },
         SubModelRef: { componentTypeId: '3d.subModelRef' },
+        PlaneGeometry: { componentTypeId: '3d.planeGeometry' },
       },
     });
 
@@ -126,5 +132,7 @@ describe('createNodeEntity', () => {
     expect(createLightEntityComponent).toBeCalledWith(light);
     expect(createSubModelRefEntityComponent).toBeCalledTimes(1);
     expect(createSubModelRefEntityComponent).toBeCalledWith(subModelRef);
+    expect(createPlaneGeometryEntityComponent).toBeCalledTimes(1);
+    expect(createPlaneGeometryEntityComponent).toBeCalledWith(planeGeometry);
   });
 });

--- a/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/createNodeEntity.ts
@@ -12,6 +12,7 @@ import {
   ILightComponent,
   IModelRefComponent,
   IMotionIndicatorComponent,
+  IPlaneGeometryComponent,
   ISubModelRefComponent,
   KnownComponentType,
 } from '../../interfaces';
@@ -26,6 +27,7 @@ import { createModelRefEntityComponent } from './modelRefComponent';
 import { createModelShaderEntityComponent } from './modelShaderComponent';
 import { createLightEntityComponent } from './lightComponent';
 import { createSubModelRefEntityComponent } from './subModelRefComponent';
+import { createPlaneGeometryEntityComponent } from './planeGeometryComponent';
 
 export const createNodeEntity = async (
   node: ISceneNodeInternal,
@@ -74,7 +76,9 @@ export const createNodeEntity = async (
         case KnownComponentType.SubModelRef:
           comp = createSubModelRefEntityComponent(compToBeCreated as ISubModelRefComponent);
           break;
-
+        case KnownComponentType.PlaneGeometry:
+          comp = createPlaneGeometryEntityComponent(compToBeCreated as IPlaneGeometryComponent);
+          break;
         default:
           throw new Error(`Component type not supported: ${compToBeCreated.type}`);
       }

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
@@ -244,6 +244,23 @@ describe('parseNode', () => {
       },
     ],
   };
+  const planeGeometryComp = {
+    componentTypeId: componentTypeToId.PlaneGeometry,
+    properties: [
+      {
+        propertyName: 'width',
+        propertyValue: 1,
+      },
+      {
+        propertyName: 'height',
+        propertyValue: 2,
+      },
+      {
+        propertyName: 'color',
+        propertyValue: '#abcdef',
+      },
+    ],
+  };
 
   const nodeComp = {
     componentTypeId: NODE_COMPONENT_TYPE_ID,
@@ -320,6 +337,7 @@ describe('parseNode', () => {
           modelShaderComp,
           lightComp,
           subModelRefComp,
+          planeGeometryComp,
         ],
       },
       nodeComp,
@@ -349,6 +367,9 @@ describe('parseNode', () => {
       }),
       expect.objectContaining({
         type: KnownComponentType.SubModelRef,
+      }),
+      expect.objectContaining({
+        type: KnownComponentType.PlaneGeometry,
       }),
     ];
     expect(result?.components).toEqual(expectedComponents);

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
@@ -20,6 +20,7 @@ import { parseMotionIndicatorComp } from './motionIndicatorComponent';
 import { parseModelShaderComp } from './modelShaderComponent';
 import { parseLightComp } from './lightComponent';
 import { parseSubModelRefComp } from './subModelRefComponent';
+import { parsePlaneGeometryComp } from './planeGeometryComponent';
 
 enum NodeComponentProperty {
   Name = 'name',
@@ -189,7 +190,13 @@ const parseNodeComponents = (components: DocumentType): ISceneComponentInternal[
         }
         break;
       }
-
+      case componentTypeToId.PlaneGeometry: {
+        const planeGeometry = parsePlaneGeometryComp(comp);
+        if (planeGeometry) {
+          results.push(planeGeometry);
+        }
+        break;
+      }
       case NODE_COMPONENT_TYPE_ID:
         // Ignore node component
         break;

--- a/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.spec.ts
@@ -1,0 +1,183 @@
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { IPlaneGeometryComponent, KnownComponentType } from '../../interfaces';
+
+import {
+  createPlaneGeometryEntityComponent,
+  parsePlaneGeometryComp,
+  updatePlaneGeometryEntityComponent,
+} from './planeGeometryComponent';
+
+const plane: IPlaneGeometryComponent = {
+  type: KnownComponentType.PlaneGeometry,
+  width: 10,
+  height: 20,
+};
+
+const coloredPlane: IPlaneGeometryComponent = {
+  type: KnownComponentType.PlaneGeometry,
+  width: 10,
+  height: 20,
+  color: '#abcdef',
+};
+
+describe('createPlaneGeometryEntityComponent', () => {
+  it('should return expected plane with no color', () => {
+    expect(
+      createPlaneGeometryEntityComponent({
+        type: KnownComponentType.PlaneGeometry,
+        width: 10,
+        height: 20,
+      }),
+    ).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.PlaneGeometry],
+      properties: {
+        width: {
+          value: {
+            doubleValue: 10,
+          },
+        },
+        height: {
+          value: {
+            doubleValue: 20,
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected plane with no color', () => {
+    expect(
+      createPlaneGeometryEntityComponent({
+        type: KnownComponentType.PlaneGeometry,
+        width: 10,
+        height: 20,
+        color: '#abcdef',
+      }),
+    ).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.PlaneGeometry],
+      properties: {
+        width: {
+          value: {
+            doubleValue: 10,
+          },
+        },
+        height: {
+          value: {
+            doubleValue: 20,
+          },
+        },
+        color: {
+          value: {
+            stringValue: '#abcdef',
+          },
+        },
+      },
+    });
+  });
+
+  describe('updatePlaneGeometryEntityComponent', () => {
+    it('should return expected plane', () => {
+      expect(updatePlaneGeometryEntityComponent(plane)).toEqual({
+        componentTypeId: componentTypeToId[KnownComponentType.PlaneGeometry],
+        propertyUpdates: expect.objectContaining({
+          width: {
+            value: {
+              doubleValue: 10,
+            },
+          },
+          height: {
+            value: {
+              doubleValue: 20,
+            },
+          },
+        }),
+      });
+    });
+
+    it('should return expected colored plane', () => {
+      expect(updatePlaneGeometryEntityComponent(coloredPlane)).toEqual({
+        componentTypeId: componentTypeToId[KnownComponentType.PlaneGeometry],
+        propertyUpdates: expect.objectContaining({
+          width: {
+            value: {
+              doubleValue: 10,
+            },
+          },
+          height: {
+            value: {
+              doubleValue: 20,
+            },
+          },
+          color: {
+            value: {
+              stringValue: '#abcdef',
+            },
+          },
+        }),
+      });
+    });
+  });
+
+  describe('parseLightComp', () => {
+    it('should parse to expected plane component', () => {
+      expect(
+        parsePlaneGeometryComp({
+          properties: [
+            {
+              propertyName: 'width',
+              propertyValue: 10,
+            },
+            {
+              propertyName: 'height',
+              propertyValue: 20,
+            },
+          ],
+        }),
+      ).toEqual({
+        ref: expect.any(String),
+        ...plane,
+      });
+    });
+
+    it('should parse to expected colored plane component', () => {
+      expect(
+        parsePlaneGeometryComp({
+          properties: [
+            {
+              propertyName: 'width',
+              propertyValue: 10,
+            },
+            {
+              propertyName: 'height',
+              propertyValue: 20,
+            },
+            {
+              propertyName: 'color',
+              propertyValue: '#abcdef',
+            },
+          ],
+        }),
+      ).toEqual({
+        ref: expect.any(String),
+        ...coloredPlane,
+      });
+    });
+
+    it('should fail to parse component missing height or width', () => {
+      expect(
+        parsePlaneGeometryComp({
+          properties: [
+            {
+              propertyName: 'color',
+              propertyValue: '#abcdef',
+            },
+          ],
+        }),
+      ).toBeUndefined();
+    });
+
+    it('should fail to parse component missing properties', () => {
+      expect(parsePlaneGeometryComp({})).toBeUndefined();
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.ts
@@ -1,0 +1,70 @@
+import { ComponentRequest, ComponentUpdateRequest } from '@aws-sdk/client-iottwinmaker';
+import { DocumentType } from '@aws-sdk/types';
+
+import { IPlaneGeometryComponent, KnownComponentType } from '../../interfaces';
+import { componentTypeToId } from '../../common/entityModelConstants';
+import { IPlaneGeometryComponentInternal } from '../../store';
+import { generateUUID } from '../mathUtils';
+
+enum PlaneGeometryComponentProperty {
+  Width = 'width',
+  Height = 'height',
+  Color = 'color',
+}
+
+export const createPlaneGeometryEntityComponent = (geometry: IPlaneGeometryComponent): ComponentRequest => {
+  const comp: ComponentRequest = {
+    componentTypeId: componentTypeToId[KnownComponentType.PlaneGeometry],
+    properties: {
+      [PlaneGeometryComponentProperty.Width]: {
+        value: {
+          doubleValue: geometry.width,
+        },
+      },
+      [PlaneGeometryComponentProperty.Height]: {
+        value: {
+          doubleValue: geometry.height,
+        },
+      },
+    },
+  };
+
+  if (geometry.color) {
+    comp.properties![PlaneGeometryComponentProperty.Color] = {
+      value: {
+        stringValue: geometry.color,
+      },
+    };
+  }
+  return comp;
+};
+
+export const updatePlaneGeometryEntityComponent = (geometry: IPlaneGeometryComponent): ComponentUpdateRequest => {
+  const request = createPlaneGeometryEntityComponent(geometry);
+  return {
+    componentTypeId: request.componentTypeId,
+    propertyUpdates: request.properties,
+  };
+};
+
+export const parsePlaneGeometryComp = (geometry: DocumentType): IPlaneGeometryComponentInternal | undefined => {
+  const findWidth = geometry?.['properties']
+    ? geometry?.['properties'].find((mp) => mp['propertyName'] === PlaneGeometryComponentProperty.Width)
+    : undefined;
+  const findHeight = geometry?.['properties']
+    ? geometry?.['properties'].find((mp) => mp['propertyName'] === PlaneGeometryComponentProperty.Height)
+    : undefined;
+  if (!findWidth || !findHeight) {
+    return undefined;
+  }
+
+  const planeGeometryComponent: IPlaneGeometryComponentInternal = {
+    ref: generateUUID(),
+    type: KnownComponentType.PlaneGeometry,
+    width: findWidth.propertyValue,
+    height: findHeight.propertyValue,
+    color: geometry?.['properties'].find((mp) => mp['propertyName'] === PlaneGeometryComponentProperty.Color)
+      ?.propertyValue,
+  };
+  return planeGeometryComponent;
+};

--- a/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.spec.ts
@@ -15,6 +15,7 @@ import { updateModelRefEntityComponent } from './modelRefComponent';
 import { updateModelShaderEntityComponent } from './modelShaderComponent';
 import { updateLightEntityComponent } from './lightComponent';
 import { updateSubModelRefEntityComponent } from './subModelRefComponent';
+import { updatePlaneGeometryEntityComponent } from './planeGeometryComponent';
 
 jest.mock('./nodeComponent', () => ({
   updateNodeEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.node' }),
@@ -42,6 +43,9 @@ jest.mock('./lightComponent', () => ({
 }));
 jest.mock('./subModelRefComponent', () => ({
   updateSubModelRefEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.subModelRef' }),
+}));
+jest.mock('./planeGeometryComponent', () => ({
+  updatePlaneGeometryEntityComponent: jest.fn().mockReturnValue({ componentTypeId: '3d.planeGeometry' }),
 }));
 
 describe('updateEntity', () => {
@@ -83,10 +87,11 @@ describe('updateEntity', () => {
     const modelShader = { type: KnownComponentType.ModelShader, ref: 'modelshader-ref' };
     const light = { type: KnownComponentType.Light, ref: 'light-ref' };
     const subModelRef = { type: KnownComponentType.SubModelRef, ref: 'subModelref-ref' };
+    const planeGeometry = { type: KnownComponentType.PlaneGeometry, ref: 'planegeometry-ref' };
 
     await updateEntity(
       defaultNode,
-      [tag, overlay, camera, motionIndicator, modelRef, modelShader, light, subModelRef],
+      [tag, overlay, camera, motionIndicator, modelRef, modelShader, light, subModelRef, planeGeometry],
       'UPDATE',
     );
 
@@ -105,6 +110,7 @@ describe('updateEntity', () => {
         ModelShader: { componentTypeId: '3d.modelShader' },
         Light: { componentTypeId: '3d.light' },
         SubModelRef: { componentTypeId: '3d.subModelRef' },
+        PlaneGeometry: { componentTypeId: '3d.planeGeometry' },
       },
     });
 
@@ -126,6 +132,8 @@ describe('updateEntity', () => {
     expect(updateLightEntityComponent).toBeCalledWith(light);
     expect(updateSubModelRefEntityComponent).toBeCalledTimes(1);
     expect(updateSubModelRefEntityComponent).toBeCalledWith(subModelRef);
+    expect(updatePlaneGeometryEntityComponent).toBeCalledTimes(1);
+    expect(updatePlaneGeometryEntityComponent).toBeCalledWith(planeGeometry);
   });
 
   it('should call update entity to update tag component', async () => {

--- a/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/updateNodeEntity.ts
@@ -8,6 +8,7 @@ import {
   ILightComponent,
   IModelRefComponent,
   IMotionIndicatorComponent,
+  IPlaneGeometryComponent,
   ISubModelRefComponent,
   KnownComponentType,
 } from '../../interfaces';
@@ -23,6 +24,7 @@ import { updateMotionIndicatorEntityComponent } from './motionIndicatorComponent
 import { updateModelShaderEntityComponent } from './modelShaderComponent';
 import { updateLightEntityComponent } from './lightComponent';
 import { updateSubModelRefEntityComponent } from './subModelRefComponent';
+import { updatePlaneGeometryEntityComponent } from './planeGeometryComponent';
 
 export const updateEntity = async (
   node: ISceneNodeInternal,
@@ -76,7 +78,9 @@ export const updateEntity = async (
           case KnownComponentType.SubModelRef:
             comp = updateSubModelRefEntityComponent(compToBeUpdated as ISubModelRefComponent);
             break;
-
+          case KnownComponentType.PlaneGeometry:
+            comp = updatePlaneGeometryEntityComponent(compToBeUpdated as IPlaneGeometryComponent);
+            break;
           default:
             throw new Error('Component type not supported');
         }

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -751,6 +751,10 @@
     "note": "select box option text value",
     "text": "Cast Shadow"
   },
+  "aiakkN": {
+    "note": "Form Field label",
+    "text": "Width"
+  },
   "ay/pmK": {
     "note": "Form field label",
     "text": "Constraints"
@@ -899,6 +903,10 @@
     "note": "Form button text",
     "text": "Fix view"
   },
+  "hiEi3h": {
+    "note": "Expandable Section title",
+    "text": "Plane Geometry"
+  },
   "ifspRT": {
     "note": "Expandable Section title",
     "text": "Model Shader"
@@ -967,6 +975,10 @@
     "note": "Menu Item",
     "text": "Add light"
   },
+  "lgxHg3": {
+    "note": "Form Field label",
+    "text": "Height"
+  },
   "lnTuMX": {
     "note": "label",
     "text": "Selected"
@@ -1002,6 +1014,10 @@
   "nhcDIE": {
     "note": "select box option text value",
     "text": "Receive Shadow"
+  },
+  "nml2b0": {
+    "note": "Menu Item label",
+    "text": "Ground Plane"
   },
   "nwQbTY": {
     "note": "Icon name label",
@@ -1074,6 +1090,10 @@
   "rBzizm": {
     "note": "label",
     "text": "Add speed rule"
+  },
+  "rC/6uY": {
+    "note": "Menu Item",
+    "text": "Add ground plane"
   },
   "rDIRVn": {
     "note": "Menu Item label",


### PR DESCRIPTION
## Overview
Allow a developer to add a visible ground plane in the scene compoesr and set it's size and color. Textures are not allowed yet.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/109186219/5b1a0279-a909-4695-b736-835c593ca2aa

ploading groundPlane.mov…
### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
