### PR TITLE
fix(react-components): confining the tooltip within chart area

### DIFF
--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -52,6 +52,7 @@ export const DEFAULT_GRID = {
 
 export const DEFAULT_TOOLTIP: TooltipComponentOption = {
   trigger: 'axis',
+  confine: true,
 };
 
 export const DEFAULT_DATA_ZOOM: DataZoomComponentOption = {


### PR DESCRIPTION
## Overview
 confining the tooltip within chart area

## Verifying Changes
refer to the screen share

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

https://github.com/awslabs/iot-app-kit/assets/135036199/f56b3d90-774e-4e6f-8fec-133ca05a9210

