### PR TITLE
fix: programatically linked the color picker control with color label in config panel text

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/shared/colorPicker.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/shared/colorPicker.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 import './styles.css';
 import type { FC } from 'react';
 
-const ColorPicker: FC<{ color: string; updateColor: (newColor: string) => void }> = ({
+const ColorPicker: FC<{ id?: string; color: string; updateColor: (newColor: string) => void }> = ({
+  id,
   color,
   updateColor,
   ...other
 }) => {
   return (
     <input
+      id={id}
       aria-label='color picker'
       type='color'
       value={color}

--- a/packages/dashboard/src/customization/propertiesSections/textSettings/text.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/textSettings/text.tsx
@@ -85,8 +85,8 @@ const TextSettings: FC<TextSettingsProps> = ({
   return (
     <ExpandableSection headerText={defaultMessages.title} defaultExpanded>
       <div className='text-configuration' style={{ gap: awsui.spaceScaledS }}>
-        <label>{defaultMessages.color}</label>
-        <ColorPicker color={fontColor} updateColor={updateFontColor} />
+        <label htmlFor='text-color-picker'>{defaultMessages.color}</label>
+        <ColorPicker id='text-color-picker' color={fontColor} updateColor={updateFontColor} />
 
         <label>{defaultMessages.style}</label>
         <SpaceBetween size='xxs' direction='horizontal'>


### PR DESCRIPTION
This PR addresses the accessibility issue [#2361](https://github.com/awslabs/iot-app-kit/issues/2361)

### Verifying changes:
There was no difference in screen reader behaviour with this change, the screen reader was already announcing the color label and color control without this change because aria-label is already present.

**DOM before making this change:**
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/629546b0-8d7c-48cb-be46-1574a9131617)


**DOM after making this change:**
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/33e2ffdb-cac9-449a-b405-9bc7a346119e)

