### PR TITLE
feat: xy-plot & bar-chart allow only datatypes (Double and Integer)

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -22,6 +22,7 @@ import { ResourceExplorerFooter } from '../../../footer/footer';
 import { SelectedAsset } from '../../types';
 import { ResourceExplorerErrorState } from '../../components/resourceExplorerErrorState';
 import { getPlugin } from '@iot-app-kit/core';
+import { isInValidProperty } from './util/resourceExplorerTableLabels';
 
 export interface ModeledDataStreamTableProps {
   onClickAddModeledDataStreams: (modeledDataStreams: ModeledDataStream[]) => void;
@@ -113,6 +114,18 @@ export function ModeledDataStreamTable({
     },
   };
 
+  const propertySelectionLabel = (selectedItems: ModeledDataStream[], modeledDataStream: ModeledDataStream) => {
+    const isPropertySelected = selectedItems?.find((item) => item.propertyId === modeledDataStream.propertyId);
+
+    if (isInValidProperty(modeledDataStream.dataType, selectedWidgets?.at(0)?.type)) {
+      return `${modeledDataStream.dataType} data not supported for the selected widget`;
+    } else if (!isPropertySelected) {
+      return `Select modeled data stream ${modeledDataStream.name}`;
+    } else {
+      return `Deselect modeled data stream ${modeledDataStream.name}`;
+    }
+  };
+
   if (isError) {
     return <ResourceExplorerErrorState title={modeledDataStreamsTitle} />;
   }
@@ -132,6 +145,7 @@ export function ModeledDataStreamTable({
       stripedRows={preferences.stripedRows}
       wrapLines={preferences.wrapLines}
       stickyColumns={preferences.stickyColumns}
+      isItemDisabled={(item) => isInValidProperty(item.dataType, selectedWidgets?.at(0)?.type)}
       empty={<ModeledDataStreamTableEmptyState isAssetSelected={selectedAsset != null} />}
       filter={<ModeledDataStreamTablePropertyFilter {...propertyFilterProps} />}
       header={
@@ -159,13 +173,11 @@ export function ModeledDataStreamTable({
       }
       preferences={<ModeledDataStreamTablePreferences preferences={preferences} updatePreferences={setPreferences} />}
       ariaLabels={{
-        itemSelectionLabel: (isNotSelected, modeledDataStream) =>
-          isNotSelected
-            ? `Select modeled data stream ${modeledDataStream.name}`
-            : `Deselect modeled data stream ${modeledDataStream.name}`,
+        itemSelectionLabel: ({ selectedItems }, modeledDataStream) =>
+          propertySelectionLabel([...selectedItems], modeledDataStream),
 
-        allItemsSelectionLabel: (isNotSelected) =>
-          isNotSelected ? `Select modeled data stream` : `Deselect modeled data stream`,
+        allItemsSelectionLabel: ({ selectedItems }) =>
+          selectedItems.length !== items.length ? 'Select modeled data stream' : 'Deselect modeled data stream',
       }}
     />
   );

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/util/resourceExplorerTableLabels.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/util/resourceExplorerTableLabels.tsx
@@ -1,0 +1,13 @@
+import { ModeledDataStream } from '../../types';
+
+export const isInValidProperty = (dataType: ModeledDataStream['dataType'], widgetType?: string) => {
+  if (!widgetType) return false;
+
+  const isNumericDataType = dataType === 'DOUBLE' || dataType === 'INTEGER';
+
+  if (widgetType === 'xy-plot' || widgetType === 'bar-chart') {
+    return !isNumericDataType;
+  }
+
+  return false;
+};


### PR DESCRIPTION
## Overview
This PR is for ticket #1952  (only for a sub-task) and to disable data streams based on data type and it includes
1. xy-plot and Bar-chart allow only data types Double and Integer to select on resource explorer.
2. disables all other data types and shows alt text "${data type} data not supported for the selected widget."
3. fixed the alt text issue for selected properties and selected all properties

## Verifying Changes
[disable-properties.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/a28d570f-bd8e-4183-bf52-11b9a2d0fc5f)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
