### PR TITLE
chore: metrics for dashboard widget add/delete, toggle setting, toggl…

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, ReactNode, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { getPlugin } from '@iot-app-kit/core';
 import { WebglContext, TrendCursorSync, TimeSync, TimeSelection } from '@iot-app-kit/react-components';
 import Box from '@cloudscape-design/components/box';
 import SpaceBetween from '@cloudscape-design/components/space-between';
@@ -93,12 +94,15 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({ onSave, edit
 
   const dispatch = useDispatch();
 
-  const createWidgets = (widgets: DashboardWidget[]) =>
+  const metricsRecorder = getPlugin('metricsRecorder');
+
+  const createWidgets = (widgets: DashboardWidget[]) => {
     dispatch(
       onCreateWidgetsAction({
         widgets,
       })
     );
+  };
 
   const copyWidgets = () => {
     dispatch(
@@ -168,6 +172,15 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({ onSave, edit
       z: 0,
     };
     createWidgets([widget]);
+
+    const widgetType = widget.type;
+    metricsRecorder?.record({
+      contexts: {
+        widgetType,
+      },
+      metricName: 'DashboardWidgetAdd',
+      metricValue: 1,
+    });
   };
 
   /**

--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -12,6 +12,7 @@ import {
   spaceScaledM,
 } from '@cloudscape-design/design-tokens';
 import { CancelableEventHandler, ClickDetail } from '@cloudscape-design/components/internal/events';
+import { getPlugin } from '@iot-app-kit/core';
 
 import { DashboardWidget } from '~/types';
 import { useDeleteWidgets } from '~/hooks/useDeleteWidgets';
@@ -57,6 +58,7 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
   const [visible, setVisible] = useState(false);
   const { iotSiteWiseClient } = useClients();
   const { onDelete } = useDeleteWidgets();
+  const metricsRecorder = getPlugin('metricsRecorder');
 
   const isRemoveable = !isReadOnly && removeable;
   const headerVisible = !isReadOnly || widget.type !== 'text';
@@ -74,9 +76,18 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ children, widget, title, remove
   };
 
   const handleSubmit = () => {
+    const widgetType = widget.type;
     onDelete(widget);
     dispatch(onChangeDashboardGridEnabledAction({ enabled: true }));
     setVisible(false);
+
+    metricsRecorder?.record({
+      contexts: {
+        widgetType,
+      },
+      metricName: 'DashboardWidgetDelete',
+      metricValue: 1,
+    });
   };
 
   return (

--- a/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { registerPlugin } from '@iot-app-kit/core';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import Dashboard, { DashboardProperties } from '../../src/components/dashboard';
@@ -58,6 +59,12 @@ const widgetDashboardConfiguration = {
   },
   onSave: () => Promise.resolve(),
 };
+
+registerPlugin('metricsRecorder', {
+  provider: () => ({
+    record: (...args) => console.log('record metric:', ...args),
+  }),
+});
 
 export default {
   title: 'Dashboard/Mocked data',

--- a/packages/dashboard/stories/dashboard/sitewise-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/sitewise-dashboard.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { registerPlugin } from '@iot-app-kit/core';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import Dashboard, { DashboardProperties } from '../../src/components/dashboard';
@@ -50,6 +51,12 @@ const args: DashboardProperties = {
     return Promise.resolve();
   },
 };
+
+registerPlugin('metricsRecorder', {
+  provider: () => ({
+    record: (...args) => console.log('record metric:', ...args),
+  }),
+});
 
 export const Main: ComponentStory<typeof Dashboard> = () => <Dashboard {...getDashboardProperties(args)} />;
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -48,6 +48,7 @@
     }
   },
   "devDependencies": {
+    "@iot-app-kit/core": "9.8.0",
     "@iot-app-kit/jest-config": "9.8.0",
     "@iot-app-kit/source-iotsitewise": "9.8.0",
     "@iot-app-kit/testing-util": "9.8.0",

--- a/packages/react-components/src/components/chart/trendCursor/mouseEvents/useTrendCursorsEvents.ts
+++ b/packages/react-components/src/components/chart/trendCursor/mouseEvents/useTrendCursorsEvents.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
+import { getPlugin } from '@iot-app-kit/core';
 import { calculateNearestTcIndex, calculateXFromTimestamp, formatCopyData } from '../calculations/calculations';
 import { v4 as uuid } from 'uuid';
 import { getNewTrendCursor } from '../getTrendCursor/getTrendCursor';
@@ -80,6 +81,12 @@ const useTrendCursorsEvents = ({
             setGraphicRef.current([...graphicRef.current, newTc]);
           }
         }
+
+        const metricsRecorder = getPlugin('metricsRecorder');
+        metricsRecorder?.record({
+          metricName: 'TrendCursorAdd',
+          metricValue: 1,
+        });
       }
     },
     [chartRef, addTrendCursorsToSyncState, groupId]
@@ -100,6 +107,12 @@ const useTrendCursorsEvents = ({
         graphicRef.current.splice(toBeDeletedGraphicIndex, 1);
         setGraphicRef.current([...graphicRef.current]);
       }
+
+      const metricsRecorder = getPlugin('metricsRecorder');
+      metricsRecorder?.record({
+        metricName: 'TrendCursorDelete',
+        metricValue: 1,
+      });
     },
     [deleteTrendCursorsInSyncState, groupId, chartRef]
   );


### PR DESCRIPTION
…e modes, toggle trend cursor

## Overview

Added count metrics for following events:
1. dashboard save
3. dashboard toggle setting model visibility
4. dashboard toggle preview/edit modes
2. dashboard widget add/delete
5. trend cursor add/delete

## Validations

Observed logs
```
record metric: {metricName: 'DashboardSave', metricValue: 1}
record metric: {metricName: 'DashboardSettingOpen', metricValue: 1}
record metric: {metricName: 'DashboardSettingClose', metricValue: 1}
record metric: {metricName: 'DashboardPreview', metricValue: 1}
record metric: {metricName: 'DashboardEdit', metricValue: 1}
record metric: {contexts:  {widgetType: 'xy-plot'}, metricName: 'DashboardWidgetAdd', metricValue: 1}
record metric: {contexts:  {widgetType: 'xy-plot'}, metricName: 'DashboardWidgetDelete', metricValue: 1}
record metric: {metricName: 'TrendCursorAdd', metricValue: 1}
record metric: {metricName: 'TrendCursorDelete', metricValue: 1}
```

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
