### PR TITLE
fix: time machine enable in edit and preview mode

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -225,7 +225,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({ onSave, edit
         </Box>
         <Box float='right' padding='xs'>
           <SpaceBetween size='s' direction='horizontal'>
-            <TimeSelection isPaginationEnabled={true} />
+            <TimeSelection isPaginationEnabled />
             <Divider key='2' />
             <Actions
               key='3'
@@ -268,7 +268,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({ onSave, edit
         </Box>
         <Box float='right' padding='s'>
           <SpaceBetween size='s' direction='horizontal'>
-            <TimeSelection />
+            <TimeSelection isPaginationEnabled />
             {editable && (
               <>
                 <Divider key='2' />


### PR DESCRIPTION
## Overview
Issue: #2309 

Enabled pagination for time machine in both edit and preview mode

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/139960352/72f284af-b97f-4575-9aab-6255548d4cdd


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
