### PR TITLE
fix: updated the resource explorer default width

### DIFF
--- a/packages/dashboard/src/components/resizablePanes/constants.ts
+++ b/packages/dashboard/src/components/resizablePanes/constants.ts
@@ -2,8 +2,6 @@ export const LEFT_WIDTH_PERCENT = 0.2;
 
 export const MINIMUM_CENTER_PANE_WIDTH = 100;
 
-export const MINIMUM_SIDE_PANE_WIDTH = 100;
-
 export const DEFAULT_SIDE_PANE_WIDTH = 500;
 
 export const MINIMUM_LEFT_SIDE_PANE_WIDTH = 300;

--- a/packages/dashboard/src/components/resizablePanes/index.tsx
+++ b/packages/dashboard/src/components/resizablePanes/index.tsx
@@ -5,7 +5,6 @@ import { spaceStaticXs } from '@cloudscape-design/design-tokens';
 import {
   LEFT_WIDTH_PERCENT,
   MINIMUM_CENTER_PANE_WIDTH,
-  MINIMUM_SIDE_PANE_WIDTH,
   DEFAULT_SIDE_PANE_WIDTH,
   DEFAULT_COLLAPSED_SIDE_PANE_WIDTH,
   MAXIMUM_PANES_PROPORTION,
@@ -67,11 +66,12 @@ export const ResizablePanes: FC<ResizablePanesProps> = ({ leftPane, centerPane, 
 
     if (storedLeftWidthPercent) {
       const storedLeftWidth = elementWidth * storedLeftWidthPercent;
-      setLeftPaneWidth(storedLeftWidth);
+      setLeftPaneWidth(storedLeftWidth > DEFAULT_SIDE_PANE_WIDTH ? storedLeftWidth : DEFAULT_SIDE_PANE_WIDTH);
     } else {
       const computedLeftPaneWidth = elementWidth * LEFT_WIDTH_PERCENT;
       const computedLeftPaneWidthWithMinimums =
-        computedLeftPaneWidth > MINIMUM_SIDE_PANE_WIDTH ? computedLeftPaneWidth : MINIMUM_SIDE_PANE_WIDTH;
+        computedLeftPaneWidth > DEFAULT_SIDE_PANE_WIDTH ? computedLeftPaneWidth : DEFAULT_SIDE_PANE_WIDTH;
+
       setLeftPaneWidth(computedLeftPaneWidthWithMinimums);
     }
   }, []);
@@ -168,7 +168,7 @@ export const ResizablePanes: FC<ResizablePanesProps> = ({ leftPane, centerPane, 
     // If proportions are too high, or next pane width is larger than minimum
     // size, use minimum size as next pane width instead.
     const nextLeftPaneWidth =
-      maybeNextLeftPaneWidth > MINIMUM_SIDE_PANE_WIDTH ? maybeNextLeftPaneWidth : MINIMUM_SIDE_PANE_WIDTH;
+      maybeNextLeftPaneWidth > DEFAULT_SIDE_PANE_WIDTH ? maybeNextLeftPaneWidth : DEFAULT_SIDE_PANE_WIDTH;
 
     // Persist percentages with sessionStorage
     const nextLeftPaneWidthPercent = nextLeftPaneWidth / elementWidth;
@@ -183,6 +183,7 @@ export const ResizablePanes: FC<ResizablePanesProps> = ({ leftPane, centerPane, 
     if (isLeftPaneCollapsed) {
       setLeftPaneWidth(DEFAULT_SIDE_PANE_WIDTH);
       setLeftPaneCollapsed(false);
+      resizeSidePanes();
     } else {
       setLeftPaneWidth(DEFAULT_COLLAPSED_SIDE_PANE_WIDTH);
       setLeftPaneCollapsed(true);


### PR DESCRIPTION
## Overview
This PR is for ticket #2292 and to fix resource explorer width in different scenarios
1. default width (500px) on first opening the dashboard
2. default width on expanding resource explorer
3.  default width on changing edit and view mode if width is equal/less than default width
4. persists width between edit and preview view if width is greater than default 


## Verifying Changes
[resource-explorer-width.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/78b80464-28fe-46d4-afd1-d01cfa120292)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
