### PR TITLE
fix: prevent ERR_CONNECTION_REFUSED in CI UI test run

### DIFF
--- a/.github/workflows/ui-test-full-suite.yml
+++ b/.github/workflows/ui-test-full-suite.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: test UI
         run:
-          npx turbo run test:ui
+          npm run test:ui -w @iot-app-kit/dashboard && npm run test:ui -w @iot-app-kit/react-components
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/packages/scene-composer/src/components/StateManager.spec.tsx
+++ b/packages/scene-composer/src/components/StateManager.spec.tsx
@@ -64,6 +64,7 @@ describe('StateManager', () => {
     getSceneProperty: jest.fn(),
   };
   const setViewportMock = jest.fn();
+  const setDataBindingQueryRefreshRateMock = jest.fn();
   const setAutoQueryEnabledMock = jest.fn();
   const createState = (connectionName: string) => ({
     ...baseState,
@@ -72,6 +73,7 @@ describe('StateManager', () => {
       connectionNameForMatterportViewer: connectionName,
       setConnectionNameForMatterportViewer: jest.fn(),
       setViewport: setViewportMock,
+      setDataBindingQueryRefreshRate: setDataBindingQueryRefreshRateMock,
       setAutoQueryEnabled: setAutoQueryEnabledMock,
     },
   });
@@ -576,6 +578,41 @@ describe('StateManager', () => {
     });
     expect(setViewportMock).toBeCalledTimes(2);
     expect(setViewportMock).toBeCalledWith(undefined);
+  });
+
+  it('should call setDataBindingQueryRefreshRate when changed', async () => {
+    useStore('default').setState(createState('random'));
+    let container;
+    await act(async () => {
+      container = create(
+        <StateManager
+          sceneLoader={mockSceneLoader}
+          sceneMetadataModule={mockSceneMetadataModule}
+          config={{ dataBindingQueryRefreshRate: 6666 }}
+          onSceneUpdated={jest.fn()}
+          viewport={viewport}
+        />,
+      );
+      await flushPromises();
+    });
+    expect(setDataBindingQueryRefreshRateMock).toBeCalledTimes(1);
+    expect(setDataBindingQueryRefreshRateMock).toBeCalledWith(6666);
+
+    // setDataBindingQueryRefreshRate with undefined
+    await act(async () => {
+      container.update(
+        <StateManager
+          sceneLoader={mockSceneLoader}
+          sceneMetadataModule={mockSceneMetadataModule}
+          config={sceneConfig}
+          onSceneUpdated={jest.fn()}
+          viewport={undefined}
+        />,
+      );
+      await flushPromises();
+    });
+    expect(setDataBindingQueryRefreshRateMock).toBeCalledTimes(2);
+    expect(setDataBindingQueryRefreshRateMock).toBeCalledWith(undefined);
   });
 
   it('should call setAutoQueryEnabled with true', async () => {

--- a/packages/scene-composer/src/components/__snapshots__/ConvertSceneModal.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/ConvertSceneModal.spec.tsx.snap
@@ -186,6 +186,9 @@ exports[`ConvertSceneModal should render with converting scene failure 1`] = `
         padding="{\\"left\\":\\"s\\"}"
       >
         failure-node
+         (
+        convert failed
+        )
       </div>
     </div>
   </div>

--- a/packages/scene-composer/src/components/three-fiber/SubModelComponent/__tests__/SubModelComponent.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/SubModelComponent/__tests__/SubModelComponent.spec.tsx
@@ -4,7 +4,7 @@ import { Mesh, Vector3 } from 'three';
 
 import SubModelComponent from '..';
 import { ISceneNodeInternal, useEditorState } from '../../../../store';
-import { ISubModelRefComponent } from '../../../../interfaces';
+import { KnownComponentType } from '../../../../interfaces';
 
 jest.mock('../../../../common/sceneComposerIdContext', () => ({
   useSceneComposerId: jest.fn(() => 'composer'),
@@ -13,6 +13,7 @@ jest.mock('../../../../common/sceneComposerIdContext', () => ({
 jest.mock('../../../../store', () => {
   return {
     useEditorState: jest.fn(),
+    useSceneDocument: jest.fn().mockReturnValue({ document: {} }),
   };
 });
 
@@ -34,7 +35,7 @@ describe('<SubModelComponent />', () => {
     }));
     getObject3DBySceneNodeRef.mockImplementation(() => obj);
 
-    render(<SubModelComponent node={node} component={undefined as unknown as ISubModelRefComponent} />);
+    render(<SubModelComponent node={node} component={{ selector: 'abc', type: KnownComponentType.SubModelRef }} />);
 
     const { x, y, z } = obj.rotation;
 

--- a/packages/scene-composer/src/components/three-fiber/SubModelComponent/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/SubModelComponent/index.tsx
@@ -2,18 +2,21 @@ import React, { useEffect, Fragment } from 'react';
 import { Mesh, Vector3, Euler } from 'three';
 
 import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
-import { ISceneNodeInternal, useEditorState } from '../../../store';
+import { ISceneNodeInternal, useEditorState, useSceneDocument } from '../../../store';
 import { ISubModelRefComponent } from '../../../interfaces';
 
 const SubModelComponent = ({ component, node }: { component: ISubModelRefComponent; node: ISceneNodeInternal }) => {
   const sceneComposerId = useSceneComposerId();
   const { getObject3DBySceneNodeRef, setSceneNodeObject3DMapping } = useEditorState(sceneComposerId);
+  // Rerender after nodeMap is changed to fix the issue when the main model is rendered after the sub model that causes
+  // the sub model component not able to find the parent object.
+  const { nodeMap: _nodeMap } = useSceneDocument(sceneComposerId).document;
 
   const object = getObject3DBySceneNodeRef(node.ref);
   const parentObj = getObject3DBySceneNodeRef(node.parentRef);
 
   useEffect(() => {
-    if (parentObj && !object) {
+    if (parentObj) {
       const obj =
         parentObj.getObjectById(Number(component.selector)) || parentObj.getObjectByName(component.selector as string);
 
@@ -21,7 +24,7 @@ const SubModelComponent = ({ component, node }: { component: ISubModelRefCompone
         setSceneNodeObject3DMapping(node.ref, obj);
       }
     } // Test
-  }, [parentObj, object]);
+  }, [parentObj]);
 
   const { transform } = node;
 

--- a/packages/scene-composer/src/hooks/useBindingData.ts
+++ b/packages/scene-composer/src/hooks/useBindingData.ts
@@ -26,6 +26,7 @@ const useBindingData = (
 
   const queries = useBindingQueries(bindings).queries;
   const viewport = useViewOptionState(sceneComposerId).viewport;
+  const refreshRate = useViewOptionState(sceneComposerId).dataBindingQueryRefreshRate ?? 5000;
   const autoQueryEnabled = useViewOptionState(sceneComposerId).autoQueryEnabled;
 
   const data = useRef<(Record<string, Primitive> | undefined)[] | undefined>(undefined);
@@ -47,7 +48,7 @@ const useBindingData = (
         settings: {
           // only support default settings for now until when customization is needed
           fetchFromStartToEnd: true,
-          refreshRate: (viewport as DurationViewport).duration ? 5000 : undefined,
+          refreshRate: (viewport as DurationViewport).duration ? refreshRate : undefined,
         },
       });
 
@@ -78,7 +79,7 @@ const useBindingData = (
     return () => {
       providers?.forEach((provider) => provider?.unsubscribe());
     };
-  }, [queries, autoQueryEnabled, viewport]);
+  }, [queries, autoQueryEnabled, viewport, refreshRate]);
 
   const result = useMemo(() => {
     return { data: data.current };

--- a/packages/scene-composer/src/interfaces/sceneViewer.ts
+++ b/packages/scene-composer/src/interfaces/sceneViewer.ts
@@ -12,6 +12,7 @@ export interface DracoDecoderConfig {
 export interface SceneViewerConfig {
   dracoDecoder?: DracoDecoderConfig;
   locale?: string;
+  dataBindingQueryRefreshRate?: number; // in milliseconds
 }
 
 export interface MatterportConfig {

--- a/packages/scene-composer/src/store/Store.ts
+++ b/packages/scene-composer/src/store/Store.ts
@@ -155,6 +155,8 @@ const nodeErrorStateSelector = (state: RootState): INodeErrorStateSlice => ({
 const viewOptionStateSelector = (state: RootState): IViewOptionStateSlice => ({
   viewport: state.noHistoryStates.viewport,
   setViewport: state.noHistoryStates.setViewport,
+  dataBindingQueryRefreshRate: state.noHistoryStates.dataBindingQueryRefreshRate,
+  setDataBindingQueryRefreshRate: state.noHistoryStates.setDataBindingQueryRefreshRate,
   autoQueryEnabled: state.noHistoryStates.autoQueryEnabled,
   setAutoQueryEnabled: state.noHistoryStates.setAutoQueryEnabled,
   componentVisibilities: state.noHistoryStates.componentVisibilities,

--- a/packages/scene-composer/src/store/StoreOperations.ts
+++ b/packages/scene-composer/src/store/StoreOperations.ts
@@ -29,6 +29,8 @@ export type SceneComposerDocumentOperation =
   | 'renderSceneNodesFromLayers'
   | 'updateSceneNodeInternal'
   | 'updateSceneNodeInternalTransient'
+  | 'updateSceneNodeInternalBatch'
+  | 'updateSceneNodeInternalBatchTransient'
   | 'updateDocumentInternal'
   | 'removeSceneNode'
   | 'updateSceneRuleMapById'
@@ -42,6 +44,7 @@ export type SceneComposerDataOperation = 'setDataInput' | 'setDataBindingTemplat
 
 export type SceneComposerViewOptionOperation =
   | 'setViewport'
+  | 'setDataBindingQueryRefreshRate'
   | 'setAutoQueryEnabled'
   | 'toggleComponentVisibility'
   | 'setTagSettings'
@@ -61,6 +64,8 @@ export const SceneComposerOperationTypeMap: Record<SceneComposerOperation, Opera
   renderSceneNodesFromLayers: 'UPDATE_DOCUMENT',
   updateSceneNodeInternal: 'UPDATE_DOCUMENT',
   updateSceneNodeInternalTransient: 'TRANSIENT',
+  updateSceneNodeInternalBatch: 'UPDATE_DOCUMENT',
+  updateSceneNodeInternalBatchTransient: 'TRANSIENT',
   updateDocumentInternal: 'UPDATE_DOCUMENT',
   removeSceneNode: 'UPDATE_DOCUMENT',
   addComponentInternal: 'UPDATE_DOCUMENT',
@@ -96,6 +101,7 @@ export const SceneComposerOperationTypeMap: Record<SceneComposerOperation, Opera
   setDataBindingTemplate: 'TRANSIENT',
 
   setViewport: 'TRANSIENT',
+  setDataBindingQueryRefreshRate: 'TRANSIENT',
   setAutoQueryEnabled: 'TRANSIENT',
   toggleComponentVisibility: 'TRANSIENT',
   setTagSettings: 'TRANSIENT',

--- a/packages/scene-composer/src/store/slices/ViewOptionStateSlice.spec.ts
+++ b/packages/scene-composer/src/store/slices/ViewOptionStateSlice.spec.ts
@@ -122,6 +122,26 @@ describe('createViewOptionStateSlice', () => {
     expect(draft.noHistoryStates.viewport).toBeUndefined();
   });
 
+  it('should be able to set data binding refresh rate', () => {
+    const draft = {
+      lastOperation: undefined,
+      noHistoryStates: { dataBindingQueryRefreshRate: undefined },
+    };
+
+    const set = jest.fn((callback) => callback(draft));
+
+    const { setDataBindingQueryRefreshRate } = createViewOptionStateSlice(set);
+    setDataBindingQueryRefreshRate(6666);
+
+    expect(draft.lastOperation!).toEqual('setDataBindingQueryRefreshRate');
+    expect(draft.noHistoryStates.dataBindingQueryRefreshRate).toEqual(6666);
+
+    setDataBindingQueryRefreshRate(undefined);
+
+    expect(draft.lastOperation!).toEqual('setDataBindingQueryRefreshRate');
+    expect(draft.noHistoryStates.dataBindingQueryRefreshRate).toBeUndefined();
+  });
+
   it('should be able to enable auto query', () => {
     const draft = {
       lastOperation: undefined,

--- a/packages/scene-composer/src/store/slices/ViewOptionStateSlice.ts
+++ b/packages/scene-composer/src/store/slices/ViewOptionStateSlice.ts
@@ -10,11 +10,13 @@ export interface IViewOptionStateSlice {
     [key in KnownComponentType | Component.DataOverlaySubType]: boolean;
   }>;
   viewport?: Viewport;
+  dataBindingQueryRefreshRate?: number;
   autoQueryEnabled?: boolean;
   tagSettings?: ITagSettings;
   connectionNameForMatterportViewer?: string;
 
   setViewport: (viewport?: Viewport) => void;
+  setDataBindingQueryRefreshRate: (dataBindingQueryRefreshRate?: number) => void;
   setAutoQueryEnabled: (autoQueryEnabled: boolean) => void;
   toggleComponentVisibility: (componentType: KnownComponentType | Component.DataOverlaySubType) => void;
   setTagSettings: (settings: ITagSettings) => void;
@@ -34,6 +36,12 @@ export const createViewOptionStateSlice = (set: SetState<RootState>): IViewOptio
     set((draft) => {
       draft.noHistoryStates.viewport = viewport;
       draft.lastOperation = 'setViewport';
+    });
+  },
+  setDataBindingQueryRefreshRate: (rate) => {
+    set((draft) => {
+      draft.noHistoryStates.dataBindingQueryRefreshRate = rate;
+      draft.lastOperation = 'setDataBindingQueryRefreshRate';
     });
   },
   setAutoQueryEnabled: (autoQueryEnabled) => {

--- a/packages/scene-composer/src/utils/entityModelUtils/processQueries.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/processQueries.spec.ts
@@ -198,7 +198,7 @@ describe('processQueries', () => {
     expect(nodes.length).toEqual(2);
     expect(nodes[0].parentRef).toEqual(parentRef);
     expect((nodes[0].components[0] as ISubModelRefComponent).parentRef).toEqual(parentRef);
-    expect(nodes[0].transform.position).toEqual([0, 0, 0]);
+    expect(nodes[0].transform.position).toEqual([3, 3, 3]);
   });
 
   it('should return expected nodes', async () => {

--- a/packages/scene-composer/src/utils/entityModelUtils/processQueries.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/processQueries.ts
@@ -92,11 +92,6 @@ export const processQueries = async (
         nodeEntity.components?.[KnownComponentType.SubModelRef].properties?.[
           SubModelRefComponentProperty.ParentRef
         ].value?.relationshipValue?.targetEntityId;
-      node.transform = {
-        position: [0, 0, 0],
-        rotation: [0, 0, 0],
-        scale: [1, 1, 1],
-      };
       node.parentRef = subModelComp.parentRef;
     }
 

--- a/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
@@ -25,6 +25,7 @@ export const defaultArgs = {
     COMPOSER_FEATURES.TagStyle,
     COMPOSER_FEATURES.AutoQuery,
     COMPOSER_FEATURES.SceneAppearance,
+    COMPOSER_FEATURES.DynamicScene,
   ],
 };
 


### PR DESCRIPTION
## Overview
This change unblocks our CI, which is currently failing on the full run of UI tests on nearly every PR and every test run.

The root cause appears to be related to an inability to start the dashboard storybook due to a dependency resolution failure with the dashboard's dependency on `@iot-app-kit/react-components`. This failure is, for some reason, only observed on the full test suite and not the suite which runs on the single PR commit.

`ModuleNotFoundError: Module not found: Error: Can't resolve '@iot-app-kit/react-components' in '/home/runner/work/iot-app-kit/iot-app-kit/packages/dashboard/src/components/actions'`

See https://github.com/awslabs/iot-app-kit/actions/runs/6882669479/job/18721635912 for an example test run.

The issue appears to be related to the usage of running the turbo command with `npx turbo` in the workflow test script. Changing the script to directly reference individual packages appears to eliminate the problem.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
