### PR TITLE
fix: remove line chart tweening animation

### DIFF
--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -142,7 +142,7 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
       yAxis,
       xAxis,
       graphic: trendCursors,
-      animation: !viewportInMs.isDurationViewport,
+      animation: false,
       appKitChartId: options.id,
     },
     settings
@@ -161,7 +161,7 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
   const handleMouseDown = (e: MouseEvent) => {
     const target = e.target;
 
-    /* Condition to check localName of Canvas to stop onMouseDouwn event 
+    /* Condition to check localName of Canvas to stop onMouseDouwn event
       propagation to fix widget dragging or moving issue while panning on chart */
     if (target instanceof Element && target.localName === 'canvas') {
       e.stopPropagation();


### PR DESCRIPTION
## Overview
This change removes the tweening animation from the line chart when zooming and panning.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
