### PR TITLE
fix: added aria label to dashboard threshold delete button

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdComponent.tsx
@@ -98,7 +98,13 @@ export const ThresholdComponent: FC<{
           </Box>
         </SpaceBetween>
       </div>
-      <Button iconName='remove' variant='icon' onClick={onDelete} data-test-id='threshold-component-delete-button' />
+      <Button
+        ariaLabel='delete threshold'
+        iconName='remove'
+        variant='icon'
+        onClick={onDelete}
+        data-test-id='threshold-component-delete-button'
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Overview
To provide an accessible name to the dashboard threshold delete button

## Verifying Changes

verified attribute is present: `aria-label="delete threshold"`

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
