### PR TITLE
fix: remove widget panel from text widget

### DIFF
--- a/packages/dashboard/src/customization/widgets/text/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/text/plugin.tsx
@@ -3,17 +3,12 @@ import TextWidgetComponent from './component';
 import TextIcon from './icon';
 import type { DashboardPlugin } from '~/customization/api';
 import type { TextWidget } from '../types';
-import WidgetTile from '~/components/widgets/tile/tile';
 import { TEXT_WIDGET_INITIAL_HEIGHT, TEXT_WIDGET_INITIAL_WIDTH } from '../constants';
 
 export const textPlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
     registerWidget<TextWidget>('text', {
-      render: (widget) => (
-        <WidgetTile widget={widget} removeable>
-          <TextWidgetComponent {...widget} />
-        </WidgetTile>
-      ),
+      render: (widget) => <TextWidgetComponent {...widget} />,
       componentLibrary: {
         name: 'Text',
         icon: TextIcon,


### PR DESCRIPTION
## Overview
This change removes the widget panel from the text widget.

### Before
<img width="339" src="https://github.com/awslabs/iot-app-kit/assets/67283114/2b5829ab-c4ad-405d-8d41-45afe8d34176">

### After
<img width="339" alt="Screenshot 2023-11-21 at 9 45 18 AM" src="https://github.com/awslabs/iot-app-kit/assets/67283114/1f80acb2-544d-4206-bb2d-877a755b780b">

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
