### PR TITLE
fix(composer): cannot delete node entity with child

### DIFF
--- a/packages/scene-composer/src/utils/entityModelUtils/deleteNodeEntity.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/deleteNodeEntity.spec.ts
@@ -17,6 +17,7 @@ describe('deleteNodeEntity', () => {
     expect(deleteSceneEntity).toBeCalledTimes(1);
     expect(deleteSceneEntity).toBeCalledWith({
       entityId: 'ref',
+      isRecursive: true,
     });
   });
 });

--- a/packages/scene-composer/src/utils/entityModelUtils/deleteNodeEntity.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/deleteNodeEntity.ts
@@ -3,5 +3,5 @@ import { DeleteEntityCommandOutput } from '@aws-sdk/client-iottwinmaker';
 import { getGlobalSettings } from '../../common/GlobalSettings';
 
 export const deleteNodeEntity = (entityId: string): Promise<DeleteEntityCommandOutput> | undefined => {
-  return getGlobalSettings().twinMakerSceneMetadataModule?.deleteSceneEntity({ entityId });
+  return getGlobalSettings().twinMakerSceneMetadataModule?.deleteSceneEntity({ entityId, isRecursive: true });
 };


### PR DESCRIPTION
## Overview
Delete node entity with child fails with "Cannot delete entity as it has child entities". Set to recursive deletion instead.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
