### PR TITLE
feat(scene): move add ground plane to settings

### DIFF
--- a/packages/scene-composer/public/scene_1.scene.json
+++ b/packages/scene-composer/public/scene_1.scene.json
@@ -24,7 +24,11 @@
       "far": 1000
     },
     "sceneBackgroundSettings": {
-      "color": "#0000ff"
+      "color": "#2a2e33"
+    },
+    "groundPlaneSettings": {
+      "color": "#00ff00",
+      "opacity": 1
     }
   },
   "nodes": [

--- a/packages/scene-composer/src/SceneViewer.tsx
+++ b/packages/scene-composer/src/SceneViewer.tsx
@@ -82,6 +82,7 @@ export const SceneViewer: React.FC<SceneViewerProps> = ({ sceneComposerId, confi
             [COMPOSER_FEATURES.Matterport]: true,
             [COMPOSER_FEATURES.TagStyle]: true,
             [COMPOSER_FEATURES.AutoQuery]: true,
+            [COMPOSER_FEATURES.SceneAppearance]: true,
           },
         }}
         onSceneLoaded={onSceneLoaded}

--- a/packages/scene-composer/src/__snapshots__/SceneViewer.spec.tsx.snap
+++ b/packages/scene-composer/src/__snapshots__/SceneViewer.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`SceneViewer should render correctly 1`] = `
   data-testid="webgl-root"
 >
   <div
-    config="{\\"mode\\":\\"Viewing\\",\\"featureConfig\\":{\\"SceneHierarchySearch\\":true,\\"SceneHierarchyReorder\\":true,\\"SubModelSelection\\":true,\\"ENHANCED_EDITING\\":true,\\"CameraView\\":true,\\"OpacityRule\\":true,\\"Overlay\\":true,\\"TagResize\\":true,\\"Matterport\\":true,\\"TagStyle\\":true,\\"AutoQuery\\":true}}"
+    config="{\\"mode\\":\\"Viewing\\",\\"featureConfig\\":{\\"SceneHierarchySearch\\":true,\\"SceneHierarchyReorder\\":true,\\"SubModelSelection\\":true,\\"ENHANCED_EDITING\\":true,\\"CameraView\\":true,\\"OpacityRule\\":true,\\"Overlay\\":true,\\"TagResize\\":true,\\"Matterport\\":true,\\"TagStyle\\":true,\\"AutoQuery\\":true,\\"SceneAppearance\\":true}}"
     data-mocked="SceneComposerInternal"
     onSceneLoaded={[Function]}
     sceneComposerId="123"

--- a/packages/scene-composer/src/components/WebGLCanvasManager.tsx
+++ b/packages/scene-composer/src/components/WebGLCanvasManager.tsx
@@ -20,6 +20,7 @@ import useMatterportViewer from '../hooks/useMatterportViewer';
 
 import Environment, { presets } from './three-fiber/Environment';
 import Fog from './three-fiber/Fog';
+import GroundPlane from './three-fiber/GroundPlane';
 import { StatsWindow } from './three-fiber/StatsWindow';
 import EntityGroup from './three-fiber/EntityGroup';
 import { EditorMainCamera } from './three-fiber/EditorCamera';
@@ -48,7 +49,6 @@ export const WebGLCanvasManager: React.FC = () => {
   const environmentPreset = getSceneProperty<string>(KnownSceneProperty.EnvironmentPreset);
   const rootNodeRefs = document.rootNodeRefs;
 
-  const editingTargetPlaneRef = useRef(null);
   const gridHelperRef = useRef<THREE.GridHelper>(null);
 
   const MAX_CLICK_DISTANCE = 2;
@@ -100,6 +100,7 @@ export const WebGLCanvasManager: React.FC = () => {
             return node && <EntityGroup key={rootNodeRef} node={node} />;
           })}
       </group>
+      <GroundPlane />
       {isEditing() && (
         <React.Fragment>
           <EditorTransformControls />
@@ -116,6 +117,7 @@ export const WebGLCanvasManager: React.FC = () => {
           <React.Fragment>
             <gridHelper
               ref={gridHelperRef}
+              position={new THREE.Vector3(0, 0.001, 0)}
               args={[
                 1000 /* size */,
                 500 /* grid# */,
@@ -123,16 +125,6 @@ export const WebGLCanvasManager: React.FC = () => {
                 hexColorFromDesignToken(awsui.colorTextInputDisabled) /* grid color */,
               ]}
             />
-            <mesh
-              ref={editingTargetPlaneRef}
-              name='Ground'
-              rotation={[THREE.MathUtils.degToRad(270), 0, 0]}
-              onClick={onClick}
-              renderOrder={enableMatterportViewer ? 1 : undefined}
-            >
-              <planeGeometry args={[1000, 1000]} />
-              <meshBasicMaterial transparent={true} opacity={0} />
-            </mesh>
             {enableMatterportViewer && <MatterportModel onClick={onClick} />}
           </React.Fragment>
           <IntlProvider locale={getGlobalSettings().locale}>

--- a/packages/scene-composer/src/components/panels/SettingsPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SettingsPanel.tsx
@@ -20,6 +20,7 @@ import { OverlayPanelVisibilityToggle } from './scene-settings/OverlayPanelVisib
 import { ConvertSceneSettings } from './scene-settings/ConvertSceneSettings';
 import { FogSettingsEditor } from './scene-settings/FogSettingsEditor';
 import { SceneBackgroundSettingsEditor } from './scene-settings/SceneBackgroundSettingsEditor';
+import { GroundPlaneSettingsEditor } from './scene-settings/GroundPlaneSettingsEditor';
 export interface SettingsPanelProps {
   valueDataBindingProvider?: IValueDataBindingProvider;
 }
@@ -189,6 +190,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
               <React.Fragment>
                 <FogSettingsEditor />
                 <SceneBackgroundSettingsEditor />
+                <GroundPlaneSettingsEditor />
               </React.Fragment>
             )}
           </SpaceBetween>

--- a/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditor.spec.tsx
@@ -31,13 +31,12 @@ describe('PlaneGeometryComponentEditor', () => {
     color: '#abcdef',
   };
 
-  const componentWithTexturedGroundPlane: IPlaneGeometryComponentInternal = {
+  const componentWithTexturedPlane: IPlaneGeometryComponentInternal = {
     ...mockComponent,
     type: KnownComponentType.PlaneGeometry,
     width: 10,
     height: 20,
     textureUri: 'filepath',
-    isGroundPlane: true,
   };
 
   const mockFeatureConfigOn = { [COMPOSER_FEATURES.Textures]: true };
@@ -159,8 +158,8 @@ describe('PlaneGeometryComponentEditor', () => {
     useStore('default').setState(baseState);
     const { container } = render(
       <PlaneGeometryComponentEditor
-        node={{ ...mockNode, components: [componentWithTexturedGroundPlane] }}
-        component={componentWithTexturedGroundPlane}
+        node={{ ...mockNode, components: [componentWithTexturedPlane] }}
+        component={componentWithTexturedPlane}
       />,
     );
     const polarisWrapper = wrapper(container);
@@ -174,32 +173,7 @@ describe('PlaneGeometryComponentEditor', () => {
     });
 
     expect(updateComponentInternalFn).toBeCalledTimes(1);
-    const { textureUri: _textureUri, ...otherComponentProps } = componentWithTexturedGroundPlane;
+    const { textureUri: _textureUri, ...otherComponentProps } = componentWithTexturedPlane;
     expect(updateComponentInternalFn).toBeCalledWith(mockNode.ref, { ...otherComponentProps, color: '#cccccc' }, true);
-  });
-
-  it('should toggle ground plane status', () => {
-    const globalSettingsMock = getGlobalSettings as jest.Mock;
-    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
-    useStore('default').setState(baseState);
-    const { container } = render(
-      <PlaneGeometryComponentEditor node={{ ...mockNode, components: [component] }} component={component} />,
-    );
-    const polarisWrapper = wrapper(container);
-    const groundPlaneCheckBox = polarisWrapper.findCheckbox('[data-testid="ground-plane-checkbox"]');
-
-    expect(groundPlaneCheckBox).toBeDefined();
-
-    // click checkbox should update store
-    act(() => {
-      groundPlaneCheckBox?.findNativeInput().click();
-    });
-    expect(updateComponentInternalFn).toBeCalledTimes(1);
-    expect(updateComponentInternalFn).toBeCalledWith(mockNode.ref, { ...component, isGroundPlane: true }, true);
-
-    act(() => {
-      groundPlaneCheckBox?.findNativeInput().click();
-    });
-    expect(updateComponentInternalFn).toBeCalledWith(mockNode.ref, { ...component, isGroundPlane: false }, true);
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useState } from 'react';
-import { Button, Checkbox, FormField, Input, SpaceBetween } from '@awsui/components-react';
+import { Button, FormField, Input, SpaceBetween } from '@awsui/components-react';
 import { useIntl } from 'react-intl';
 
 import { IComponentEditorProps } from '../ComponentEditor';
@@ -34,7 +34,6 @@ export const PlaneGeometryComponentEditor: React.FC<IPlaneGeometryComponentEdito
   const [internalHeight, setInternalHeight] = useState(planeGeometryComponent.height);
   const [internalColor, setInternalColor] = useState(planeGeometryComponent.color || '#cccccc');
   const [internalUri, setInternalUri] = useState(planeGeometryComponent.textureUri || '');
-  const [internalGroundPlane, setInternalGroundPlane] = useState(planeGeometryComponent.isGroundPlane || false);
 
   const onUpdateCallback = useCallback(
     (componentPartial: IPlaneGeometryComponentInternal, replace?: boolean) => {
@@ -83,17 +82,17 @@ export const PlaneGeometryComponentEditor: React.FC<IPlaneGeometryComponentEdito
   const onTextureSelectClick = useCallback(() => {
     if (showAssetBrowserCallback) {
       showAssetBrowserCallback((s3BucketArn, contentLocation) => {
-        let textureUri: string;
+        let localTextureUri: string;
         if (s3BucketArn === null) {
           // This should be used for local testing only
-          textureUri = contentLocation;
+          localTextureUri = contentLocation;
         } else {
-          textureUri = `s3://${parseS3BucketFromArn(s3BucketArn)}/${contentLocation}`;
+          localTextureUri = `s3://${parseS3BucketFromArn(s3BucketArn)}/${contentLocation}`;
         }
 
-        setInternalUri(textureUri);
+        setInternalUri(localTextureUri);
         const { color: _color, ...otherComponentProps } = planeGeometryComponent;
-        const updatedComponent = { ...otherComponentProps, textureUri };
+        const updatedComponent = { ...otherComponentProps, textureUri: localTextureUri };
         onUpdateCallback(updatedComponent, true);
       });
     } else {
@@ -107,15 +106,6 @@ export const PlaneGeometryComponentEditor: React.FC<IPlaneGeometryComponentEdito
     const updatedComponent = { ...otherComponentProps, color: internalColor };
     onUpdateCallback(updatedComponent, true);
   }, [planeGeometryComponent, internalColor]);
-
-  const onGroundPlaneChecked = useCallback(
-    (checked: boolean) => {
-      setInternalGroundPlane(checked);
-      const updatedComponent = { ...planeGeometryComponent, isGroundPlane: checked };
-      onUpdateCallback(updatedComponent, true);
-    },
-    [planeGeometryComponent],
-  );
 
   return (
     <SpaceBetween size='s'>
@@ -168,13 +158,6 @@ export const PlaneGeometryComponentEditor: React.FC<IPlaneGeometryComponentEdito
           <Input value={internalUri} disabled />
         </SpaceBetween>
       )}
-      <FormField label={intl.formatMessage({ defaultMessage: 'Ground Plane', description: 'Form Field label' })}>
-        <Checkbox
-          data-testid='ground-plane-checkbox'
-          checked={internalGroundPlane}
-          onChange={({ detail }) => onGroundPlaneChecked(detail.checked)}
-        />
-      </FormField>
     </SpaceBetween>
   );
 };

--- a/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditorSnap.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/PlaneGeometryComponentEditorSnap.spec.tsx
@@ -34,13 +34,12 @@ describe('PlaneGeometryComponentEditor', () => {
     color: '#abcdef',
   };
 
-  const componentWithTexturedGroundPlane: IPlaneGeometryComponentInternal = {
+  const componentWithTexturedPlane: IPlaneGeometryComponentInternal = {
     ...mockComponent,
     type: KnownComponentType.PlaneGeometry,
     width: 10,
     height: 20,
     textureUri: 'filepath',
-    isGroundPlane: true,
   };
 
   const updateComponentInternalFn = jest.fn();
@@ -78,7 +77,7 @@ describe('PlaneGeometryComponentEditor', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should render correctly with textured ground plane', () => {
+  it('should render correctly with textured plane', () => {
     const globalSettingsMock = getGlobalSettings as jest.Mock;
     globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfig });
 
@@ -86,8 +85,8 @@ describe('PlaneGeometryComponentEditor', () => {
 
     const { container } = render(
       <PlaneGeometryComponentEditor
-        node={{ ...mockNode, components: [componentWithTexturedGroundPlane] }}
-        component={componentWithTexturedGroundPlane}
+        node={{ ...mockNode, components: [componentWithTexturedPlane] }}
+        component={componentWithTexturedPlane}
       />,
     );
     expect(container).toMatchSnapshot();

--- a/packages/scene-composer/src/components/panels/scene-components/__snapshots__/PlaneGeometryComponentEditorSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-components/__snapshots__/PlaneGeometryComponentEditorSnap.spec.tsx.snap
@@ -48,15 +48,6 @@ exports[`PlaneGeometryComponentEditor should render correctly 1`] = `
         value=""
       />
     </div>
-    <div
-      data-mocked="FormField"
-      label="Ground Plane"
-    >
-      <div
-        data-mocked="Checkbox"
-        data-testid="ground-plane-checkbox"
-      />
-    </div>
   </div>
 </div>
 `;
@@ -109,20 +100,11 @@ exports[`PlaneGeometryComponentEditor should render correctly with color 1`] = `
         value=""
       />
     </div>
-    <div
-      data-mocked="FormField"
-      label="Ground Plane"
-    >
-      <div
-        data-mocked="Checkbox"
-        data-testid="ground-plane-checkbox"
-      />
-    </div>
   </div>
 </div>
 `;
 
-exports[`PlaneGeometryComponentEditor should render correctly with textured ground plane 1`] = `
+exports[`PlaneGeometryComponentEditor should render correctly with textured plane 1`] = `
 <div>
   <div
     data-mocked="SpaceBetween"
@@ -169,15 +151,6 @@ exports[`PlaneGeometryComponentEditor should render correctly with textured grou
         data-mocked="Input"
         disabled=""
         value="filepath"
-      />
-    </div>
-    <div
-      data-mocked="FormField"
-      label="Ground Plane"
-    >
-      <div
-        data-mocked="Checkbox"
-        data-testid="ground-plane-checkbox"
       />
     </div>
   </div>

--- a/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.spec.tsx
@@ -23,18 +23,18 @@ describe('FogSettingsEditor', () => {
     jest.clearAllMocks();
   });
 
-  it('should save fogsettings when checked', async () => {
+  it('should save fogsettings when enabled', async () => {
     getScenePropertyMock.mockReturnValue(undefined);
     useStore('default').setState(baseState);
     const { container } = render(<FogSettingsEditor />);
     const polarisWrapper = wrapper(container);
-    const checkbox = polarisWrapper.findCheckbox();
+    const toggle = polarisWrapper.findToggle();
 
-    expect(checkbox).toBeDefined();
+    expect(toggle).toBeDefined();
 
-    // click checkbox should update store
+    // click should update store
     act(() => {
-      checkbox?.findNativeInput().click();
+      toggle?.findNativeInput().click();
     });
     expect(setScenePropertyMock).toBeCalledTimes(1);
     expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, {
@@ -44,7 +44,7 @@ describe('FogSettingsEditor', () => {
     });
   });
 
-  it('should clear fogsettings when unchecked', async () => {
+  it('should clear fogsettings when untoggled', async () => {
     getScenePropertyMock.mockReturnValue({
       color: '#cccccc',
       near: 1,
@@ -53,13 +53,13 @@ describe('FogSettingsEditor', () => {
     useStore('default').setState(baseState);
     const { container } = render(<FogSettingsEditor />);
     const polarisWrapper = wrapper(container);
-    const checkbox = polarisWrapper.findCheckbox();
+    const toggle = polarisWrapper.findToggle();
 
-    expect(checkbox).toBeDefined();
+    expect(toggle).toBeDefined();
 
-    // click checkbox should update store
+    // click should update store
     act(() => {
-      checkbox?.findNativeInput().click();
+      toggle?.findNativeInput().click();
     });
     expect(setScenePropertyMock).toBeCalledTimes(1);
     expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.FogSettings, undefined);
@@ -134,7 +134,6 @@ describe('FogSettingsEditor', () => {
 
     expect(colorInput).toBeDefined();
 
-    // click checkbox should update store
     colorInput!.focus();
     colorInput!.setInputValue('#FFFFFF');
     colorInput!.blur();

--- a/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { Checkbox, FormField, Input, SpaceBetween } from '@awsui/components-react';
+import { FormField, Input, SpaceBetween, Toggle } from '@awsui/components-react';
 
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { IFogSettings, KnownSceneProperty } from '../../../interfaces';
@@ -41,7 +41,7 @@ export const FogSettingsEditor: React.FC = () => {
       }
       setFogEnabled(checked);
     },
-    [fogSettings, internalColor, internalNearDistance, internalFarDistance],
+    [internalColor, internalNearDistance, internalFarDistance],
   );
 
   const onInputBlur = useCallback(() => {
@@ -72,7 +72,10 @@ export const FogSettingsEditor: React.FC = () => {
 
   const onNearChange = useCallback(
     (event) => {
-      const value = Number(event.detail.value);
+      let value = Number(event.detail.value);
+      if (value < 0) {
+        value = 0;
+      }
       if (value !== internalNearDistance) {
         setInternalNearDistance(value);
       }
@@ -82,7 +85,10 @@ export const FogSettingsEditor: React.FC = () => {
 
   const onFarChange = useCallback(
     (event) => {
-      const value = Number(event.detail.value);
+      let value = Number(event.detail.value);
+      if (value < 0) {
+        value = 0;
+      }
       if (value !== internalFarDistance) {
         setInternalFarDistance(value);
       }
@@ -93,13 +99,9 @@ export const FogSettingsEditor: React.FC = () => {
   return (
     <React.Fragment>
       <SpaceBetween size='s'>
-        <Checkbox
-          data-testid='enable-fog-checkbox'
-          checked={!!fogSettings}
-          onChange={(e) => onToggleFog(e.detail.checked)}
-        >
-          {intl.formatMessage({ defaultMessage: 'Enable Fog', description: 'checkbox label' })}
-        </Checkbox>
+        <Toggle data-testid='enable-fog-toggle' checked={!!fogSettings} onChange={(e) => onToggleFog(e.detail.checked)}>
+          {intl.formatMessage({ description: 'Toggle label', defaultMessage: 'Enable Fog' })}
+        </Toggle>
         {!!fogSettings && (
           <>
             <ColorSelectorCombo

--- a/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.spec.tsx
@@ -6,7 +6,7 @@ import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { useStore } from '../../../store';
 import { KnownSceneProperty, COMPOSER_FEATURES } from '../../../interfaces';
 
-import { SceneBackgroundSettingsEditor } from './SceneBackgroundSettingsEditor';
+import { GroundPlaneSettingsEditor } from './GroundPlaneSettingsEditor';
 
 jest.mock('../../../common/GlobalSettings');
 
@@ -14,7 +14,7 @@ jest.mock('@awsui/components-react', () => ({
   ...jest.requireActual('@awsui/components-react'),
 }));
 
-describe('SceneBackgroundSettingsEditor', () => {
+describe('GroundPlaneSettingsEditor', () => {
   const setScenePropertyMock = jest.fn();
   const getScenePropertyMock = jest.fn();
   const showAssetBrowserCallbackMock = jest.fn();
@@ -33,27 +33,14 @@ describe('SceneBackgroundSettingsEditor', () => {
     jest.clearAllMocks();
   });
 
-  it('should save background on clean scene', () => {
-    getScenePropertyMock.mockReturnValue(undefined);
-    const globalSettingsMock = getGlobalSettings as jest.Mock;
-    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
-    useStore('default').setState(baseState);
-
-    render(<SceneBackgroundSettingsEditor />);
-
-    expect(setScenePropertyMock).toBeCalledTimes(1);
-    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneBackgroundSettings, {
-      color: '#2a2e33',
-    });
-  });
-
   it('should update background when colors changes', () => {
     getScenePropertyMock.mockImplementation((property: string) => {
-      if (property === KnownSceneProperty.SceneBackgroundSettings) {
+      if (property === KnownSceneProperty.GroundPlaneSettings) {
         return {
           color: '#cccccc',
+          opacity: 1,
         };
-      } else if (property === KnownSceneProperty.BackgroundCustomColors) {
+      } else if (property === KnownSceneProperty.GroundCustomColors) {
         const customColors: string[] = [];
         return customColors;
       }
@@ -61,7 +48,7 @@ describe('SceneBackgroundSettingsEditor', () => {
     const globalSettingsMock = getGlobalSettings as jest.Mock;
     globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
     useStore('default').setState(baseState);
-    const { container } = render(<SceneBackgroundSettingsEditor />);
+    const { container } = render(<GroundPlaneSettingsEditor />);
     const polarisWrapper = wrapper(container);
     const colorInput = polarisWrapper.findInput('[data-testid="hexcode"]');
 
@@ -72,14 +59,16 @@ describe('SceneBackgroundSettingsEditor', () => {
     colorInput!.setInputValue('#FFFFFF');
     colorInput!.blur();
     expect(setScenePropertyMock).toBeCalledTimes(2);
-    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneBackgroundSettings, {
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.GroundPlaneSettings, {
       color: '#FFFFFF',
+      opacity: 1,
     });
   });
 
   it('should open asset browser when select texture clicked and set texture uri', () => {
     getScenePropertyMock.mockReturnValue({
       color: '#cccccc',
+      opacity: 1,
     });
     const globalSettingsMock = getGlobalSettings as jest.Mock;
     globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
@@ -87,7 +76,7 @@ describe('SceneBackgroundSettingsEditor', () => {
       cb(null, 'c:\file.jpg');
     });
     useStore('default').setState(baseState);
-    const { container } = render(<SceneBackgroundSettingsEditor />);
+    const { container } = render(<GroundPlaneSettingsEditor />);
     const polarisWrapper = wrapper(container);
     const selectTextureButton = polarisWrapper.findButton('[data-testid="select-texture-button"]');
 
@@ -98,19 +87,21 @@ describe('SceneBackgroundSettingsEditor', () => {
       selectTextureButton!.click();
     });
     expect(showAssetBrowserCallbackMock).toBeCalledTimes(1);
-    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneBackgroundSettings, {
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.GroundPlaneSettings, {
       textureUri: 'c:\file.jpg',
+      opacity: 1,
     });
   });
 
   it('should remove texture uri', () => {
     getScenePropertyMock.mockReturnValue({
       textureUri: 'filepath',
+      opacity: 1,
     });
     const globalSettingsMock = getGlobalSettings as jest.Mock;
     globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
     useStore('default').setState(baseState);
-    const { container } = render(<SceneBackgroundSettingsEditor />);
+    const { container } = render(<GroundPlaneSettingsEditor />);
     const polarisWrapper = wrapper(container);
     const removeTextureButton = polarisWrapper.findButton('[data-testid="remove-texture-button"]');
 
@@ -120,8 +111,34 @@ describe('SceneBackgroundSettingsEditor', () => {
     act(() => {
       removeTextureButton!.click();
     });
-    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.SceneBackgroundSettings, {
-      color: '#2a2e33',
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.GroundPlaneSettings, {
+      color: '#00FF00',
+      opacity: 1,
+    });
+  });
+
+  it('should update opacity', () => {
+    getScenePropertyMock.mockReturnValue({
+      textureUri: 'filepath',
+      opacity: 0,
+    });
+    const globalSettingsMock = getGlobalSettings as jest.Mock;
+    globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
+    useStore('default').setState(baseState);
+    const { container } = render(<GroundPlaneSettingsEditor />);
+    const polarisWrapper = wrapper(container);
+    const opacityInput = polarisWrapper.findInput('[data-testid="ground-plane-opacity-input"]');
+
+    expect(opacityInput).toBeDefined();
+
+    // click checkbox should update store
+    opacityInput!.focus();
+    opacityInput!.setInputValue('100'); //input is in percent
+    opacityInput!.blur();
+
+    expect(setScenePropertyMock).toBeCalledWith(KnownSceneProperty.GroundPlaneSettings, {
+      textureUri: 'filepath',
+      opacity: 1,
     });
   });
 });

--- a/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.tsx
@@ -1,0 +1,167 @@
+import React, { useCallback, useContext, useState } from 'react';
+import { useIntl } from 'react-intl';
+import { Button, FormField, Input, SpaceBetween } from '@awsui/components-react';
+
+import { getGlobalSettings } from '../../../common/GlobalSettings';
+import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
+import { IGroundPlaneSettings, KnownSceneProperty, COMPOSER_FEATURES } from '../../../interfaces';
+import useLifecycleLogging from '../../../logger/react-logger/hooks/useLifecycleLogging';
+import { useStore } from '../../../store';
+import { ColorSelectorCombo } from '../scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo';
+import { parseS3BucketFromArn } from '../../../utils/pathUtils';
+
+export const GroundPlaneSettingsEditor: React.FC = () => {
+  useLifecycleLogging('GroundPlaneSettingsEditor');
+  const texturesEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Textures];
+
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const intl = useIntl();
+  const setSceneProperty = useStore(sceneComposerId)(
+    (state) => state.setSceneProperty<IGroundPlaneSettings | undefined>,
+  );
+  const groundSettings = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<IGroundPlaneSettings>(KnownSceneProperty.GroundPlaneSettings),
+  );
+
+  const [internalColor, setInternalColor] = useState(groundSettings?.color || '#00FF00');
+  const [internalUri, setInternalUri] = useState(groundSettings?.textureUri || '');
+  const [internalOpacity, setInternalOpacity] = useState(groundSettings?.opacity || 0);
+
+  const showAssetBrowserCallback = useStore(sceneComposerId)(
+    (state) => state.getEditorConfig().showAssetBrowserCallback,
+  );
+
+  const groundColors = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<string[]>(KnownSceneProperty.GroundCustomColors, []),
+  );
+  const setGroundColorsSceneProperty = useStore(sceneComposerId)((state) => state.setSceneProperty<string[]>);
+
+  const onInputBlur = useCallback(() => {
+    if (groundSettings?.opacity !== internalOpacity) {
+      if (groundSettings?.textureUri) {
+        setSceneProperty(KnownSceneProperty.GroundPlaneSettings, {
+          opacity: internalOpacity,
+          textureUri: internalUri,
+        });
+      } else {
+        setSceneProperty(KnownSceneProperty.GroundPlaneSettings, {
+          opacity: internalOpacity,
+          color: internalColor,
+        });
+      }
+    }
+  }, [groundSettings, internalColor, internalOpacity, internalUri]);
+
+  const onOpacityChange = useCallback(
+    (event) => {
+      let value = Number(event.detail.value);
+      value = value / 100; //convert from percentage
+      if (value > 1) {
+        value = 1;
+      } else if (value < 0) {
+        value = 0;
+      }
+      if (value !== internalOpacity) {
+        setInternalOpacity(value);
+      }
+    },
+    [internalOpacity],
+  );
+
+  const onColorChange = useCallback(
+    (color: string) => {
+      if (color !== internalColor) {
+        setInternalColor(color);
+        setSceneProperty(KnownSceneProperty.GroundPlaneSettings, {
+          color: color,
+          opacity: internalOpacity,
+        });
+      }
+    },
+    [internalColor, internalOpacity],
+  );
+
+  const onTextureSelectClick = useCallback(() => {
+    if (showAssetBrowserCallback) {
+      showAssetBrowserCallback((s3BucketArn, contentLocation) => {
+        let localTextureUri: string;
+        if (s3BucketArn === null) {
+          // This should be used for local testing only
+          localTextureUri = contentLocation;
+        } else {
+          localTextureUri = `s3://${parseS3BucketFromArn(s3BucketArn)}/${contentLocation}`;
+        }
+
+        setInternalUri(localTextureUri);
+        setSceneProperty(KnownSceneProperty.GroundPlaneSettings, {
+          textureUri: localTextureUri,
+          opacity: internalOpacity,
+        });
+      });
+    } else {
+      console.info('No asset browser available');
+    }
+  }, [internalOpacity]);
+
+  const onTextureRemoveClick = useCallback(() => {
+    setInternalUri('');
+    setSceneProperty(KnownSceneProperty.GroundPlaneSettings, {
+      color: internalColor,
+      opacity: internalOpacity,
+    });
+  }, [internalColor, internalOpacity]);
+
+  return (
+    <React.Fragment>
+      <FormField label={intl.formatMessage({ defaultMessage: 'Ground Plane', description: 'Form Field label' })}>
+        <SpaceBetween size='s' direction='vertical'>
+          {(!groundSettings?.textureUri || !texturesEnabled) && (
+            <>
+              <ColorSelectorCombo
+                color={internalColor}
+                onSelectColor={(pickedColor) => onColorChange(pickedColor)}
+                onUpdateCustomColors={(chosenCustomColors) =>
+                  setGroundColorsSceneProperty(KnownSceneProperty.GroundCustomColors, chosenCustomColors)
+                }
+                customColors={groundColors}
+                colorPickerLabel={intl.formatMessage({ defaultMessage: 'Color', description: 'Color' })}
+                customColorLabel={intl.formatMessage({ defaultMessage: 'Custom colors', description: 'Custom colors' })}
+              />
+            </>
+          )}
+          <FormField label={intl.formatMessage({ defaultMessage: 'Opacity %', description: 'Form Field label' })}>
+            <Input
+              data-testid='ground-plane-opacity-input'
+              value={String(internalOpacity * 100)}
+              type='number'
+              onBlur={onInputBlur}
+              onChange={onOpacityChange}
+              onKeyDown={(e) => {
+                if (e.detail.key === 'Enter') onInputBlur();
+              }}
+              step={1}
+            />
+          </FormField>
+          {texturesEnabled && (
+            <SpaceBetween size='s' direction='vertical'>
+              <SpaceBetween size='s' direction='horizontal'>
+                <Button data-testid='select-texture-button' onClick={onTextureSelectClick}>
+                  {intl.formatMessage({ defaultMessage: 'Select Texture', description: 'select texture Button Text' })}
+                </Button>
+                {internalUri && (
+                  <Button data-testid='remove-texture-button' onClick={onTextureRemoveClick}>
+                    {intl.formatMessage({
+                      defaultMessage: 'Remove Texture',
+                      description: 'remove texture Button Text',
+                    })}
+                  </Button>
+                )}
+                {internalUri && <Input value={internalUri} disabled />}
+              </SpaceBetween>
+            </SpaceBetween>
+          )}
+        </SpaceBetween>
+      </FormField>
+    </React.Fragment>
+  );
+};

--- a/packages/scene-composer/src/components/three-fiber/GroundPlane.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/GroundPlane.spec.tsx
@@ -1,0 +1,148 @@
+import React, { useRef } from 'react';
+import ReactThreeTestRenderer from '@react-three/test-renderer';
+import { Mesh, Texture, MeshStandardMaterial } from 'three';
+import { useFrame } from '@react-three/fiber';
+jest.useFakeTimers();
+
+import { useEditorState, useStore } from '../../store';
+import useTwinMakerTextureLoader from '../../hooks/useTwinMakerTextureLoader';
+import useAddWidget from '../../hooks/useAddWidget';
+
+//we need actual drei code to test with r3f renderer
+jest.mock('@react-three/drei', () => {
+  const originalModule = jest.requireActual('@react-three/drei');
+  return {
+    ...originalModule,
+  };
+});
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useRef: jest.fn(),
+}));
+
+// Mock Hooks
+jest.mock('@react-three/fiber', () => {
+  const originalModule = jest.requireActual('@react-three/fiber');
+  return {
+    ...originalModule,
+    useFrame: jest.fn(),
+  };
+});
+
+import GroundPlane from './GroundPlane';
+
+jest.mock('../../utils/objectThreeUtils', () => {
+  return {
+    acceleratedRaycasting: jest.fn(),
+  };
+});
+
+jest.mock('../../hooks/useAddWidget', () => {
+  return jest.fn();
+});
+
+const mockTexture = new Texture();
+mockTexture.name = 'testTextureName';
+
+const mockLoadTexture = (uri, mesh: Mesh) => {
+  (mesh.material as MeshStandardMaterial).map = mockTexture;
+};
+const mockClearTexture = (mesh: Mesh) => {
+  (mesh.material as MeshStandardMaterial).map = null;
+};
+
+jest.mock('../../hooks/useTwinMakerTextureLoader', () => {
+  return jest.fn();
+});
+
+jest.mock('../../hooks/useAddWidget', () => {
+  return jest.fn();
+});
+
+jest.mock('../../store/', () => ({
+  ...jest.requireActual('../../store/'),
+  useEditorState: jest.fn(),
+}));
+
+const mockHandleAddWidget = jest.fn();
+
+const getScenePropertyMock = jest.fn();
+const baseState = {
+  getSceneProperty: getScenePropertyMock,
+};
+
+describe('GroundPlane', () => {
+  const setup = () => {
+    jest.resetAllMocks();
+    (useFrame as jest.Mock).mockImplementation((cb) => cb());
+    (useTwinMakerTextureLoader as jest.Mock).mockImplementation(() => ({
+      loadTextureOnMesh: mockLoadTexture,
+      clearTextureOnMesh: mockClearTexture,
+    }));
+    (useAddWidget as jest.Mock).mockImplementation(() => ({
+      handleAddWidget: mockHandleAddWidget,
+    }));
+
+    useStore('default').setState(baseState);
+  };
+
+  beforeEach(() => {
+    setup();
+  });
+
+  it(`should not render with when not set and not in editing`, async () => {
+    getScenePropertyMock.mockReturnValue(undefined);
+    (useEditorState as jest.Mock).mockImplementation(() => ({
+      isEditing: jest.fn().mockReturnValue(false),
+      addingWidget: true,
+    }));
+
+    (useRef as jest.Mock).mockReturnValue({ current: null });
+    const rendered = await ReactThreeTestRenderer.create(<GroundPlane />);
+    expect(rendered.scene.children.length === 0);
+  });
+
+  it(`should render invisible when not enabled in editing`, async () => {
+    getScenePropertyMock.mockReturnValue(undefined);
+    (useEditorState as jest.Mock).mockImplementation(() => ({
+      isEditing: jest.fn().mockReturnValue(true),
+      addingWidget: true,
+    }));
+
+    (useRef as jest.Mock).mockReturnValue({ current: null });
+    const rendered = await ReactThreeTestRenderer.create(<GroundPlane />);
+
+    const material = (rendered.scene.children[0].instance as Mesh).material as MeshStandardMaterial;
+    expect(material.transparent).toBeTruthy();
+    expect(material.opacity).toBe(0);
+  });
+
+  it(`should render with predefined color`, async () => {
+    getScenePropertyMock.mockReturnValue({ color: '#abcdef' });
+    (useEditorState as jest.Mock).mockImplementation(() => ({
+      isEditing: jest.fn().mockReturnValue(true),
+      addingWidget: true,
+    }));
+
+    (useRef as jest.Mock).mockReturnValue({ current: null });
+    const rendered = await ReactThreeTestRenderer.create(<GroundPlane />);
+    const material = (rendered.scene.children[0].instance as Mesh).material as MeshStandardMaterial;
+    expect(material.color.getHexString()).toBe('abcdef');
+    expect(material.map).toBeNull();
+  });
+
+  it('should trigger on click', async () => {
+    getScenePropertyMock.mockReturnValue({ color: '#abcdef' });
+    (useEditorState as jest.Mock).mockImplementation(() => ({
+      isEditing: jest.fn().mockReturnValue(true),
+      addingWidget: true,
+    }));
+
+    (useRef as jest.Mock).mockReturnValue({ current: null });
+    const rendered = await ReactThreeTestRenderer.create(<GroundPlane />);
+    const mesh = rendered.scene.children[0];
+    await rendered.fireEvent(mesh, 'click', { delta: 0.1 });
+    expect(mockHandleAddWidget).toBeCalled();
+  });
+});

--- a/packages/scene-composer/src/components/three-fiber/GroundPlane.tsx
+++ b/packages/scene-composer/src/components/three-fiber/GroundPlane.tsx
@@ -1,0 +1,93 @@
+import * as THREE from 'three';
+import React, { useRef, useEffect, useState } from 'react';
+import { ThreeEvent, useFrame } from '@react-three/fiber';
+import { Plane } from '@react-three/drei';
+
+import { IGroundPlaneSettings, KnownSceneProperty } from '../../interfaces';
+import { useSceneComposerId } from '../../common/sceneComposerIdContext';
+import useAddWidget from '../../hooks/useAddWidget';
+import useMatterportViewer from '../../hooks/useMatterportViewer';
+import useTwinMakerTextureLoader from '../../hooks/useTwinMakerTextureLoader';
+import { useEditorState, useStore } from '../../store';
+import { acceleratedRaycasting } from '../../utils/objectThreeUtils';
+
+const GroundPlane: React.FC = () => {
+  const meshRef = useRef<THREE.Mesh>();
+  const sceneComposerId = useSceneComposerId();
+  const { isEditing, addingWidget } = useEditorState(sceneComposerId);
+  const { handleAddWidget } = useAddWidget();
+  const { loadTextureOnMesh, clearTextureOnMesh } = useTwinMakerTextureLoader();
+  const groundPlaneSettings = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty<IGroundPlaneSettings>(KnownSceneProperty.GroundPlaneSettings),
+  );
+  const { enableMatterportViewer } = useMatterportViewer();
+
+  const [meshId, setMeshId] = useState('');
+  const [dirtyTexture, setDirtyTexture] = useState(false);
+
+  const MAX_CLICK_DISTANCE = 2;
+
+  const onClick = (e: ThreeEvent<MouseEvent>) => {
+    if (e.delta <= MAX_CLICK_DISTANCE) {
+      if (isEditing() && addingWidget) {
+        handleAddWidget(e);
+      }
+    }
+  };
+
+  useFrame(() => {
+    if (meshRef.current && meshRef.current.uuid !== meshId) {
+      acceleratedRaycasting(meshRef.current);
+      setMeshId(meshRef.current.uuid);
+    }
+    if (meshRef.current?.material && dirtyTexture) {
+      if (groundPlaneSettings?.textureUri) {
+        loadTextureOnMesh(groundPlaneSettings.textureUri, meshRef.current);
+      }
+      setDirtyTexture(false);
+    }
+  });
+
+  useEffect(() => {
+    if (meshRef.current?.material) {
+      if (groundPlaneSettings?.textureUri) {
+        loadTextureOnMesh(groundPlaneSettings.textureUri, meshRef.current);
+      } else {
+        clearTextureOnMesh(meshRef.current);
+      }
+    } else if (groundPlaneSettings?.textureUri && !!loadTextureOnMesh) {
+      setDirtyTexture(true);
+    }
+  }, [meshRef.current, groundPlaneSettings?.textureUri, loadTextureOnMesh, clearTextureOnMesh]);
+
+  return groundPlaneSettings ? (
+    <Plane
+      name='Ground'
+      rotation={[THREE.MathUtils.degToRad(270), 0, 0]}
+      args={[1000, 1000]}
+      ref={meshRef}
+      onClick={onClick}
+      renderOrder={enableMatterportViewer ? 1 : undefined}
+    >
+      <meshStandardMaterial
+        color={groundPlaneSettings.color ? groundPlaneSettings.color : undefined}
+        side={THREE.DoubleSide}
+        transparent={groundPlaneSettings.opacity !== 1 ? true : false}
+        opacity={groundPlaneSettings.opacity}
+      />
+    </Plane>
+  ) : isEditing() ? (
+    <Plane
+      name='Ground'
+      rotation={[THREE.MathUtils.degToRad(270), 0, 0]}
+      args={[1000, 1000]}
+      ref={meshRef}
+      onClick={onClick}
+      renderOrder={enableMatterportViewer ? 1 : undefined}
+    >
+      <meshBasicMaterial transparent={true} opacity={0} side={THREE.DoubleSide} />
+    </Plane>
+  ) : null;
+};
+
+export default GroundPlane;

--- a/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.spec.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.spec.tsx
@@ -1,8 +1,8 @@
 import React, { useRef } from 'react';
 import { render } from '@testing-library/react';
 import ReactThreeTestRenderer from '@react-three/test-renderer';
-import { Scene, Camera, Mesh, Texture, MeshStandardMaterial } from 'three';
-import { useThree, useFrame } from '@react-three/fiber';
+import { Mesh, Texture, MeshStandardMaterial } from 'three';
+import { useFrame } from '@react-three/fiber';
 jest.useFakeTimers();
 
 import { KnownComponentType } from '../../../interfaces';
@@ -28,7 +28,6 @@ jest.mock('@react-three/fiber', () => {
   const originalModule = jest.requireActual('@react-three/fiber');
   return {
     ...originalModule,
-    useThree: jest.fn(),
     useFrame: jest.fn(),
   };
 });
@@ -72,11 +71,6 @@ jest.mock('../../../store/', () => ({
 const mockHandleAddWidget = jest.fn();
 
 describe('PlaneGeometryComponent', () => {
-  const mockThreeStates = {
-    camera: new Camera(),
-    scene: new Scene(),
-  };
-
   const baseNode: ISceneNodeInternal = {
     ref: 'mock-node',
     name: 'mock-node',
@@ -112,7 +106,6 @@ describe('PlaneGeometryComponent', () => {
 
   const setup = () => {
     jest.resetAllMocks();
-    (useThree as jest.Mock).mockReturnValue(mockThreeStates);
     (useFrame as jest.Mock).mockImplementation((cb) => cb());
     (useTwinMakerTextureLoader as jest.Mock).mockImplementation(() => ({
       loadTextureOnMesh: mockLoadTexture,

--- a/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/PlaneGeometryComponent.tsx
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import React, { useRef, useEffect, useState } from 'react';
-import { createPortal, ThreeEvent, useFrame, useThree } from '@react-three/fiber';
+import { ThreeEvent, useFrame } from '@react-three/fiber';
 import { Plane } from '@react-three/drei';
 
 import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
@@ -23,8 +23,6 @@ const PlaneGeometryComponent: React.FC<PlaneGeometryComponentProps> = ({
   const { isEditing, addingWidget } = useEditorState(sceneComposerId);
   const { handleAddWidget } = useAddWidget();
   const { loadTextureOnMesh, clearTextureOnMesh } = useTwinMakerTextureLoader();
-  const scene = useThree((state) => state.scene);
-  const camera = useThree((state) => state.camera);
   const [meshId, setMeshId] = useState('');
   const [dirtyTexture, setDirtyTexture] = useState(false);
 
@@ -61,33 +59,12 @@ const PlaneGeometryComponent: React.FC<PlaneGeometryComponentProps> = ({
     } else if (component.textureUri && !!loadTextureOnMesh) {
       setDirtyTexture(true);
     }
-  }, [meshId, component.textureUri, loadTextureOnMesh, clearTextureOnMesh]);
+  }, [component.textureUri, loadTextureOnMesh, clearTextureOnMesh]);
 
-  return component.isGroundPlane ? (
-    createPortal(
-      <group
-        name={getComponentGroupName(node.ref, 'PLANE_GEOMETRY')}
-        parent={scene}
-        position={node.transform.position}
-        rotation={new THREE.Euler(...node.transform.rotation, 'XYZ')}
-        scale={node.transform.scale}
-      >
-        <Plane
-          args={[component.width, component.height]}
-          ref={meshRef}
-          onClick={onClick}
-          userData={{ nodeRef: node.ref }}
-        >
-          <meshStandardMaterial color={component.color ? component.color : 'undefined'} side={THREE.DoubleSide} />
-        </Plane>
-      </group>,
-      scene,
-      { camera },
-    )
-  ) : (
+  return (
     <group name={getComponentGroupName(node.ref, 'PLANE_GEOMETRY')}>
       <Plane args={[component.width, component.height]} ref={meshRef} onClick={onClick}>
-        <meshStandardMaterial color={component.color ? component.color : 'undefined'} />
+        <meshStandardMaterial color={component.color ? component.color : undefined} />
       </Plane>
     </group>
   );

--- a/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/__snapshots__/PlaneGeometryComponent.spec.tsx.snap
+++ b/packages/scene-composer/src/components/three-fiber/ModelGeometryComponents/__snapshots__/PlaneGeometryComponent.spec.tsx.snap
@@ -8,9 +8,7 @@ exports[`PlaneGeometryComponent should render 1`] = `
         args="10,20"
         attach="geometry"
       />
-      <meshstandardmaterial
-        color="undefined"
-      />
+      <meshstandardmaterial />
     </mesh>
   </group>
 </div>

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -16,7 +16,6 @@ import {
   ISceneNode,
   KnownComponentType,
   SceneResourceType,
-  IPlaneGeometryComponent,
 } from '../../../../interfaces';
 import { sceneComposerIdContext } from '../../../../common/sceneComposerIdContext';
 import { Component, LightType, ModelType } from '../../../../models/SceneModels';
@@ -44,7 +43,6 @@ enum ObjectTypes {
   Light = 'add-object-light',
   ViewCamera = 'add-object-view-camera',
   Annotation = 'add-object-annotation',
-  GroundPlane = 'add-object-ground-plane',
 }
 
 type AddObjectMenuItem = ToolbarItemOptions & {
@@ -62,7 +60,6 @@ const labelStrings: { [key in ObjectTypes]: MessageDescriptor } = defineMessages
   [ObjectTypes.MotionIndicator]: { defaultMessage: 'Motion indicator', description: 'Menu Item label' },
   [ObjectTypes.ViewCamera]: { defaultMessage: 'Camera', description: 'Menu Item label' },
   [ObjectTypes.Annotation]: { defaultMessage: 'Annotation', description: 'Menu Item label' },
-  [ObjectTypes.GroundPlane]: { defaultMessage: 'Ground Plane', description: 'Menu Item label' },
 });
 
 const textStrings = defineMessages({
@@ -75,7 +72,6 @@ const textStrings = defineMessages({
   [ObjectTypes.MotionIndicator]: { defaultMessage: 'Add motion indicator', description: 'Menu Item' },
   [ObjectTypes.ViewCamera]: { defaultMessage: 'Add camera from current view', description: 'Menu Item' },
   [ObjectTypes.Annotation]: { defaultMessage: 'Add annotation', description: 'Menu Item' },
-  [ObjectTypes.GroundPlane]: { defaultMessage: 'Add ground plane', description: 'Menu Item' },
 });
 
 interface AddObjectMenuProps {
@@ -168,10 +164,6 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
         },
         {
           uuid: ObjectTypes.MotionIndicator,
-        },
-        {
-          uuid: ObjectTypes.GroundPlane,
-          feature: { name: COMPOSER_FEATURES.SceneAppearance },
         },
       ].map(mapToMenuItem),
     [
@@ -314,28 +306,6 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
     }
   };
 
-  const handleAddGroundPlane = () => {
-    const planeComponent: IPlaneGeometryComponent = {
-      type: 'PlaneGeometry',
-      width: 1000,
-      height: 1000,
-      color: 'green',
-      isGroundPlane: true,
-    };
-    const node = {
-      name: 'Ground Plane',
-      components: [planeComponent],
-      parentRef: undefined, //force to root
-    } as unknown as ISceneNodeInternal;
-    const newNode = createNodeWithTransform(
-      node,
-      new THREE.Vector3(0, -0.001, 0), //position
-      new THREE.Euler(Math.PI / 2, 0, 0), //rotation on X 90 degrees to place in X-Z plane instead of X-Y plane
-      new THREE.Vector3(1, 1, 1), //scale
-    );
-    appendSceneNode(newNode);
-  };
-
   const handleAddMotionIndicator = () => {
     const motionIndicatorComponent: IMotionIndicatorComponent = {
       type: 'MotionIndicator',
@@ -421,9 +391,6 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
             break;
           case ObjectTypes.Annotation:
             handleAddOverlay(Component.DataOverlaySubType.TextAnnotation);
-            break;
-          case ObjectTypes.GroundPlane:
-            handleAddGroundPlane();
             break;
         }
 

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -75,10 +75,12 @@ export enum KnownSceneProperty {
   TagCustomColors = 'tagCustomColors',
   FogSettings = 'fogSettings',
   SceneBackgroundSettings = 'sceneBackgroundSettings',
+  GroundPlaneSettings = 'groundPlaneSettings',
   FogCustomColors = 'fogCustomColors',
   BackgroundCustomColors = 'backgroundCustomColors',
   LayerDefaultRefreshInterval = 'layerDefaultRefreshInterval',
   GeometryCustomColors = 'geometryCustomColors',
+  GroundCustomColors = 'groundCustomColors,',
 }
 
 /************************************************
@@ -157,4 +159,10 @@ export interface IFogSettings {
 export interface ISceneBackgroundSetting {
   color?: string;
   textureUri?: string;
+}
+
+export interface IGroundPlaneSettings {
+  color?: string;
+  textureUri?: string;
+  opacity: number;
 }

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -285,6 +285,5 @@ export namespace Component {
     height: number;
     color?: string;
     textureUri?: string;
-    isGroundPlane?: boolean;
   }
 }

--- a/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.spec.ts
@@ -25,7 +25,6 @@ const texturedGroundPlane: IPlaneGeometryComponent = {
   width: 10,
   height: 20,
   textureUri: 'filepath',
-  isGroundPlane: true,
 };
 
 describe('createPlaneGeometryEntityComponent', () => {
@@ -87,11 +86,6 @@ describe('createPlaneGeometryEntityComponent', () => {
         textureUri: {
           value: {
             stringValue: 'filepath',
-          },
-        },
-        isGroundPlane: {
-          value: {
-            booleanValue: true,
           },
         },
       },
@@ -159,11 +153,6 @@ describe('createPlaneGeometryEntityComponent', () => {
               stringValue: 'filepath',
             },
           },
-          isGroundPlane: {
-            value: {
-              booleanValue: true,
-            },
-          },
         }),
       });
     });
@@ -229,10 +218,6 @@ describe('createPlaneGeometryEntityComponent', () => {
             {
               propertyName: 'textureUri',
               propertyValue: 'filepath',
-            },
-            {
-              propertyName: 'isGroundPlane',
-              propertyValue: true,
             },
           ],
         }),

--- a/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/planeGeometryComponent.ts
@@ -11,7 +11,6 @@ enum PlaneGeometryComponentProperty {
   Height = 'height',
   Color = 'color',
   TextureUri = 'textureUri',
-  IsGroundPlane = 'isGroundPlane',
 }
 
 export const createPlaneGeometryEntityComponent = (geometry: IPlaneGeometryComponent): ComponentRequest => {
@@ -42,13 +41,6 @@ export const createPlaneGeometryEntityComponent = (geometry: IPlaneGeometryCompo
     comp.properties![PlaneGeometryComponentProperty.TextureUri] = {
       value: {
         stringValue: geometry.textureUri,
-      },
-    };
-  }
-  if (geometry.isGroundPlane) {
-    comp.properties![PlaneGeometryComponentProperty.IsGroundPlane] = {
-      value: {
-        booleanValue: geometry.isGroundPlane,
       },
     };
   }
@@ -83,9 +75,6 @@ export const parsePlaneGeometryComp = (geometry: DocumentType): IPlaneGeometryCo
       ?.propertyValue,
     textureUri: geometry?.['properties'].find((mp) => mp['propertyName'] === PlaneGeometryComponentProperty.TextureUri)
       ?.propertyValue,
-    isGroundPlane: geometry?.['properties'].find(
-      (mp) => mp['propertyName'] === PlaneGeometryComponentProperty.IsGroundPlane,
-    )?.propertyValue,
   };
   return planeGeometryComponent;
 };

--- a/packages/scene-composer/stories/components/scene-composer.tsx
+++ b/packages/scene-composer/stories/components/scene-composer.tsx
@@ -132,7 +132,7 @@ const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
   const mockAssetBrowserCallback: ShowAssetBrowserCallback = useCallback(
     (cb: AssetBrowserResultCallback) => {
       actionRecorderShowAssetBrowserCallback(cb);
-      if (source == 'local') {
+      if (source === 'local') {
         cb(null, 'PALLET_JACK.glb');
       } else {
         cb(null, 'CookieFactoryMixer.glb'); // Update the string to a model available in your S3 bucket

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -455,6 +455,10 @@
     "note": "Placeholder",
     "text": "Choose a speed value"
   },
+  "KCtA9Z": {
+    "note": "Form Field label",
+    "text": "Opacity %"
+  },
   "Kchdc4": {
     "note": "Placeholder",
     "text": "Choose a rule"
@@ -519,10 +523,6 @@
     "note": "Form field errorText",
     "text": "FOV cannot be less than 10"
   },
-  "NZvDHt": {
-    "note": "checkbox label",
-    "text": "Enable Fog"
-  },
   "Nj6Ob1": {
     "note": "Select Color type option",
     "text": "Define arrow color"
@@ -538,6 +538,10 @@
   "OUX68J": {
     "note": "Menu Item",
     "text": "Pan"
+  },
+  "OgfeEl": {
+    "note": "Toggle label",
+    "text": "Enable Fog"
   },
   "OpGIbY": {
     "note": "Scene Icon types in a dropdown menu",
@@ -634,10 +638,6 @@
   "T1kJTq": {
     "note": "label",
     "text": "Select color"
-  },
-  "TWQfaz": {
-    "note": "checkbox label",
-    "text": "Enable Background"
   },
   "TZDmnV": {
     "note": "label for when the user searches for a nonexistent animation",
@@ -931,6 +931,10 @@
     "note": "Button text for color opacity percentage",
     "text": "Opacity : {opacityPercentage, number, percent}"
   },
+  "k0JbYO": {
+    "note": "Form Field label",
+    "text": "Scene Background"
+  },
   "k5xCpx": {
     "note": "Form field label",
     "text": "FOV"
@@ -1019,10 +1023,6 @@
     "note": "select box option text value",
     "text": "Receive Shadow"
   },
-  "nml2b0": {
-    "note": "Menu Item label",
-    "text": "Ground Plane"
-  },
   "nwQbTY": {
     "note": "Icon name label",
     "text": "Video icon"
@@ -1098,10 +1098,6 @@
   "rBzizm": {
     "note": "label",
     "text": "Add speed rule"
-  },
-  "rC/6uY": {
-    "note": "Menu Item",
-    "text": "Add ground plane"
   },
   "rDIRVn": {
     "note": "Menu Item label",


### PR DESCRIPTION
## Overview
1. Move Add ground plane to Scene Settings
2. instead add/remove with ground plane Toggle
3. Swap Enable Fog, to toggle instead
4. remove enable background - always on but with default color 
5. For implementation the ground plane not a toggle, - add transparency and default to a color and 100% transparency so not visible until edited.
6. Ground plane is NOT visible in scene hierarchy
7. Ground plane is edited in Scene Settings NOT node inspector and can set Color, Texture, Transparency. It can't be resized anymore
8. Clicking the ground plane does NOT parent an item to it, instead it parents to the scene root

## Verifying Changes


https://github.com/awslabs/iot-app-kit/assets/109186219/f15e1658-7eb6-4dee-bf33-2ff2a6c929ef



### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
