### PR TITLE
feat(ResourceExplorer):  hide properties table when not needed to be displayed

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -147,7 +147,7 @@ export function ModeledDataStreamTable({
       stickyColumns={preferences.stickyColumns}
       isItemDisabled={(item) => isInValidProperty(item.dataType, selectedWidgets?.at(0)?.type)}
       empty={<ModeledDataStreamTableEmptyState isAssetSelected={selectedAsset != null} />}
-      filter={<ModeledDataStreamTablePropertyFilter {...propertyFilterProps} />}
+      filter={modeledDataStreams.length > 0 && <ModeledDataStreamTablePropertyFilter {...propertyFilterProps} />}
       header={
         <ModeledDataStreamTableHeader
           selectedItemCount={collectionProps.selectedItems?.length}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTablePropertyFilter.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTablePropertyFilter.tsx
@@ -44,43 +44,46 @@ type ModeledDataStreamPropertyFilterProps = Omit<PropertyFilterProps, 'i18nStrin
 
 export function ModeledDataStreamTablePropertyFilter(props: ModeledDataStreamPropertyFilterProps) {
   return (
-    <PropertyFilter
-      {...props}
-      filteringLoadingText='Loading suggestions'
-      filteringErrorText='Error fetching suggestions.'
-      filteringRecoveryText='Retry'
-      filteringFinishedText='End of results'
-      filteringEmpty='No suggestions found'
-      i18nStrings={{
-        filteringAriaLabel: 'Filter modeled data streams by text, property, or value',
-        dismissAriaLabel: 'Dismiss',
-        filteringPlaceholder: 'Filter modeled data streams by text, property, or value',
-        groupValuesText: 'Values',
-        groupPropertiesText: 'Properties',
-        operatorsText: 'Operators',
-        operationAndText: 'and',
-        operationOrText: 'or',
-        operatorLessText: 'Less than',
-        operatorLessOrEqualText: 'Less than or equal',
-        operatorGreaterText: 'Greater than',
-        operatorGreaterOrEqualText: 'Greater than or equal',
-        operatorContainsText: 'Contains',
-        operatorDoesNotContainText: 'Does not contain',
-        operatorEqualsText: 'Equals',
-        operatorDoesNotEqualText: 'Does not equal',
-        editTokenHeader: 'Edit filter',
-        propertyText: 'Property',
-        operatorText: 'Operator',
-        valueText: 'Value',
-        cancelActionText: 'Cancel',
-        applyActionText: 'Apply',
-        allPropertiesLabel: 'All properties',
-        tokenLimitShowMore: 'Show more',
-        tokenLimitShowFewer: 'Show fewer',
-        clearFiltersText: 'Clear filters',
-        removeTokenButtonAriaLabel: (token) => `Remove token ${token.propertyKey} ${token.operator} ${token.value}`,
-        enteredTextLabel: (text) => `Use: "${text}"`,
-      }}
-    />
+    <>
+      <strong>Filter by:</strong>
+      <PropertyFilter
+        {...props}
+        filteringLoadingText='Loading suggestions'
+        filteringErrorText='Error fetching suggestions.'
+        filteringRecoveryText='Retry'
+        filteringFinishedText='End of results'
+        filteringEmpty='No suggestions found'
+        i18nStrings={{
+          filteringAriaLabel: 'Filter modeled data streams by text, property, or value',
+          dismissAriaLabel: 'Dismiss',
+          filteringPlaceholder: 'Filter modeled data streams by text, property, or value',
+          groupValuesText: 'Values',
+          groupPropertiesText: 'Properties',
+          operatorsText: 'Operators',
+          operationAndText: 'and',
+          operationOrText: 'or',
+          operatorLessText: 'Less than',
+          operatorLessOrEqualText: 'Less than or equal',
+          operatorGreaterText: 'Greater than',
+          operatorGreaterOrEqualText: 'Greater than or equal',
+          operatorContainsText: 'Contains',
+          operatorDoesNotContainText: 'Does not contain',
+          operatorEqualsText: 'Equals',
+          operatorDoesNotEqualText: 'Does not equal',
+          editTokenHeader: 'Edit filter',
+          propertyText: 'Property',
+          operatorText: 'Operator',
+          valueText: 'Value',
+          cancelActionText: 'Cancel',
+          applyActionText: 'Apply',
+          allPropertiesLabel: 'All properties',
+          tokenLimitShowMore: 'Show more',
+          tokenLimitShowFewer: 'Show fewer',
+          clearFiltersText: 'Clear filters',
+          removeTokenButtonAriaLabel: (token) => `Remove token ${token.propertyKey} ${token.operator} ${token.value}`,
+          enteredTextLabel: (text) => `Use: "${text}"`,
+        }}
+      />
+    </>
   );
 }

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamQueryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamQueryEditor.tsx
@@ -52,29 +52,34 @@ export function ModeledDataStreamQueryEditor({
       {selectedSegment === BROWSE_SEGMENT_ID ? (
         <>
           <AssetExplorer client={iotSiteWiseClient} onSelect={handleOnSelectAsset} />
-          <ModeledDataStreamExplorer
-            client={iotSiteWiseClient}
-            onClickAddModeledDataStreams={onClickAdd}
-            selectedAsset={
-              selectedAsset?.id && selectedAsset?.assetModelId
-                ? { assetId: selectedAsset.id, assetModelId: selectedAsset.assetModelId }
-                : undefined
-            }
-          />
+          <br />
+          {selectedAsset != null && (
+            <ModeledDataStreamExplorer
+              client={iotSiteWiseClient}
+              onClickAddModeledDataStreams={onClickAdd}
+              selectedAsset={
+                selectedAsset?.id && selectedAsset?.assetModelId
+                  ? { assetId: selectedAsset.id, assetModelId: selectedAsset.assetModelId }
+                  : undefined
+              }
+            />
+          )}
         </>
       ) : (
         <>
           <DataStreamSearch onSubmit={setSearchFieldValues} client={iotTwinMakerClient} />
-          <ModeledDataStreamExplorer
-            hasNextPage={hasNextPage}
-            isFetching={isFetching}
-            client={iotSiteWiseClient}
-            dataStreams={modeledDataStreams}
-            onClickAddModeledDataStreams={onClickAdd}
-            onClickNextPage={fetchNextPage}
-            isSearchError={isError}
-            searchQuery={searchFieldValues.searchQuery}
-          />
+          {searchFieldValues.searchQuery.length > 0 && (
+            <ModeledDataStreamExplorer
+              hasNextPage={hasNextPage}
+              isFetching={isFetching}
+              client={iotSiteWiseClient}
+              dataStreams={modeledDataStreams}
+              onClickAddModeledDataStreams={onClickAdd}
+              onClickNextPage={fetchNextPage}
+              isSearchError={isError}
+              searchQuery={searchFieldValues.searchQuery}
+            />
+          )}
         </>
       )}
     </Box>


### PR DESCRIPTION
The purpose of this change is to make minor UX changes to the resource explorer that make the work flow more clear.

Users are confused by the filter workflow on the table, and confuse it with search, and often go directly to filter to try to find results.

I've mitigated this by hiding the filter and property table when it does not need to be shown. 


UX changes can be seen in the following screenshots:

![Screenshot 2023-12-15 at 1 46 56 PM](https://github.com/awslabs/iot-app-kit/assets/77755322/a5736e0a-47a9-478c-a947-446cdef4a084)
![Screenshot 2023-12-15 at 1 46 42 PM](https://github.com/awslabs/iot-app-kit/assets/77755322/901a36ab-e4dc-498e-8fe3-7104323c03bc)
![Screenshot 2023-12-15 at 1 46 32 PM](https://github.com/awslabs/iot-app-kit/assets/77755322/f453473d-e6ae-48f5-b525-3636874d54b2)
![Screenshot 2023-12-15 at 1 46 25 PM](https://github.com/awslabs/iot-app-kit/assets/77755322/643943af-94a6-4b6d-8e49-aa4396783675)
![Screenshot 2023-12-15 at 1 46 18 PM](https://github.com/awslabs/iot-app-kit/assets/77755322/82463358-2ba2-47fa-8da2-95820fe831c5)
