### PR TITLE
fix: download button and zoom undo button

### DIFF
--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -60,7 +60,7 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
   const { onDelete } = useDeleteWidgets();
 
   const isRemoveable = !isReadOnly && removeable;
-  const headerVisible = !isReadOnly || title;
+  const headerVisible = !isReadOnly || widget.type !== 'text';
 
   const handleDelete: CancelableEventHandler<ClickDetail> = (e) => {
     e.preventDefault();

--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -11,7 +11,10 @@ export const DEFAULT_TOOLBOX_CONFIG: ToolboxComponentOption = {
   show: true,
   right: 30,
   feature: {
-    dataZoom: { yAxisIndex: false, title: { back: 'Zoom\nreset' } },
+    dataZoom: { yAxisIndex: false, title: { back: 'Undo\nzoom' } },
+  },
+  iconStyle: {
+    borderColor: '#414d5c',
   },
 };
 


### PR DESCRIPTION
## Overview
- always show tile header area in view mode (unless its a text widget)
- change name of `reset zoom` button

<img width="1512" alt="Screenshot 2023-11-17 at 10 57 53" src="https://github.com/awslabs/iot-app-kit/assets/28601414/b198a70a-9779-4c27-b9ae-28389dd6baad">
<img width="1512" alt="Screenshot 2023-11-17 at 10 57 49" src="https://github.com/awslabs/iot-app-kit/assets/28601414/194cb022-359c-4096-bc73-f0cd1fe73457">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
