### PR TITLE
fix: table resize button aria label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "dependencies": {
         "@cloudscape-design/collection-hooks": "1.0.22",
         "@cloudscape-design/component-toolkit": "1.0.0-beta.26",
-        "@cloudscape-design/components": "3.0.415",
+        "@cloudscape-design/components": "3.0.421",
         "@cloudscape-design/design-tokens": "3.0.15",
         "@cloudscape-design/global-styles": "1.0.12"
       },
@@ -10309,8 +10309,9 @@
       }
     },
     "node_modules/@cloudscape-design/components": {
-      "version": "3.0.415",
-      "integrity": "sha512-QazrO1NFkOcAs57tlPpmIET1aRGjiNDpYQmCXOlGlLnGBaji/Yamc87qbGihx9d6H2NoiFoaoDkAmpI23UBCaQ==",
+      "version": "3.0.421",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.421.tgz",
+      "integrity": "sha512-K5K2gFBoOyey6W3ewOjPNzZYdQm66KK8F4tC//ZcevJlGP4eVIWC8bHN7rYjKa7f1UqRIX8TBuV2V5HjXYGxVA==",
       "dependencies": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
         "@cloudscape-design/component-toolkit": "^1.0.0-beta",
@@ -62168,7 +62169,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudscape-design/collection-hooks": "1.0.22",
-        "@cloudscape-design/components": "3.0.415",
+        "@cloudscape-design/components": "3.0.421",
         "@cloudscape-design/design-tokens": "3.0.15",
         "@iot-app-kit/charts": "2.1.2",
         "@iot-app-kit/charts-core": "2.1.2",
@@ -72645,8 +72646,9 @@
       }
     },
     "@cloudscape-design/components": {
-      "version": "3.0.415",
-      "integrity": "sha512-QazrO1NFkOcAs57tlPpmIET1aRGjiNDpYQmCXOlGlLnGBaji/Yamc87qbGihx9d6H2NoiFoaoDkAmpI23UBCaQ==",
+      "version": "3.0.421",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.421.tgz",
+      "integrity": "sha512-K5K2gFBoOyey6W3ewOjPNzZYdQm66KK8F4tC//ZcevJlGP4eVIWC8bHN7rYjKa7f1UqRIX8TBuV2V5HjXYGxVA==",
       "requires": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
         "@cloudscape-design/component-toolkit": "^1.0.0-beta",
@@ -76543,7 +76545,7 @@
       "version": "file:packages/react-components",
       "requires": {
         "@cloudscape-design/collection-hooks": "1.0.22",
-        "@cloudscape-design/components": "3.0.415",
+        "@cloudscape-design/components": "3.0.421",
         "@cloudscape-design/design-tokens": "3.0.15",
         "@iot-app-kit/charts": "2.1.2",
         "@iot-app-kit/charts-core": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@cloudscape-design/component-toolkit": "1.0.0-beta.26",
     "@cloudscape-design/collection-hooks": "1.0.22",
-    "@cloudscape-design/components": "3.0.415",
+    "@cloudscape-design/components": "3.0.421",
     "@cloudscape-design/design-tokens": "3.0.15",
     "@cloudscape-design/global-styles": "1.0.12"
   },

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesTable/assetModelPropertiesTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesTable/assetModelPropertiesTable.tsx
@@ -133,6 +133,7 @@ export function AssetModelPropertiesTable({
         <AssetModelPropertiesTablePreferences preferences={preferences} updatePreferences={updatePreferences} />
       }
       ariaLabels={{
+        resizerRoleDescription: 'Resize button',
         itemSelectionLabel: (isNotSelected, assetModelProperty) =>
           isNotSelected
             ? `Select asset model property ${assetModelProperty.name}`

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTable.tsx
@@ -128,6 +128,7 @@ export function AssetTable({
       }
       preferences={<AssetTablePreferences preferences={preferences} updatePreferences={updatePreferences} />}
       ariaLabels={{
+        resizerRoleDescription: 'Resize button',
         itemSelectionLabel: (isNotSelected, asset) =>
           isNotSelected ? `Select asset ${asset.name}` : `Deselect asset ${asset.name}`,
       }}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -175,7 +175,7 @@ export function ModeledDataStreamTable({
       ariaLabels={{
         itemSelectionLabel: ({ selectedItems }, modeledDataStream) =>
           propertySelectionLabel([...selectedItems], modeledDataStream),
-
+        resizerRoleDescription: 'Resize button',
         allItemsSelectionLabel: ({ selectedItems }) =>
           selectedItems.length !== items.length ? 'Select modeled data stream' : 'Deselect modeled data stream',
       }}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
@@ -270,6 +270,11 @@ export function UnmodeledDataStreamTable({
           }}
         />
       }
+      ariaLabels={{
+        resizerRoleDescription: 'Resize button',
+        allItemsSelectionLabel: ({ selectedItems }) =>
+          selectedItems.length !== items.length ? 'Select unmodeled data stream' : 'Deselect unmodeled data stream',
+      }}
     />
   );
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -98,7 +98,7 @@
   },
   "dependencies": {
     "@cloudscape-design/collection-hooks": "1.0.22",
-    "@cloudscape-design/components": "3.0.415",
+    "@cloudscape-design/components": "3.0.421",
     "@cloudscape-design/design-tokens": "3.0.15",
     "@iot-app-kit/charts": "2.1.2",
     "@iot-app-kit/charts-core": "2.1.2",


### PR DESCRIPTION
## Overview
Bump cloudscape components package to `3.0.421`
to have access to the aria label `resizerRoleDescription` which labels the resizable column separator

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
