### PR TITLE
fix(ResourceExplorer): filter out invalid twinmaker execute query sea…

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/dataStreamSearch/queryResponseProcessor.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/dataStreamSearch/queryResponseProcessor.ts
@@ -25,15 +25,14 @@ export class QueryResponseProcessor {
   static #convertResponseToModeledDataStreams(
     rows: NonNullable<ExecuteQueryCommandOutput['rows']>
   ): ModeledDataStream[] {
-    const modeledDataStreams = rows.map((row) => {
-      const rowAsModel: Model = row.rowData as unknown as Model;
-
-      const modeledDataStream = this.#convertRowToModeledDataStream(rowAsModel);
-
-      return modeledDataStream;
-    });
-
-    return modeledDataStreams;
+    return (
+      rows
+        // Filter out any invalid rows. Situation has occured where `null` was being returned for propertyId and propertyName which causes downstream bugs.
+        .filter(
+          (row) => row.rowData && row.rowData.length === 4 && row.rowData.every((cell) => typeof cell === 'string')
+        )
+        .map((row) => this.#convertRowToModeledDataStream(row.rowData as Model))
+    );
   }
 
   static #convertRowToModeledDataStream(rowData: Model): ModeledDataStream {


### PR DESCRIPTION
Twinmaker execute query API (https://docs.aws.amazon.com/iot-twinmaker/latest/apireference/API_ExecuteQuery.html) returns `null` for propertyId and propertyName in certain edge cases (likely an issue with asset sync and expired assets from the demo windmill assets.

This ends up causing blank rows appear on the resource explorer, and repeated failures in attempt to fetch latest value to display on the resource explorer.

This fix addresses it by filtering out invalid responses from the ExecuteQuery