### PR TITLE
feat(dashboard): add metrics for query editor usage

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelDataStreamExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelDataStreamExplorer.tsx
@@ -15,12 +15,14 @@ import { createNonNullableList } from '~/helpers/lists/createNonNullableList';
 import { getAssetModelQueryInformation } from './getAssetModelQueryInformation';
 import { useModelBasedQuery } from './modelBasedQuery/useModelBasedQuery';
 import { useModelBasedQuerySelection } from './modelBasedQuery/useModelBasedQuerySelection';
+import { getPlugin } from '@iot-app-kit/core';
 
 export interface AssetModelDataStreamExplorerProps {
   client: IoTSiteWiseClient;
 }
 
 export const AssetModelDataStreamExplorer = ({ client }: AssetModelDataStreamExplorerProps) => {
+  const metricsRecorder = getPlugin('metricsRecorder');
   const { assetModelId, assetIds, clearModelBasedWidgets, updateSelectedAsset } = useModelBasedQuery();
   const { assetModels, updateAssetModels, modelBasedWidgetsSelected } = useModelBasedQuerySelection();
 
@@ -56,6 +58,10 @@ export const AssetModelDataStreamExplorer = ({ client }: AssetModelDataStreamExp
           assetModelPropertyIds: createNonNullableList(selectedAssetModelProperties.map(({ id }) => id)),
         })
       );
+      metricsRecorder?.record({
+        metricName: 'AssetModelDataStreamAdd',
+        metricValue: 1,
+      });
     }
   };
 

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/browseSearchToggle.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/browseSearchToggle.tsx
@@ -1,4 +1,5 @@
 import SegmentedControl from '@cloudscape-design/components/segmented-control';
+import { getPlugin } from '@iot-app-kit/core';
 import React, { useState } from 'react';
 
 export const BROWSE_SEGMENT_ID = 'browse-assets';
@@ -12,10 +13,21 @@ export interface BrowseSearchToggleProps {
 }
 
 export function BrowseSearchToggle({ selectedSegment, onChange }: BrowseSearchToggleProps) {
+  const metricsRecorder = getPlugin('metricsRecorder');
+  const handleChangeSegment = (segment: SegmentId) => {
+    onChange(selectedSegment);
+    metricsRecorder?.record({
+      contexts: {
+        searchBy: segment,
+      },
+      metricName: 'ModeledDataStreamSearchChanged',
+      metricValue: 1,
+    });
+  };
   return (
     <SegmentedControl
       selectedId={selectedSegment}
-      onChange={({ detail: { selectedId: selectedSegment } }) => onChange(selectedSegment as SegmentId)}
+      onChange={({ detail: { selectedId: selectedSegment } }) => handleChangeSegment(selectedSegment as SegmentId)}
       options={[
         { text: 'Browse', id: BROWSE_SEGMENT_ID },
         { text: 'Search', id: SEARCH_SEGMENT_ID },

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -21,6 +21,7 @@ import { DashboardState } from '~/store/state';
 import { ResourceExplorerFooter } from '../../../footer/footer';
 import { SelectedAsset } from '../../types';
 import { ResourceExplorerErrorState } from '../../components/resourceExplorerErrorState';
+import { getPlugin } from '@iot-app-kit/core';
 
 export interface ModeledDataStreamTableProps {
   onClickAddModeledDataStreams: (modeledDataStreams: ModeledDataStream[]) => void;
@@ -45,6 +46,7 @@ export function ModeledDataStreamTable({
   hasNextPage,
   modeledDataStreamsTitle,
 }: ModeledDataStreamTableProps) {
+  const metricsRecorder = getPlugin('metricsRecorder');
   const significantDigits = useSelector((state: DashboardState) => state.significantDigits);
   const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
 
@@ -145,6 +147,10 @@ export function ModeledDataStreamTable({
           addDisabled={collectionProps.selectedItems?.length === 0 || selectedWidgets.length !== 1}
           onAdd={() => {
             onClickAddModeledDataStreams(collectionProps.selectedItems as unknown as ModeledDataStream[]);
+            metricsRecorder?.record({
+              metricName: 'ModeledDataStreamAdd',
+              metricValue: 1,
+            });
           }}
         />
       }

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
@@ -18,6 +18,7 @@ import { useLatestValues } from '../../useLatestValues';
 import { DashboardState } from '~/store/state';
 import { getFormattedDateTimeFromEpoch } from '~/components/util/dateTimeUtil';
 import { ResourceExplorerFooter } from '../../footer/footer';
+import { getPlugin } from '@iot-app-kit/core';
 
 export interface UnmodeledDataStreamTableProps {
   onClickAdd: (unmodeledDataStreams: UnmodeledDataStream[]) => void;
@@ -34,6 +35,7 @@ export function UnmodeledDataStreamTable({
   client,
   hasNextPage,
 }: UnmodeledDataStreamTableProps) {
+  const metricsRecorder = getPlugin('metricsRecorder');
   const significantDigits = useSelector((state: DashboardState) => state.significantDigits);
   const selectedWidgets = useSelector((state: DashboardState) => state.selectedWidgets);
   const [preferences, setPreferences] = useExplorerPreferences({
@@ -113,7 +115,13 @@ export function UnmodeledDataStreamTable({
           resetDisabled={collectionProps.selectedItems?.length === 0}
           onReset={() => actions.setSelectedItems([])}
           addDisabled={collectionProps.selectedItems?.length === 0 || selectedWidgets.length !== 1}
-          onAdd={() => onClickAdd(collectionProps.selectedItems as unknown as UnmodeledDataStream[])}
+          onAdd={() => {
+            onClickAdd(collectionProps.selectedItems as unknown as UnmodeledDataStream[]);
+            metricsRecorder?.record({
+              metricName: 'UnmodeledDataStreamAdd',
+              metricValue: 1,
+            });
+          }}
         />
       }
       resizableColumns


### PR DESCRIPTION
## Overview
Implement metrics recording for query editor flows. Tracking when users add a data stream via modeled / unmodeled / asset modeled, and tracking which browsing feature they use for modeled data.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
