### PR TITLE
fix: missing raect key internal space between

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
@@ -5,7 +5,6 @@ import { nanoid } from '@reduxjs/toolkit';
 
 import { Button, ExpandableSection, SpaceBetween, Toggle } from '@cloudscape-design/components';
 
-import ExpandableSectionHeader from '../shared/expandableSectionHeader';
 import { DEFAULT_THRESHOLD_COLOR } from './defaultValues';
 import type { StyledThreshold, ThresholdWithId } from '~/customization/settings';
 import { Maybe, maybeWithDefault } from '~/util/maybe';
@@ -19,7 +18,7 @@ import { ThresholdStyleSettings, convertOptionToThresholdStyle, styledOptions } 
 import { ThresholdStyleType } from '@iot-app-kit/react-components/src/components/chart/types';
 
 const ThresholdsExpandableSection: React.FC<React.PropsWithChildren<{ title: string }>> = ({ children, title }) => (
-  <ExpandableSection headerText={<ExpandableSectionHeader>{title}</ExpandableSectionHeader>} defaultExpanded>
+  <ExpandableSection headerText={title} defaultExpanded>
     <SpaceBetween size='m' direction='vertical'>
       {children}
     </SpaceBetween>


### PR DESCRIPTION
## Overview
This PR is for #2266 

Since <ExpandableSectionHeader/> component causing the unique key issue I removed it.

## Verifying Changes
![image](https://github.com/awslabs/iot-app-kit/assets/139960352/1f975e7b-5894-40d9-96bf-2822e1a7defe)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
