### PR TITLE
fix(composer): trigger onSceneLoaded after dynamic scene is loaded

### DIFF
--- a/packages/scene-composer/src/components/WebGLCanvasManager.tsx
+++ b/packages/scene-composer/src/components/WebGLCanvasManager.tsx
@@ -4,7 +4,6 @@ import React, { useContext, useEffect, useRef } from 'react';
 import { GizmoHelper, GizmoViewport } from '@react-three/drei';
 import { ThreeEvent, useThree } from '@react-three/fiber';
 import { MatterportModel } from '@matterport/r3f/dist';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { KnownSceneProperty, COMPOSER_FEATURES } from '../interfaces';
 import useLifecycleLogging from '../logger/react-logger/hooks/useLifecycleLogging';
@@ -18,7 +17,6 @@ import { getIntersectionTransform } from '../utils/raycastUtils';
 import { createNodeWithPositionAndNormal } from '../utils/nodeUtils';
 import { EnvironmentLoadingManager } from '../common/loadingManagers';
 import useMatterportViewer from '../hooks/useMatterportViewer';
-import useDynamicScene from '../hooks/useDynamicScene';
 
 import Environment, { presets } from './three-fiber/Environment';
 import Fog from './three-fiber/Fog';
@@ -29,9 +27,6 @@ import { EditorTransformControls } from './three-fiber/EditorTransformControls';
 import { SceneInfoView } from './three-fiber/SceneInfoView';
 import SceneBackground from './three-fiber/SceneBackground';
 import IntlProvider from './IntlProvider';
-import { SceneLayers } from './SceneLayers';
-
-const queryClient = new QueryClient();
 
 const GIZMO_MARGIN: [number, number] = [72, 72];
 
@@ -52,7 +47,6 @@ export const WebGLCanvasManager: React.FC = () => {
   const domRef = useRef<HTMLElement>(gl.domElement.parentElement);
   const environmentPreset = getSceneProperty<string>(KnownSceneProperty.EnvironmentPreset);
   const rootNodeRefs = document.rootNodeRefs;
-  const dynamicSceneEnabled = useDynamicScene();
 
   const editingTargetPlaneRef = useRef(null);
   const gridHelperRef = useRef<THREE.GridHelper>(null);
@@ -98,11 +92,6 @@ export const WebGLCanvasManager: React.FC = () => {
       <EditorMainCamera />
       {environmentPreset && environmentPreset in presets && (
         <Environment preset={environmentPreset} extensions={envLoaderExtension} />
-      )}
-      {dynamicSceneEnabled && (
-        <QueryClientProvider client={queryClient}>
-          <SceneLayers />
-        </QueryClientProvider>
       )}
       <group name={ROOT_OBJECT_3D_NAME} dispose={null}>
         {rootNodeRefs &&

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
@@ -5,6 +5,7 @@ import { Canvas, ThreeEvent } from '@react-three/fiber';
 import { useContextBridge } from '@react-three/drei/core/useContextBridge';
 import { MatterportViewer, MpSdk } from '@matterport/r3f/dist';
 import { isEmpty } from 'lodash';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { setMatterportSdk } from '../../common/GlobalSettings';
 import LoggingContext from '../../logger/react-logger/contexts/logging';
@@ -30,10 +31,14 @@ import useMatterportViewer from '../../hooks/useMatterportViewer';
 import useSelectedNode from '../../hooks/useSelectedNode';
 import { findComponentByType } from '../../utils/nodeUtils';
 import ConvertSceneModal from '../../components/ConvertSceneModal';
+import useDynamicScene from '../../hooks/useDynamicScene';
+import { SceneLayers } from '../../components/SceneLayers';
 
 import { Direction } from './components/utils';
 import ScenePanel from './components/ScenePanel';
 import CameraPreviewTrack from './components/CameraPreviewTrack';
+
+const queryClient = new QueryClient();
 
 const UnselectableCanvas = styled(Canvas)`
   user-select: none;
@@ -123,6 +128,8 @@ const SceneLayout: FC<SceneLayoutProps> = ({
     return isViewing ? false : !!findComponentByType(selectedNode.selectedSceneNode, KnownComponentType.Camera);
   }, [selectedNode]);
 
+  const dynamicSceneEnabled = useDynamicScene();
+
   const leftPanelEditModeProps = {
     direction: Direction.Left,
     panels: {
@@ -163,6 +170,12 @@ const SceneLayout: FC<SceneLayoutProps> = ({
           <LogProvider namespace='SceneLayout' ErrorView={DefaultErrorFallback}>
             <FloatingToolbar isViewing={isViewing} />
             <ContextBridge>
+              {dynamicSceneEnabled && (
+                <QueryClientProvider client={queryClient}>
+                  <SceneLayers />
+                </QueryClientProvider>
+              )}
+
               {shouldShowPreview && (
                 <CameraPreviewTrack ref={renderDisplayRef} title={selectedNode.selectedSceneNode?.name} />
               )}

--- a/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
+++ b/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
@@ -134,7 +134,11 @@ export const createSceneDocumentSlice = (set: SetState<RootState>, get: GetState
             overlaySettings.overlayPanelVisible;
         }
 
-        draft.sceneLoaded = true;
+        const dynamicSceneEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.DynamicScene];
+
+        if (!dynamicSceneEnabled || !isDynamicScene(result.document)) {
+          draft.sceneLoaded = true;
+        }
         draft.lastOperation = 'loadScene';
       });
 
@@ -241,6 +245,7 @@ export const createSceneDocumentSlice = (set: SetState<RootState>, get: GetState
 
         renderSceneNodesFromLayers(nodes, layerId, document, LOG);
 
+        draft.sceneLoaded = true;
         draft.lastOperation = 'renderSceneNodesFromLayers';
       });
     },


### PR DESCRIPTION
## Overview
trigger onSceneLoaded after dynamic scene is loaded

## Verifying Changes

Tested with static scene, dynamic scene, static matterport scene and dynamic matterport scene, onSceneLoaded is triggered once after nodes and matterport are ready

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
