### PR TITLE
feat(react-components): brush zoom line chart

### DIFF
--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -23,7 +23,7 @@ import { MultiYAxisLegend } from './multiYAxis/multiYAxis';
 import './chart.css';
 import { useContextMenu } from './contextMenu/useContextMenu';
 import { useViewportToMS } from './hooks/useViewportToMS';
-import { DEFAULT_CHART_VISUALIZATION } from './eChartsConstants';
+import { DEFAULT_CHART_VISUALIZATION, DEFAULT_TOOLBOX_CONFIG } from './eChartsConstants';
 import { useDataZoom } from './hooks/useDataZoom';
 import { useViewport } from '../../hooks/useViewport';
 import { getXAxis } from './chartOptions/axes/xAxis';
@@ -143,6 +143,7 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
       ...chartEventsOptions,
       tooltip: toolTipOptions,
       series,
+      toolbox: DEFAULT_TOOLBOX_CONFIG,
       yAxis,
       xAxis,
       graphic: trendCursors,

--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -1,10 +1,19 @@
 import type {
   DataZoomComponentOption,
   LegendComponentOption,
+  ToolboxComponentOption,
   TooltipComponentOption,
   XAXisComponentOption,
   YAXisComponentOption,
 } from 'echarts';
+
+export const DEFAULT_TOOLBOX_CONFIG: ToolboxComponentOption = {
+  show: true,
+  right: 30,
+  feature: {
+    dataZoom: { yAxisIndex: false, title: { back: 'Zoom\nreset' } },
+  },
+};
 
 export const DEFAULT_X_AXIS: XAXisComponentOption = {
   show: true,


### PR DESCRIPTION
## Overview
- enable the brush zoom + zoom reset toolbox
- works in dashboard + in the solo react-component
- does not break existing pan gestures

panning+brush zoom:

![view](https://github.com/awslabs/iot-app-kit/assets/28601414/8b0858ea-59d4-4a8f-991b-1c1fb6c8d4ab)

trend Cursors:
![TC](https://github.com/awslabs/iot-app-kit/assets/28601414/d4080b11-8fd1-4f65-a35d-92782d28b2f6)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
