### PR TITLE
fix: missing pagination handling for searched model data #1994

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/dataStreamSearch/useSearch.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/dataStreamSearch/useSearch.ts
@@ -21,7 +21,7 @@ interface UseSearchProps {
 
 /** Use to send a search request. */
 export function useSearch({ workspaceId, searchQuery, client }: UseSearchProps) {
-  const { data } = useInfiniteQuery({
+  const { data, hasNextPage, isFetching, fetchNextPage } = useInfiniteQuery({
     enabled: searchQuery !== '',
     queryKey: CACHE_KEYS.search({ workspaceId, searchQuery }),
     queryFn: createQueryFn(client),
@@ -30,7 +30,7 @@ export function useSearch({ workspaceId, searchQuery, client }: UseSearchProps) 
 
   const modeledDataStreams = data?.pages.flatMap(({ modeledDataStreams }) => modeledDataStreams) ?? [];
 
-  return { modeledDataStreams };
+  return { modeledDataStreams, hasNextPage, isFetching, fetchNextPage };
 }
 
 function createQueryFn(client: IoTTwinMakerClient) {

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamExplorer.tsx
@@ -8,16 +8,22 @@ import { SelectedAsset } from '../types';
 
 export interface ModeledDataStreamExplorerProps {
   onClickAddModeledDataStreams: (modeledDataStreams: ModeledDataStream[]) => void;
+  onClickNextPage?: () => void;
   selectedAsset?: SelectedAsset;
   dataStreams?: ModeledDataStream[];
   client: IoTSiteWiseClient;
+  hasNextPage?: boolean;
+  isFetching?: boolean;
 }
 
 export function ModeledDataStreamExplorer({
   onClickAddModeledDataStreams,
+  onClickNextPage,
   selectedAsset,
   dataStreams,
   client,
+  hasNextPage,
+  isFetching,
 }: ModeledDataStreamExplorerProps) {
   const { assetProperties, isFetching: isFetchingAssetProperties } = useModeledDataStreams({
     assetProps: selectedAsset ? [selectedAsset] : [],
@@ -27,10 +33,12 @@ export function ModeledDataStreamExplorer({
   return (
     <ModeledDataStreamTable
       onClickAddModeledDataStreams={onClickAddModeledDataStreams}
+      onClickNextPage={onClickNextPage}
       modeledDataStreams={dataStreams ?? assetProperties}
       selectedAsset={selectedAsset}
-      isLoading={isFetchingAssetProperties}
+      isLoading={isFetching ?? isFetchingAssetProperties}
       client={client}
+      hasNextPage={hasNextPage}
     />
   );
 }

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { isFunction } from 'lodash';
 import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 import Table from '@cloudscape-design/components/table';
@@ -22,18 +23,22 @@ import { SelectedAsset } from '../../types';
 
 export interface ModeledDataStreamTableProps {
   onClickAddModeledDataStreams: (modeledDataStreams: ModeledDataStream[]) => void;
+  onClickNextPage?: () => void;
   selectedAsset?: SelectedAsset;
   modeledDataStreams: ModeledDataStream[];
   isLoading: boolean;
   client: IoTSiteWiseClient;
+  hasNextPage?: boolean;
 }
 
 export function ModeledDataStreamTable({
   onClickAddModeledDataStreams,
+  onClickNextPage,
   selectedAsset,
   modeledDataStreams,
   isLoading,
   client,
+  hasNextPage,
 }: ModeledDataStreamTableProps) {
   const significantDigits = useSelector((state: DashboardState) => state.significantDigits);
   const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
@@ -70,8 +75,15 @@ export function ModeledDataStreamTable({
     }
   );
 
+  const handleClickNextPage = () => {
+    if (isFunction(onClickNextPage)) {
+      onClickNextPage();
+    }
+  };
+
   const paginationPropsWithAriaLabels = {
     ...paginationProps,
+    openEnd: hasNextPage,
     ariaLabels: {
       nextPageLabel: 'Next page',
       paginationLabel: 'Modeled DataStream Table pagination',
@@ -113,7 +125,9 @@ export function ModeledDataStreamTable({
           }}
         />
       }
-      pagination={<ModeledDataStreamTablePagination {...paginationPropsWithAriaLabels} />}
+      pagination={
+        <ModeledDataStreamTablePagination {...paginationPropsWithAriaLabels} onNextPageClick={handleClickNextPage} />
+      }
       preferences={<ModeledDataStreamTablePreferences preferences={preferences} updatePreferences={setPreferences} />}
       ariaLabels={{
         itemSelectionLabel: (isNotSelected, modeledDataStream) =>

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamQueryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamQueryEditor.tsx
@@ -39,7 +39,7 @@ export function ModeledDataStreamQueryEditor({
       ? searchFieldValues.workspace.value
       : undefined;
 
-  const { modeledDataStreams } = useSearch({
+  const { modeledDataStreams, hasNextPage, isFetching, fetchNextPage } = useSearch({
     workspaceId: workspaceId ?? '',
     client: iotTwinMakerClient,
     searchQuery: searchFieldValues.searchQuery,
@@ -66,9 +66,12 @@ export function ModeledDataStreamQueryEditor({
         <>
           <DataStreamSearch onSubmit={setSearchFieldValues} client={iotTwinMakerClient} />
           <ModeledDataStreamExplorer
+            hasNextPage={hasNextPage}
+            isFetching={isFetching}
             client={iotSiteWiseClient}
-            onClickAddModeledDataStreams={onClickAdd}
             dataStreams={modeledDataStreams}
+            onClickAddModeledDataStreams={onClickAdd}
+            onClickNextPage={fetchNextPage}
           />
         </>
       )}


### PR DESCRIPTION
## Overview
This PR is for #1994 
Added hasNext, fetchNextPage, isFetching data in useSearch hook and passed them to the ModeledDataStreamsTable component. Also added onNextPageClick in the pagination to call fetchNextPage callback.


## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/139960352/8549f407-4ba6-47f6-b486-83fd86f0db96


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
