### PR TITLE
fix: use datastream id as legend table row key

### DIFF
--- a/packages/react-components/src/components/chart/legend/legend.tsx
+++ b/packages/react-components/src/components/chart/legend/legend.tsx
@@ -28,7 +28,7 @@ const Legend = (legendOptions: {
         items={items}
         stickyColumns={{ first: 1, last: 0 }}
         stickyHeader
-        trackBy='name'
+        trackBy='id'
         variant='embedded'
         preferences={<></>}
         contentDensity='compact'


### PR DESCRIPTION
## Overview
Change legend table row key to a unique value (datastream id), instead of the non-unique datastream name.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
