### PR TITLE
fix(composer): improve load sub model latency

### DIFF
--- a/examples/react-app/src/components/SceneViewer.tsx
+++ b/examples/react-app/src/components/SceneViewer.tsx
@@ -6,6 +6,7 @@ import { sceneId, componentTypeQueries, entityQueries, dataBindingTemplate } fro
 import './SceneViewer.scss';
 
 const sceneLoader = dataSource.s3SceneLoader(sceneId);
+const sceneMetadataModule = dataSource.sceneMetadataModule(sceneId);
 
 const queries = [
   ...componentTypeQueries.map((q) => dataSource.query.timeSeriesData(q)),
@@ -30,6 +31,7 @@ const SceneViewer: FC<SceneViewerProps> = ({ onSelectionChanged, onWidgetClick }
           },
         }}
         onSelectionChanged={onSelectionChanged}
+        sceneMetadataModule={sceneMetadataModule}
         onWidgetClick={onWidgetClick}
         queries={queries}
         dataBindingTemplate={dataBindingTemplate}

--- a/packages/scene-composer/src/common/entityModelConstants.ts
+++ b/packages/scene-composer/src/common/entityModelConstants.ts
@@ -21,6 +21,7 @@ export const componentTypeToId: Record<KnownComponentType, string> = {
 };
 export const DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME = 'isVisualOf';
 export const DEFAULT_PARENT_RELATIONSHIP_NAME = 'isChildOf';
+export const SUB_MODEL_REF_PARENT_RELATIONSHIP_NAME = 'parentRef';
 export const DEFAULT_NODE_COMPONENT_NAME = 'Node';
 export const SCENE_ROOT_ENTITY_ID = 'SCENES_EntityId';
 export const SCENE_ROOT_ENTITY_NAME = '$SCENES';

--- a/packages/scene-composer/src/components/SceneLayers.spec.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.spec.tsx
@@ -145,7 +145,7 @@ describe('SceneLayers', () => {
     expect(processQueries as jest.Mock).toBeCalledWith(
       [
         expect.stringContaining("AND e.entityId = 'layer1'"),
-        expect.stringContaining(`MATCH (binding)<-[r2:${DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME}]-(entity)-[r]->(e)`),
+        expect.stringContaining(`MATCH (binding)<-[r2]-(entity)-[r]->(e)`),
       ],
       expect.anything(),
     );

--- a/packages/scene-composer/src/components/SceneLayers.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.tsx
@@ -9,6 +9,7 @@ import { KnownSceneProperty } from '../interfaces';
 import {
   DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME,
   DEFAULT_LAYER_RELATIONSHIP_NAME,
+  SUB_MODEL_REF_PARENT_RELATIONSHIP_NAME,
 } from '../common/entityModelConstants';
 
 export const SceneLayers: React.FC = () => {
@@ -34,12 +35,14 @@ export const SceneLayers: React.FC = () => {
         MATCH (entity)-[r]->(e)
         WHERE r.relationshipName = '${DEFAULT_LAYER_RELATIONSHIP_NAME}'
         AND e.entityId = '${layerId}'`,
-          // Get entityBinding for the nodes in the layer
+          // Get entityBinding and subModel parentRef for the nodes in the layer
           `SELECT entity, r2, binding
         FROM EntityGraph 
-        MATCH (binding)<-[r2:${DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME}]-(entity)-[r]->(e)
+        MATCH (binding)<-[r2]-(entity)-[r]->(e)
         WHERE r.relationshipName = '${DEFAULT_LAYER_RELATIONSHIP_NAME}'
-        AND e.entityId = '${layerId}'`,
+        AND e.entityId = '${layerId}'
+        AND (r2.relationshipName = '${DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME}'
+        OR r2.relationshipName = '${SUB_MODEL_REF_PARENT_RELATIONSHIP_NAME}')`,
         ],
         (node) => (node.properties.layerIds = [...(node.properties.layerIds ?? []), layerId!]),
       );

--- a/packages/scene-composer/src/utils/entityModelUtils/processQueries.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/processQueries.spec.ts
@@ -5,12 +5,12 @@ import {
   DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME,
   DEFAULT_PARENT_RELATIONSHIP_NAME,
   NODE_COMPONENT_TYPE_ID,
+  SUB_MODEL_REF_PARENT_RELATIONSHIP_NAME,
   componentTypeToId,
 } from '../../common/entityModelConstants';
 import { ISubModelRefComponent, KnownComponentType } from '../../interfaces';
 
 import { isValidSceneNodeEntity, processQueries } from './processQueries';
-import { SubModelRefComponentProperty } from './subModelRefComponent';
 
 jest.mock('../mathUtils', () => ({
   generateUUID: jest.fn(() => 'random-uuid'),
@@ -31,10 +31,8 @@ describe('isValidSceneNodeEntity', () => {
 
 describe('processQueries', () => {
   const executeQuery = jest.fn();
-  const getSceneEntity = jest.fn();
   const mockMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
     kgModule: { executeQuery },
-    getSceneEntity,
   };
 
   const mockRows = [
@@ -160,6 +158,11 @@ describe('processQueries', () => {
               },
             ],
           },
+          {
+            relationshipName: SUB_MODEL_REF_PARENT_RELATIONSHIP_NAME,
+            sourceEntityId: 'id1',
+            targetEntityId: parentRef,
+          },
         ],
       },
       {
@@ -177,21 +180,6 @@ describe('processQueries', () => {
       },
     ];
     executeQuery.mockResolvedValue({ rows: rows });
-    getSceneEntity.mockResolvedValue({
-      components: {
-        SubModelRef: {
-          properties: {
-            [SubModelRefComponentProperty.ParentRef]: {
-              value: {
-                relationshipValue: {
-                  targetEntityId: parentRef,
-                },
-              },
-            },
-          },
-        },
-      },
-    });
 
     const nodes = await processQueries(['random query']);
 


### PR DESCRIPTION
## Overview
Improve the latency when fetching parentRef of sub model node by querying the relationship instead of calling get entity for each.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
