### PR TITLE
fix: added aria-label to the config panel text link control for accessibility

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/textSettings/link.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/textSettings/link.tsx
@@ -50,7 +50,12 @@ const LinkSettings: FC<LinkSettingsProps> = ({ href = '', updateHref, isUrl = fa
       <div className='link-configuration' style={{ gap: awsui.spaceScaledS }}>
         <label className='section-item-label'>{defaultMessages.url}</label>
         <div className='link-input'>
-          <Input value={href} onChange={onLinkTextChange} data-test-id='text-widget-link-input' />
+          <Input
+            ariaLabel='text widget link input'
+            value={href}
+            onChange={onLinkTextChange}
+            data-test-id='text-widget-link-input'
+          />
         </div>
       </div>
     </ExpandableSection>


### PR DESCRIPTION
This PR fixes the accessibility issue [#2362](https://github.com/awslabs/iot-app-kit/issues/2362)

### Verifying changes:

Accessibility report using axe DevTools before fix:
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/36b5844f-e1d5-409d-b05a-5d0c4d963383)

Accessibility report using axe DevTools after fix:
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/f429a14c-925b-43c9-ad4d-53e6e98cc44e)

Screen reader is able to read the URL Input field.



