### PR TITLE
fix(dashboard): csv will download if viewport has no data

### DIFF
--- a/packages/dashboard/src/components/csvDownloadButton/index.tsx
+++ b/packages/dashboard/src/components/csvDownloadButton/index.tsx
@@ -7,6 +7,24 @@ import { StyledSiteWiseQueryConfig } from '~/customization/widgets/types';
 import { useViewportData } from '~/components/csvDownloadButton/useViewportData';
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 
+const EMPTY_DATA = [
+  {
+    timestamp: '',
+    dataQuality: '',
+    value: '',
+    unit: '',
+    aggregationType: '',
+    resolution: '',
+    propertyName: '',
+    assetName: '',
+    propertyAlias: '',
+    assetId: '',
+    dataType: '',
+    dataTypeSpec: '',
+    propertyId: '',
+  },
+];
+
 const isQueryEmpty = (queryConfig: StyledSiteWiseQueryConfig) => {
   const query = queryConfig.query;
   return !query?.assets?.length && !query?.properties?.length && !query?.assetModels?.length;
@@ -28,13 +46,13 @@ export const CSVDownloadButton = ({
 
     const { data, isError } = await fetchViewportData(requestDateMS);
 
-    if (isError || !data || data.length === 0) {
+    if (isError || !data) {
       isError && console.error('Unable to download CSV data');
       setIsDownloading(false);
       return;
     }
 
-    const stringCSVData = unparse(data);
+    const stringCSVData = data.length === 0 ? unparse(EMPTY_DATA) : unparse(data);
     const file = new Blob([stringCSVData], { type: 'text/csv' });
 
     // create Anchor element with download attribute, click on it, and then delete it


### PR DESCRIPTION
## Overview
- Download a CSV file when viewport is empty and there are no errors present
- File will still have column names so it not just an empty CSV
- Fix tests to match this new behavior
<img width="625" alt="image" src="https://github.com/awslabs/iot-app-kit/assets/28601414/bcb2c92d-0326-4afe-86d5-9b6671f392fc">

example empty CSV file:
[xy-plot 2023-11-15T14 48 06.034Z.csv](https://github.com/awslabs/iot-app-kit/files/13366219/xy-plot.2023-11-15T14.48.06.034Z.csv)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
