### PR TITLE
fix: accessible property filter labels

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesTable/assetModelPropertiesTableFilter.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesTable/assetModelPropertiesTableFilter.tsx
@@ -22,7 +22,7 @@ export function AssetModelPropertiesTablePropertyFilter(props: AssetModelPropert
       filteringFinishedText='End of results'
       filteringEmpty='No suggestions found'
       i18nStrings={{
-        filteringAriaLabel: 'your choice',
+        filteringAriaLabel: 'Filter asset model properties by text, property, or value',
         dismissAriaLabel: 'Dismiss',
         filteringPlaceholder: 'Filter asset model properties by text, property, or value',
         groupValuesText: 'Values',

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTableNameLink.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTableNameLink.tsx
@@ -10,7 +10,7 @@ export interface AssetTableNameLinkProps {
 export function AssetTableNameLink({ assetId, assetName, updateParentAssetId }: AssetTableNameLinkProps) {
   return (
     <Link
-      ariaLabel='List child assets'
+      ariaLabel={`List child assets of ${assetName}`}
       onFollow={(event) => {
         event.preventDefault();
         updateParentAssetId(assetId);

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTablePropertyFilter.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTablePropertyFilter.tsx
@@ -28,7 +28,7 @@ export function AssetTablePropertyFilter(props: AssetTablePropertyFilterProps) {
       filteringFinishedText='End of results'
       filteringEmpty='No suggestions found'
       i18nStrings={{
-        filteringAriaLabel: 'your choice',
+        filteringAriaLabel: 'Filter assets by text, property, or value',
         dismissAriaLabel: 'Dismiss',
         filteringPlaceholder: 'Filter assets by text, property, or value',
         groupValuesText: 'Values',

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTablePropertyFilter.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTablePropertyFilter.tsx
@@ -52,7 +52,7 @@ export function ModeledDataStreamTablePropertyFilter(props: ModeledDataStreamPro
       filteringFinishedText='End of results'
       filteringEmpty='No suggestions found'
       i18nStrings={{
-        filteringAriaLabel: 'your choice',
+        filteringAriaLabel: 'Filter modeled data streams by text, property, or value',
         dismissAriaLabel: 'Dismiss',
         filteringPlaceholder: 'Filter modeled data streams by text, property, or value',
         groupValuesText: 'Values',

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
@@ -190,7 +190,7 @@ export function UnmodeledDataStreamTable({
           filteringFinishedText='End of results'
           filteringEmpty='No suggestions found'
           i18nStrings={{
-            filteringAriaLabel: 'your choice',
+            filteringAriaLabel: 'Filter unmodeled data streams by text, property, or value',
             dismissAriaLabel: 'Dismiss',
             filteringPlaceholder: 'Filter unmodeled data streams by text, property, or value',
             groupValuesText: 'Values',

--- a/packages/react-components/src/components/table/messages.ts
+++ b/packages/react-components/src/components/table/messages.ts
@@ -16,7 +16,7 @@ export const DEFAULT_TABLE_CELL_MESSAGES: TableCellMessages = {
 };
 
 export const DEFAULT_PROPERTY_FILTER_MESSAGES: PropertyFilterMessages = {
-  filteringAriaLabel: 'your choice',
+  filteringAriaLabel: 'Search table',
   dismissAriaLabel: 'Dismiss',
   filteringPlaceholder: 'Search',
   groupValuesText: 'Values',


### PR DESCRIPTION
## Overview
Update all property filter aria labels from "your choice" to something actually descriptive
change clickable asset name aria label from "list child assets" to "List child assets of ${assetName}"

## Verifying Changes

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
