### PR TITLE
fix(dashboard): use more descriptive name for the settings label

### DIFF
--- a/packages/dashboard/src/components/actions/index.tsx
+++ b/packages/dashboard/src/components/actions/index.tsx
@@ -87,7 +87,12 @@ const Actions: React.FC<ActionsProps> = ({
         {onSave && <Button onClick={handleOnSave}>Save</Button>}
         {editable && <Button onClick={handleOnReadOnly}>{readOnly ? 'Edit' : 'Preview'}</Button>}
         {editable && !readOnly && (
-          <Button onClick={() => setSettingVisibility(true)} iconName='settings' variant='icon' ariaLabel='Settings' />
+          <Button
+            onClick={() => setSettingVisibility(true)}
+            iconName='settings'
+            variant='icon'
+            ariaLabel='Dashboard settings'
+          />
         )}
         <DashboardSettings isVisible={dashboardSettingsVisible} onClose={() => setSettingVisibility(false)} />
       </SpaceBetween>


### PR DESCRIPTION
## Overview
Changing the label on the settings button to be more descriptive of what the action enables.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
