### PR TITLE
feat: added the error state for resource explorer tables

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/dataStreamSearch/useSearch.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/dataStreamSearch/useSearch.ts
@@ -21,7 +21,7 @@ interface UseSearchProps {
 
 /** Use to send a search request. */
 export function useSearch({ workspaceId, searchQuery, client }: UseSearchProps) {
-  const { data, hasNextPage, isFetching, fetchNextPage } = useInfiniteQuery({
+  const { data, hasNextPage, isFetching, fetchNextPage, isError } = useInfiniteQuery({
     enabled: searchQuery !== '',
     queryKey: CACHE_KEYS.search({ workspaceId, searchQuery }),
     queryFn: createQueryFn(client),
@@ -30,7 +30,7 @@ export function useSearch({ workspaceId, searchQuery, client }: UseSearchProps) 
 
   const modeledDataStreams = data?.pages.flatMap(({ modeledDataStreams }) => modeledDataStreams) ?? [];
 
-  return { modeledDataStreams, hasNextPage, isFetching, fetchNextPage };
+  return { modeledDataStreams, hasNextPage, isFetching, fetchNextPage, isError };
 }
 
 function createQueryFn(client: IoTTwinMakerClient) {

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetExplorer.tsx
@@ -19,6 +19,7 @@ export function AssetExplorer({ onSelect, isWithoutHeader, client }: AssetExplor
     isFetching,
     fetchNextPage,
     hasNextPage = false,
+    isError,
   } = useAssets({
     assetId: parentAssetId,
     client,
@@ -32,6 +33,7 @@ export function AssetExplorer({ onSelect, isWithoutHeader, client }: AssetExplor
       onClickNextPage={fetchNextPage}
       onSelectAsset={onSelect}
       isLoading={isFetching}
+      isError={isError}
       isWithoutHeader={isWithoutHeader}
       client={client}
       hasNextPage={hasNextPage}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTable.test.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTable.test.tsx
@@ -1,4 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { createMockSiteWiseSDK } from '@iot-app-kit/testing-util';
+import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { sampleAssetSummary } from '@iot-app-kit/source-iotsitewise';
 import { AssetTableColumnDefinitionsFactory } from './assetTableColumnDefinitionsFactory';
+import { AssetTable } from './assetTable';
 
 describe('AssetTableColumnDefinitionsFactory', () => {
   describe('create', () => {
@@ -29,5 +36,29 @@ describe('AssetTableColumnDefinitionsFactory', () => {
       expect(columnDefinitions.some((def) => def.id === 'creationDate')).toBe(true);
       expect(columnDefinitions.some((def) => def.id === 'lastUpdateDate')).toBe(true);
     });
+  });
+});
+
+describe('AssetTable component', () => {
+  test('renders AssetTable component correctly when an error occurs', () => {
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <AssetTable
+          assets={[sampleAssetSummary]}
+          parentAssetId='parentAssetId'
+          onClickAsset={jest.fn()}
+          onClickNextPage={jest.fn()}
+          onSelectAsset={jest.fn()}
+          isLoading={false}
+          isError={true}
+          isWithoutHeader={false}
+          client={createMockSiteWiseSDK() as IoTSiteWiseClient}
+          hasNextPage={true}
+        />
+      </QueryClientProvider>
+    );
+
+    const errorMessage = screen.getByText('an error has occurred.');
+    expect(errorMessage).toBeInTheDocument();
   });
 });

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTable.tsx
@@ -12,6 +12,7 @@ import { AssetTableColumnDefinitionsFactory } from './assetTableColumnDefinition
 import { AssetTableNameLink } from './assetTableNameLink';
 import { AssetTableHierarchyPath } from './assetTableHierarchyPath';
 import { useExplorerPreferences } from '../../../useExplorerPreferences';
+import { ResourceExplorerErrorState } from '../../components/resourceExplorerErrorState';
 
 export interface AssetTableProps {
   parentAssetId?: string;
@@ -20,6 +21,7 @@ export interface AssetTableProps {
   onSelectAsset: (asset?: AssetSummary) => void;
   assets: AssetSummary[];
   isLoading: boolean;
+  isError: boolean;
   hasNextPage: boolean;
   isWithoutHeader?: boolean;
   client: IoTSiteWiseClient;
@@ -32,6 +34,7 @@ export function AssetTable({
   onClickNextPage,
   onSelectAsset,
   isLoading,
+  isError,
   hasNextPage,
   isWithoutHeader,
   client,
@@ -73,6 +76,10 @@ export function AssetTable({
     NameLink: AssetTableNameLink,
     onClickNameLink: handleClickAsset,
   });
+
+  if (isError) {
+    return <ResourceExplorerErrorState title='Browse assets (0)' />;
+  }
 
   return (
     <Table

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/components/resourceExplorerErrorState.spec.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/components/resourceExplorerErrorState.spec.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ResourceExplorerErrorState } from './resourceExplorerErrorState';
+
+describe('Error component', () => {
+  test('renders the title correctly', () => {
+    const title = 'Test Error';
+    render(<ResourceExplorerErrorState title={title} />);
+    const titleLabel = screen.getByText('Test Error');
+    expect(titleLabel).toHaveTextContent(title);
+  });
+
+  test('renders the error message correctly', () => {
+    render(<ResourceExplorerErrorState />);
+    const errorMessage = screen.getByText('an error has occurred.');
+    expect(errorMessage).toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/components/resourceExplorerErrorState.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/components/resourceExplorerErrorState.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Alert, Box, SpaceBetween } from '@cloudscape-design/components';
+
+export const ResourceExplorerErrorState = ({ title }: { title?: string }) => {
+  return (
+    <Box variant='h3'>
+      <SpaceBetween size='s'>
+        {title && <label> {title}</label>}
+        <Alert dismissible statusIconAriaLabel='Error' type='error' header='an error has occurred.' />
+      </SpaceBetween>
+    </Box>
+  );
+};

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamExplorer.tsx
@@ -14,6 +14,8 @@ export interface ModeledDataStreamExplorerProps {
   client: IoTSiteWiseClient;
   hasNextPage?: boolean;
   isFetching?: boolean;
+  isSearchError?: boolean;
+  searchQuery?: string;
 }
 
 export function ModeledDataStreamExplorer({
@@ -24,11 +26,18 @@ export function ModeledDataStreamExplorer({
   client,
   hasNextPage,
   isFetching,
+  isSearchError,
+  searchQuery,
 }: ModeledDataStreamExplorerProps) {
-  const { assetProperties, isFetching: isFetchingAssetProperties } = useModeledDataStreams({
+  const {
+    assetProperties,
+    isFetching: isFetchingAssetProperties,
+    isError: isAssetPropertiesError,
+  } = useModeledDataStreams({
     assetProps: selectedAsset ? [selectedAsset] : [],
     client,
   });
+  const modeledDataStreamsTitle = isSearchError ? `Search result for "${searchQuery}" (0)` : 'Modeled data streams (0)';
 
   return (
     <ModeledDataStreamTable
@@ -37,7 +46,9 @@ export function ModeledDataStreamExplorer({
       modeledDataStreams={dataStreams ?? assetProperties}
       selectedAsset={selectedAsset}
       isLoading={isFetching ?? isFetchingAssetProperties}
+      isError={isSearchError ?? isAssetPropertiesError}
       client={client}
+      modeledDataStreamsTitle={modeledDataStreamsTitle}
       hasNextPage={hasNextPage}
     />
   );

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.test.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, screen } from '@testing-library/react';
+import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { createMockSiteWiseSDK } from '@iot-app-kit/testing-util';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { configureDashboardStore } from '~/store';
+import { ModeledDataStream } from '../types';
+import { ModeledDataStreamTable } from './modeledDataStreamTable';
+import { SelectedAsset } from '../../types';
+
+describe('ModeledDataStreamTable component', () => {
+  test('renders error component when isError is true', () => {
+    const modeledDataStreams = [
+      {
+        assetId: 'asset-1',
+        propertyId: 'property-1',
+      },
+    ] as ModeledDataStream[];
+
+    const selectedAssets = {
+      assetId: 'asset-1',
+      assetModelId: 'property-1',
+    } as SelectedAsset;
+
+    render(
+      <Provider
+        store={configureDashboardStore({
+          dashboardConfiguration: {
+            widgets: [],
+          },
+        })}
+      >
+        <QueryClientProvider client={new QueryClient()}>
+          <ModeledDataStreamTable
+            onClickAddModeledDataStreams={jest.fn()}
+            selectedAsset={selectedAssets}
+            modeledDataStreams={modeledDataStreams}
+            isLoading={false}
+            isError={true}
+            client={createMockSiteWiseSDK() as IoTSiteWiseClient}
+          />
+        </QueryClientProvider>
+      </Provider>
+    );
+
+    const errorMessage = screen.getByText('an error has occurred.');
+    expect(errorMessage).toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -20,6 +20,7 @@ import type { ModeledDataStream } from '../types';
 import { DashboardState } from '~/store/state';
 import { ResourceExplorerFooter } from '../../../footer/footer';
 import { SelectedAsset } from '../../types';
+import { ResourceExplorerErrorState } from '../../components/resourceExplorerErrorState';
 
 export interface ModeledDataStreamTableProps {
   onClickAddModeledDataStreams: (modeledDataStreams: ModeledDataStream[]) => void;
@@ -27,8 +28,10 @@ export interface ModeledDataStreamTableProps {
   selectedAsset?: SelectedAsset;
   modeledDataStreams: ModeledDataStream[];
   isLoading: boolean;
+  isError: boolean;
   client: IoTSiteWiseClient;
   hasNextPage?: boolean;
+  modeledDataStreamsTitle?: string;
 }
 
 export function ModeledDataStreamTable({
@@ -37,8 +40,10 @@ export function ModeledDataStreamTable({
   selectedAsset,
   modeledDataStreams,
   isLoading,
+  isError,
   client,
   hasNextPage,
+  modeledDataStreamsTitle,
 }: ModeledDataStreamTableProps) {
   const significantDigits = useSelector((state: DashboardState) => state.significantDigits);
   const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
@@ -91,6 +96,10 @@ export function ModeledDataStreamTable({
       pageLabel: (pageNumber: number) => `Page ${pageNumber}`,
     },
   };
+
+  if (isError) {
+    return <ResourceExplorerErrorState title={modeledDataStreamsTitle} />;
+  }
 
   return (
     <Table

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/useModeledDataStreams/useModeledDataStreams.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/useModeledDataStreams/useModeledDataStreams.ts
@@ -25,8 +25,9 @@ export function useModeledDataStreams({ assetProps, client }: UseModeledDataStre
 
   const assetProperties = queries.flatMap(({ data = [] }) => data);
   const isFetching = queries.some(({ isFetching }) => isFetching);
+  const isError = queries.some(({ isError }) => isError);
 
-  return { assetProperties, isFetching };
+  return { assetProperties, isFetching, isError };
 }
 
 function createCompositeQueryFn(client: IoTSiteWiseClient) {

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamQueryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamQueryEditor.tsx
@@ -39,7 +39,7 @@ export function ModeledDataStreamQueryEditor({
       ? searchFieldValues.workspace.value
       : undefined;
 
-  const { modeledDataStreams, hasNextPage, isFetching, fetchNextPage } = useSearch({
+  const { modeledDataStreams, hasNextPage, isFetching, fetchNextPage, isError } = useSearch({
     workspaceId: workspaceId ?? '',
     client: iotTwinMakerClient,
     searchQuery: searchFieldValues.searchQuery,
@@ -72,6 +72,8 @@ export function ModeledDataStreamQueryEditor({
             dataStreams={modeledDataStreams}
             onClickAddModeledDataStreams={onClickAdd}
             onClickNextPage={fetchNextPage}
+            isSearchError={isError}
+            searchQuery={searchFieldValues.searchQuery}
           />
         </>
       )}


### PR DESCRIPTION
## Overview
This PR is for ticket (a few sub tasks are covered here(3, 4 & 5)) #2242 and to update error state in Resource explorer tables
1. added error state for browse assets table
2. added error state for browse data streams table
3. added error state for search data streams table


## Verifying Changes
Assets table error state:
![assets-error](https://github.com/awslabs/iot-app-kit/assets/142866907/5ca3de71-32f3-441a-9e44-81a1fbcb4c9b)
Browse data stream table:
![datastream-error](https://github.com/awslabs/iot-app-kit/assets/142866907/07d69b96-9e78-4ed8-9765-6c6e3514fccd)
Search data stream table:
![search-error-state](https://github.com/awslabs/iot-app-kit/assets/142866907/505a23c2-26d0-45d4-99ef-87ea3717bdc0)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
