### PR TITLE
fix(core): increase cache and min request interval to prevent making many requests for near now data

### DIFF
--- a/packages/core/src/data-module/TimeSeriesDataModule.spec.ts
+++ b/packages/core/src/data-module/TimeSeriesDataModule.spec.ts
@@ -987,7 +987,7 @@ describe('request scheduler', () => {
         queries: [DATA_STREAM_QUERY],
         request: {
           viewport: { duration: 900000 },
-          settings: { fetchFromStartToEnd: true, refreshRate: SECOND_IN_MS * 0.1 },
+          settings: { fetchFromStartToEnd: true, refreshRate: SECOND_IN_MS * 1.5 },
         },
       },
       timeSeriesCallback
@@ -995,13 +995,13 @@ describe('request scheduler', () => {
 
     await flushPromises();
     timeSeriesCallback.mockClear();
-    jest.advanceTimersByTime(SECOND_IN_MS * 0.11);
+    jest.advanceTimersByTime(SECOND_IN_MS * 1.51);
 
     await flushPromises();
     expect(timeSeriesCallback).toBeCalledTimes(2);
 
     timeSeriesCallback.mockClear();
-    jest.advanceTimersByTime(SECOND_IN_MS * 0.11);
+    jest.advanceTimersByTime(SECOND_IN_MS * 1.51);
 
     await flushPromises();
     expect(timeSeriesCallback).toBeCalledTimes(2);
@@ -1105,7 +1105,7 @@ describe('request scheduler', () => {
           viewport: { start: new Date(2000, 0, 0), end: new Date(2001, 0, 0) },
           settings: {
             fetchMostRecentBeforeEnd: true,
-            refreshRate: SECOND_IN_MS * 0.1,
+            refreshRate: SECOND_IN_MS * 1.5,
           },
         },
       },
@@ -1118,21 +1118,21 @@ describe('request scheduler', () => {
       request: {
         viewport: { duration: MINUTE_IN_MS },
         settings: {
-          refreshRate: SECOND_IN_MS * 0.1,
+          refreshRate: SECOND_IN_MS * 1.5,
           fetchFromStartToEnd: true,
         },
       },
     });
     timeSeriesCallback.mockClear();
 
-    jest.advanceTimersByTime(SECOND_IN_MS * 0.11);
+    jest.advanceTimersByTime(SECOND_IN_MS * 1.51);
     await flushPromises();
     expect(timeSeriesCallback).toBeCalledTimes(2);
 
     await flushPromises();
     timeSeriesCallback.mockClear();
 
-    jest.advanceTimersByTime(SECOND_IN_MS * 0.11);
+    jest.advanceTimersByTime(SECOND_IN_MS * 1.51);
     await flushPromises();
 
     expect(timeSeriesCallback).toBeCalledTimes(2);
@@ -1233,12 +1233,12 @@ describe('request scheduler', () => {
     await update({
       request: {
         viewport: { start: START, end: END },
-        settings: { refreshRate: SECOND_IN_MS * 0.1, fetchFromStartToEnd: true },
+        settings: { refreshRate: SECOND_IN_MS * 1.5, fetchFromStartToEnd: true },
       },
     });
     timeSeriesCallback.mockClear();
 
-    jest.advanceTimersByTime(SECOND_IN_MS * 0.11);
+    jest.advanceTimersByTime(SECOND_IN_MS * 1.51);
     await flushPromises();
 
     expect(timeSeriesCallback).toBeCalledTimes(2);

--- a/packages/core/src/data-module/TimeSeriesDataModule.ts
+++ b/packages/core/src/data-module/TimeSeriesDataModule.ts
@@ -21,7 +21,7 @@ import type { TimeSeriesDataRequest, Viewport } from './data-cache/requestTypes'
 
 export const DEFAULT_CACHE_SETTINGS = {
   ttlDurationMapping: {
-    [1.2 * MINUTE_IN_MS]: 0,
+    [1.2 * MINUTE_IN_MS]: SECOND_IN_MS * 1.5,
     [3 * MINUTE_IN_MS]: 30 * SECOND_IN_MS,
     [20 * MINUTE_IN_MS]: 5 * MINUTE_IN_MS,
   },

--- a/packages/core/src/data-module/data-cache/caching/caching.ts
+++ b/packages/core/src/data-module/data-cache/caching/caching.ts
@@ -27,7 +27,7 @@ const TOO_CLOSE_MS = MINUTE_IN_MS;
 // Don't request anything with less than a second - SiteWise API will return 400
 // as it will think the start and the end date are the same if they are not
 // far enough apart.
-const MINIMUM_INTERVAL = SECOND_IN_MS;
+const MINIMUM_INTERVAL = SECOND_IN_MS * 3;
 
 /**
  * Combine Short Intervals


### PR DESCRIPTION
## Overview
Prevent requests for each previous second when panning continuously over a viewport with the current time in view.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
