### PR TITLE
feat: dashboard new header design #1947

### DIFF
--- a/packages/dashboard/e2e/tests/dashboard/dashboard.spec.ts
+++ b/packages/dashboard/e2e/tests/dashboard/dashboard.spec.ts
@@ -6,10 +6,8 @@ import { COMPONENT_SELECTOR, TEST_IFRAME, TEST_PAGE } from '../constants';
 
 test('dashboard', async ({ page }) => {
   await page.goto(TEST_PAGE);
-  const frame = page.locator(TEST_IFRAME); // Need to go into frame otherwise the `locator` won't locate the selection.
 
-  // KPI will always show value shows value
-  await expect(frame.locator(COMPONENT_SELECTOR)).toContainText('Time machine');
+  await expect(page.getByTestId('time-selection')).toBeVisible();
 });
 
 // TODO: fix these tests (failure due to stetchToFit removal from dashboard)
@@ -88,12 +86,8 @@ test.skip('dashboard resize, move, and select gestures', async ({ page }) => {
 
 test('dashboard add and remove multiple widgets', async ({ page }) => {
   await page.goto(TEST_PAGE);
-  const frame = page.locator(TEST_IFRAME); // Need to go into frame otherwise the `locator` won't locate the selection.
 
   const grid = gridUtil(page);
-
-  // KPI will always show value shows value
-  await expect(frame.locator(COMPONENT_SELECTOR)).toContainText('Time machine');
 
   const location1 = await grid.cellLocation(0, 0);
   const location2 = await grid.cellLocation(1, 0);
@@ -123,14 +117,14 @@ test('dashboard add and remove multiple widgets', async ({ page }) => {
 
 test('pagination buttons', async ({ page }) => {
   await page.goto(TEST_PAGE);
-  const frame = page.locator(TEST_IFRAME); // Need to go into frame otherwise the `locator` won't locate the selection.
 
-  await expect(frame.locator(COMPONENT_SELECTOR)).toContainText('Time machine');
+  await expect(page.getByTestId('time-selection')).toBeVisible();
+
   const forwardBtn = await page.getByRole('button', {
     name: /paginate-foward/i,
   });
+  await expect(page.getByTestId('time-selection')).toBeVisible();
 
-  await expect(frame.locator(COMPONENT_SELECTOR)).toContainText('Time machine');
   const backBtn = await page.getByRole('button', {
     name: /paginate-backward/i,
   });

--- a/packages/dashboard/src/components/actions/index.tsx
+++ b/packages/dashboard/src/components/actions/index.tsx
@@ -1,14 +1,16 @@
 import React, { memo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { isEqual, pick } from 'lodash';
 
 import { getPlugin } from '@iot-app-kit/core';
 import { useViewport } from '@iot-app-kit/react-components';
 import { Button, SpaceBetween, Box } from '@cloudscape-design/components';
+
 import { onSelectWidgetsAction, onToggleReadOnly } from '~/store/actions';
 import type { DashboardState } from '~/store/state';
-import { isEqual, pick } from 'lodash';
 import { DashboardSave } from '~/types';
 import DashboardSettings from './settings';
+import CustomOrangeButton from '../customOrangeButton';
 
 const DEFAULT_VIEWPORT = { duration: '10m' };
 
@@ -81,11 +83,10 @@ const Actions: React.FC<ActionsProps> = ({
   };
 
   return (
-    <>
-      <Box variant='awsui-key-label'>Actions</Box>
+    <Box padding={{ top: 'xxs' }} data-testid='dashboard-actions'>
       <SpaceBetween size='s' direction='horizontal'>
         {onSave && <Button onClick={handleOnSave}>Save</Button>}
-        {editable && <Button onClick={handleOnReadOnly}>{readOnly ? 'Edit' : 'Preview'}</Button>}
+        {editable && <CustomOrangeButton title={readOnly ? 'Edit' : 'Preview'} handleClick={handleOnReadOnly} />}
         {editable && !readOnly && (
           <Button
             onClick={() => setSettingVisibility(true)}
@@ -96,15 +97,16 @@ const Actions: React.FC<ActionsProps> = ({
         )}
         <DashboardSettings isVisible={dashboardSettingsVisible} onClose={() => setSettingVisibility(false)} />
       </SpaceBetween>
-    </>
+    </Box>
   );
 };
 
 const gridAsComparable = (grid: DashboardState['grid']) => pick(grid, ['height', 'width', 'cellSize']);
 const actionsComparator = (a: Readonly<ActionsProps>, b: Readonly<ActionsProps>): boolean => {
+  const readOnlyIsSame = a.readOnly === b.readOnly;
   const gridIsSame = isEqual(gridAsComparable(a.grid), gridAsComparable(b.grid));
   const dashboardConfigurationIsSame = isEqual(a.dashboardConfiguration, b.dashboardConfiguration);
-  return gridIsSame && dashboardConfigurationIsSame;
+  return gridIsSame && dashboardConfigurationIsSame && readOnlyIsSame;
 };
 
 export default memo(Actions, actionsComparator);

--- a/packages/dashboard/src/components/assetModelSelection/assetModelSelect.tsx
+++ b/packages/dashboard/src/components/assetModelSelection/assetModelSelect.tsx
@@ -11,8 +11,16 @@ type AssetModelSelectOptions = {
   client: IoTSiteWiseClient;
   assetModelId: string;
   selectedAssetId?: string;
+  hideTitle?: boolean;
+  controlId?: string;
 };
-export const AssetModelSelect = ({ client, assetModelId, selectedAssetId }: AssetModelSelectOptions) => {
+export const AssetModelSelect = ({
+  client,
+  assetModelId,
+  selectedAssetId,
+  hideTitle = false,
+  controlId,
+}: AssetModelSelectOptions) => {
   const { updateSelectedAsset } = useModelBasedQuery();
 
   const { assetSummaries } = useAssetsForAssetModel({ assetModelId, client, fetchAll: true });
@@ -20,12 +28,13 @@ export const AssetModelSelect = ({ client, assetModelId, selectedAssetId }: Asse
   const selectedAsset = assetSummaries.find(({ id }) => id === selectedAssetId);
 
   return (
-    <FormField label='Asset'>
+    <FormField label={`${!hideTitle ? 'Asset' : ''}`}>
       <AssetForAssetModelSelect
         assetModelId={assetModelId}
         selectedAsset={selectedAsset}
         onSelectAsset={updateSelectedAsset}
         client={client}
+        controlId={controlId}
       />
     </FormField>
   );

--- a/packages/dashboard/src/components/assetModelSelection/assetModelSelection.css
+++ b/packages/dashboard/src/components/assetModelSelection/assetModelSelection.css
@@ -1,0 +1,4 @@
+.asset-model-selection {
+  display: flex;
+  align-items: center;
+}

--- a/packages/dashboard/src/components/assetModelSelection/assetModelSelection.tsx
+++ b/packages/dashboard/src/components/assetModelSelection/assetModelSelection.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
 
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import {
+  colorBorderDividerDefault,
+  colorTextBodyDefault,
+  spaceScaledS,
+  spaceScaledXxxs,
+  spaceStaticXxl,
+} from '@cloudscape-design/design-tokens';
+
 import { AssetModelSelect } from './assetModelSelect';
 import { useModelBasedQuery } from '../queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/modelBasedQuery/useModelBasedQuery';
+import './assetModelSelection.css';
 
 type AssetModelSelectionOptions = {
   client: IoTSiteWiseClient;
@@ -11,8 +20,33 @@ type AssetModelSelectionOptions = {
 export const AssetModelSelection = ({ client }: AssetModelSelectionOptions) => {
   const { assetModelId, assetIds, hasModelBasedQuery } = useModelBasedQuery();
   const selectedAssetId = assetIds?.at(0);
+  const assetModelSelectionControlId = 'asset-model-select-dropdown';
+
+  const divider = {
+    borderLeft: `solid ${spaceScaledXxxs} ${colorBorderDividerDefault}`,
+    height: spaceStaticXxl,
+    margin: `0 ${spaceScaledS}`,
+  };
+
+  const Divider = () => <div style={divider} />;
 
   if (!hasModelBasedQuery || !assetModelId) return null;
 
-  return <AssetModelSelect assetModelId={assetModelId} selectedAssetId={selectedAssetId} client={client} />;
+  return (
+    <div className='asset-model-selection'>
+      <h4 style={{ color: colorTextBodyDefault }}>
+        <label htmlFor={assetModelSelectionControlId}>Assets</label>
+      </h4>
+      <Divider />
+      <div style={{ width: '300px' }}>
+        <AssetModelSelect
+          assetModelId={assetModelId}
+          selectedAssetId={selectedAssetId}
+          client={client}
+          controlId={assetModelSelectionControlId}
+          hideTitle
+        />
+      </div>
+    </div>
+  );
 };

--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -7,7 +7,7 @@ import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 
 it('renders', function () {
-  const { queryByText } = render(
+  const { queryByText, queryByTestId } = render(
     <Dashboard
       onSave={() => Promise.resolve()}
       dashboardConfiguration={{
@@ -27,12 +27,12 @@ it('renders', function () {
   );
 
   expect(queryByText(/component library/i)).not.toBeInTheDocument();
-  expect(queryByText(/actions/i)).toBeInTheDocument();
-  expect(queryByText(/time machine/i)).toBeInTheDocument();
+  expect(queryByTestId(/dashboard-actions/i)).toBeInTheDocument();
+  expect(queryByTestId(/time-selection/i)).toBeInTheDocument();
 });
 
 it('renders in readonly initially', function () {
-  const { queryByText } = render(
+  const { queryByText, queryByTestId } = render(
     <Dashboard
       onSave={() => Promise.resolve()}
       dashboardConfiguration={{
@@ -53,6 +53,53 @@ it('renders in readonly initially', function () {
   );
 
   expect(queryByText(/component library/i)).not.toBeInTheDocument();
-  expect(queryByText(/actions/i)).toBeInTheDocument();
-  expect(queryByText(/time machine/i)).toBeInTheDocument();
+  expect(queryByTestId(/dashboard-actions/i)).toBeInTheDocument();
+  expect(queryByTestId(/time-selection/i)).toBeInTheDocument();
+});
+
+it('renders dashboard name', function () {
+  const { queryByText } = render(
+    <Dashboard
+      onSave={() => Promise.resolve()}
+      dashboardConfiguration={{
+        displaySettings: {
+          numColumns: 100,
+          numRows: 100,
+        },
+        widgets: [],
+        viewport: { duration: '5m' },
+      }}
+      name='Test dashboard'
+      clientConfiguration={{
+        iotEventsClient: createMockIoTEventsSDK(),
+        iotSiteWiseClient: createMockSiteWiseSDK() as IoTSiteWiseClient,
+        iotTwinMakerClient: { send: jest.fn() } as unknown as IoTTwinMakerClient,
+      }}
+    />
+  );
+
+  expect(queryByText(/Test dashboard/i)).toBeInTheDocument();
+});
+
+it('renders without dashboard name', function () {
+  const { queryByText } = render(
+    <Dashboard
+      onSave={() => Promise.resolve()}
+      dashboardConfiguration={{
+        displaySettings: {
+          numColumns: 100,
+          numRows: 100,
+        },
+        widgets: [],
+        viewport: { duration: '5m' },
+      }}
+      clientConfiguration={{
+        iotEventsClient: createMockIoTEventsSDK(),
+        iotSiteWiseClient: createMockSiteWiseSDK() as IoTSiteWiseClient,
+        iotTwinMakerClient: { send: jest.fn() } as unknown as IoTTwinMakerClient,
+      }}
+    />
+  );
+
+  expect(queryByText(/Test dashboard/i)).not.toBeInTheDocument();
 });

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -26,6 +26,7 @@ export type DashboardProperties = {
   clientConfiguration: DashboardClientConfiguration;
   dashboardConfiguration: DashboardConfiguration;
   initialViewMode?: 'preview' | 'edit';
+  name?: string;
 };
 
 const Dashboard: React.FC<DashboardProperties> = ({
@@ -33,6 +34,7 @@ const Dashboard: React.FC<DashboardProperties> = ({
   clientConfiguration,
   dashboardConfiguration,
   initialViewMode,
+  name,
 }) => {
   useDashboardPlugins();
   useDashboardViewport(dashboardConfiguration.viewport);
@@ -50,7 +52,7 @@ const Dashboard: React.FC<DashboardProperties> = ({
                 enableKeyboardEvents: true,
               }}
             >
-              <InternalDashboard onSave={onSave} editable={true} propertiesPanel={<PropertiesPanel />} />
+              <InternalDashboard onSave={onSave} editable={true} name={name} propertiesPanel={<PropertiesPanel />} />
             </DndProvider>
           </Provider>
           <ReactQueryDevtools initialIsOpen={false} />

--- a/packages/dashboard/src/components/dashboard/view.test.tsx
+++ b/packages/dashboard/src/components/dashboard/view.test.tsx
@@ -7,7 +7,7 @@ import DashboardView from './view';
 import React from 'react';
 
 it('renders', function () {
-  const { queryByText } = render(
+  const { queryByText, queryByTestId } = render(
     <DashboardView
       dashboardConfiguration={{
         displaySettings: {
@@ -26,6 +26,6 @@ it('renders', function () {
   );
 
   expect(queryByText(/component library/i)).not.toBeInTheDocument();
-  expect(queryByText(/actions/i)).not.toBeInTheDocument();
-  expect(queryByText(/time machine/i)).toBeInTheDocument();
+  expect(queryByTestId(/dashboard-actions/i)).not.toBeInTheDocument();
+  expect(queryByTestId(/time-selection/i)).toBeInTheDocument();
 });

--- a/packages/dashboard/src/components/internalDashboard/collapsiblePanel.tsx
+++ b/packages/dashboard/src/components/internalDashboard/collapsiblePanel.tsx
@@ -5,6 +5,7 @@ import {
   colorBackgroundButtonPrimaryDefault,
   colorBorderDividerDefault,
   spaceContainerHorizontal,
+  spaceStaticL,
   spaceStaticXxxs,
 } from '@cloudscape-design/design-tokens';
 import Box, { BoxProps } from '@cloudscape-design/components/box';
@@ -60,7 +61,9 @@ export function CollapsiblePanel(props: CollapsiblePanelProps) {
           </Box>
         </Box>
       </div>
-      <div className='collapsible-panel-content'>{props.panelContent}</div>
+      <div className='collapsible-panel-content' style={{ paddingBottom: spaceStaticL }}>
+        {props.panelContent}
+      </div>
     </div>
   );
 

--- a/packages/dashboard/src/components/internalDashboard/dashboardHeader.spec.tsx
+++ b/packages/dashboard/src/components/internalDashboard/dashboardHeader.spec.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import DashboardHeader from './dashboardHeader';
+
+describe('DashboardHeader', () => {
+  it('should render the dashboard title', () => {
+    const props = {
+      name: 'My Dashboard',
+      editable: false,
+      readOnly: true,
+      onSave: jest.fn(),
+      dashboardConfiguration: {
+        widgets: [],
+      },
+      grid: {
+        enabled: true,
+        width: 1,
+        height: 1,
+        cellSize: 1,
+      },
+      significantDigits: 2,
+    };
+    const { getByText } = render(<DashboardHeader {...props} />);
+    const titleElement = getByText('My Dashboard');
+    expect(titleElement).toBeInTheDocument();
+  });
+
+  it('should render the TimeSelection component when editable is false', () => {
+    const props = {
+      name: 'My Dashboard',
+      editable: false,
+      readOnly: true,
+      onSave: jest.fn(),
+      dashboardConfiguration: {
+        widgets: [],
+      },
+      grid: {
+        enabled: true,
+        width: 1,
+        height: 1,
+        cellSize: 1,
+      },
+      significantDigits: 2,
+    };
+    const { getByTestId } = render(<DashboardHeader {...props} />);
+    const timeSelectionElement = getByTestId('time-selection');
+    expect(timeSelectionElement).toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/components/internalDashboard/dashboardHeader.tsx
+++ b/packages/dashboard/src/components/internalDashboard/dashboardHeader.tsx
@@ -1,0 +1,74 @@
+import React, { memo } from 'react';
+
+import { Box, Header, SpaceBetween } from '@cloudscape-design/components';
+import { TimeSelection } from '@iot-app-kit/react-components';
+
+import { colorChartsLineGrid, spaceScaledXs, spaceScaledXxxl, spaceScaledXxxs } from '@cloudscape-design/design-tokens';
+
+import Actions from '../actions';
+import type { DashboardSave, DashboardWidget } from '~/types';
+
+type DashboardHeaderProps = {
+  name?: string;
+  editable?: boolean;
+  readOnly: boolean;
+  dashboardConfiguration: {
+    widgets: DashboardWidget<Record<string, unknown>>[];
+  };
+  grid: {
+    enabled: boolean;
+    width: number;
+    height: number;
+    cellSize: number;
+  };
+  significantDigits: number;
+  onSave?: DashboardSave;
+};
+
+const Divider = () => (
+  <div
+    style={{
+      width: spaceScaledXxxs,
+      height: spaceScaledXxxl,
+      margin: `0 ${spaceScaledXs}`,
+      background: colorChartsLineGrid,
+    }}
+  />
+);
+
+const DashboardHeader = ({
+  name,
+  editable,
+  readOnly,
+  onSave,
+  dashboardConfiguration,
+  grid,
+  significantDigits,
+}: DashboardHeaderProps) => (
+  <Box padding={{ horizontal: 's', top: 'm' }}>
+    <Box float='left'>
+      <Header variant='h1'>{name}</Header>
+    </Box>
+    <Box float='right'>
+      <SpaceBetween size='s' direction='horizontal'>
+        <TimeSelection isPaginationEnabled hideTitle />
+        {editable && (
+          <>
+            <Divider key='2' />
+            <Actions
+              key='3'
+              readOnly={readOnly}
+              onSave={onSave}
+              dashboardConfiguration={dashboardConfiguration}
+              grid={grid}
+              significantDigits={significantDigits}
+              editable={editable}
+            />
+          </>
+        )}
+      </SpaceBetween>
+    </Box>
+  </Box>
+);
+
+export default memo(DashboardHeader);

--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -1,7 +1,7 @@
 @import '../../styles/variables.css';
 
 .dashboard {
-  height: 100vh;
+  height: calc(100vh - var(--dashboard-header-height));
   display: flex;
   flex-direction: column;
 
@@ -33,11 +33,7 @@
   background-color: var(--colors-white);
 }
 
-.dashboard .dashboard-toolbar-read-only {
-  display: inline;
-}
-
-.dashboard .dashboard-toolbar {
+.dashboard .dashboard-toolbar .dashboard-toolbar-read-only {
   display: grid;
   grid-template-columns: auto max-content;
   grid-template-rows: auto;
@@ -84,15 +80,11 @@
   width: 15%;
   min-width: 0;
   height: 100%;
+  max-height: calc(100vh - var(--toolbar-overlay-height));
   z-index: var(--stack-order-grid-inputs);
   background-color: var(--colors-white);
 }
 
 .collapsible-panel-right {
-  max-height: calc(100vh - var(--right-toolbar-overlay-height));
   border-left: 2px solid var(--colors-grey-border);
-}
-
-.collapsible-panel-left {
-  max-height: calc(100vh - var(--left-toolbar-overlay-height));
 }

--- a/packages/dashboard/src/components/palette/index.tsx
+++ b/packages/dashboard/src/components/palette/index.tsx
@@ -2,7 +2,6 @@ import React, { memo } from 'react';
 import {
   colorBorderDividerDefault,
   colorTextBodyDefault,
-  spaceFieldHorizontal,
   spaceScaledS,
   spaceScaledXxxs,
   spaceStaticXxl,
@@ -13,11 +12,6 @@ import {
 } from '~/customization/componentLibraryComponentMap';
 import PaletteComponent from './component';
 import './index.css';
-
-/* added left padding as per UX and top padding for positioning Icons Vertically centre */
-const palettePadding = {
-  padding: `${spaceFieldHorizontal} ${0} ${0} ${spaceFieldHorizontal}`,
-};
 
 const widgetFont = {
   color: colorTextBodyDefault,
@@ -33,7 +27,7 @@ const Divider = () => <div style={divider} />;
 
 const Palette = () => {
   return (
-    <div className='widget-panel' style={palettePadding}>
+    <div className='widget-panel'>
       <h4 style={widgetFont}>Widgets</h4>
       <Divider />
       <ul className='component-palette-widgets'>

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetsForAssetModelSelect/assetForAssetModelSelect.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetsForAssetModelSelect/assetForAssetModelSelect.tsx
@@ -12,6 +12,7 @@ export type AssetForAssetModelSelectOptions = {
   selectedAsset?: SelectedAsset;
   onSelectAsset: (assetSummary: AssetSummary | undefined) => void;
   client: IoTSiteWiseClient;
+  controlId?: string;
 };
 
 const getStatus = ({
@@ -42,6 +43,7 @@ export const AssetForAssetModelSelect = ({
   assetModelId,
   selectedAsset,
   onSelectAsset,
+  controlId,
 }: AssetForAssetModelSelectOptions) => {
   const {
     assetSummaries,
@@ -76,6 +78,7 @@ export const AssetForAssetModelSelect = ({
 
   return (
     <Select
+      controlId={controlId}
       virtualScroll={assetOptions.length > 500}
       disabled={!isEnabled(assetModelId)}
       selectedOption={selectedAssetOption}

--- a/packages/dashboard/src/styles/variables.css
+++ b/packages/dashboard/src/styles/variables.css
@@ -37,8 +37,8 @@
   --size-asset-ghost-width: 300px;
   --radius-context-menu: 3px;
   --radius-component-palette-icon: 8px;
-  --right-toolbar-overlay-height: 116px;
-  --left-toolbar-overlay-height: 136px;
+  --dashboard-header-height: 72px;
+  --toolbar-overlay-height: 160px;
   --button-action-gap: 0.5rem;
   --colors-background-button: #f90;
   --colors-button-hover: #ec7211;

--- a/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
@@ -57,6 +57,7 @@ const widgetDashboardConfiguration = {
       },
     ],
   },
+  name: 'EC2 test dashboard',
   onSave: () => Promise.resolve(),
 };
 

--- a/packages/react-components/src/components/time-sync/timeSelection.tsx
+++ b/packages/react-components/src/components/time-sync/timeSelection.tsx
@@ -61,7 +61,13 @@ const messages: ViewportMessages = {
  * parent TimeSync and affect all other viewports in
  * that TimeSync group.
  */
-export const TimeSelection = ({ isPaginationEnabled }: { isPaginationEnabled?: boolean }) => {
+export const TimeSelection = ({
+  isPaginationEnabled,
+  hideTitle,
+}: {
+  isPaginationEnabled?: boolean;
+  hideTitle?: boolean;
+}) => {
   const { viewport, setViewport } = useViewport();
 
   const handleChangeDateRange: NonCancelableEventHandler<DateRangePickerProps.ChangeDetail> = (event) => {
@@ -114,7 +120,7 @@ export const TimeSelection = ({ isPaginationEnabled }: { isPaginationEnabled?: b
   const { title, placeholder, dateRangeIncompleteError, dateRangeInvalidError, ...i18nStrings } = messages;
 
   return (
-    <FormField label={title}>
+    <FormField label={!hideTitle ? title : ''} data-testid='time-selection'>
       <SpaceBetween direction='horizontal' size='xxs'>
         {isPaginationEnabled && (
           <Tooltip


### PR DESCRIPTION
## Overview
This change is for the ticket #1947 

- Added new header design at the top.
- Displayed dashboard title on the left side and time series and actions buttons on the right side.
- Also displayed the asset model selection dropdown on the white background toolbar in preview mode.
- Fixed scroll issue and bar chart alignment issue due to new header height.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/139960352/fc438b1d-fc4f-4f73-a49a-cca82414df65


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
