### PR TITLE
revert: fix - dashboard settings to set correct columns and rows #2313"

### DIFF
--- a/packages/dashboard/src/store/actions/changeDashboardGrid/changeHeight.spec.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardGrid/changeHeight.spec.ts
@@ -1,6 +1,5 @@
 import { changeDashboardHeight, onChangeDashboardHeightAction } from './changeHeight';
 import { initialState } from '../../state';
-import { MOCK_LINE_CHART_WIDGET } from '../../../../testing/mocks';
 
 it('can change the height of the dashboard', () => {
   expect(
@@ -11,32 +10,6 @@ it('can change the height of the dashboard', () => {
       })
     ).grid.height
   ).toEqual(10);
-});
-
-it('can update the widget selection with changed height of the dashboard', () => {
-  const store = {
-    ...initialState,
-    dashboardConfiguration: {
-      ...initialState.dashboardConfiguration,
-      widgets: [{ ...MOCK_LINE_CHART_WIDGET }],
-    },
-    selectedWidgets: [{ ...MOCK_LINE_CHART_WIDGET }],
-  };
-  const updatedStore = changeDashboardHeight(
-    store,
-    onChangeDashboardHeightAction({
-      height: 10,
-    })
-  );
-  expect(updatedStore.selectedWidgets[0].height).toEqual(10);
-  expect(
-    changeDashboardHeight(
-      updatedStore,
-      onChangeDashboardHeightAction({
-        height: 100,
-      })
-    ).selectedWidgets[0].height
-  ).toEqual(20);
 });
 
 it('does not allow negative heights', () => {

--- a/packages/dashboard/src/store/actions/changeDashboardGrid/changeWidth.spec.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardGrid/changeWidth.spec.ts
@@ -1,6 +1,5 @@
 import { changeDashboardWidth, onChangeDashboardWidthAction } from './changeWidth';
 import { initialState } from '../../state';
-import { MOCK_LINE_CHART_WIDGET } from '../../../../testing/mocks';
 
 it('can change the width of the dashboard', () => {
   expect(
@@ -11,32 +10,6 @@ it('can change the width of the dashboard', () => {
       })
     ).grid.width
   ).toEqual(10);
-});
-
-it('can update the widget selection with changed width of the dashboard', () => {
-  const store = {
-    ...initialState,
-    dashboardConfiguration: {
-      ...initialState.dashboardConfiguration,
-      widgets: [{ ...MOCK_LINE_CHART_WIDGET }],
-    },
-    selectedWidgets: [{ ...MOCK_LINE_CHART_WIDGET }],
-  };
-  const updatedStore = changeDashboardWidth(
-    store,
-    onChangeDashboardWidthAction({
-      width: 10,
-    })
-  );
-  expect(updatedStore.selectedWidgets[0].width).toEqual(10);
-  expect(
-    changeDashboardWidth(
-      updatedStore,
-      onChangeDashboardWidthAction({
-        width: 100,
-      })
-    ).selectedWidgets[0].width
-  ).toEqual(33);
 });
 
 it('does not allow negative widths', () => {

--- a/packages/dashboard/src/store/actions/changeDashboardGrid/updateGrid.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardGrid/updateGrid.ts
@@ -1,7 +1,5 @@
 import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
 import type { DashboardState } from '../../state';
-import { WidgetPropertiesGeneratorMap } from '~/customization/widgetPropertiesGeneratorMap';
-import { WIDGET_INITIAL_HEIGHT, WIDGET_INITIAL_WIDTH } from '~/customization/widgets/constants';
 
 type GridProperties = keyof DashboardState['grid'];
 type GridValues = DashboardState['grid'][GridProperties];
@@ -16,23 +14,7 @@ export const changeGridProperty = (
     [property]: value,
   };
   const widgets = state.dashboardConfiguration.widgets.map((w) => {
-    const { initialSize } = WidgetPropertiesGeneratorMap[w.type] || {};
-
-    const { width: widgetPixelWidth, height: widgetPixelHeight } = initialSize || {
-      height: WIDGET_INITIAL_HEIGHT,
-      width: WIDGET_INITIAL_WIDTH,
-    };
-    const width = Math.min(Math.ceil(widgetPixelWidth / state.grid.cellSize), grid.width);
-    const height = Math.min(Math.ceil(widgetPixelHeight / state.grid.cellSize), grid.height);
-
-    return constrainWidgetPositionToGrid(
-      { x: 0, y: 0, width: grid.width, height: grid.height },
-      { ...w, ...(property !== 'cellSize' && { width: width, height: height }) }
-    );
-  });
-
-  const updatedSelectedWidgets = state.selectedWidgets.map((w) => {
-    return widgets.find((k) => k.id === w.id) || w;
+    return constrainWidgetPositionToGrid({ x: 0, y: 0, width: grid.width, height: grid.height }, w);
   });
 
   return {
@@ -42,6 +24,5 @@ export const changeGridProperty = (
       widgets,
     },
     grid,
-    selectedWidgets: [...updatedSelectedWidgets],
   };
 };


### PR DESCRIPTION
This reverts commit 5eb72e7f92b07e6678227d332031642baa8332ff.

## Overview
this commit is causing the other widgets to shrink when you drag and drop a "Text" widget

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
Before 

https://github.com/awslabs/iot-app-kit/assets/135036199/6eeb2e26-cb2f-4631-bef8-691d8a182749



After 
https://github.com/awslabs/iot-app-kit/assets/135036199/753a0b65-0cc1-41fa-80ea-36dd968fffdc

