### PR TITLE
fix: added experimental plugin exports

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,5 +25,6 @@ export const MINUTE_IN_MS = 60 * SECOND_IN_MS;
 export const HOUR_IN_MS = 60 * MINUTE_IN_MS;
 export const DAY_IN_MS = 24 * HOUR_IN_MS;
 
-export type { Logger } from './logger/logger.interface';
-export type { MetricsRecorder } from './metric-recorder/metricsRecorder.interface';
+export type { Log, Logger } from './logger/logger.interface';
+export type { Metric, MetricsRecorder } from './metricRecorder/metricsRecorder.interface';
+export { registerPlugin, getPlugin } from './plugins/pluginsRegistry';

--- a/packages/core/src/logger/logger.interface.ts
+++ b/packages/core/src/logger/logger.interface.ts
@@ -1,7 +1,7 @@
 /**
  * Log represents a single event message to record.
  */
-type Log = {
+export type Log = {
   /**
    * Additional contexts to include.
    */

--- a/packages/core/src/metricRecorder/metricsRecorder.interface.ts
+++ b/packages/core/src/metricRecorder/metricsRecorder.interface.ts
@@ -38,7 +38,7 @@
  *   metricValue: 2,
  * };
  */
-type Metric = {
+export type Metric = {
   /**
    * Additional contexts to separate the metricName.
    */

--- a/packages/core/src/plugins/loggerSettings.ts
+++ b/packages/core/src/plugins/loggerSettings.ts
@@ -1,3 +1,3 @@
 import type { Logger } from '../logger/logger.interface';
 
-export type LoggerSettings = { provider: () => Logger };
+export type LoggerSettings = { provider: () => Logger | undefined };

--- a/packages/core/src/plugins/metricsRecorderSettings.ts
+++ b/packages/core/src/plugins/metricsRecorderSettings.ts
@@ -1,3 +1,3 @@
-import type { MetricsRecorder } from '../metric-recorder/metricsRecorder.interface';
+import type { MetricsRecorder } from '../metricRecorder/metricsRecorder.interface';
 
-export type MetricsRecorderSettings = { provider: () => MetricsRecorder };
+export type MetricsRecorderSettings = { provider: () => MetricsRecorder | undefined };

--- a/packages/core/src/plugins/pluginsRegistry.spec.ts
+++ b/packages/core/src/plugins/pluginsRegistry.spec.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '../logger/logger.interface';
-import type { MetricsRecorder } from '../metric-recorder/metricsRecorder.interface';
-import { getLogger, getMetricsRecorder, registerLogger, registerMetricsRecorder } from './pluginsRegistry';
+import type { MetricsRecorder } from '../metricRecorder/metricsRecorder.interface';
+import { registerPlugin, getPlugin } from './pluginsRegistry';
 
 describe('Logger registry', () => {
   class MockLogClient implements Logger {
@@ -10,7 +10,7 @@ describe('Logger registry', () => {
   }
 
   test('does not provide logger by default', () => {
-    const logger = getLogger();
+    const logger = getPlugin('logger');
 
     expect(logger).toBeUndefined();
   });
@@ -19,10 +19,10 @@ describe('Logger registry', () => {
     const mockLogClient = new MockLogClient();
     const mockProvider = jest.fn().mockReturnValue(mockLogClient);
 
-    registerLogger({
+    registerPlugin('logger', {
       provider: mockProvider,
     });
-    const logger = getLogger();
+    const logger = getPlugin('logger');
 
     expect(logger).toBe(mockLogClient);
     expect(mockProvider).toBeCalled();
@@ -35,7 +35,7 @@ describe('MetricsRecorder registry', () => {
   }
 
   test('does not provide MetricsRecorder by default', () => {
-    const metricsRecorder = getMetricsRecorder();
+    const metricsRecorder = getPlugin('metricsRecorder');
 
     expect(metricsRecorder).toBeUndefined();
   });
@@ -44,10 +44,10 @@ describe('MetricsRecorder registry', () => {
     const mockMetricsRecorder = new MockMetricsRecorder();
     const mockProvider = jest.fn().mockReturnValue(mockMetricsRecorder);
 
-    registerMetricsRecorder({
+    registerPlugin('metricsRecorder', {
       provider: mockProvider,
     });
-    const metricsRecorder = getMetricsRecorder();
+    const metricsRecorder = getPlugin('metricsRecorder');
 
     expect(metricsRecorder).toBe(mockMetricsRecorder);
     expect(mockProvider).toBeCalled();


### PR DESCRIPTION
## Overview

1. added experimental plugin exports
2. Refactored experimental plugin to have the following structure:
```
// example of a registration and usage of metricsRecorder plugin
registerPlugin('metricsRecorder', {
  provider: () => ({
    // record and console log all metrics
    record: (metric) => {
      console.log(metric);
    },
  }),
});

// example of getting metricsRecorder plugin
const metricsRecorder = getPlugin('metricsRecorder');

metricsRecorder?.record({
  metricName: 'test',
  metricValue: 123
});
```
3. previously requires a pair of function per plugin type; making the new structure more scalable
```
registerLogger(...)
getLogger()

registerMetricsRecorder(...)
getMetricsRecorder()
```

## Verifying Changes

added and validated examples; type changes only;

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
