### PR TITLE
fix(dashboard): color picker has keyboard focus and can be interacted with

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/shared/colorPicker.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/shared/colorPicker.tsx
@@ -8,16 +8,17 @@ const ColorPicker: FC<{ color: string; updateColor: (newColor: string) => void }
   ...other
 }) => {
   return (
-    <div className='color-picker-container' style={{ backgroundColor: color }} {...other}>
-      <input
-        aria-label='color picker'
-        type='color'
-        value={color}
-        onChange={(e) => {
-          updateColor(e.target.value);
-        }}
-      />
-    </div>
+    <input
+      aria-label='color picker'
+      type='color'
+      value={color}
+      onChange={(e) => {
+        updateColor(e.target.value);
+      }}
+      className='color-picker'
+      style={{ backgroundColor: color }}
+      {...other}
+    />
   );
 };
 

--- a/packages/dashboard/src/customization/propertiesSections/shared/styles.css
+++ b/packages/dashboard/src/customization/propertiesSections/shared/styles.css
@@ -20,10 +20,15 @@
   justify-content: end;
 }
 
-.color-picker-container {
+.color-picker {
   width: 2.28rem;
   height: 1.57rem;
   border-radius: 0.57rem;
+}
+
+.color-picker:focus {
+  outline: 2px solid #06f;
+  outline-offset: 1.5px; /* added extra half pixel incase outline color and color picked are similar */
 }
 
 /* hide default color input */
@@ -38,4 +43,14 @@
   display: flex;
   align-items: center;
   height: 100%;
+}
+
+/* removes the color input box in Chrome */
+input[type="color"]::-webkit-color-swatch {
+  border: none;
+}
+
+/* removes the color input box in Edge/Firefox */
+input[type="color"]::-moz-color-swatch {
+  border: none;
 }


### PR DESCRIPTION
## Overview
Removed div surrounding color picker input and used the input tags default keyboard focus state. Added CSS to maintain status quo visually.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/bac78cb3-4935-4fb1-9aa9-7fd59c0e27ca



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
