### PR TITLE
fix: bar chart breaks due to css property of line chart

### DIFF
--- a/packages/dashboard/src/components/widgets/tile/tile.css
+++ b/packages/dashboard/src/components/widgets/tile/tile.css
@@ -7,7 +7,7 @@
 }
 
 .widget-tile-body {
-  display: flex;
+  display: grid;
   flex: 1;
 }
 


### PR DESCRIPTION
- The Bar chart was broken due to the property which was add for Line chart.
- rectified it by changing the display value form 'flex' to 'grid'.

Before - 
![Screenshot at Dec 12 17-51-38](https://github.com/awslabs/iot-app-kit/assets/65999096/9c89ff2f-0061-4ff5-aaec-b96411d15560)

After -
![Screenshot at Dec 12 17-54-31](https://github.com/awslabs/iot-app-kit/assets/65999096/0e82b088-63c6-45f2-97a9-ca19231791fd)
