### PR TITLE
feat(scene): textures for backgrounds and planes

### DIFF
--- a/packages/scene-composer/public/scene_1.scene.json
+++ b/packages/scene-composer/public/scene_1.scene.json
@@ -17,6 +17,14 @@
           "sel_comp"
         ]
       }
+    },
+    "fogSettings": {
+      "color": "#dddddd",
+      "near": 10,
+      "far": 1000
+    },
+    "sceneBackgroundSettings": {
+      "color": "#0000ff"
     }
   },
   "nodes": [

--- a/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditor.spec.tsx
@@ -1,12 +1,15 @@
 import wrapper from '@awsui/components-react/test-utils/dom';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import React from 'react';
 
+import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { IPlaneGeometryComponentInternal, useStore } from '../../../store';
-import { KnownComponentType } from '../../../interfaces';
+import { KnownComponentType, COMPOSER_FEATURES } from '../../../interfaces';
 import { mockNode, mockComponent } from '../../../../tests/components/panels/scene-components/MockComponents';
 
 import { PlaneGeometryComponentEditor } from './PlaneGeometryComponentEditor';
+
+jest.mock('../../../common/GlobalSettings');
 
 jest.mock('@awsui/components-react', () => ({
   ...jest.requireActual('@awsui/components-react'),
@@ -28,17 +31,33 @@ describe('PlaneGeometryComponentEditor', () => {
     color: '#abcdef',
   };
 
-  const updateComponentInternalFn = jest.fn();
+  const componentWithTexturedGroundPlane: IPlaneGeometryComponentInternal = {
+    ...mockComponent,
+    type: KnownComponentType.PlaneGeometry,
+    width: 10,
+    height: 20,
+    textureUri: 'filepath',
+    isGroundPlane: true,
+  };
 
+  const mockFeatureConfigOn = { [COMPOSER_FEATURES.Textures]: true };
+
+  const updateComponentInternalFn = jest.fn();
+  const showAssetBrowserCallbackMock = jest.fn();
   const baseState = {
     updateComponentInternal: updateComponentInternalFn,
+    getEditorConfig: () => ({
+      showAssetBrowserCallback: showAssetBrowserCallbackMock,
+    }),
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should update width when width changes', async () => {
+  it('should update width when width changes', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
     useStore('default').setState(baseState);
     const { container } = render(
       <PlaneGeometryComponentEditor node={{ ...mockNode, components: [component] }} component={component} />,
@@ -53,14 +72,13 @@ describe('PlaneGeometryComponentEditor', () => {
     widthInput!.blur();
 
     expect(updateComponentInternalFn).toBeCalledTimes(1);
-    expect(updateComponentInternalFn).toBeCalledWith(
-      mockNode.ref,
-      { ...component, ref: component.ref, width: 2, height: component.height },
-      true,
-    );
+    expect(updateComponentInternalFn).toBeCalledWith(mockNode.ref, { ...component, width: 2 }, true);
   });
 
-  it('should update height when height changes', async () => {
+  it('should update height when height changes', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
+
     useStore('default').setState(baseState);
     const { container } = render(
       <PlaneGeometryComponentEditor node={{ ...mockNode, components: [component] }} component={component} />,
@@ -75,14 +93,13 @@ describe('PlaneGeometryComponentEditor', () => {
     heightInput!.blur();
 
     expect(updateComponentInternalFn).toBeCalledTimes(1);
-    expect(updateComponentInternalFn).toBeCalledWith(
-      mockNode.ref,
-      { ...component, ref: component.ref, width: component.width, height: 2 },
-      true,
-    );
+    expect(updateComponentInternalFn).toBeCalledWith(mockNode.ref, { ...component, height: 2 }, true);
   });
 
-  it('should update background when colors changes', async () => {
+  it('should update when colors changes', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
+
     useStore('default').setState(baseState);
     const { container } = render(
       <PlaneGeometryComponentEditor
@@ -100,10 +117,89 @@ describe('PlaneGeometryComponentEditor', () => {
     colorInput!.setInputValue('#FFFFFF');
     colorInput!.blur();
     expect(updateComponentInternalFn).toBeCalledTimes(1);
+    expect(updateComponentInternalFn).toBeCalledWith(mockNode.ref, { ...componentWithColor, color: '#FFFFFF' }, true);
+  });
+
+  it('should add open resource manager when select texture clicked and set texture', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
+
+    showAssetBrowserCallbackMock.mockImplementation((cb) => {
+      cb(null, 'c:\file.jpg');
+    });
+    useStore('default').setState(baseState);
+    const { container } = render(
+      <PlaneGeometryComponentEditor
+        node={{ ...mockNode, components: [componentWithColor] }}
+        component={componentWithColor}
+      />,
+    );
+    const polarisWrapper = wrapper(container);
+    const selectTextureButton = polarisWrapper.findButton('[data-testid="select-texture-button"]');
+
+    expect(selectTextureButton).toBeDefined();
+
+    // click checkbox should update store
+    act(() => {
+      selectTextureButton!.click();
+    });
+    expect(showAssetBrowserCallbackMock).toBeCalledTimes(1);
+    const { color: _color, ...otherComponentProps } = componentWithColor;
     expect(updateComponentInternalFn).toBeCalledWith(
       mockNode.ref,
-      { ...component, ref: component.ref, width: component.width, height: component.height, color: '#FFFFFF' },
+      { ...otherComponentProps, textureUri: 'c:\file.jpg' },
       true,
     );
+  });
+
+  it('should remove texture', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
+
+    useStore('default').setState(baseState);
+    const { container } = render(
+      <PlaneGeometryComponentEditor
+        node={{ ...mockNode, components: [componentWithTexturedGroundPlane] }}
+        component={componentWithTexturedGroundPlane}
+      />,
+    );
+    const polarisWrapper = wrapper(container);
+    const removeTextureButton = polarisWrapper.findButton('[data-testid="remove-texture-button"]');
+
+    expect(removeTextureButton).toBeDefined();
+
+    // click checkbox should update store
+    act(() => {
+      removeTextureButton!.click();
+    });
+
+    expect(updateComponentInternalFn).toBeCalledTimes(1);
+    const { textureUri: _textureUri, ...otherComponentProps } = componentWithTexturedGroundPlane;
+    expect(updateComponentInternalFn).toBeCalledWith(mockNode.ref, { ...otherComponentProps, color: '#cccccc' }, true);
+  });
+
+  it('should toggle ground plane status', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
+    useStore('default').setState(baseState);
+    const { container } = render(
+      <PlaneGeometryComponentEditor node={{ ...mockNode, components: [component] }} component={component} />,
+    );
+    const polarisWrapper = wrapper(container);
+    const groundPlaneCheckBox = polarisWrapper.findCheckbox('[data-testid="ground-plane-checkbox"]');
+
+    expect(groundPlaneCheckBox).toBeDefined();
+
+    // click checkbox should update store
+    act(() => {
+      groundPlaneCheckBox?.findNativeInput().click();
+    });
+    expect(updateComponentInternalFn).toBeCalledTimes(1);
+    expect(updateComponentInternalFn).toBeCalledWith(mockNode.ref, { ...component, isGroundPlane: true }, true);
+
+    act(() => {
+      groundPlaneCheckBox?.findNativeInput().click();
+    });
+    expect(updateComponentInternalFn).toBeCalledWith(mockNode.ref, { ...component, isGroundPlane: false }, true);
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditorSnap.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditorSnap.spec.tsx
@@ -1,11 +1,14 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
+import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { IPlaneGeometryComponentInternal, useStore } from '../../../store';
-import { KnownComponentType } from '../../../interfaces';
+import { KnownComponentType, COMPOSER_FEATURES } from '../../../interfaces';
 import { mockNode, mockComponent } from '../../../../tests/components/panels/scene-components/MockComponents';
 
 import { PlaneGeometryComponentEditor } from './PlaneGeometryComponentEditor';
+
+jest.mock('../../../common/GlobalSettings');
 
 jest.mock('../scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo', () => {
   return {
@@ -14,6 +17,8 @@ jest.mock('../scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo',
 });
 
 describe('PlaneGeometryComponentEditor', () => {
+  const mockFeatureConfig = { [COMPOSER_FEATURES.Textures]: true };
+
   const component: IPlaneGeometryComponentInternal = {
     ...mockComponent,
     type: KnownComponentType.PlaneGeometry,
@@ -29,6 +34,15 @@ describe('PlaneGeometryComponentEditor', () => {
     color: '#abcdef',
   };
 
+  const componentWithTexturedGroundPlane: IPlaneGeometryComponentInternal = {
+    ...mockComponent,
+    type: KnownComponentType.PlaneGeometry,
+    width: 10,
+    height: 20,
+    textureUri: 'filepath',
+    isGroundPlane: true,
+  };
+
   const updateComponentInternalFn = jest.fn();
 
   const baseState = {
@@ -40,6 +54,8 @@ describe('PlaneGeometryComponentEditor', () => {
   });
 
   it('should render correctly', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfig });
     useStore('default').setState(baseState);
 
     const { container } = render(
@@ -49,12 +65,29 @@ describe('PlaneGeometryComponentEditor', () => {
   });
 
   it('should render correctly with color', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfig });
     useStore('default').setState(baseState);
 
     const { container } = render(
       <PlaneGeometryComponentEditor
         node={{ ...mockNode, components: [componentWithColor] }}
         component={componentWithColor}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render correctly with textured ground plane', () => {
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfig });
+
+    useStore('default').setState(baseState);
+
+    const { container } = render(
+      <PlaneGeometryComponentEditor
+        node={{ ...mockNode, components: [componentWithTexturedGroundPlane] }}
+        component={componentWithTexturedGroundPlane}
       />,
     );
     expect(container).toMatchSnapshot();

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/PlaneGeometryComponentEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/PlaneGeometryComponentEditorSnap.spec.tsx.snap
@@ -32,6 +32,31 @@ exports[`PlaneGeometryComponentEditor should render correctly 1`] = `
     >
       [{"color":"#cccccc","customColors":[],"colorPickerLabel":"Color","customColorLabel":"Custom colors"},{}]
     </div>
+    <div
+      data-mocked="SpaceBetween"
+      direction="horizontal"
+    >
+      <div
+        data-mocked="Button"
+        data-testid="select-texture-button"
+      >
+        Select Texture
+      </div>
+      <div
+        data-mocked="Input"
+        disabled=""
+        value=""
+      />
+    </div>
+    <div
+      data-mocked="FormField"
+      label="Ground Plane"
+    >
+      <div
+        data-mocked="Checkbox"
+        data-testid="ground-plane-checkbox"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -67,6 +92,93 @@ exports[`PlaneGeometryComponentEditor should render correctly with color 1`] = `
       id="ColorSelectorCombo"
     >
       [{"color":"#abcdef","customColors":[],"colorPickerLabel":"Color","customColorLabel":"Custom colors"},{}]
+    </div>
+    <div
+      data-mocked="SpaceBetween"
+      direction="horizontal"
+    >
+      <div
+        data-mocked="Button"
+        data-testid="select-texture-button"
+      >
+        Select Texture
+      </div>
+      <div
+        data-mocked="Input"
+        disabled=""
+        value=""
+      />
+    </div>
+    <div
+      data-mocked="FormField"
+      label="Ground Plane"
+    >
+      <div
+        data-mocked="Checkbox"
+        data-testid="ground-plane-checkbox"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PlaneGeometryComponentEditor should render correctly with textured ground plane 1`] = `
+<div>
+  <div
+    data-mocked="SpaceBetween"
+  >
+    <div
+      data-mocked="FormField"
+      label="Width"
+    >
+      <div
+        data-mocked="Input"
+        data-testid="plane-width-input"
+        type="number"
+        value="10"
+      />
+    </div>
+    <div
+      data-mocked="FormField"
+      label="Height"
+    >
+      <div
+        data-mocked="Input"
+        data-testid="plane-height-input"
+        type="number"
+        value="20"
+      />
+    </div>
+    <div
+      data-mocked="SpaceBetween"
+      direction="horizontal"
+    >
+      <div
+        data-mocked="Button"
+        data-testid="select-texture-button"
+      >
+        Select Texture
+      </div>
+      <div
+        data-mocked="Button"
+        data-testid="remove-texture-button"
+      >
+        Remove Texture
+      </div>
+      <div
+        data-mocked="Input"
+        disabled=""
+        value="filepath"
+      />
+    </div>
+    <div
+      data-mocked="FormField"
+      label="Ground Plane"
+    >
+      <div
+        data-mocked="Checkbox"
+        data-testid="ground-plane-checkbox"
+      />
     </div>
   </div>
 </div>

--- a/packages/scene-composer/src/components/panels/scene-settings/SceneBackgroundSettingsEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/SceneBackgroundSettingsEditor.spec.tsx
@@ -2,10 +2,13 @@ import wrapper from '@awsui/components-react/test-utils/dom';
 import { act, render } from '@testing-library/react';
 import React from 'react';
 
+import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { useStore } from '../../../store';
-import { KnownSceneProperty } from '../../../interfaces';
+import { KnownSceneProperty, COMPOSER_FEATURES } from '../../../interfaces';
 
 import { SceneBackgroundSettingsEditor } from './SceneBackgroundSettingsEditor';
+
+jest.mock('../../../common/GlobalSettings');
 
 jest.mock('@awsui/components-react', () => ({
   ...jest.requireActual('@awsui/components-react'),
@@ -14,18 +17,28 @@ jest.mock('@awsui/components-react', () => ({
 describe('SceneBackgroundSettingsEditor', () => {
   const setScenePropertyMock = jest.fn();
   const getScenePropertyMock = jest.fn();
+  const showAssetBrowserCallbackMock = jest.fn();
+
+  const mockFeatureConfigOn = { [COMPOSER_FEATURES.Textures]: true };
+
   const baseState = {
     setSceneProperty: setScenePropertyMock,
     getSceneProperty: getScenePropertyMock,
+    getEditorConfig: () => ({
+      showAssetBrowserCallback: showAssetBrowserCallbackMock,
+    }),
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should save background when checked', async () => {
+  it('should save background when checked', () => {
     getScenePropertyMock.mockReturnValue(undefined);
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
     useStore('default').setState(baseState);
+
     const { container } = render(<SceneBackgroundSettingsEditor />);
     const polarisWrapper = wrapper(container);
     const checkbox = polarisWrapper.findCheckbox();
@@ -42,10 +55,12 @@ describe('SceneBackgroundSettingsEditor', () => {
     });
   });
 
-  it('should clear background when unchecked', async () => {
+  it('should clear background when unchecked', () => {
     getScenePropertyMock.mockReturnValue({
       color: '#cccccc',
     });
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
     useStore('default').setState(baseState);
     const { container } = render(<SceneBackgroundSettingsEditor />);
     const polarisWrapper = wrapper(container);
@@ -61,17 +76,19 @@ describe('SceneBackgroundSettingsEditor', () => {
     expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneBackgroundSettings, undefined);
   });
 
-  it('should update background when colors changes', async () => {
+  it('should update background when colors changes', () => {
     getScenePropertyMock.mockImplementation((property: string) => {
       if (property === KnownSceneProperty.SceneBackgroundSettings) {
         return {
           color: '#cccccc',
         };
-      } else if (property === KnownSceneProperty.TagCustomColors) {
+      } else if (property === KnownSceneProperty.BackgroundCustomColors) {
         const customColors: string[] = [];
         return customColors;
       }
     });
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
     useStore('default').setState(baseState);
     const { container } = render(<SceneBackgroundSettingsEditor />);
     const polarisWrapper = wrapper(container);
@@ -86,6 +103,54 @@ describe('SceneBackgroundSettingsEditor', () => {
     expect(setScenePropertyMock).toBeCalledTimes(2);
     expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneBackgroundSettings, {
       color: '#FFFFFF',
+    });
+  });
+
+  it('should open asset browser when select texture clicked and set texture uri', () => {
+    getScenePropertyMock.mockReturnValue({
+      color: '#cccccc',
+    });
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
+    showAssetBrowserCallbackMock.mockImplementation((cb) => {
+      cb(null, 'c:\file.jpg');
+    });
+    useStore('default').setState(baseState);
+    const { container } = render(<SceneBackgroundSettingsEditor />);
+    const polarisWrapper = wrapper(container);
+    const selectTextureButton = polarisWrapper.findButton('[data-testid="select-texture-button"]');
+
+    expect(selectTextureButton).toBeDefined();
+
+    // click checkbox should update store
+    act(() => {
+      selectTextureButton!.click();
+    });
+    expect(showAssetBrowserCallbackMock).toBeCalledTimes(1);
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneBackgroundSettings, {
+      textureUri: 'c:\file.jpg',
+    });
+  });
+
+  it('should remove texture uri', () => {
+    getScenePropertyMock.mockReturnValue({
+      textureUri: 'filepath',
+    });
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
+    useStore('default').setState(baseState);
+    const { container } = render(<SceneBackgroundSettingsEditor />);
+    const polarisWrapper = wrapper(container);
+    const removeTextureButton = polarisWrapper.findButton('[data-testid="remove-texture-button"]');
+
+    expect(removeTextureButton).toBeDefined();
+
+    // click checkbox should update store
+    act(() => {
+      removeTextureButton!.click();
+    });
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneBackgroundSettings, {
+      color: '#cccccc',
     });
   });
 });

--- a/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.spec.tsx
@@ -1,58 +1,171 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { render } from '@testing-library/react';
+import ReactThreeTestRenderer from '@react-three/test-renderer';
+import { Scene, Camera, Mesh, Texture, MeshStandardMaterial } from 'three';
+import { useThree, useFrame } from '@react-three/fiber';
+jest.useFakeTimers();
 
 import { KnownComponentType } from '../../../interfaces';
-import { IPlaneGeometryComponentInternal } from '../../../store';
-import { mockNode, mockComponent } from '../../../../tests/components/panels/scene-components/MockComponents';
+import { IPlaneGeometryComponentInternal, ISceneNodeInternal, useEditorState } from '../../../store';
+import useTwinMakerTextureLoader from '../../../hooks/useTwinMakerTextureLoader';
+import useAddWidget from '../../../hooks/useAddWidget';
+
+//we need actual drei code to test with r3f renderer
+jest.mock('@react-three/drei', () => {
+  const originalModule = jest.requireActual('@react-three/drei');
+  return {
+    ...originalModule,
+  };
+});
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useRef: jest.fn(),
+}));
+
+// Mock Hooks
+jest.mock('@react-three/fiber', () => {
+  const originalModule = jest.requireActual('@react-three/fiber');
+  return {
+    ...originalModule,
+    useThree: jest.fn(),
+    useFrame: jest.fn(),
+  };
+});
 
 import PlaneGeometryComponent from './PlaneGeometryComponent';
 
-jest.doMock('../../../utils/objectThreeUtils', () => {
+jest.mock('../../../utils/objectThreeUtils', () => {
   return {
     acceleratedRaycasting: jest.fn(),
+    getComponentGroupName: jest.fn().mockReturnValue('mockComponentGroupName'),
   };
 });
 
-const handleAddWidgetMock = jest.fn();
-jest.doMock('../../../hooks/useAddWidget', () => {
-  return {
-    handleAddWidget: handleAddWidgetMock,
-  };
+jest.mock('../../../hooks/useAddWidget', () => {
+  return jest.fn();
 });
+
+const mockTexture = new Texture();
+mockTexture.name = 'testTextureName';
+
+const mockLoadTexture = (uri, mesh: Mesh) => {
+  (mesh.material as MeshStandardMaterial).map = mockTexture;
+};
+const mockClearTexture = (mesh: Mesh) => {
+  (mesh.material as MeshStandardMaterial).map = null;
+};
+
+jest.mock('../../../hooks/useTwinMakerTextureLoader', () => {
+  return jest.fn();
+});
+
+jest.mock('../../../hooks/useAddWidget', () => {
+  return jest.fn();
+});
+
+jest.mock('../../../store/', () => ({
+  ...jest.requireActual('../../../store/'),
+  useEditorState: jest.fn(),
+}));
+
+const mockHandleAddWidget = jest.fn();
 
 describe('PlaneGeometryComponent', () => {
+  const mockThreeStates = {
+    camera: new Camera(),
+    scene: new Scene(),
+  };
+
+  const baseNode: ISceneNodeInternal = {
+    ref: 'mock-node',
+    name: 'mock-node',
+    transform: { position: [0, 0, 0], rotation: [0, 0, 0], scale: [0, 0, 0] },
+    transformConstraint: { snapToFloor: false },
+    components: [],
+    childRefs: ['childRef1', 'childRef2'],
+    properties: { hiddenWhileImmersive: true },
+  };
+
   const component: IPlaneGeometryComponentInternal = {
-    ...mockComponent,
+    ref: 'componentRef1',
     type: KnownComponentType.PlaneGeometry,
     width: 10,
     height: 20,
   };
 
   const componentWithColor: IPlaneGeometryComponentInternal = {
-    ...mockComponent,
+    ref: 'componentRef1',
     type: KnownComponentType.PlaneGeometry,
     width: 10,
     height: 20,
     color: '#abcdef',
   };
 
+  const componentWithTexture: IPlaneGeometryComponentInternal = {
+    ref: 'componentRef1',
+    type: KnownComponentType.PlaneGeometry,
+    width: 10,
+    height: 20,
+    textureUri: 'filepath',
+  };
+
   const setup = () => {
     jest.resetAllMocks();
+    (useThree as jest.Mock).mockReturnValue(mockThreeStates);
+    (useFrame as jest.Mock).mockImplementation((cb) => cb());
+    (useTwinMakerTextureLoader as jest.Mock).mockImplementation(() => ({
+      loadTextureOnMesh: mockLoadTexture,
+      clearTextureOnMesh: mockClearTexture,
+    }));
+    (useAddWidget as jest.Mock).mockImplementation(() => ({
+      handleAddWidget: mockHandleAddWidget,
+    }));
+    (useEditorState as jest.Mock).mockImplementation(() => ({
+      isEditing: jest.fn().mockReturnValue(true),
+      addingWidget: true,
+    }));
   };
 
   beforeEach(() => {
     setup();
   });
 
-  it(`should render`, async () => {
-    const { container } = render(<PlaneGeometryComponent component={component} node={mockNode} />);
+  it(`should render`, () => {
+    (useRef as jest.Mock).mockImplementation(() => ({ current: undefined }));
+    const { container } = render(<PlaneGeometryComponent component={component} node={baseNode} />);
 
     expect(container).toMatchSnapshot();
   });
 
-  it(`should render with predefined color`, () => {
-    const { container } = render(<PlaneGeometryComponent component={componentWithColor} node={mockNode} />);
+  it(`should render with predefined color`, async () => {
+    (useRef as jest.Mock).mockReturnValue({ current: null });
+    const rendered = await ReactThreeTestRenderer.create(
+      <PlaneGeometryComponent component={componentWithColor} node={baseNode} />,
+    );
+    const material = (rendered.scene.children[0].children[0].instance as Mesh).material as MeshStandardMaterial;
+    expect(material.color.getHexString()).toBe('abcdef');
+    expect(material.map).toBeNull();
+  });
 
-    expect(container).toMatchSnapshot();
+  it(`should render with predefined texture uri`, async () => {
+    const material = new MeshStandardMaterial();
+    const mesh = new Mesh(undefined, material);
+    (useRef as jest.Mock).mockReturnValue({ current: mesh });
+    const rendered = await ReactThreeTestRenderer.create(
+      <PlaneGeometryComponent component={componentWithTexture} node={baseNode} />,
+    );
+    const renderedMaterial = (rendered.scene.children[0].children[0].instance as Mesh).material as MeshStandardMaterial;
+    expect(renderedMaterial.map?.name).toEqual(mockTexture.name);
+  });
+
+  it('should trigger on click', async () => {
+    (useRef as jest.Mock).mockReturnValue({ current: null });
+    const rendered = await ReactThreeTestRenderer.create(
+      <PlaneGeometryComponent component={componentWithColor} node={baseNode} />,
+    );
+    const mesh = rendered.scene.children[0].children[0];
+    await rendered.fireEvent(mesh, 'click', { delta: 0.1 });
+    expect(mockHandleAddWidget).toBeCalled();
   });
 });

--- a/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.tsx
@@ -1,14 +1,15 @@
 import * as THREE from 'three';
-import React, { useRef, useEffect } from 'react';
-import { ThreeEvent } from '@react-three/fiber';
+import React, { useRef, useEffect, useState } from 'react';
+import { createPortal, ThreeEvent, useFrame, useThree } from '@react-three/fiber';
 import { Plane } from '@react-three/drei';
 
 import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
 import useAddWidget from '../../../hooks/useAddWidget';
+import useTwinMakerTextureLoader from '../../../hooks/useTwinMakerTextureLoader';
 import { IPlaneGeometryComponentInternal, ISceneNodeInternal, useEditorState } from '../../../store';
 import { acceleratedRaycasting, getComponentGroupName } from '../../../utils/objectThreeUtils';
 
-interface PlaneGeometryComponentProps {
+export interface PlaneGeometryComponentProps {
   node: ISceneNodeInternal;
   component: IPlaneGeometryComponentInternal;
 }
@@ -17,14 +18,19 @@ const PlaneGeometryComponent: React.FC<PlaneGeometryComponentProps> = ({
   component,
   node,
 }: PlaneGeometryComponentProps) => {
-  const meshRef = useRef<THREE.Mesh | null>(null);
+  const meshRef = useRef<THREE.Mesh>();
   const sceneComposerId = useSceneComposerId();
   const { isEditing, addingWidget } = useEditorState(sceneComposerId);
   const { handleAddWidget } = useAddWidget();
+  const { loadTextureOnMesh, clearTextureOnMesh } = useTwinMakerTextureLoader();
+  const scene = useThree((state) => state.scene);
+  const camera = useThree((state) => state.camera);
+  const [meshId, setMeshId] = useState('');
+  const [dirtyTexture, setDirtyTexture] = useState(false);
+
   const MAX_CLICK_DISTANCE = 2;
 
   const onClick = (e: ThreeEvent<MouseEvent>) => {
-    console.log('click triggered, ', e);
     if (e.delta <= MAX_CLICK_DISTANCE) {
       if (isEditing() && addingWidget) {
         handleAddWidget(e);
@@ -32,16 +38,56 @@ const PlaneGeometryComponent: React.FC<PlaneGeometryComponentProps> = ({
     }
   };
 
-  useEffect(() => {
-    if (meshRef.current) {
+  useFrame(() => {
+    if (meshRef.current && meshRef.current.uuid !== meshId) {
       acceleratedRaycasting(meshRef.current);
+      setMeshId(meshRef.current.uuid);
     }
-  }, [meshRef.current]);
+    if (meshRef.current?.material && dirtyTexture) {
+      if (component.textureUri) {
+        loadTextureOnMesh(component.textureUri, meshRef.current);
+      }
+      setDirtyTexture(false);
+    }
+  });
 
-  return (
+  useEffect(() => {
+    if (meshRef.current?.material) {
+      if (component.textureUri) {
+        loadTextureOnMesh(component.textureUri, meshRef.current);
+      } else {
+        clearTextureOnMesh(meshRef.current);
+      }
+    } else if (component.textureUri && !!loadTextureOnMesh) {
+      setDirtyTexture(true);
+    }
+  }, [meshId, component.textureUri, loadTextureOnMesh, clearTextureOnMesh]);
+
+  return component.isGroundPlane ? (
+    createPortal(
+      <group
+        name={getComponentGroupName(node.ref, 'PLANE_GEOMETRY')}
+        parent={scene}
+        position={node.transform.position}
+        rotation={new THREE.Euler(...node.transform.rotation, 'XYZ')}
+        scale={node.transform.scale}
+      >
+        <Plane
+          args={[component.width, component.height]}
+          ref={meshRef}
+          onClick={onClick}
+          userData={{ nodeRef: node.ref }}
+        >
+          <meshStandardMaterial color={component.color ? component.color : 'undefined'} side={THREE.DoubleSide} />
+        </Plane>
+      </group>,
+      scene,
+      { camera },
+    )
+  ) : (
     <group name={getComponentGroupName(node.ref, 'PLANE_GEOMETRY')}>
       <Plane args={[component.width, component.height]} ref={meshRef} onClick={onClick}>
-        <meshBasicMaterial color={component.color ? component.color : '#CCCCCC'} side={THREE.DoubleSide} />
+        <meshStandardMaterial color={component.color ? component.color : 'undefined'} />
       </Plane>
     </group>
   );

--- a/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/__snapshots__/PlaneGeometryComponent.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/__snapshots__/PlaneGeometryComponent.spec.tsx.snap
@@ -2,36 +2,16 @@
 
 exports[`PlaneGeometryComponent should render 1`] = `
 <div>
-  <group
-    name="PLANE_GEOMETRY_COMPONENT_nodeRef"
-  >
-    <div
-      args="[10,20]"
-      data-mocked="Plane"
-    >
-      <meshbasicmaterial
-        color="#CCCCCC"
-        side="2"
+  <group>
+    <mesh>
+      <planegeometry
+        args="10,20"
+        attach="geometry"
       />
-    </div>
-  </group>
-</div>
-`;
-
-exports[`PlaneGeometryComponent should render with predefined color 1`] = `
-<div>
-  <group
-    name="PLANE_GEOMETRY_COMPONENT_nodeRef"
-  >
-    <div
-      args="[10,20]"
-      data-mocked="Plane"
-    >
-      <meshbasicmaterial
-        color="#abcdef"
-        side="2"
+      <meshstandardmaterial
+        color="undefined"
       />
-    </div>
+    </mesh>
   </group>
 </div>
 `;

--- a/packages/scene-composer/src/components/three-fiber/SceneBackground.tsx
+++ b/packages/scene-composer/src/components/three-fiber/SceneBackground.tsx
@@ -1,21 +1,44 @@
-import { Color } from 'three';
-import { FC, useContext, useEffect } from 'react';
+import { Color, Texture } from 'three';
+import { FC, useCallback, useContext, useEffect, useRef } from 'react';
 import { useThree } from '@react-three/fiber';
 
-import { useStore } from '../../store';
-import { ISceneBackgroundSetting, KnownSceneProperty } from '../../interfaces';
+import { getGlobalSettings } from '../../common/GlobalSettings';
 import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
+import { useStore } from '../../store';
+import { COMPOSER_FEATURES, ISceneBackgroundSetting, KnownSceneProperty } from '../../interfaces';
+import useTwinMakerTextureLoader from '../../hooks/useTwinMakerTextureLoader';
+import { ResponseContentType } from '../../three/types';
 
 const SceneBackground: FC = () => {
+  const texturesEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Textures];
   const sceneComposerId = useContext(sceneComposerIdContext);
   const scene = useThree((state) => state.scene);
   const sceneBackgroundSettings = useStore(sceneComposerId)((state) =>
     state.getSceneProperty<ISceneBackgroundSetting>(KnownSceneProperty.SceneBackgroundSettings),
   );
+  const { loadTexture } = useTwinMakerTextureLoader({ imageOrientation: 'flipY' });
+
+  const textureRef = useRef<Texture | null>(null);
+
+  const setBackgroundCallback = useCallback(
+    (result: ResponseContentType) => {
+      const oldTexture = textureRef.current;
+      textureRef.current = result as unknown as Texture;
+      scene.background = textureRef.current ? textureRef.current : null;
+      if (oldTexture) {
+        oldTexture.dispose();
+      }
+    },
+    [scene],
+  );
 
   useEffect(() => {
-    scene.background = sceneBackgroundSettings?.color ? new Color(sceneBackgroundSettings.color) : null;
-  }, [scene, sceneBackgroundSettings]);
+    if (texturesEnabled && sceneBackgroundSettings?.textureUri) {
+      loadTexture(sceneBackgroundSettings.textureUri, setBackgroundCallback);
+    } else {
+      scene.background = sceneBackgroundSettings?.color ? new Color(sceneBackgroundSettings.color) : null;
+    }
+  }, [scene, sceneBackgroundSettings, loadTexture]);
 
   return null;
 };

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -320,6 +320,7 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
       width: 1000,
       height: 1000,
       color: 'green',
+      isGroundPlane: true,
     };
     const node = {
       name: 'Ground Plane',

--- a/packages/scene-composer/src/hooks/useTwinMakerTextureLoader.spec.tsx
+++ b/packages/scene-composer/src/hooks/useTwinMakerTextureLoader.spec.tsx
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { Mesh, Texture, MeshStandardMaterial } from 'three';
+
+jest.mock('../common/GlobalSettings', () => ({
+  getGlobalSettings: jest.fn(() => ({
+    getSceneObjectFunction: jest.fn(),
+  })),
+}));
+
+const texture = new Texture();
+texture.name = 'testTexture';
+
+const oldTexture = new Texture();
+texture.name = 'oldTexture';
+
+jest.mock('../three/TwinMakerTextureLoader', () => {
+  return {
+    TwinMakerTextureLoader: jest.fn().mockImplementation(() => {
+      return {
+        setOptions: jest.fn(),
+        load: jest.fn((url, onLoad) => {
+          onLoad(texture);
+        }),
+        setGetSceneObjectFunction: jest.fn(),
+        manager: {
+          onStart: jest.fn(),
+          onLoad: jest.fn(),
+          onError: jest.fn(),
+        },
+      };
+    }),
+  };
+});
+
+import useTwinMakerTextureLoader from './useTwinMakerTextureLoader';
+
+describe('useTwinMakerTextureLoader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call texture load callback', () => {
+    const { loadTexture } = renderHook(() => useTwinMakerTextureLoader({ imageOrientation: 'flipY' })).result.current;
+    const mockOnLoadCallback = jest.fn();
+    loadTexture('myUri', mockOnLoadCallback);
+
+    expect(mockOnLoadCallback).toBeCalledWith(texture);
+  });
+
+  it('should load texture on mesh', () => {
+    const material = new MeshStandardMaterial();
+    const mesh = new Mesh(undefined, material);
+    const { loadTextureOnMesh } = renderHook(() => useTwinMakerTextureLoader()).result.current;
+    loadTextureOnMesh('myUri', mesh);
+
+    expect(mesh.material.map).toEqual(texture);
+  });
+
+  it('should replace a texture on mesh', () => {
+    const material = new MeshStandardMaterial();
+    material.map = oldTexture;
+    const mesh = new Mesh(undefined, material);
+    const { loadTextureOnMesh } = renderHook(() => useTwinMakerTextureLoader()).result.current;
+    loadTextureOnMesh('myUri', mesh);
+
+    expect(mesh.material.map).toEqual(texture);
+  });
+
+  it('should remove texture on mesh', () => {
+    const material = new MeshStandardMaterial();
+    material.map = texture;
+    const mesh = new Mesh(undefined, material);
+    const { clearTextureOnMesh } = renderHook(() => useTwinMakerTextureLoader()).result.current;
+    clearTextureOnMesh(mesh);
+
+    expect(mesh.material.map).toBeNull();
+  });
+});

--- a/packages/scene-composer/src/hooks/useTwinMakerTextureLoader.tsx
+++ b/packages/scene-composer/src/hooks/useTwinMakerTextureLoader.tsx
@@ -1,0 +1,101 @@
+import { Color, LoadingManager, Mesh, Texture } from 'three';
+import { useCallback, useState, useEffect } from 'react';
+
+import { getGlobalSettings } from '../common/GlobalSettings';
+import { useSceneComposerId } from '../common/sceneComposerIdContext';
+import { useStore } from '../store';
+import { TwinMakerTextureLoader, TwinMakerTextureLoaderOptions } from '../three/TwinMakerTextureLoader';
+import { OnFileLoaderLoadFunc } from '../three/types';
+import { appendFunction } from '../utils/objectUtils';
+
+const useTwinMakerTextureLoader: (options?: TwinMakerTextureLoaderOptions) => {
+  loadTextureOnMesh: (uri: string, mesh: Mesh) => void;
+  clearTextureOnMesh: (mesh: Mesh) => void;
+  loadTexture: (uri: string, onLoadCallback: OnFileLoaderLoadFunc) => void;
+} = (options?: TwinMakerTextureLoaderOptions) => {
+  const sceneComposerId = useSceneComposerId();
+  const globalSettings = getGlobalSettings();
+  const [textureLoader, setTextureLoader] = useState<TwinMakerTextureLoader | undefined>(undefined);
+  const uriModifier = useStore(sceneComposerId)((state) => state.getEditorConfig().uriModifier);
+
+  useEffect(() => {
+    if (textureLoader && options) {
+      textureLoader.setOptions(options);
+    }
+  }, [textureLoader, options]);
+
+  useEffect(() => {
+    if (globalSettings.getSceneObjectFunction) {
+      if (!textureLoader) {
+        const loadingManager = new LoadingManager();
+        const newTextureLoader = new TwinMakerTextureLoader(loadingManager);
+        newTextureLoader.setGetSceneObjectFunction(globalSettings.getSceneObjectFunction);
+        newTextureLoader.manager.onStart = appendFunction(newTextureLoader.manager.onStart, () => {
+          // Use setTimeout to avoid mutating the state during rendering process
+          setTimeout(() => {
+            useStore(sceneComposerId).getState().setLoadingModelState(true);
+          }, 0);
+        });
+        newTextureLoader.manager.onLoad = appendFunction(newTextureLoader.manager.onLoad, () => {
+          // Use setTimeout to avoid mutating the state during rendering process
+          setTimeout(() => {
+            useStore(sceneComposerId).getState().setLoadingModelState(false);
+          }, 0);
+        });
+        newTextureLoader.manager.onError = appendFunction(newTextureLoader.manager.onError, () => {
+          // Use setTimeout to avoid mutating the state during rendering process
+          setTimeout(() => {
+            useStore(sceneComposerId).getState().setLoadingModelState(false);
+          }, 0);
+        });
+        setTextureLoader(newTextureLoader);
+      } else {
+        textureLoader.setGetSceneObjectFunction(globalSettings.getSceneObjectFunction);
+      }
+    }
+  }, [globalSettings.getSceneObjectFunction, textureLoader]);
+
+  const loadTexture = useCallback(
+    (uri: string, onLoadCallback: OnFileLoaderLoadFunc) => {
+      if (textureLoader) {
+        const path = uriModifier?.(uri) ?? uri;
+        textureLoader.load(path, onLoadCallback);
+      }
+    },
+    [textureLoader],
+  );
+
+  const loadTextureOnMesh = useCallback(
+    (uri: string, mesh: Mesh) => {
+      if (textureLoader) {
+        const material = mesh.material as THREE.MeshStandardMaterial;
+        const oldTexture = material.map;
+        material.color = new Color('#FFFFFF');
+        loadTexture(uri, (result) => {
+          material.map = result as unknown as Texture;
+          material.needsUpdate = true;
+        });
+        if (oldTexture) {
+          oldTexture.dispose();
+        }
+      }
+    },
+    [textureLoader, loadTexture],
+  );
+
+  const clearTextureOnMesh = useCallback((mesh: Mesh) => {
+    if (mesh) {
+      const material = mesh.material as THREE.MeshStandardMaterial;
+      const oldTexture = material.map;
+      material.map = null;
+      material.needsUpdate = true;
+      if (oldTexture) {
+        oldTexture.dispose();
+      }
+    }
+  }, []);
+
+  return { loadTextureOnMesh, clearTextureOnMesh, loadTexture };
+};
+
+export default useTwinMakerTextureLoader;

--- a/packages/scene-composer/src/interfaces/feature.ts
+++ b/packages/scene-composer/src/interfaces/feature.ts
@@ -20,6 +20,7 @@ export enum COMPOSER_FEATURES {
   DynamicScene = 'DynamicScene',
   FirstPerson = 'FirstPerson',
   SceneAppearance = 'SceneAppearance',
+  Textures = 'Textures',
 
   // Deprecated features (to be removed)
   EnvironmentModel = 'EnvironmentModel',

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -156,4 +156,5 @@ export interface IFogSettings {
 
 export interface ISceneBackgroundSetting {
   color?: string;
+  textureUri?: string;
 }

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -284,5 +284,7 @@ export namespace Component {
     width: number;
     height: number;
     color?: string;
+    textureUri?: string;
+    isGroundPlane?: boolean;
   }
 }

--- a/packages/scene-composer/src/three/TwinMakerTextureLoader.ts
+++ b/packages/scene-composer/src/three/TwinMakerTextureLoader.ts
@@ -43,11 +43,6 @@ export class TwinMakerTextureLoader extends THREE.Loader {
       const texture = new THREE.Texture(imageBitmap);
       texture.needsUpdate = true;
 
-      // https://threejs.org/docs/#api/en/textures/Texture.flipY
-      if (this.options.imageOrientation === 'flipY') {
-        texture.flipY = true;
-      }
-
       // From @types/three, the response type is "string | ArrayBuffer", but the THREE.TextureLoader
       // returns THREE.Texture , so we need to cast here.
       _onLoadTexture(texture as any);

--- a/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.spec.ts
@@ -20,15 +20,17 @@ const coloredPlane: IPlaneGeometryComponent = {
   color: '#abcdef',
 };
 
+const texturedGroundPlane: IPlaneGeometryComponent = {
+  type: KnownComponentType.PlaneGeometry,
+  width: 10,
+  height: 20,
+  textureUri: 'filepath',
+  isGroundPlane: true,
+};
+
 describe('createPlaneGeometryEntityComponent', () => {
   it('should return expected plane with no color', () => {
-    expect(
-      createPlaneGeometryEntityComponent({
-        type: KnownComponentType.PlaneGeometry,
-        width: 10,
-        height: 20,
-      }),
-    ).toEqual({
+    expect(createPlaneGeometryEntityComponent(plane)).toEqual({
       componentTypeId: componentTypeToId[KnownComponentType.PlaneGeometry],
       properties: {
         width: {
@@ -45,15 +47,8 @@ describe('createPlaneGeometryEntityComponent', () => {
     });
   });
 
-  it('should return expected plane with no color', () => {
-    expect(
-      createPlaneGeometryEntityComponent({
-        type: KnownComponentType.PlaneGeometry,
-        width: 10,
-        height: 20,
-        color: '#abcdef',
-      }),
-    ).toEqual({
+  it('should return expected plane with color', () => {
+    expect(createPlaneGeometryEntityComponent(coloredPlane)).toEqual({
       componentTypeId: componentTypeToId[KnownComponentType.PlaneGeometry],
       properties: {
         width: {
@@ -69,6 +64,34 @@ describe('createPlaneGeometryEntityComponent', () => {
         color: {
           value: {
             stringValue: '#abcdef',
+          },
+        },
+      },
+    });
+  });
+
+  it('should return expected plane with texture', () => {
+    expect(createPlaneGeometryEntityComponent(texturedGroundPlane)).toEqual({
+      componentTypeId: componentTypeToId[KnownComponentType.PlaneGeometry],
+      properties: {
+        width: {
+          value: {
+            doubleValue: 10,
+          },
+        },
+        height: {
+          value: {
+            doubleValue: 20,
+          },
+        },
+        textureUri: {
+          value: {
+            stringValue: 'filepath',
+          },
+        },
+        isGroundPlane: {
+          value: {
+            booleanValue: true,
           },
         },
       },
@@ -111,6 +134,34 @@ describe('createPlaneGeometryEntityComponent', () => {
           color: {
             value: {
               stringValue: '#abcdef',
+            },
+          },
+        }),
+      });
+    });
+
+    it('should return expected textured ground plane', () => {
+      expect(updatePlaneGeometryEntityComponent(texturedGroundPlane)).toEqual({
+        componentTypeId: componentTypeToId[KnownComponentType.PlaneGeometry],
+        propertyUpdates: expect.objectContaining({
+          width: {
+            value: {
+              doubleValue: 10,
+            },
+          },
+          height: {
+            value: {
+              doubleValue: 20,
+            },
+          },
+          textureUri: {
+            value: {
+              stringValue: 'filepath',
+            },
+          },
+          isGroundPlane: {
+            value: {
+              booleanValue: true,
             },
           },
         }),
@@ -160,6 +211,34 @@ describe('createPlaneGeometryEntityComponent', () => {
       ).toEqual({
         ref: expect.any(String),
         ...coloredPlane,
+      });
+    });
+
+    it('should parse to expected textured ground plane component', () => {
+      expect(
+        parsePlaneGeometryComp({
+          properties: [
+            {
+              propertyName: 'width',
+              propertyValue: 10,
+            },
+            {
+              propertyName: 'height',
+              propertyValue: 20,
+            },
+            {
+              propertyName: 'textureUri',
+              propertyValue: 'filepath',
+            },
+            {
+              propertyName: 'isGroundPlane',
+              propertyValue: true,
+            },
+          ],
+        }),
+      ).toEqual({
+        ref: expect.any(String),
+        ...texturedGroundPlane,
       });
     });
 

--- a/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.ts
@@ -10,6 +10,8 @@ enum PlaneGeometryComponentProperty {
   Width = 'width',
   Height = 'height',
   Color = 'color',
+  TextureUri = 'textureUri',
+  IsGroundPlane = 'isGroundPlane',
 }
 
 export const createPlaneGeometryEntityComponent = (geometry: IPlaneGeometryComponent): ComponentRequest => {
@@ -33,6 +35,20 @@ export const createPlaneGeometryEntityComponent = (geometry: IPlaneGeometryCompo
     comp.properties![PlaneGeometryComponentProperty.Color] = {
       value: {
         stringValue: geometry.color,
+      },
+    };
+  }
+  if (geometry.textureUri) {
+    comp.properties![PlaneGeometryComponentProperty.TextureUri] = {
+      value: {
+        stringValue: geometry.textureUri,
+      },
+    };
+  }
+  if (geometry.isGroundPlane) {
+    comp.properties![PlaneGeometryComponentProperty.IsGroundPlane] = {
+      value: {
+        booleanValue: geometry.isGroundPlane,
       },
     };
   }
@@ -65,6 +81,11 @@ export const parsePlaneGeometryComp = (geometry: DocumentType): IPlaneGeometryCo
     height: findHeight.propertyValue,
     color: geometry?.['properties'].find((mp) => mp['propertyName'] === PlaneGeometryComponentProperty.Color)
       ?.propertyValue,
+    textureUri: geometry?.['properties'].find((mp) => mp['propertyName'] === PlaneGeometryComponentProperty.TextureUri)
+      ?.propertyValue,
+    isGroundPlane: geometry?.['properties'].find(
+      (mp) => mp['propertyName'] === PlaneGeometryComponentProperty.IsGroundPlane,
+    )?.propertyValue,
   };
   return planeGeometryComponent;
 };

--- a/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
@@ -26,6 +26,7 @@ export const defaultArgs = {
     COMPOSER_FEATURES.AutoQuery,
     COMPOSER_FEATURES.SceneAppearance,
     COMPOSER_FEATURES.DynamicScene,
+    COMPOSER_FEATURES.Textures,
   ],
 };
 

--- a/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
@@ -7,9 +7,8 @@ import { COMPOSER_FEATURES } from '../../src/interfaces/feature';
 <Meta title="Developer/Scene Viewer" component={SceneViewer} argTypes={argTypes} />
 
 export const defaultArgs = {
+  source: 'local',
   scene: 'scene1',
-  workspaceId: 'CookieFactory',
-  sceneId: 'CookieFactory',
   theme: 'dark',
   density: 'comfortable',
   features: [
@@ -21,6 +20,7 @@ export const defaultArgs = {
     COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.Matterport,
     COMPOSER_FEATURES.SceneAppearance,
+    COMPOSER_FEATURES.Textures,
   ]
 }
 

--- a/packages/scene-composer/stories/components/scene-composer.tsx
+++ b/packages/scene-composer/stories/components/scene-composer.tsx
@@ -6,6 +6,7 @@ import { Viewport } from '@iot-app-kit/core';
 import { TimeSync, TimeSelection } from '@iot-app-kit/react-components';
 
 import {
+  AssetBrowserResultCallback,
   COMPOSER_FEATURES,
   ExternalLibraryConfig,
   ISceneDocumentSnapshot,
@@ -13,6 +14,7 @@ import {
   OperationMode,
   SceneComposerInternal,
   SceneViewerPropsShared,
+  ShowAssetBrowserCallback,
 } from '../../src';
 import { convertDataInputToDataStreams, getTestDataInputContinuous } from '../../tests/testData';
 
@@ -49,6 +51,7 @@ interface SceneComposerWrapperProps extends SceneViewerPropsShared, ThemeManager
   onSceneUpdated?: OnSceneUpdateCallback;
   viewportDurationSecs?: number;
   queriesJSON?: string;
+  showAssetBrowserCallback: ShowAssetBrowserCallback;
 }
 
 const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
@@ -67,6 +70,7 @@ const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
   matterportApplicationKey,
   viewportDurationSecs,
   queriesJSON,
+  showAssetBrowserCallback: actionRecorderShowAssetBrowserCallback,
   ...props
 }: SceneComposerWrapperProps) => {
   const duration = viewportDurationSecs ? viewportDurationSecs : 300; //default 5 minutes
@@ -125,6 +129,18 @@ const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
     onSceneUpdated(sceneSnapshot);
   }, []);
 
+  const mockAssetBrowserCallback: ShowAssetBrowserCallback = useCallback(
+    (cb: AssetBrowserResultCallback) => {
+      actionRecorderShowAssetBrowserCallback(cb);
+      if (source == 'local') {
+        cb(null, 'PALLET_JACK.glb');
+      } else {
+        cb(null, 'CookieFactoryMixer.glb'); // Update the string to a model available in your S3 bucket
+      }
+    },
+    [source],
+  );
+
   if (loader) {
     return (
       <TimeSync group='scene-composer' initialViewport={viewport}>
@@ -140,13 +156,7 @@ const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
               valueDataBindingProviders={bindingProvider}
               onSceneUpdated={handleSceneUpdated}
               dataStreams={source === 'local' ? convertDataInputToDataStreams(getTestDataInputContinuous()) : undefined}
-              showAssetBrowserCallback={(cb) => {
-                if (source == 'local') {
-                  cb(null, 'PALLET_JACK.glb');
-                } else {
-                  cb(null, 'CookieFactoryMixer.glb'); // Update the string to a model available in your S3 bucket
-                }
-              }}
+              showAssetBrowserCallback={mockAssetBrowserCallback}
               {...props}
             />
           </SceneComposerContainer>

--- a/packages/scene-composer/stories/components/scene-viewer.tsx
+++ b/packages/scene-composer/stories/components/scene-viewer.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { SceneViewerPropsShared } from '../../src';
+import { SceneViewerPropsShared, COMPOSER_FEATURES } from '../../src';
 
 import { ThemeManagerProps } from './theme-manager';
 import SceneComposerWrapper from './scene-composer';
@@ -12,7 +12,7 @@ export interface StorybookSceneViewerProps extends SceneViewerPropsShared, Theme
   sceneId?: string;
   awsCredentials?: any;
   workspaceId?: string;
-  features?: string[];
+  features?: COMPOSER_FEATURES[];
   locale: string;
 }
 

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -59,6 +59,10 @@
     "note": "Menu Item",
     "text": "Rotate object"
   },
+  "051ah6": {
+    "note": "select texture Button Text",
+    "text": "Select Texture"
+  },
   "07ZORc": {
     "note": "Toggle label",
     "text": "Always on"
@@ -1035,6 +1039,10 @@
     "note": "Motion Indicator Shape in a dropdown menu",
     "text": "Linear Plane"
   },
+  "oEnP1z": {
+    "note": "Form Field label",
+    "text": "Ground Plane"
+  },
   "oRdrN4": {
     "note": "Menu Item",
     "text": "Remove overlay"
@@ -1126,6 +1134,10 @@
   "sI/yrM": {
     "note": "Distance Units in a dropdown menu",
     "text": "centimeters"
+  },
+  "sevj7L": {
+    "note": "remove texture Button Text",
+    "text": "Remove Texture"
   },
   "skIt5u": {
     "note": "Menu Item",


### PR DESCRIPTION
## Overview
1.  Add texture selection support for backgrounds and planes
2. Fix camera loading too far out when a ground plane is in use

https://github.com/awslabs/iot-app-kit/assets/109186219/fabb0b63-fa1d-4034-9f2b-c13585612787


## Verifying Changes
1. in stories/componens/scene-composer update the mockAssetBrowserCallBack to point at an image file you have locally instead of the models it defaults too
2. try and select a texture

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
