### PR TITLE
fix: broken search results disabled state

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/util/resourceExplorerTableLabels.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/util/resourceExplorerTableLabels.tsx
@@ -1,7 +1,7 @@
 import { ModeledDataStream } from '../../types';
 
 export const isInValidProperty = (dataType: ModeledDataStream['dataType'], widgetType?: string) => {
-  if (!widgetType) return false;
+  if (!widgetType || !dataType) return false;
 
   const isNumericDataType = dataType === 'DOUBLE' || dataType === 'INTEGER';
 


### PR DESCRIPTION
## Overview
Search results do not have a data type, leading to always being disabled
Added check where if widget type OR data type are undefined then the item will not be disabled

before:
https://github.com/awslabs/iot-app-kit/assets/28601414/0151a446-5d13-4e13-99de-0243bca7baa9


after: 
https://github.com/awslabs/iot-app-kit/assets/28601414/590a23a4-57bd-402f-a6ab-e0b1f237df5c

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
