### PR TITLE
feat(composer): enable auto query feature

### DIFF
--- a/docs/SceneViewer.md
+++ b/docs/SceneViewer.md
@@ -23,6 +23,14 @@ const sceneLoader = initialize({ ... }).s3SceneLoader('scene-id');
 />
 ```
 
+### Data bindings and rules
+
+When the widgets, like tag, motion indicator, overlay, etc, have configured with data binding (entityId, componentName, propertyName), the SceneViewer component will need to get the property values of the data bindings so that the widgets can change based on value changes.
+
+A `viewport` property will be required in this case so the SceneViewer can know the expected time range for the property values.
+
+`queries` or `dataStreams` props can also be passed in which return the property values to be used by data bindings. If they are not provided, the SceneViewer component will automatically fetch property values for each data bindings exist in the rendered scene.
+
 ## Properties
 
 The SceneViewer component contains the following properties that you can customize. 
@@ -49,13 +57,15 @@ The `meta` field of each stream is required to contain values for keys `entityId
 
 Type: `DataStream[]` defined in `@iot-app-kit/core`
 
+Note: This property needs to be used together with `viewport`.
+
 ### `queries`
 
 (Optional) Selects what data to be fetched. Learn more about queries, see [Core](https://github.com/awslabs/iot-app-kit/tree/main/docs/Core.md). 
 
 Type: `TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>[]` defined in `@iot-app-kit/core`
 
-This property is used together with `viewport`.
+Note: This property needs to be used together with `viewport`.
 
 ### `viewport` 
 
@@ -63,7 +73,7 @@ This property is used together with `viewport`.
 
 Type: `Viewport` defined in `@iot-app-kit/core`
 
-This property is used together with `queires`.
+Note: This property is needed to make the data binding and rules work with property data. If `queires` or `dataStreams` are not provided, the property data will be fetched by the SceneViewer component.
 
 ### `dataBindingTemplate`
 

--- a/packages/scene-composer/src/SceneViewer.tsx
+++ b/packages/scene-composer/src/SceneViewer.tsx
@@ -81,6 +81,7 @@ export const SceneViewer: React.FC<SceneViewerProps> = ({ sceneComposerId, confi
             [COMPOSER_FEATURES.TagResize]: true,
             [COMPOSER_FEATURES.Matterport]: true,
             [COMPOSER_FEATURES.TagStyle]: true,
+            [COMPOSER_FEATURES.AutoQuery]: true,
           },
         }}
         onSceneLoaded={onSceneLoaded}

--- a/packages/scene-composer/src/__snapshots__/SceneViewer.spec.tsx.snap
+++ b/packages/scene-composer/src/__snapshots__/SceneViewer.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`SceneViewer should render correctly 1`] = `
   data-testid="webgl-root"
 >
   <div
-    config="{\\"mode\\":\\"Viewing\\",\\"featureConfig\\":{\\"SceneHierarchySearch\\":true,\\"SceneHierarchyReorder\\":true,\\"SubModelSelection\\":true,\\"ENHANCED_EDITING\\":true,\\"CameraView\\":true,\\"OpacityRule\\":true,\\"Overlay\\":true,\\"TagResize\\":true,\\"Matterport\\":true,\\"TagStyle\\":true}}"
+    config="{\\"mode\\":\\"Viewing\\",\\"featureConfig\\":{\\"SceneHierarchySearch\\":true,\\"SceneHierarchyReorder\\":true,\\"SubModelSelection\\":true,\\"ENHANCED_EDITING\\":true,\\"CameraView\\":true,\\"OpacityRule\\":true,\\"Overlay\\":true,\\"TagResize\\":true,\\"Matterport\\":true,\\"TagStyle\\":true,\\"AutoQuery\\":true}}"
     data-mocked="SceneComposerInternal"
     onSceneLoaded={[Function]}
     sceneComposerId="123"


### PR DESCRIPTION
## Overview
Enable the auto query feature flag and add documentation

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
