### PR TITLE
fix: dashboard settings to set correct columns and rows

### DIFF
--- a/packages/dashboard/src/store/actions/changeDashboardGrid/changeEnabled.spec.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardGrid/changeEnabled.spec.ts
@@ -1,22 +1,28 @@
 import { initialState } from '../../state';
 import { changeDashboardGridDragEnabled, onChangeDashboardGridEnabledAction } from './changeEnabled';
+import { MOCK_LINE_CHART_WIDGET } from '../../../../testing/mocks';
 
 it('can change grid enabled', () => {
-  expect(
-    changeDashboardGridDragEnabled(
-      initialState,
-      onChangeDashboardGridEnabledAction({
-        enabled: false,
-      })
-    ).grid.enabled
-  ).toEqual(false);
+  const store = {
+    ...initialState,
+    dashboardConfiguration: {
+      ...initialState.dashboardConfiguration,
+      widgets: [{ ...MOCK_LINE_CHART_WIDGET }],
+    },
+    selectedWidgets: [{ ...MOCK_LINE_CHART_WIDGET }],
+  };
 
-  expect(
-    changeDashboardGridDragEnabled(
-      initialState,
+  const gridEnabled = [false, true];
+
+  gridEnabled.forEach((enabled) => {
+    const updatedStore = changeDashboardGridDragEnabled(
+      store,
       onChangeDashboardGridEnabledAction({
-        enabled: true,
+        enabled: enabled,
       })
-    ).grid.enabled
-  ).toEqual(true);
+    );
+    expect(updatedStore.grid.enabled).toEqual(enabled);
+    expect(updatedStore.selectedWidgets[0].height).toEqual(MOCK_LINE_CHART_WIDGET.height);
+    expect(updatedStore.selectedWidgets[0].width).toEqual(MOCK_LINE_CHART_WIDGET.width);
+  });
 });

--- a/packages/dashboard/src/store/actions/changeDashboardGrid/changeHeight.spec.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardGrid/changeHeight.spec.ts
@@ -1,5 +1,6 @@
 import { changeDashboardHeight, onChangeDashboardHeightAction } from './changeHeight';
 import { initialState } from '../../state';
+import { MOCK_LINE_CHART_WIDGET } from '../../../../testing/mocks';
 
 it('can change the height of the dashboard', () => {
   expect(
@@ -10,6 +11,32 @@ it('can change the height of the dashboard', () => {
       })
     ).grid.height
   ).toEqual(10);
+});
+
+it('can update the widget selection with changed height of the dashboard', () => {
+  const store = {
+    ...initialState,
+    dashboardConfiguration: {
+      ...initialState.dashboardConfiguration,
+      widgets: [{ ...MOCK_LINE_CHART_WIDGET }],
+    },
+    selectedWidgets: [{ ...MOCK_LINE_CHART_WIDGET }],
+  };
+  const updatedStore = changeDashboardHeight(
+    store,
+    onChangeDashboardHeightAction({
+      height: 10,
+    })
+  );
+  expect(updatedStore.selectedWidgets[0].height).toEqual(10);
+  expect(
+    changeDashboardHeight(
+      updatedStore,
+      onChangeDashboardHeightAction({
+        height: 100,
+      })
+    ).selectedWidgets[0].height
+  ).toEqual(20);
 });
 
 it('does not allow negative heights', () => {

--- a/packages/dashboard/src/store/actions/changeDashboardGrid/changeWidth.spec.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardGrid/changeWidth.spec.ts
@@ -1,5 +1,6 @@
 import { changeDashboardWidth, onChangeDashboardWidthAction } from './changeWidth';
 import { initialState } from '../../state';
+import { MOCK_LINE_CHART_WIDGET } from '../../../../testing/mocks';
 
 it('can change the width of the dashboard', () => {
   expect(
@@ -10,6 +11,32 @@ it('can change the width of the dashboard', () => {
       })
     ).grid.width
   ).toEqual(10);
+});
+
+it('can update the widget selection with changed width of the dashboard', () => {
+  const store = {
+    ...initialState,
+    dashboardConfiguration: {
+      ...initialState.dashboardConfiguration,
+      widgets: [{ ...MOCK_LINE_CHART_WIDGET }],
+    },
+    selectedWidgets: [{ ...MOCK_LINE_CHART_WIDGET }],
+  };
+  const updatedStore = changeDashboardWidth(
+    store,
+    onChangeDashboardWidthAction({
+      width: 10,
+    })
+  );
+  expect(updatedStore.selectedWidgets[0].width).toEqual(10);
+  expect(
+    changeDashboardWidth(
+      updatedStore,
+      onChangeDashboardWidthAction({
+        width: 100,
+      })
+    ).selectedWidgets[0].width
+  ).toEqual(33);
 });
 
 it('does not allow negative widths', () => {

--- a/packages/dashboard/src/store/actions/changeDashboardGrid/updateGrid.ts
+++ b/packages/dashboard/src/store/actions/changeDashboardGrid/updateGrid.ts
@@ -1,5 +1,7 @@
 import { constrainWidgetPositionToGrid } from '~/util/constrainWidgetPositionToGrid';
 import type { DashboardState } from '../../state';
+import { WidgetPropertiesGeneratorMap } from '~/customization/widgetPropertiesGeneratorMap';
+import { WIDGET_INITIAL_HEIGHT, WIDGET_INITIAL_WIDTH } from '~/customization/widgets/constants';
 
 type GridProperties = keyof DashboardState['grid'];
 type GridValues = DashboardState['grid'][GridProperties];
@@ -14,7 +16,23 @@ export const changeGridProperty = (
     [property]: value,
   };
   const widgets = state.dashboardConfiguration.widgets.map((w) => {
-    return constrainWidgetPositionToGrid({ x: 0, y: 0, width: grid.width, height: grid.height }, w);
+    const { initialSize } = WidgetPropertiesGeneratorMap[w.type] || {};
+
+    const { width: widgetPixelWidth, height: widgetPixelHeight } = initialSize || {
+      height: WIDGET_INITIAL_HEIGHT,
+      width: WIDGET_INITIAL_WIDTH,
+    };
+    const width = Math.min(Math.ceil(widgetPixelWidth / state.grid.cellSize), grid.width);
+    const height = Math.min(Math.ceil(widgetPixelHeight / state.grid.cellSize), grid.height);
+
+    return constrainWidgetPositionToGrid(
+      { x: 0, y: 0, width: grid.width, height: grid.height },
+      { ...w, ...((property === 'width' || property === 'height') && { width: width, height: height }) }
+    );
+  });
+
+  const updatedSelectedWidgets = state.selectedWidgets.map((w) => {
+    return widgets.find((k) => k.id === w.id) || w;
   });
 
   return {
@@ -24,5 +42,6 @@ export const changeGridProperty = (
       widgets,
     },
     grid,
+    selectedWidgets: [...updatedSelectedWidgets],
   };
 };


### PR DESCRIPTION
## Overview
This PR is for ticket #2313  and to correctly display columns and rows and it includes
1. widget selection is now updates with columns and rows changes
2. widget width and height will reset back to default when the columns and rows are reduced to less the widget width and height and set max value again and will persist the x & y values as 0

## Verifying Changes
[settings-update.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/870a9cfb-7498-4b64-8d59-5a302cd64efa)

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
