### PR TITLE
fix: added aria-label for config panel text url input for accessibility

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/textSettings/link.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/textSettings/link.tsx
@@ -50,7 +50,12 @@ const LinkSettings: FC<LinkSettingsProps> = ({ href = '', updateHref, isUrl = fa
       <div className='link-configuration' style={{ gap: awsui.spaceScaledS }}>
         <label className='section-item-label'>{defaultMessages.url}</label>
         <div className='link-input'>
-          <Input value={href} onChange={onLinkTextChange} data-test-id='text-widget-link-input' />
+          <Input
+            ariaLabel='text widget link input'
+            value={href}
+            onChange={onLinkTextChange}
+            data-test-id='text-widget-link-input'
+          />
         </div>
       </div>
     </ExpandableSection>


### PR DESCRIPTION


This PR fixes accessibility issue [#2362](https://github.com/awslabs/iot-app-kit/issues/2362)
We have added aria-label to the input so it is now accessible to screen reader.

Verified changes:

Accessibility report using axe DevTools before fix:
![image](https://github.com/awslabs/iot-app-kit/assets/126452015/df863052-ddc7-43e1-8cd6-a47a3646e030)

Accessibility report using axe DevTools after fix:
![image](https://github.com/awslabs/iot-app-kit/assets/126452015/625372af-63b6-45a7-893c-9c629eb75809)

Screen reader reading the URL input field now:
