### PR TITLE
revert: "perf: increase batch size"

### DIFF
--- a/packages/source-iotsitewise/src/time-series-data/client/batch.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batch.spec.ts
@@ -1,32 +1,36 @@
-import { createEntryBatches, shouldFetchNextBatch } from './batch';
+import {
+  createEntryBatches,
+  calculateNextBatchSize,
+  shouldFetchNextBatch,
+  MAX_BATCH_RESULTS,
+  MAX_BATCH_ENTRIES,
+  NO_LIMIT_BATCH,
+} from './batch';
 
 describe('createEntryBatches', () => {
   it('buckets entries by maxResults for a given batch', () => {
-    const batches = createEntryBatches(
-      [
-        {
-          id: '1',
-          maxResults: undefined,
-        },
-        {
-          id: '2',
-          maxResults: 2000,
-        },
-        {
-          id: '3',
-          maxResults: 2000,
-        },
-        {
-          id: '4',
-          maxResults: 10,
-        },
-        {
-          id: '5',
-          maxResults: 2000,
-        },
-      ],
-      16
-    );
+    const batches = createEntryBatches([
+      {
+        id: '1',
+        maxResults: undefined,
+      },
+      {
+        id: '2',
+        maxResults: 2000,
+      },
+      {
+        id: '3',
+        maxResults: 2000,
+      },
+      {
+        id: '4',
+        maxResults: 10,
+      },
+      {
+        id: '5',
+        maxResults: 2000,
+      },
+    ]);
 
     expect(batches).toEqual(
       expect.arrayContaining([
@@ -37,7 +41,7 @@ describe('createEntryBatches', () => {
               maxResults: undefined,
             },
           ],
-          -1,
+          NO_LIMIT_BATCH,
         ],
         [
           [
@@ -54,7 +58,7 @@ describe('createEntryBatches', () => {
               maxResults: 2000,
             },
           ],
-          2000,
+          6000,
         ],
         [
           [
@@ -69,12 +73,11 @@ describe('createEntryBatches', () => {
     );
   });
 
-  it('chunks batches that exceed max batch size', () => {
+  it('chunks batches that exceed max entry size (16)', () => {
     const entrySize = 2000;
-    const batchSize = 16;
 
     const entries = [
-      ...[...Array(batchSize * 3)].map((_args, index) => ({
+      ...[...Array(MAX_BATCH_ENTRIES * 3)].map((_args, index) => ({
         id: String(index),
         maxResults: entrySize,
       })),
@@ -84,30 +87,63 @@ describe('createEntryBatches', () => {
       },
     ];
 
-    const batches = createEntryBatches(entries, 16);
+    const batches = createEntryBatches(entries);
 
     expect(batches).toEqual(
       expect.arrayContaining([
-        [entries.slice(0, batchSize), entrySize],
-        [entries.slice(batchSize, 2 * batchSize), entrySize],
-        [entries.slice(batchSize * 2, batchSize * 3), entrySize],
-        [[entries[batchSize * 3]], 10],
+        [entries.slice(0, MAX_BATCH_ENTRIES), MAX_BATCH_ENTRIES * entrySize],
+        [entries.slice(MAX_BATCH_ENTRIES, 2 * MAX_BATCH_ENTRIES), MAX_BATCH_ENTRIES * entrySize],
+        [entries.slice(MAX_BATCH_ENTRIES * 2, MAX_BATCH_ENTRIES * 3), MAX_BATCH_ENTRIES * entrySize],
+        [[entries[MAX_BATCH_ENTRIES * 3]], 10],
       ])
     );
   });
 
   it('handles empty input', () => {
-    const batches = createEntryBatches([], 16);
+    const batches = createEntryBatches([]);
     expect(batches).toEqual([]);
   });
 });
 
+describe('calculateNextBatchSize', () => {
+  it('returns the correct max batch size for no limit batches', () => {
+    expect(calculateNextBatchSize({ maxResults: NO_LIMIT_BATCH, dataPointsFetched: 0 })).toBe(MAX_BATCH_RESULTS);
+    expect(calculateNextBatchSize({ maxResults: NO_LIMIT_BATCH, dataPointsFetched: 100000 })).toBe(MAX_BATCH_RESULTS);
+  });
+
+  it('returns the correct max batch size when specified and need to fetch more than MAX_BATCH_SIZE', () => {
+    expect(calculateNextBatchSize({ maxResults: MAX_BATCH_RESULTS * 3, dataPointsFetched: 0 })).toBe(MAX_BATCH_RESULTS);
+  });
+
+  it('returns the correct max batch size when specified and need to fetch less than MAX_BATCH SIZE', () => {
+    expect(calculateNextBatchSize({ maxResults: MAX_BATCH_RESULTS / 2, dataPointsFetched: 0 })).toBe(
+      MAX_BATCH_RESULTS / 2
+    );
+    expect(calculateNextBatchSize({ maxResults: MAX_BATCH_RESULTS, dataPointsFetched: MAX_BATCH_RESULTS / 2 })).toBe(
+      MAX_BATCH_RESULTS / 2
+    );
+  });
+});
+
 describe('shouldFetchNextBatch', () => {
-  it('returns true if next token exists', () => {
-    expect(shouldFetchNextBatch({ nextToken: '123' })).toBe(true);
+  it('returns true if next token exists and batch has no limit', () => {
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: NO_LIMIT_BATCH, dataPointsFetched: 0 })).toBe(true);
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: NO_LIMIT_BATCH, dataPointsFetched: 500000 })).toBe(
+      true
+    );
+  });
+
+  it('returns true if next token exists and there is still data that needs to be fetched', () => {
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 3000, dataPointsFetched: 0 })).toBe(true);
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 10000, dataPointsFetched: 9999 })).toBe(true);
+  });
+
+  it('returns false if next token exists but data points have already been fetched', () => {
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 3000, dataPointsFetched: 3000 })).toBe(false);
+    expect(shouldFetchNextBatch({ nextToken: '123', maxResults: 0, dataPointsFetched: 0 })).toBe(false);
   });
 
   it('returns false if next token does not exist', () => {
-    expect(shouldFetchNextBatch({ nextToken: undefined })).toBe(false);
+    expect(shouldFetchNextBatch({ nextToken: undefined, maxResults: 3000, dataPointsFetched: 0 })).toBe(false);
   });
 });

--- a/packages/source-iotsitewise/src/time-series-data/client/batch.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batch.ts
@@ -1,8 +1,8 @@
 // current maximum batch size when using batch APIs
-// export const MAX_BATCH_RESULTS = 4000;
+export const MAX_BATCH_RESULTS = 4000;
 
 // current batch API entry limit
-// export const MAX_BATCH_ENTRIES = 16;
+export const MAX_BATCH_ENTRIES = 16;
 
 // use -1 to represent a batch with no max result limit
 export const NO_LIMIT_BATCH = -1;
@@ -14,10 +14,7 @@ export const NO_LIMIT_BATCH = -1;
  * @param entries
  * @returns buckets: [BatchHistoricalEntry[], number | undefined][]
  */
-export const createEntryBatches = <T extends { maxResults?: number }>(
-  entries: T[],
-  batchSize: number
-): [T[], number][] => {
+export const createEntryBatches = <T extends { maxResults?: number }>(entries: T[]): [T[], number][] => {
   const buckets: { [key: number]: T[] } = {};
 
   entries.forEach((entry) => {
@@ -30,29 +27,55 @@ export const createEntryBatches = <T extends { maxResults?: number }>(
     }
   });
 
+  // chunk buckets that are larger than MAX_BATCH_ENTRIES
   return Object.keys(buckets)
     .map((key) => {
       const maxEntryResults = Number(key);
       const bucket = buckets[maxEntryResults];
 
-      return chunkBatch(bucket, batchSize).map((chunk): [T[], number] => [chunk, maxEntryResults]);
+      return chunkBatch(bucket).map((chunk): [T[], number] => [
+        chunk,
+        maxEntryResults === NO_LIMIT_BATCH ? NO_LIMIT_BATCH : chunk.length * maxEntryResults,
+      ]);
     })
     .flat();
 };
 
 /**
+ * calculate the required size of the next batch
+ */
+export const calculateNextBatchSize = ({
+  maxResults,
+  dataPointsFetched,
+}: {
+  maxResults: number;
+  dataPointsFetched: number;
+}) => (maxResults === NO_LIMIT_BATCH ? MAX_BATCH_RESULTS : Math.min(maxResults - dataPointsFetched, MAX_BATCH_RESULTS));
+
+/**
  * check if batch still needs to be paginated.
  */
-export const shouldFetchNextBatch = ({ nextToken }: { nextToken: string | undefined }) => !!nextToken;
+export const shouldFetchNextBatch = ({
+  nextToken,
+  maxResults,
+  dataPointsFetched,
+}: {
+  nextToken: string | undefined;
+  maxResults: number;
+  dataPointsFetched?: number;
+}) =>
+  !!nextToken &&
+  (maxResults === NO_LIMIT_BATCH ||
+    (dataPointsFetched !== null && dataPointsFetched !== undefined && dataPointsFetched < maxResults));
 
 /**
  * chunk batches by MAX_BATCH_ENTRIES
  */
-const chunkBatch = <T>(batch: T[], batchSize: number): T[][] => {
+const chunkBatch = <T>(batch: T[]): T[][] => {
   const chunks = [];
 
-  for (let i = 0; i < batch.length; i += batchSize) {
-    chunks.push(batch.slice(i, i + batchSize));
+  for (let i = 0; i < batch.length; i += MAX_BATCH_ENTRIES) {
+    chunks.push(batch.slice(i, i + MAX_BATCH_ENTRIES));
   }
 
   return chunks;

--- a/packages/source-iotsitewise/src/time-series-data/client/client.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/client.spec.ts
@@ -8,6 +8,7 @@ import {
   BATCH_ASSET_PROPERTY_AGGREGATES,
 } from '../../__mocks__/assetPropertyValue';
 import { toId } from '../util/dataStreamId';
+import { MAX_BATCH_RESULTS } from './batch';
 import flushPromises from 'flush-promises';
 import { HOUR_IN_MS } from '../util/timeConstants';
 import { createMockSiteWiseSDK } from '@iot-app-kit/testing-util';
@@ -57,8 +58,7 @@ describe('getHistoricalPropertyDataPoints', () => {
   it('batches and paginates', async () => {
     const batchGetAssetPropertyValueHistory = jest
       .fn()
-      .mockResolvedValueOnce({ ...BATCH_ASSET_PROPERTY_VALUE_HISTORY, nextToken: 'nextToken' })
-      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_VALUE_HISTORY });
+      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_VALUE_HISTORY, nextToken: 'nextToken' });
     const assetId1 = 'some-asset-id-1';
     const propertyId1 = 'some-property-id-1';
 
@@ -94,11 +94,13 @@ describe('getHistoricalPropertyDataPoints', () => {
       requestInformations: [requestInformation1],
       onSuccess,
       onError,
+      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
     client.getHistoricalPropertyDataPoints({
       requestInformations: [requestInformation2],
       onSuccess,
       onError,
+      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
 
     await flushPromises();
@@ -209,6 +211,7 @@ describe('getHistoricalPropertyDataPoints', () => {
       requestInformations: [requestInformation1],
       onSuccess,
       onError,
+      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
 
     await flushPromises();
@@ -538,8 +541,7 @@ describe('getAggregatedPropertyDataPoints', () => {
   it('batches and paginates', async () => {
     const batchGetAssetPropertyAggregates = jest
       .fn()
-      .mockResolvedValueOnce({ ...BATCH_ASSET_PROPERTY_AGGREGATES, nextToken: 'nextToken' })
-      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_AGGREGATES });
+      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_AGGREGATES, nextToken: 'nextToken' });
     const assetId1 = 'some-asset-id-1';
     const propertyId1 = 'some-property-id-1';
 
@@ -578,11 +580,13 @@ describe('getAggregatedPropertyDataPoints', () => {
       requestInformations: [requestInformation1],
       onSuccess,
       onError,
+      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
     client.getAggregatedPropertyDataPoints({
       requestInformations: [requestInformation2],
       onSuccess,
       onError,
+      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
 
     await flushPromises();
@@ -712,6 +716,7 @@ describe('getAggregatedPropertyDataPoints', () => {
       requestInformations: [requestInformation1],
       onSuccess,
       onError,
+      maxResults: MAX_BATCH_RESULTS, // ensure pagination happens exactly once
     });
 
     await flushPromises();

--- a/packages/source-iotsitewise/src/time-series-data/client/client.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/client.ts
@@ -14,12 +14,14 @@ export type LatestPropertyParams = {
 
 export type HistoricalPropertyParams = {
   requestInformations: RequestInformationAndRange[];
+  maxResults?: number;
   onError: ErrorCallback;
   onSuccess: OnSuccessCallback;
 };
 
 export type AggregatedPropertyParams = {
   requestInformations: RequestInformationAndRange[];
+  maxResults?: number;
   onError: ErrorCallback;
   onSuccess: OnSuccessCallback;
 };


### PR DESCRIPTION
This reverts commit 15a6e6ad8b861384775e96616a985a0074d6a379.

## Overview
This change is being reverted as it introduced an infinite pagination bug for the bar chart and status timeline components. The bug-free optimization will come in a separate PR.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
