### PR TITLE
fix: msw batchGetAssetPropertyValueHandler response timeInSeconds values

### DIFF
--- a/packages/dashboard/src/msw/iot-sitewise/handlers/batchGetAssetPropertyValue/batchGetAssetPropertyValueHandler.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/handlers/batchGetAssetPropertyValue/batchGetAssetPropertyValueHandler.ts
@@ -108,7 +108,7 @@ export class AssetPropertyValueFactory {
 
   #createDefaults() {
     const quality = 'GOOD' as Quality;
-    const timestamp = { timeInSeconds: Date.now() };
+    const timestamp = { timeInSeconds: Math.floor(Date.now() / 1000) };
     const defaults = { quality, timestamp };
 
     return defaults;
@@ -155,7 +155,7 @@ export function batchGetAssetPropertyValueHistoryHandler() {
           .map((date) => {
             const assetPropertyValue = factory.createIntegerAssetPropertyValue({
               timestamp: {
-                timeInSeconds: date.getTime(),
+                timeInSeconds: Math.floor(date.getTime() / 1000),
               },
             });
 


### PR DESCRIPTION
## Overview
Currently, the value provided to `timeInSeconds` is in `ms` but the expected unit is `s`.
This PR fixes the value provided to `timeInSeconds` by dropping the last 3 digits.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
