### PR TITLE
fix(dashboard): clear selected properties on asset change

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { isFunction } from 'lodash';
 import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
@@ -79,6 +79,20 @@ export function ModeledDataStreamTable({
       sorting: {},
     }
   );
+
+  /**
+   * Reset selected items if the user changes the asset
+   * to avoid confusing add UX
+   */
+  useEffect(() => {
+    actions.setSelectedItems([]);
+    /**
+     * adding actions as a dependency causes
+     * the hook to run on every change becuase useCollection
+     * returns a new action reference
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedAsset]);
 
   const handleClickNextPage = () => {
     if (isFunction(onClickNextPage)) {


### PR DESCRIPTION
## Overview
Bugfix for resource explorer selected properties in the modeled datastreams tab to clear the selection whenever the selected asset changes so that only the properties for the current selection are added.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
