### PR TITLE
fix: panel resizing issue fix

### DIFF
--- a/packages/dashboard/e2e/tests/utils/resourceExplorer.ts
+++ b/packages/dashboard/e2e/tests/utils/resourceExplorer.ts
@@ -1,11 +1,5 @@
 import { Page, expect } from '@playwright/test';
-import {
-  RESOURCE_EXPLORER_ICON,
-  RESOURCE_EXPLORER_FRAME,
-  MODELED_TAB,
-  UNMODELED_TAB,
-  ASSET_MODEL_TAB,
-} from '../constants';
+import { RESOURCE_EXPLORER_FRAME, MODELED_TAB, UNMODELED_TAB, ASSET_MODEL_TAB } from '../constants';
 
 const tabMap = {
   modeled: MODELED_TAB,
@@ -76,7 +70,6 @@ export const resourceExplorerUtil = (page: Page) => {
      * @returns void
      */
     open: async () => {
-      await frame.locator(RESOURCE_EXPLORER_ICON).click();
       await expect(page.getByText('Resource explorer')).toBeVisible();
     },
     /**

--- a/packages/dashboard/src/components/actions/index.tsx
+++ b/packages/dashboard/src/components/actions/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import { useViewport } from '@iot-app-kit/react-components';
 import { Button, SpaceBetween, Box } from '@cloudscape-design/components';
-import { onToggleReadOnly } from '~/store/actions';
+import { onSelectWidgetsAction, onToggleReadOnly } from '~/store/actions';
 import type { DashboardState } from '~/store/state';
 import { isEqual, pick } from 'lodash';
 import { DashboardSave } from '~/types';
@@ -49,6 +49,12 @@ const Actions: React.FC<ActionsProps> = ({
 
   const handleOnReadOnly = () => {
     dispatch(onToggleReadOnly());
+    dispatch(
+      onSelectWidgetsAction({
+        widgets: [],
+        union: false,
+      })
+    );
   };
 
   const handleOnClose = () => {

--- a/packages/dashboard/src/components/resizablePanes/constants.ts
+++ b/packages/dashboard/src/components/resizablePanes/constants.ts
@@ -1,7 +1,5 @@
 export const LEFT_WIDTH_PERCENT = 0.2;
 
-export const RIGHT_WIDTH_PERCENT = 0.2;
-
 export const MINIMUM_CENTER_PANE_WIDTH = 100;
 
 export const MINIMUM_SIDE_PANE_WIDTH = 100;
@@ -17,5 +15,3 @@ export const DEFAULT_COLLAPSED_SIDE_PANE_WIDTH = 80;
 export const MAXIMUM_PANES_PROPORTION = 0.8;
 
 export const LEFT_WIDTH_PERCENT_STORAGE_KEY = 'iot-dashboard-pane-left-width';
-
-export const RIGHT_WIDTH_PERCENT_STORAGE_KEY = 'iot-dashboard-pane-right-width';

--- a/packages/dashboard/src/components/resizablePanes/index.test.tsx
+++ b/packages/dashboard/src/components/resizablePanes/index.test.tsx
@@ -3,17 +3,6 @@ import { render } from '@testing-library/react';
 
 import { ResizablePanes } from './index';
 
-const useSelectionMock = jest.fn();
-jest.mock('~/customization/propertiesSection', () => ({
-  useSelection: () => useSelectionMock(),
-}));
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
-  useDispatch: jest.fn(),
-}));
-
 const leftPaneContent = `Warp core monitor`;
 const centerPaneContent = `Forward viewscreen`;
 const rightPaneContent = `Phaser controls`;
@@ -30,5 +19,5 @@ it('renders panes', () => {
   const paraEls = container.querySelectorAll('p');
   expect(paraEls[0].textContent).toEqual(leftPaneContent);
   expect(paraEls[1].textContent).toEqual(centerPaneContent);
-  expect(paraEls[2].textContent).toEqual(rightPaneContent);
+  expect(paraEls.length).toEqual(2);
 });


### PR DESCRIPTION
## Overview
This PR is for ticket #2256 and to fix resizing issue for configuration and resource explorer panels when the user toggle between edit and preview mode.
1.  first time resource explorer will be open and configuration panel will closed on dashboard open
2. when the user goes to preview mode and comes back to edit mode
- the selected widgets will reset (i.e selected widgets should be an empty array)
- config panel will be closed
- resource explorer will be open  
3. removed the right draghandle  code related to resize listening

## Verifying Changes
[edit-preview.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/bb2dd6e4-3d9b-48d2-a464-62ba4a1960d7)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
