### PR TITLE
build: lock boolean package comply with internal SW registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28096,8 +28096,8 @@
       "license": "ISC"
     },
     "node_modules/boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.4.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
     },
     "node_modules/bowser": {
@@ -33695,7 +33695,7 @@
       "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.9.tgz",
       "integrity": "sha512-FChq8hbz65WMj4rstcQsFB0O7Cy++nmbNfLYnD9cYv2cRn8EG6k/MGn9kO/tjO66t09DLDugj3yL+V2o6Qftrg==",
       "dependencies": {
-        "boolean": "^3.1.4"
+        "boolean": "3.1.4"
       },
       "engines": {
         "node": ">=10.0"
@@ -89625,8 +89625,8 @@
       "dev": true
     },
     "boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.4.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
     },
     "bowser": {
@@ -93678,7 +93678,7 @@
       "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.9.tgz",
       "integrity": "sha512-FChq8hbz65WMj4rstcQsFB0O7Cy++nmbNfLYnD9cYv2cRn8EG6k/MGn9kO/tjO66t09DLDugj3yL+V2o6Qftrg==",
       "requires": {
-        "boolean": "^3.1.4"
+        "boolean": "3.1.4"
       }
     },
     "fast-shallow-equal": {


### PR DESCRIPTION


## Overview
This PR locks turbowatch>roarr>fast-printf>boolean to 3.1.4 to comply with amazon internal software registry NpmPrettyMuch. Once boolean 3.2.0 is approved we can remove the lock.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
