### PR TITLE
fix: full UI test suite CI

### DIFF
--- a/.github/workflows/ui-test-full-suite.yml
+++ b/.github/workflows/ui-test-full-suite.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: test UI
         run:
-          npx turbo run test:ui
+          npm run test:ui -w @iot-app-kit/dashboard && npm run test:ui -w @iot-app-kit/react-components
       - uses: actions/upload-artifact@v3
         if: failure()
         with:


### PR DESCRIPTION
## Overview
This change unblocks our CI, which is currently failing on the full run of UI tests on nearly every PR and every test run.

The root cause appears to be related to an inability to start the dashboard storybook due to a dependency resolution failure with the dashboard's dependency on `@iot-app-kit/react-components`. This failure is, for some reason, only observed on the full test suite and not the suite which runs on the single PR commit.

`ModuleNotFoundError: Module not found: Error: Can't resolve '@iot-app-kit/react-components' in '/home/runner/work/iot-app-kit/iot-app-kit/packages/dashboard/src/components/actions'`

See https://github.com/awslabs/iot-app-kit/actions/runs/6882669479/job/18721635912 for an example test run.

The issue appears to be related to the usage of running the turbo command with `npx turbo` in the workflow test script. Changing the script to directly reference individual packages appears to eliminate the problem.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
