### PR TITLE
fix(react-components): trendcursor hotkey indicates addition state

### DIFF
--- a/packages/react-components/src/components/chart/trendCursor/mouseEvents/handlers/mouseover/index.ts
+++ b/packages/react-components/src/components/chart/trendCursor/mouseEvents/handlers/mouseover/index.ts
@@ -1,8 +1,14 @@
 import { MutableRefObject } from 'react';
 import { ECharts } from 'echarts';
+import { MAX_TREND_CURSORS } from '../../../constants';
+import { InternalGraphicComponentGroupOption } from '../../../types';
 
-export const mouseoverHandler = (isInCursorAddMode: boolean, chartRef: MutableRefObject<ECharts | null>) => {
-  if (isInCursorAddMode) {
+export const mouseoverHandler = (
+  isInCursorAddMode: boolean,
+  tcGraphicList: InternalGraphicComponentGroupOption[],
+  chartRef: MutableRefObject<ECharts | null>
+) => {
+  if (isInCursorAddMode && tcGraphicList.length < MAX_TREND_CURSORS) {
     chartRef.current?.getZr().setCursorStyle('crosshair');
   }
 };

--- a/packages/react-components/src/components/chart/trendCursor/mouseEvents/useTrendCursorsEvents.ts
+++ b/packages/react-components/src/components/chart/trendCursor/mouseEvents/useTrendCursorsEvents.ts
@@ -126,8 +126,13 @@ const useTrendCursorsEvents = ({
   // standalone mode --> updates the local state
   useEffect(() => {
     const currentChart = chartRef.current;
+    if (isInCursorAddModeRef.current && graphicRef.current.length < MAX_TREND_CURSORS) {
+      chartRef.current?.getZr().setCursorStyle('crosshair');
+    } else {
+      chartRef.current?.getZr().setCursorStyle('default'); // in case we get out of add mode and mouse does not move, switch back to default cursor
+    }
 
-    const mouseMoveEventHandler = () => mouseoverHandler(isInCursorAddModeRef.current, chartRef);
+    const mouseMoveEventHandler = () => mouseoverHandler(isInCursorAddModeRef.current, graphicRef.current, chartRef);
 
     // this handles all the clicks on the chart
     // this click would be either
@@ -246,7 +251,15 @@ const useTrendCursorsEvents = ({
       currentChart?.getZr()?.off('dragstart', dragStartEventHandler);
       currentChart?.off('datazoom', zoomHandler);
     };
-  }, [addNewTrendCursor, deleteTrendCursor, groupId, updateTrendCursorsInSyncState, chartRef, setGraphic]);
+  }, [
+    addNewTrendCursor,
+    deleteTrendCursor,
+    groupId,
+    updateTrendCursorsInSyncState,
+    chartRef,
+    setGraphic,
+    isInCursorAddMode,
+  ]);
 
   const copyTrendCursorData = (posX: number) => {
     const timestampOfClick = calculateTimeStamp(posX, chartRef);


### PR DESCRIPTION
## Overview
The trend cursor hotkey (T key) did not specify that the user was in a state to add a TC. To fix this, we change the cursor to a cross hair cursor on keydown to a crosshair instead of on mouse move.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/68daa931-0b51-420b-897f-e56eca9fd813





## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
