### PR TITLE
feat: xy-plot y axis lable changes #2378

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
@@ -212,6 +212,13 @@ const RenderLineAndScatterStyleSettingsSection = ({
     });
   };
 
+  const handleUpdateYLabel = (yLabel: string | null) => {
+    updateAxis({ ...axis, yLabel: yLabel ?? undefined });
+    logCustomYAxis({
+      yLabel: `${yLabel}`,
+    });
+  };
+
   return (
     <SpaceBetween size='s' direction='vertical'>
       <AggregationAndResolutionSection
@@ -226,9 +233,11 @@ const RenderLineAndScatterStyleSettingsSection = ({
         visible={axis?.yVisible ?? true}
         min={axis?.yMin ?? null}
         max={axis?.yMax ?? null}
+        yLabel={axis?.yLabel ?? null}
         setVisible={handleSetVisible}
         updateMin={handleUpdateMin}
         updateMax={handleUpdateMax}
+        updateYLabel={handleUpdateYLabel}
       />
       <LineStyleSection
         lineType={connectionStyle}

--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/yAxis.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/yAxis.tsx
@@ -1,20 +1,33 @@
+import React from 'react';
+import type { FC } from 'react';
+
 import FormField from '@cloudscape-design/components/form-field';
 import Input from '@cloudscape-design/components/input';
-import type { FC } from 'react';
-import React from 'react';
-import StyleExpandableSection from '../shared/styleExpandableSection/styleExpandableSection';
 import Box from '@cloudscape-design/components/box';
+
+import StyleExpandableSection from '../shared/styleExpandableSection/styleExpandableSection';
 
 type YAxisSectionOptions = {
   visible: boolean;
   min: number | null;
   max: number | null;
+  yLabel: string | null;
   setVisible: (visible: boolean) => void;
   updateMin: (min: number | null) => void;
   updateMax: (max: number | null) => void;
+  updateYLabel: (yLabel: string | null) => void;
 };
 
-export const YAxisSection: FC<YAxisSectionOptions> = ({ visible, min, max, setVisible, updateMin, updateMax }) => {
+export const YAxisSection: FC<YAxisSectionOptions> = ({
+  visible,
+  min,
+  max,
+  yLabel,
+  setVisible,
+  updateMin,
+  updateMax,
+  updateYLabel,
+}) => {
   const onSetRange = (updater: (value: number | null) => void, value: string) => {
     const parsed = parseInt(value);
     updater(isNaN(parsed) ? null : parsed);
@@ -23,25 +36,37 @@ export const YAxisSection: FC<YAxisSectionOptions> = ({ visible, min, max, setVi
   return (
     <StyleExpandableSection header='Y-axis' visible={visible} setVisible={setVisible}>
       <Box padding='s'>
-        <FormField description='Leave empty to auto-calculate based on all the values' label='Range'>
-          <label htmlFor='y-axis-min'>Min</label>
-          <Input
-            placeholder='Auto'
-            controlId='y-axis-min'
-            value={`${min ?? ''}`}
-            type='number'
-            onChange={({ detail }) => onSetRange(updateMin, detail.value)}
-          />
+        <Box padding={{ bottom: 'xs' }}>
+          <FormField label='Label'>
+            <Input
+              placeholder='Input Y-axis label'
+              value={`${yLabel ?? ''}`}
+              type='text'
+              onChange={({ detail }) => updateYLabel(detail.value)}
+            />
+          </FormField>
+        </Box>
+        <Box>
+          <FormField description='Leave empty to auto-calculate based on all the values' label='Range'>
+            <label htmlFor='y-axis-min'>Min</label>
+            <Input
+              placeholder='Auto'
+              controlId='y-axis-min'
+              value={`${min ?? ''}`}
+              type='number'
+              onChange={({ detail }) => onSetRange(updateMin, detail.value)}
+            />
 
-          <label htmlFor='y-axis-max'>Max</label>
-          <Input
-            placeholder='Auto'
-            controlId='y-axis-max'
-            value={`${max ?? ''}`}
-            type='number'
-            onChange={({ detail }) => onSetRange(updateMax, detail.value)}
-          />
-        </FormField>
+            <label htmlFor='y-axis-max'>Max</label>
+            <Input
+              placeholder='Auto'
+              controlId='y-axis-max'
+              value={`${max ?? ''}`}
+              type='number'
+              onChange={({ detail }) => onSetRange(updateMax, detail.value)}
+            />
+          </FormField>
+        </Box>
       </Box>
     </StyleExpandableSection>
   );

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -115,6 +115,7 @@ const convertAxis = (axis: ChartAxisOptions | undefined) => ({
   showX: axis?.xVisible,
   yMin: axis?.yMin,
   yMax: axis?.yMax,
+  yLabel: axis?.yLabel,
 });
 
 const removeHiddenDataStreams = (widget: LineScatterChartWidget): LineScatterChartWidget => ({

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -133,6 +133,7 @@ export type YAxisOptions = YAxisRange & {
 export type ChartAxisOptions = YAxisRange & {
   yVisible?: boolean;
   xVisible?: boolean;
+  yLabel?: string;
 };
 
 type ChartLegendContent = 'unit' | 'asset';

--- a/packages/react-components/src/components/chart/chartOptions/axes/yAxis.ts
+++ b/packages/react-components/src/components/chart/chartOptions/axes/yAxis.ts
@@ -4,7 +4,7 @@ import { DEFAULT_Y_AXIS } from '../../eChartsConstants';
 
 export const convertYAxis = (axis: ChartAxisOptions | undefined): YAXisComponentOption => ({
   ...DEFAULT_Y_AXIS,
-  name: axis?.yAxisLabel,
+  name: axis?.yLabel,
   show: axis?.showY ?? DEFAULT_Y_AXIS.show,
   min: axis?.yMin ?? undefined,
   max: axis?.yMax ?? undefined,
@@ -12,4 +12,6 @@ export const convertYAxis = (axis: ChartAxisOptions | undefined): YAXisComponent
     hideOverlap: true,
     color: '#5f6b7a',
   },
+  nameLocation: 'middle',
+  nameGap: 30,
 });

--- a/packages/react-components/src/components/chart/chartOptions/converters.spec.ts
+++ b/packages/react-components/src/components/chart/chartOptions/converters.spec.ts
@@ -48,28 +48,28 @@ describe('testing converters', () => {
   it('converts axis to eCharts axis', async () => {
     [
       {
-        yAxisLabel: 'Y Value',
+        yLabel: 'Y Value',
         yMin: 0,
         yMax: 100,
         showY: true,
         showX: true,
       },
       {
-        yAxisLabel: 'Y Value',
+        yLabel: 'Y Value',
         yMin: 0,
         yMax: 100,
         showY: false,
         showX: false,
       },
       {
-        yAxisLabel: 'Y Value',
+        yLabel: 'Y Value',
         yMin: 0,
         yMax: 100,
         showY: true,
         showX: false,
       },
       {
-        yAxisLabel: 'Y Value',
+        yLabel: 'Y Value',
         yMin: 0,
         yMax: 100,
         showY: false,
@@ -79,7 +79,7 @@ describe('testing converters', () => {
       const convertedYAxis = convertYAxis(axis_values);
 
       expect(convertedYAxis).toHaveProperty('type', 'value');
-      expect(convertedYAxis).toHaveProperty('name', axis_values.yAxisLabel);
+      expect(convertedYAxis).toHaveProperty('name', axis_values.yLabel);
       expect(convertedYAxis).toHaveProperty('show', axis_values.showY);
     });
   });

--- a/packages/react-components/src/components/chart/chartOptions/seriesAndYAxis/convertSeriesAndYAxis.ts
+++ b/packages/react-components/src/components/chart/chartOptions/seriesAndYAxis/convertSeriesAndYAxis.ts
@@ -110,7 +110,7 @@ const convertYAxis = ({ color, yAxis }: ChartStyleSettingsOptions): YAXisCompone
      */
     show: true,
     axisLabel: { show: false },
-    name: yAxis.yAxisLabel,
+    name: yAxis.yLabel,
     min: yAxis.yMin,
     max: yAxis.yMax,
     alignTicks: true,

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -3,7 +3,7 @@ import { OptionId } from 'echarts/types/src/util/types';
 import { InternalGraphicComponentGroupOption } from './trendCursor/types';
 
 export type YAxisOptions = {
-  yAxisLabel?: string;
+  yLabel?: string;
   yMin?: number;
   yMax?: number;
 };


### PR DESCRIPTION
## Overview
This PR is for the ticket: #2378 

- Added Y-axis input field in the config panel under widget level-> y-axis container.
- Also added nameLocation and nameGap props to set the location and alignment for the y-axis label.
- Added y-axis label updater callback to update the y-label in the line scatter widget.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/139960352/0195057a-67b4-4544-b1a2-123e35608eb1

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
