### PR TITLE
feat: added title in bar and status timeline

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
@@ -4,7 +4,6 @@ import SpaceBetween from '@cloudscape-design/components/space-between';
 import { PropertiesSection } from '~/customization/propertiesSectionComponent';
 import { LineScatterChartWidget, LineStyles, SymbolStyles } from '~/customization/widgets/types';
 import { DashboardWidget } from '~/types';
-import { TitleSection } from './titleSection';
 import { LineStyleSection } from './lineStyleSection';
 import { YAxisSection } from './yAxis';
 import { LegendSection } from './legendSection';
@@ -32,14 +31,6 @@ const RenderLineAndScatterStyleSettingsSection = ({
         ...properties.line,
         connectionStyle: updatedConnectionStyle,
       },
-    })
-  );
-
-  const [titleMaybe, updateTitle] = useProperty(
-    (properties) => properties.title,
-    (properties, updatedTitle) => ({
-      ...properties,
-      title: updatedTitle,
     })
   );
 
@@ -164,7 +155,6 @@ const RenderLineAndScatterStyleSettingsSection = ({
   );
 
   const connectionStyle = maybeWithDefault(undefined, connectionStyleMaybe);
-  const title = maybeWithDefault(undefined, titleMaybe);
   const lineStyle = maybeWithDefault(undefined, lineStyleMaybe);
   const lineThickness = maybeWithDefault(undefined, lineThicknessMaybe);
   const dataPointStyle = maybeWithDefault(undefined, dataPointStyleMaybe);
@@ -181,7 +171,6 @@ const RenderLineAndScatterStyleSettingsSection = ({
 
   return (
     <SpaceBetween size='s' direction='vertical'>
-      <TitleSection title={title} updateTitle={updateTitle} />
       <AggregationAndResolutionSection
         aggregation={aggregationType}
         resolution={resolution}

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/styleTab.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/styleTab.tsx
@@ -7,10 +7,12 @@ import { AxisSettingsConfiguration } from '../axisSettings';
 import { SettingsConfiguration } from '../settings';
 import { TextSettingsConfiguration } from '../textSettings';
 import { LineAndScatterStyleSettingsSection } from '../lineAndScatterStyleSettings/section';
+import { WidgetTitle } from '../widgetTitle';
 
 export const StylesSection = () => (
   <div>
     <SpaceBetween size='s' direction='vertical'>
+      <WidgetTitle />
       <LineAndScatterStyleSettingsSection />
       <AggregationsSettingsConfiguration />
       <AxisSettingsConfiguration />

--- a/packages/dashboard/src/customization/propertiesSections/widgetTitle/index.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/widgetTitle/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import { PropertiesSection } from '~/customization/propertiesSectionComponent';
+import { CommonChartProperties } from '~/customization/widgets/types';
+import { DashboardWidget } from '~/types';
+import { TitleSection } from './titleSection';
+import { maybeWithDefault } from '~/util/maybe';
+import { PropertyLens } from '~/customization/propertiesSection';
+
+const isWidgetTitle = (w: DashboardWidget): w is DashboardWidget<CommonChartProperties> =>
+  'queryConfig' in w.properties &&
+  !(w.type === 'kpi' || w.type === 'status' || w.type === 'table' || w.type === 'text');
+
+const RenderWidgetTitleSection = ({
+  useProperty,
+}: {
+  useProperty: PropertyLens<DashboardWidget<CommonChartProperties>>;
+}) => {
+  const [titleMaybe, updateTitle] = useProperty(
+    (properties) => properties.title,
+    (properties, updatedTitle) => ({
+      ...properties,
+      title: updatedTitle,
+    })
+  );
+
+  const title = maybeWithDefault(undefined, titleMaybe);
+
+  return (
+    <SpaceBetween size='s' direction='vertical'>
+      <TitleSection title={title} updateTitle={updateTitle} />
+    </SpaceBetween>
+  );
+};
+
+export const WidgetTitle: React.FC = () => (
+  <PropertiesSection
+    isVisible={isWidgetTitle}
+    render={({ useProperty }) => <RenderWidgetTitleSection useProperty={useProperty} />}
+  />
+);

--- a/packages/dashboard/src/customization/propertiesSections/widgetTitle/titleSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/widgetTitle/titleSection.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import FormField from '@cloudscape-design/components/form-field';
 import Input from '@cloudscape-design/components/input';
 import Box from '@cloudscape-design/components/box';
-import './lineAndScatterStyleSettings.css';
 import { spaceStaticXxs } from '@cloudscape-design/design-tokens';
 
 type TitleSectionOptions = {

--- a/packages/dashboard/src/customization/propertiesSections/widgetTitle/widgetTitle.test.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/widgetTitle/widgetTitle.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { getByLabelText, getByPlaceholderText, queryByLabelText, render } from '@testing-library/react';
+import { configureDashboardStore } from '~/store';
+import { DashboardWidget } from '~/types';
+import { WidgetTitle } from './index';
+import {
+  MOCK_LINE_CHART_WIDGET,
+  MOCK_TEXT_WIDGET,
+  MOCK_KPI_WIDGET,
+  MOCK_RECTANGLE_WIDGET,
+} from '../../../../testing/mocks';
+
+const store = (widgets: DashboardWidget) =>
+  configureDashboardStore({
+    dashboardConfiguration: {
+      widgets: [widgets],
+    },
+    selectedWidgets: [widgets],
+  });
+
+const TestComponent = (widget: DashboardWidget) => (
+  <Provider store={store(widget)}>
+    <WidgetTitle />
+  </Provider>
+);
+
+it('renders', () => {
+  const elem = render(<TestComponent {...MOCK_LINE_CHART_WIDGET} />).baseElement;
+  expect(elem).toBeTruthy();
+});
+
+it('renders the widget title input', () => {
+  const TITLE_WIDGETS = [MOCK_LINE_CHART_WIDGET];
+  TITLE_WIDGETS.map((widget) => {
+    const elem = render(<TestComponent {...widget} />).baseElement;
+    expect(getByLabelText(elem, 'Widget title')).toBeTruthy();
+    expect(getByPlaceholderText(elem, 'Input title')).toBeTruthy();
+  });
+});
+
+it('renders the without widget title input', () => {
+  const NO_TITLE_WIDGETS = [MOCK_KPI_WIDGET, MOCK_RECTANGLE_WIDGET, MOCK_TEXT_WIDGET];
+  NO_TITLE_WIDGETS.map((widget) => {
+    const elem = render(<TestComponent {...widget} />).baseElement;
+    expect(queryByLabelText(elem, 'Widget title')).toBeNull();
+    expect(queryByLabelText(elem, 'Input title')).toBeNull();
+  });
+});

--- a/packages/dashboard/src/customization/widgets/barChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/component.tsx
@@ -19,6 +19,7 @@ const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
   const chartSize = useChartSize(widget);
 
   const {
+    title,
     queryConfig,
     styleSettings,
     axis,
@@ -42,7 +43,7 @@ const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
   // the 44 is from the widget tile header's height
   const size = { width: chartSize.width, height: chartSize.height - 44 };
   return (
-    <WidgetTile widget={widget} removeable title='Bar Chart'>
+    <WidgetTile widget={widget} removeable title={title}>
       <BarChart
         chartSize={size}
         key={key}

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -207,7 +207,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (widge
   const isEmptyWidget = queries.length === 0;
   if (isEmptyWidget) {
     return (
-      <WidgetTile widget={widget} removeable>
+      <WidgetTile widget={widget} removeable title={title}>
         <NoChartData
           icon={lineSvgDark}
           emptyStateText='Browse and select to add your asset properties in your line widget.'

--- a/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
+++ b/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
@@ -17,6 +17,7 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (widget) =
   const dashboardSignificantDigits = useSelector((state: DashboardState) => state.significantDigits);
 
   const {
+    title,
     queryConfig,
     styleSettings,
     axis,
@@ -33,7 +34,7 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (widget) =
   const isEmptyWidget = queries.length === 0;
   if (isEmptyWidget) {
     return (
-      <WidgetTile widget={widget} removeable>
+      <WidgetTile widget={widget} removeable title={title}>
         <NoChartData
           icon={timelineSvgDark}
           emptyStateText='Browse and select to add your asset properties in your line widget.'
@@ -43,7 +44,7 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (widget) =
   }
 
   return (
-    <WidgetTile widget={widget} removeable key={key}>
+    <WidgetTile widget={widget} removeable title={title} key={key}>
       <StatusTimeline
         queries={queries}
         viewport={viewport}

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -26,6 +26,7 @@ export type QueryProperties = {
 };
 
 export type KPIProperties = QueryProperties & {
+  title?: string;
   primaryFont: SimpleFontSettings;
   secondaryFont: SimpleFontSettings;
   showValue?: boolean;
@@ -39,6 +40,7 @@ export type KPIProperties = QueryProperties & {
 export type KPIPropertiesKeys = keyof KPIProperties;
 
 export type StatusProperties = QueryProperties & {
+  title?: string;
   primaryFont: SimpleFontSettings;
   secondaryFont: SimpleFontSettings;
   showValue?: boolean;
@@ -52,6 +54,7 @@ export type StatusProperties = QueryProperties & {
 export type StatusPropertiesKeys = keyof StatusProperties;
 
 export type StatusTimelineProperties = QueryProperties & {
+  title?: string;
   thresholds?: ThresholdWithId[];
   thresholdSettings?: ThresholdSettings;
   axis?: AxisSettings;
@@ -138,6 +141,7 @@ export type LineScatterChartProperties = LineAndScatterStyles & {
 export type LineScatterChartPropertiesKeys = keyof LineScatterChartProperties;
 
 export type BarChartProperties = QueryProperties & {
+  title?: string;
   thresholds?: ThresholdWithId[];
   thresholdSettings?: ThresholdSettings;
   axis?: AxisSettings;
@@ -148,6 +152,7 @@ export type BarChartProperties = QueryProperties & {
 export type BarChartPropertiesKeys = keyof BarChartProperties;
 
 export type TableProperties = QueryProperties & {
+  title?: string;
   thresholds?: ThresholdWithId[];
   fontSettings?: ComplexFontSettings;
   items?: TableItem[];


### PR DESCRIPTION
## Overview
This PR is for ticket #2312 and to show working title in Bar and status timeline widgets. and it includes
1. updated functioning tilte for Bar chart widget
2. showing title in empty state for xy-ploy / status-timeline
3. added functioning tilte for status-timeline widget

## Verifying Changes
[bar&timeline-title.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/1c7707ad-e489-4d71-be41-b3a13e419a34)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
