### PR TITLE
fix(dashboard): datastreams are displayed in msw

### DIFF
--- a/packages/dashboard/src/msw/iot-sitewise/handlers/listAssets/listAssetsHandler.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/handlers/listAssets/listAssetsHandler.ts
@@ -1,4 +1,4 @@
-import { type ListAssetsResponse } from '@aws-sdk/client-iotsitewise';
+import { type AssetSummary, type ListAssetsResponse } from '@aws-sdk/client-iotsitewise';
 import { rest } from 'msw';
 
 import { LIST_ASSETS_URL } from './constants';
@@ -7,11 +7,19 @@ import { summarizeAsset } from '../../resources/assets/summarizeAssetDescription
 
 export function listAssetsHandler() {
   return rest.get(LIST_ASSETS_URL, (_req, res, ctx) => {
-    const rootAssets = ASSET_HIERARCHY.getRootAssets();
-    const rootAssetSummaries = rootAssets.map(summarizeAsset);
+    const url = new URL(_req.url);
+    const assetModelId = url.searchParams.get('assetModelId');
+    let assetSummaries: AssetSummary[] = [];
+    if (assetModelId) {
+      const assets = ASSET_HIERARCHY.getAssetsByAssetModelId(assetModelId);
+      assetSummaries = assets.map(summarizeAsset);
+    } else {
+      const rootAssets = ASSET_HIERARCHY.getRootAssets();
+      assetSummaries = rootAssets.map(summarizeAsset);
+    }
 
     const response: ListAssetsResponse = {
-      assetSummaries: rootAssetSummaries,
+      assetSummaries: assetSummaries,
       nextToken: undefined,
     };
 

--- a/packages/dashboard/src/msw/iot-sitewise/resources/assets/AssetFactory.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/resources/assets/AssetFactory.ts
@@ -12,22 +12,26 @@ export class AssetFactory {
 
   public create({ assetName }: Pick<Asset, 'assetName'>): Asset {
     const asset = {
-      ...this.#createDefaults(),
+      ...this.#createDefaults(assetName),
       assetName,
     };
 
     return asset;
   }
 
-  #createDefaults() {
+  #createDefaults(assetName: string | undefined) {
     const assetId = uuid();
     const assetArn = `arn:aws:iotsitewise:us-east-1:123456789012:asset/${assetId}`;
     const assetModelId = this.#assetModel.assetModelId;
     const assetProperties =
       this.#assetModel.assetModelProperties?.map(({ id, name, dataType }) => ({
         id,
-        name,
-        dataType,
+        name: name,
+        dataType: dataType,
+        path: [
+          { id: assetId, name: assetName ?? '' },
+          { id: id, name: name },
+        ],
       })) ?? [];
     const assetHierarchies = this.#assetModel.assetModelHierarchies;
     const assetCreationDate = new Date();

--- a/packages/dashboard/src/msw/iot-sitewise/resources/assets/index.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/resources/assets/index.ts
@@ -27,6 +27,11 @@ class AssetHierarchyClient {
     return rootAssets;
   }
 
+  public getAssetsByAssetModelId(assetModelId: string): Asset[] {
+    const assetList = this.#searchByAssetModelId(assetModelId, this.#assetHierarchy);
+    return assetList;
+  }
+
   public findAssetById(assetId: string): Asset | undefined {
     const node = this.#searchById(assetId, this.#assetHierarchy);
     const asset = node?.asset;
@@ -67,6 +72,20 @@ class AssetHierarchyClient {
         }
       }
     }
+  }
+
+  #searchByAssetModelId(assetModelId: string, assetHierarchy: AssetHierarchy, assetList?: Asset[]) {
+    const assetsMatchingModelIdList = assetList ? assetList : [];
+    for (const node of assetHierarchy) {
+      if (node.asset.assetModelId === assetModelId) {
+        assetsMatchingModelIdList.push(node.asset);
+      }
+
+      if (node.children) {
+        this.#searchByAssetModelId(assetModelId, node.children, assetsMatchingModelIdList);
+      }
+    }
+    return assetsMatchingModelIdList;
   }
 
   #searchParentById(


### PR DESCRIPTION
## Overview
Extended the fields in the asset factory to have path and other meta data needed to mock call. This allows the datastream to be completed with the right meta data and therefore display correctly on the dashboard. 

Edited the listAssetHandlers to list assets based on assetModel id if the call is made from the dynamic asset panel to display the values in the asset dropdown after model selection. 

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/25986991-1de3-416f-a230-a1244df81698

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
