### PR TITLE
perf: increase batch size

### DIFF
--- a/packages/source-iotsitewise/src/time-series-data/client/batch.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batch.spec.ts
@@ -1,36 +1,32 @@
-import {
-  createEntryBatches,
-  calculateNextBatchSize,
-  shouldFetchNextBatch,
-  MAX_BATCH_RESULTS,
-  MAX_BATCH_ENTRIES,
-  NO_LIMIT_BATCH,
-} from './batch';
+import { createEntryBatches, shouldFetchNextBatch } from './batch';
 
 describe('createEntryBatches', () => {
   it('buckets entries by maxResults for a given batch', () => {
-    const batches = createEntryBatches([
-      {
-        id: '1',
-        maxResults: undefined,
-      },
-      {
-        id: '2',
-        maxResults: 2000,
-      },
-      {
-        id: '3',
-        maxResults: 2000,
-      },
-      {
-        id: '4',
-        maxResults: 10,
-      },
-      {
-        id: '5',
-        maxResults: 2000,
-      },
-    ]);
+    const batches = createEntryBatches(
+      [
+        {
+          id: '1',
+          maxResults: undefined,
+        },
+        {
+          id: '2',
+          maxResults: 2000,
+        },
+        {
+          id: '3',
+          maxResults: 2000,
+        },
+        {
+          id: '4',
+          maxResults: 10,
+        },
+        {
+          id: '5',
+          maxResults: 2000,
+        },
+      ],
+      16
+    );
 
     expect(batches).toEqual(
       expect.arrayContaining([
@@ -41,7 +37,7 @@ describe('createEntryBatches', () => {
               maxResults: undefined,
             },
           ],
-          NO_LIMIT_BATCH,
+          -1,
         ],
         [
           [
@@ -58,7 +54,7 @@ describe('createEntryBatches', () => {
               maxResults: 2000,
             },
           ],
-          6000,
+          2000,
         ],
         [
           [
@@ -73,11 +69,12 @@ describe('createEntryBatches', () => {
     );
   });
 
-  it('chunks batches that exceed max entry size (16)', () => {
+  it('chunks batches that exceed max batch size', () => {
     const entrySize = 2000;
+    const batchSize = 16;
 
     const entries = [
-      ...[...Array(MAX_BATCH_ENTRIES * 3)].map((_args, index) => ({
+      ...[...Array(batchSize * 3)].map((_args, index) => ({
         id: String(index),
         maxResults: entrySize,
       })),
@@ -87,63 +84,30 @@ describe('createEntryBatches', () => {
       },
     ];
 
-    const batches = createEntryBatches(entries);
+    const batches = createEntryBatches(entries, 16);
 
     expect(batches).toEqual(
       expect.arrayContaining([
-        [entries.slice(0, MAX_BATCH_ENTRIES), MAX_BATCH_ENTRIES * entrySize],
-        [entries.slice(MAX_BATCH_ENTRIES, 2 * MAX_BATCH_ENTRIES), MAX_BATCH_ENTRIES * entrySize],
-        [entries.slice(MAX_BATCH_ENTRIES * 2, MAX_BATCH_ENTRIES * 3), MAX_BATCH_ENTRIES * entrySize],
-        [[entries[MAX_BATCH_ENTRIES * 3]], 10],
+        [entries.slice(0, batchSize), entrySize],
+        [entries.slice(batchSize, 2 * batchSize), entrySize],
+        [entries.slice(batchSize * 2, batchSize * 3), entrySize],
+        [[entries[batchSize * 3]], 10],
       ])
     );
   });
 
   it('handles empty input', () => {
-    const batches = createEntryBatches([]);
+    const batches = createEntryBatches([], 16);
     expect(batches).toEqual([]);
   });
 });
 
-describe('calculateNextBatchSize', () => {
-  it('returns the correct max batch size for no limit batches', () => {
-    expect(calculateNextBatchSize({ maxResults: NO_LIMIT_BATCH, dataPointsFetched: 0 })).toBe(MAX_BATCH_RESULTS);
-    expect(calculateNextBatchSize({ maxResults: NO_LIMIT_BATCH, dataPointsFetched: 100000 })).toBe(MAX_BATCH_RESULTS);
-  });
-
-  it('returns the correct max batch size when specified and need to fetch more than MAX_BATCH_SIZE', () => {
-    expect(calculateNextBatchSize({ maxResults: MAX_BATCH_RESULTS * 3, dataPointsFetched: 0 })).toBe(MAX_BATCH_RESULTS);
-  });
-
-  it('returns the correct max batch size when specified and need to fetch less than MAX_BATCH SIZE', () => {
-    expect(calculateNextBatchSize({ maxResults: MAX_BATCH_RESULTS / 2, dataPointsFetched: 0 })).toBe(
-      MAX_BATCH_RESULTS / 2
-    );
-    expect(calculateNextBatchSize({ maxResults: MAX_BATCH_RESULTS, dataPointsFetched: MAX_BATCH_RESULTS / 2 })).toBe(
-      MAX_BATCH_RESULTS / 2
-    );
-  });
-});
-
 describe('shouldFetchNextBatch', () => {
-  it('returns true if next token exists and batch has no limit', () => {
-    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: NO_LIMIT_BATCH, dataPointsFetched: 0 })).toBe(true);
-    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: NO_LIMIT_BATCH, dataPointsFetched: 500000 })).toBe(
-      true
-    );
-  });
-
-  it('returns true if next token exists and there is still data that needs to be fetched', () => {
-    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 3000, dataPointsFetched: 0 })).toBe(true);
-    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 10000, dataPointsFetched: 9999 })).toBe(true);
-  });
-
-  it('returns false if next token exists but data points have already been fetched', () => {
-    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 3000, dataPointsFetched: 3000 })).toBe(false);
-    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 0, dataPointsFetched: 0 })).toBe(false);
+  it('returns true if next token exists', () => {
+    expect(shouldFetchNextBatch({ nextToken: '123' })).toBe(true);
   });
 
   it('returns false if next token does not exist', () => {
-    expect(shouldFetchNextBatch({ nextToken: undefined, maxResults: 3000, dataPointsFetched: 0 })).toBe(false);
+    expect(shouldFetchNextBatch({ nextToken: undefined })).toBe(false);
   });
 });

--- a/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.ts
@@ -3,7 +3,7 @@ import { toDataPoint } from '../util/toDataPoint';
 import { dataStreamFromSiteWise } from '../dataStreamFromSiteWise';
 import { fromId } from '../util/dataStreamId';
 import { isDefined } from '../../common/predicates';
-import { createEntryBatches, calculateNextBatchSize, shouldFetchNextBatch } from './batch';
+import { createEntryBatches, shouldFetchNextBatch } from './batch';
 import { deduplicateBatch } from '../util/deduplication';
 import { RESOLUTION_TO_MS_MAPPING } from '../util/resolution';
 import type {
@@ -29,26 +29,25 @@ type BatchEntryCallbackCache = {
   };
 };
 
+const BATCH_SIZE = 16;
+const ENTRY_SIZE = 20_000;
+
 const sendRequest = ({
   client,
   batch,
   maxResults,
   requestIndex, // used to create and regenerate (for paginating) a unique entryId
   nextToken: prevToken,
-  dataPointsFetched = 0, // track number of data points fetched so far
 }: {
   client: IoTSiteWiseClient;
   batch: BatchHistoricalEntry[];
   maxResults: number;
   requestIndex: number;
   nextToken?: string;
-  dataPointsFetched?: number;
 }) => {
   // callback cache makes it convenient to capture request data in a closure.
   // the cache exposes methods that only require batch response entry as an argument.
   const callbackCache: BatchEntryCallbackCache = {};
-
-  const batchSize = calculateNextBatchSize({ maxResults, dataPointsFetched });
 
   client
     .send(
@@ -101,7 +100,7 @@ const sendRequest = ({
             timeOrdering: TimeOrdering.DESCENDING,
           };
         }),
-        maxResults: batchSize,
+        maxResults,
         nextToken: prevToken,
       })
     )
@@ -115,16 +114,13 @@ const sendRequest = ({
       successEntries?.forEach((entry) => entry.entryId && callbackCache[entry.entryId]?.onSuccess(entry));
 
       // increment number of data points fetched
-      dataPointsFetched += batchSize;
-
-      if (shouldFetchNextBatch({ nextToken, maxResults, dataPointsFetched })) {
+      if (shouldFetchNextBatch({ nextToken })) {
         sendRequest({
           client,
           batch,
           maxResults,
           requestIndex,
           nextToken,
-          dataPointsFetched,
         });
       }
     });
@@ -137,7 +133,7 @@ const batchGetHistoricalPropertyDataPointsForProperty = ({
   client: IoTSiteWiseClient;
   entries: BatchHistoricalEntry[];
 }) =>
-  createEntryBatches<BatchHistoricalEntry>(entries)
+  createEntryBatches<BatchHistoricalEntry>(entries, BATCH_SIZE)
     .filter((batch) => batch.length > 0) // filter out empty batches
     .map(([batch, maxResults], requestIndex) => sendRequest({ client, batch, maxResults, requestIndex }));
 
@@ -151,7 +147,7 @@ export const batchGetHistoricalPropertyDataPoints = ({
   const entries: BatchHistoricalEntry[] = [];
 
   // fan out params into individual entries, handling fetchMostRecentBeforeStart
-  params.forEach(({ requestInformations, maxResults, onSuccess, onError }) => {
+  params.forEach(({ requestInformations, onSuccess, onError }) => {
     requestInformations
       .filter(({ resolution }) => resolution === '0')
       .forEach((requestInformation) => {
@@ -159,7 +155,7 @@ export const batchGetHistoricalPropertyDataPoints = ({
 
         entries.push({
           requestInformation,
-          maxResults: fetchMostRecentBeforeStart ? 1 : maxResults,
+          maxResults: fetchMostRecentBeforeStart ? 1 : ENTRY_SIZE,
           onSuccess,
           onError,
           requestStart: fetchMostRecentBeforeStart ? new Date(0, 0, 0) : start,

--- a/packages/source-iotsitewise/src/time-series-data/client/batchGetLatestPropertyDataPoints.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batchGetLatestPropertyDataPoints.ts
@@ -3,7 +3,7 @@ import { toDataPoint } from '../util/toDataPoint';
 import { dataStreamFromSiteWise } from '../dataStreamFromSiteWise';
 import { fromId } from '../util/dataStreamId';
 import { isDefined } from '../../common/predicates';
-import { createEntryBatches, shouldFetchNextBatch, NO_LIMIT_BATCH } from './batch';
+import { createEntryBatches, shouldFetchNextBatch } from './batch';
 import { deduplicateBatch } from '../util/deduplication';
 import type {
   BatchGetAssetPropertyValueErrorEntry,
@@ -27,6 +27,8 @@ type BatchEntryCallbackCache = {
     onSuccess: (entry: BatchGetAssetPropertyValueSuccessEntry) => void;
   };
 };
+
+const BATCH_SIZE = 128;
 
 /**
  *  This API currently does not paginate and nextToken will always be null. However, once
@@ -99,7 +101,7 @@ const sendRequest = ({
       errorEntries?.forEach((entry) => entry.entryId && callbackCache[entry.entryId]?.onError(entry));
       successEntries?.forEach((entry) => entry.entryId && callbackCache[entry.entryId]?.onSuccess(entry));
 
-      if (shouldFetchNextBatch({ nextToken, maxResults: NO_LIMIT_BATCH })) {
+      if (shouldFetchNextBatch({ nextToken })) {
         sendRequest({
           client,
           batch,
@@ -117,7 +119,7 @@ const batchGetLatestPropertyDataPointsForProperty = ({
   client: IoTSiteWiseClient;
   entries: BatchLatestEntry[];
 }) =>
-  createEntryBatches<BatchLatestEntry>(entries)
+  createEntryBatches<BatchLatestEntry>(entries, BATCH_SIZE)
     .filter((batch) => batch.length > 0) // filter out empty batches
     .map(([batch], requestIndex) => sendRequest({ client, batch, requestIndex }));
 

--- a/packages/source-iotsitewise/src/time-series-data/client/client.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/client.spec.ts
@@ -8,7 +8,6 @@ import {
   BATCH_ASSET_PROPERTY_AGGREGATES,
 } from '../../__mocks__/assetPropertyValue';
 import { toId } from '../util/dataStreamId';
-import { MAX_BATCH_RESULTS } from './batch';
 import flushPromises from 'flush-promises';
 import { HOUR_IN_MS } from '../util/timeConstants';
 import { createMockSiteWiseSDK } from '@iot-app-kit/testing-util';
@@ -58,7 +57,8 @@ describe('getHistoricalPropertyDataPoints', () => {
   it('batches and paginates', async () => {
     const batchGetAssetPropertyValueHistory = jest
       .fn()
-      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_VALUE_HISTORY, nextToken: 'nextToken' });
+      .mockResolvedValueOnce({ ...BATCH_ASSET_PROPERTY_VALUE_HISTORY, nextToken: 'nextToken' })
+      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_VALUE_HISTORY });
     const assetId1 = 'some-asset-id-1';
     const propertyId1 = 'some-property-id-1';
 
@@ -94,13 +94,11 @@ describe('getHistoricalPropertyDataPoints', () => {
       requestInformations: [requestInformation1],
       onSuccess,
       onError,
-      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
     client.getHistoricalPropertyDataPoints({
       requestInformations: [requestInformation2],
       onSuccess,
       onError,
-      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
 
     await flushPromises();
@@ -211,7 +209,6 @@ describe('getHistoricalPropertyDataPoints', () => {
       requestInformations: [requestInformation1],
       onSuccess,
       onError,
-      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
 
     await flushPromises();
@@ -541,7 +538,8 @@ describe('getAggregatedPropertyDataPoints', () => {
   it('batches and paginates', async () => {
     const batchGetAssetPropertyAggregates = jest
       .fn()
-      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_AGGREGATES, nextToken: 'nextToken' });
+      .mockResolvedValueOnce({ ...BATCH_ASSET_PROPERTY_AGGREGATES, nextToken: 'nextToken' })
+      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_AGGREGATES });
     const assetId1 = 'some-asset-id-1';
     const propertyId1 = 'some-property-id-1';
 
@@ -580,13 +578,11 @@ describe('getAggregatedPropertyDataPoints', () => {
       requestInformations: [requestInformation1],
       onSuccess,
       onError,
-      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
     client.getAggregatedPropertyDataPoints({
       requestInformations: [requestInformation2],
       onSuccess,
       onError,
-      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
 
     await flushPromises();
@@ -716,7 +712,6 @@ describe('getAggregatedPropertyDataPoints', () => {
       requestInformations: [requestInformation1],
       onSuccess,
       onError,
-      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
 
     await flushPromises();

--- a/packages/source-iotsitewise/src/time-series-data/client/client.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/client.ts
@@ -14,14 +14,12 @@ export type LatestPropertyParams = {
 
 export type HistoricalPropertyParams = {
   requestInformations: RequestInformationAndRange[];
-  maxResults?: number;
   onError: ErrorCallback;
   onSuccess: OnSuccessCallback;
 };
 
 export type AggregatedPropertyParams = {
   requestInformations: RequestInformationAndRange[];
-  maxResults?: number;
   onError: ErrorCallback;
   onSuccess: OnSuccessCallback;
 };


### PR DESCRIPTION
## Overview
This change improves SiteWise data source performance by:
- Increasing the number of historical data points requested from 4k to 20k
- Increasing the batch size of latest value from 16 to 128.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
