### PR TITLE
fix(dashboard): listAssetPropertiesCall for msw + path objects for all assetModels

### DIFF
--- a/packages/dashboard/src/msw/handlers.ts
+++ b/packages/dashboard/src/msw/handlers.ts
@@ -9,6 +9,7 @@ import { listAssetsHandler } from './iot-sitewise/handlers/listAssets/listAssets
 import { listAssociatedAssetsHandler } from './iot-sitewise/handlers/listAssociatedAssets/listAssociatedAssetsHandler';
 import { listAssetModelsHandler } from './iot-sitewise/handlers/listAssetModels/listAssetModels';
 import { listAssetModelPropertiesHandler } from './iot-sitewise/handlers/listAssetModelProperties/listAssetModelProperties';
+import { listAssetPropertiesHandler } from './iot-sitewise/handlers/listAssetProperties/listAssetProperties';
 
 export const handlers = [
   batchGetAssetPropertyAggregatesHandler(),
@@ -20,4 +21,5 @@ export const handlers = [
   listAssetModelsHandler(),
   listAssociatedAssetsHandler(),
   listAssetModelPropertiesHandler(),
+  listAssetPropertiesHandler(),
 ];

--- a/packages/dashboard/src/msw/iot-sitewise/handlers/listAssetProperties/constants.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/handlers/listAssetProperties/constants.ts
@@ -1,0 +1,3 @@
+import { SITEWISE_CONTROL_PLANE_API_BASE_URL } from '../../constants';
+
+export const LIST_ASSETS_PROPERTIES_URL = `${SITEWISE_CONTROL_PLANE_API_BASE_URL}/assets/:assetId/properties`;

--- a/packages/dashboard/src/msw/iot-sitewise/handlers/listAssetProperties/listAssetProperties.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/handlers/listAssetProperties/listAssetProperties.ts
@@ -1,0 +1,21 @@
+import { rest } from 'msw';
+import { LIST_ASSETS_PROPERTIES_URL } from './constants';
+import { ASSET_HIERARCHY } from '../../resources/assets';
+import { ListAssetPropertiesResponse } from '@aws-sdk/client-iotsitewise';
+
+export function listAssetPropertiesHandler() {
+  return rest.get(LIST_ASSETS_PROPERTIES_URL, (req, res, ctx) => {
+    const { assetId } = req.params as { assetId: string };
+    const asset = ASSET_HIERARCHY.findAssetById(assetId);
+
+    if (!asset) {
+      return res(ctx.status(404));
+    }
+
+    const response: ListAssetPropertiesResponse = {
+      assetPropertySummaries: asset.assetProperties,
+    };
+
+    return res(ctx.delay(), ctx.status(200), ctx.json(response));
+  });
+}

--- a/packages/dashboard/src/msw/iot-sitewise/resources/assetModels/index.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/resources/assetModels/index.ts
@@ -1,38 +1,142 @@
 import { v4 as uuid } from 'uuid';
 import { AssetModelFactory } from './AssetModelFactory';
 
-const assetModelFactory = new AssetModelFactory();
+const reactorAssetModelId = uuid();
+const reactorAssetModelTemperatureId = uuid();
+const reactorAssetModelMaxTemperatureId = uuid();
+const reactorAssetModelMinTemperatureId = uuid();
+const reactorAssetModelPressureId = uuid();
+const reactorAssetModelMaxPressureId = uuid();
+const reactorAssetModelMinPressureId = uuid();
 
+const assetModelFactory = new AssetModelFactory();
 export const REACTOR_ASSET_MODEL = assetModelFactory.create({
+  assetModelId: reactorAssetModelId,
   assetModelName: 'Reactor',
   assetModelDescription: 'Reactor Asset Model',
   assetModelProperties: [
-    { name: 'Temperature', id: uuid(), dataType: 'DOUBLE', type: { measurement: {} } },
-    { name: 'Max Temperature', id: uuid(), dataType: 'DOUBLE', type: { attribute: {} } },
-    { name: 'Min Temperature', id: uuid(), dataType: 'DOUBLE', type: { attribute: {} } },
-    { name: 'Pressure', id: uuid(), dataType: 'DOUBLE', type: { measurement: {} } },
-    { name: 'Max Pressure', id: uuid(), dataType: 'DOUBLE', type: { attribute: {} } },
-    { name: 'Min Pressure', id: uuid(), dataType: 'DOUBLE', type: { attribute: {} } },
+    {
+      name: 'Temperature',
+      id: reactorAssetModelTemperatureId,
+      dataType: 'DOUBLE',
+      type: { measurement: {} },
+      externalId: 'temp',
+      unit: 'Celcius',
+      path: [
+        { id: reactorAssetModelId, name: 'Reactor' },
+        { id: reactorAssetModelTemperatureId, name: 'Temperature' },
+      ],
+    },
+    {
+      name: 'Max Temperature',
+      id: reactorAssetModelMaxTemperatureId,
+      dataType: 'DOUBLE',
+      type: { attribute: {} },
+      externalId: 'maxTemp',
+      unit: 'Celcius',
+      path: [
+        { id: reactorAssetModelId, name: 'Reactor' },
+        { id: reactorAssetModelMaxTemperatureId, name: 'Max Temperature' },
+      ],
+    },
+    {
+      name: 'Min Temperature',
+      id: reactorAssetModelMinTemperatureId,
+      dataType: 'DOUBLE',
+      type: { attribute: {} },
+      externalId: 'minTemp',
+      unit: 'Celcius',
+      path: [
+        { id: reactorAssetModelId, name: 'Reactor' },
+        { id: reactorAssetModelMinTemperatureId, name: 'Min Temperature' },
+      ],
+    },
+    {
+      name: 'Pressure',
+      id: reactorAssetModelPressureId,
+      dataType: 'DOUBLE',
+      type: { measurement: {} },
+      unit: 'Pascal',
+      path: [
+        { id: reactorAssetModelId, name: 'Reactor' },
+        { id: reactorAssetModelPressureId, name: 'Pressure' },
+      ],
+    },
+    {
+      name: 'Max Pressure',
+      id: reactorAssetModelMaxPressureId,
+      dataType: 'DOUBLE',
+      type: { attribute: {} },
+      externalId: 'maxP',
+      unit: 'Pascal',
+      path: [
+        { id: reactorAssetModelId, name: 'Reactor' },
+        { id: reactorAssetModelMaxPressureId, name: 'Max Pressure' },
+      ],
+    },
+    {
+      name: 'Min Pressure',
+      id: reactorAssetModelMinPressureId,
+      dataType: 'DOUBLE',
+      type: { attribute: {} },
+      externalId: 'minP',
+      unit: 'Pascal',
+      path: [
+        { id: reactorAssetModelId, name: 'Reactor' },
+        { id: reactorAssetModelMinPressureId, name: 'Min Pressure' },
+      ],
+    },
   ],
 });
 
+const storageTankAssetModelId = uuid();
+const storageTankAssetModelCapacityId = uuid();
+const storageTankAssetModelVolumeId = uuid();
+
 export const STORAGE_TANK_ASSET_MODEL = assetModelFactory.create({
+  assetModelId: storageTankAssetModelId,
   assetModelName: 'Storage Tank',
   assetModelDescription: 'Storage Tank Asset Model',
   assetModelProperties: [
-    { name: 'Capacity', id: uuid(), dataType: 'INTEGER', type: { attribute: {} } },
-    { name: 'Volume', id: uuid(), dataType: 'INTEGER', type: { measurement: {} } },
+    {
+      name: 'Capacity',
+      id: storageTankAssetModelCapacityId,
+      dataType: 'INTEGER',
+      type: { attribute: {} },
+      externalId: 'f',
+      unit: 'Liters',
+      path: [
+        { id: storageTankAssetModelId, name: 'Storage Tank' },
+        { id: storageTankAssetModelCapacityId, name: 'Capacity' },
+      ],
+    },
+    {
+      name: 'Volume',
+      id: storageTankAssetModelVolumeId,
+      dataType: 'INTEGER',
+      type: { measurement: {} },
+      externalId: 'g',
+      unit: 'Liters/Sqft',
+      path: [
+        { id: storageTankAssetModelId, name: 'Storage Tank' },
+        { id: storageTankAssetModelVolumeId, name: 'Volume' },
+      ],
+    },
   ],
 });
 
+const reactorAssetModelHeirarchyId = uuid();
+
 export const REACTOR_ASSET_MODEL_HIERARCHY = {
-  id: uuid(),
+  id: reactorAssetModelHeirarchyId,
   name: 'Reactor',
   childAssetModelId: REACTOR_ASSET_MODEL.assetModelId,
 };
 
+const storageTankAssetModelHeirarchyId = uuid();
+
 export const STORAGE_TANK_ASSET_MODEL_HIERARCHY = {
-  id: uuid(),
+  id: storageTankAssetModelHeirarchyId,
   name: 'Storage Tank',
   childAssetModelId: STORAGE_TANK_ASSET_MODEL.assetModelId,
 };
@@ -43,25 +147,49 @@ export const PRODUCTION_LINE_ASSET_MODEL = assetModelFactory.create({
   assetModelHierarchies: [REACTOR_ASSET_MODEL_HIERARCHY, STORAGE_TANK_ASSET_MODEL_HIERARCHY],
 });
 
+const productionLineAssetModelHierarchyId = uuid();
+
 export const PRODUCTION_LINE_ASSET_MODEL_HIERARCHY = {
-  id: uuid(),
+  id: productionLineAssetModelHierarchyId,
   name: 'Production Line',
   childAssetModelId: PRODUCTION_LINE_ASSET_MODEL.assetModelId,
 };
 
+const siteAssetModelId = uuid();
+const siteAssetModelCoordinatesId = uuid();
+
+const siteAssetModelProductionRateId = uuid();
+
 export const SITE_ASSET_MODEL = assetModelFactory.create({
+  assetModelId: siteAssetModelId,
   assetModelName: 'Site',
   assetModelDescription: 'Production Site Asset Model',
   assetModelProperties: [
     {
       name: 'Coordinates',
-      id: uuid(),
+      id: siteAssetModelCoordinatesId,
       dataType: 'STRING',
       type: {
         measurement: {},
       },
+      externalId: 'h',
+      path: [
+        { id: siteAssetModelId, name: 'Site' },
+        { id: siteAssetModelCoordinatesId, name: 'Coordinates' },
+      ],
     },
-    { name: 'Production Rate', id: uuid(), dataType: 'DOUBLE', type: { measurement: {} } },
+    {
+      name: 'Production Rate',
+      id: siteAssetModelProductionRateId,
+      dataType: 'DOUBLE',
+      type: { measurement: {} },
+      externalId: 'i',
+      path: [
+        { id: siteAssetModelId, name: 'Site' },
+        { id: siteAssetModelProductionRateId, name: 'Production Rate' },
+      ],
+      unit: 'rate',
+    },
   ],
   assetModelHierarchies: [PRODUCTION_LINE_ASSET_MODEL_HIERARCHY],
 });


### PR DESCRIPTION
## Overview
This change implements a listAssetProperties call to assetProperties.This enables two actions using MSW. Model Centric Visualization can now display the correct name in the legend and property config panel and the resource explorer can now be used to add datastreams to a widget. 

This is part 1 of a MSW change. Next part will solve the issues of 
- only IDs showing up in the legend when modeled resources are added 
- properties config panel not showing data
- addition of composition models.

## Verifying Changes


https://github.com/awslabs/iot-app-kit/assets/145582655/3150d0a9-e3f3-41c8-a1ca-15845cb56500



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
