### PR TITLE
fix(dashboard): padding for tabs in config panel + remove scroll in threshold panel

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-import SpaceBetween from '@cloudscape-design/components/space-between';
 import { PropertiesSection } from '~/customization/propertiesSectionComponent';
 import { ChartLegend, LineScatterChartWidget, LineStyles, SymbolStyles } from '~/customization/widgets/types';
 import { DashboardWidget } from '~/types';
@@ -220,7 +218,7 @@ const RenderLineAndScatterStyleSettingsSection = ({
   };
 
   return (
-    <SpaceBetween size='s' direction='vertical'>
+    <>
       <AggregationAndResolutionSection
         aggregation={aggregationType}
         resolution={resolution}
@@ -257,7 +255,7 @@ const RenderLineAndScatterStyleSettingsSection = ({
         setVisible={updateLegendVisible}
         setAlignment={(position) => updateLegendPosition(position as ChartLegend['position'])}
       />
-    </SpaceBetween>
+    </>
   );
 };
 

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/index.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/index.tsx
@@ -7,6 +7,7 @@ import { GeneralPropertiesAlarmsSection } from './section';
 import { StyledPropertiesAlarmsSection } from './styledSection';
 import { PropertyLens } from '~/customization/propertiesSection';
 import { useClients } from '~/components/dashboard/clientContext';
+import { spaceScaledXs } from '@cloudscape-design/design-tokens';
 
 // exclude table because it is handled specially
 const isQueryWidgetExcludesTable = (w: DashboardWidget): w is QueryWidget =>
@@ -88,8 +89,12 @@ const RenderPropertiesSectionForTables = ({ useProperty }: { useProperty: Proper
   );
 };
 
+const propertiesAndAlarmSettingstyle = {
+  padding: spaceScaledXs,
+};
+
 export const PropertiesAndAlarmsSettingsConfiguration: React.FC = () => (
-  <>
+  <div style={propertiesAndAlarmSettingstyle}>
     <PropertiesSection
       isVisible={isStyledWidget}
       render={({ useProperty }) => <RenderPropertiesSectionWithStyledQuery useProperty={useProperty} />}
@@ -102,5 +107,5 @@ export const PropertiesAndAlarmsSettingsConfiguration: React.FC = () => (
       isVisible={isTableWidget}
       render={({ useProperty }) => <RenderPropertiesSectionForTables useProperty={useProperty} />}
     />
-  </>
+  </div>
 );

--- a/packages/dashboard/src/customization/propertiesSections/propertiesSectionsStyle.css
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesSectionsStyle.css
@@ -1,0 +1,16 @@
+.remove-scroll {
+  overflow: hidden;
+}
+
+.accordian-header > :first-child {
+  background-color: #f8f8f8;
+}
+
+.accordian-header [class*="awsui_expand-button"] {
+  padding-left: 8px;
+  width: 100%;
+}
+
+.accordian-header [class*="awsui_header-text"] {
+  width: 100%;
+}

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdComponent.css
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdComponent.css
@@ -10,6 +10,6 @@
 
 .threshold-configuration {
   display: grid;
-  grid-template-columns: max-content 1fr 1fr 60px 0.5fr;
+  grid-template-columns: max-content 1fr 1fr 60px 0.5fr 0.3fr;
   align-items: center;
 }

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdComponent.tsx
@@ -94,17 +94,17 @@ export const ThresholdComponent: FC<{
                 updateColor={onUpdateColor}
                 data-test-id='threshold-component-color-picker'
               />
+              <Button
+                ariaLabel='delete threshold'
+                iconName='remove'
+                variant='icon'
+                onClick={onDelete}
+                data-test-id='threshold-component-delete-button'
+              />
             </div>
           </Box>
         </SpaceBetween>
       </div>
-      <Button
-        ariaLabel='delete threshold'
-        iconName='remove'
-        variant='icon'
-        onClick={onDelete}
-        data-test-id='threshold-component-delete-button'
-      />
     </div>
   );
 };

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.tsx
@@ -4,6 +4,7 @@ import { OptionDefinition } from '@cloudscape-design/components/internal/compone
 // FIXME: Export ThresholdStyleType from @iot-app-kit/react-components
 // eslint-disable-next-line no-restricted-imports
 import { ThresholdStyleType } from '@iot-app-kit/react-components/src/components/chart/types';
+import { spaceScaledXs } from '@cloudscape-design/design-tokens';
 
 export type ThresholdStyleSettingsProps = {
   thresholdStyle: ThresholdStyleType;
@@ -59,6 +60,10 @@ const convertThresholdStyleToOption = (thresholdStyle: ThresholdStyleType): Opti
   }
 };
 
+const style = {
+  padding: spaceScaledXs,
+};
+
 export const ThresholdStyleSettings: React.FC<ThresholdStyleSettingsProps> = ({
   thresholdStyle,
   updateAllThresholdStyles,
@@ -68,17 +73,19 @@ export const ThresholdStyleSettings: React.FC<ThresholdStyleSettingsProps> = ({
   );
 
   return (
-    <FormField label='Show thresholds'>
-      <Select
-        onChange={({ detail }) => {
-          setSelectedOption(detail.selectedOption);
-          const thresholdStyle = convertOptionToThresholdStyle(detail.selectedOption);
-          // Update styles of all thresholds
-          updateAllThresholdStyles(thresholdStyle);
-        }}
-        options={styledOptions}
-        selectedOption={selectedOption}
-      />
-    </FormField>
+    <div style={style}>
+      <FormField label='Show thresholds'>
+        <Select
+          onChange={({ detail }) => {
+            setSelectedOption(detail.selectedOption);
+            const thresholdStyle = convertOptionToThresholdStyle(detail.selectedOption);
+            // Update styles of all thresholds
+            updateAllThresholdStyles(thresholdStyle);
+          }}
+          options={styledOptions}
+          selectedOption={selectedOption}
+        />
+      </FormField>
+    </div>
   );
 };

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
@@ -18,9 +18,11 @@ import { ThresholdStyleSettings, convertOptionToThresholdStyle, styledOptions } 
 // FIXME: Export ThresholdStyleType from @iot-app-kit/react-components
 // eslint-disable-next-line no-restricted-imports
 import { ThresholdStyleType } from '@iot-app-kit/react-components/src/components/chart/types';
+import '../propertiesSectionsStyle.css';
+import { spaceScaledXs } from '@cloudscape-design/design-tokens';
 
 const ThresholdsExpandableSection: React.FC<React.PropsWithChildren<{ title: string }>> = ({ children, title }) => (
-  <ExpandableSection headerText={title} defaultExpanded>
+  <ExpandableSection className='accordian-header' headerText={title} defaultExpanded>
     <SpaceBetween size='m' direction='vertical'>
       {children}
     </SpaceBetween>
@@ -195,16 +197,23 @@ const ThresholdsSection: FC<ThresholdsSectionProps> = ({
           handleUpdateStyledThresholds([...styledThresholdsValue, newStyledThreshold]);
         }
       };
+
+      const thresholdComponentStyle = {
+        padding: spaceScaledXs,
+      };
+
       const thresholdsComponent = (
-        <SpaceBetween size='m' direction='vertical'>
-          {styledThresholdsEnabled && hideThresholdsToggle}
-          <ThresholdsList
-            thresholds={thresholdsEnabled ? thresholdsValue : styledThresholdsEnabled ? styledThresholdsValue : []}
-            updateThresholds={thresholdsEnabled ? updateThresholds : handleUpdateStyledThresholds}
-            comparisonOperators={comparisonOperators}
-          />
-          <Button onClick={onAddNewThreshold}>Add a threshold</Button>
-        </SpaceBetween>
+        <div style={thresholdComponentStyle}>
+          <SpaceBetween size='m' direction='vertical'>
+            {styledThresholdsEnabled && hideThresholdsToggle}
+            <ThresholdsList
+              thresholds={thresholdsEnabled ? thresholdsValue : styledThresholdsEnabled ? styledThresholdsValue : []}
+              updateThresholds={thresholdsEnabled ? updateThresholds : handleUpdateStyledThresholds}
+              comparisonOperators={comparisonOperators}
+            />
+            <Button onClick={onAddNewThreshold}>Add a threshold</Button>
+          </SpaceBetween>
+        </div>
       );
       return thresholdsComponent;
     }
@@ -261,7 +270,7 @@ const ThresholdsSection: FC<ThresholdsSectionProps> = ({
   const thresholdsStyleComponent = renderThresholdStyle();
 
   return (
-    <>
+    <div className='remove-scroll'>
       <ThresholdsExpandableSection title='Thresholds'>{thresholdsComponent}</ThresholdsExpandableSection>
       {annotationsComponent && (
         <ThresholdsExpandableSection title='Threshold style'>{annotationsComponent}</ThresholdsExpandableSection>
@@ -269,7 +278,7 @@ const ThresholdsSection: FC<ThresholdsSectionProps> = ({
       {thresholdsStyleComponent && (
         <ThresholdsExpandableSection title='Threshold style'>{thresholdsStyleComponent}</ThresholdsExpandableSection>
       )}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Overview
Added 8px padding on the left to every item in each tab in the config panel. Also removed the horizontal scroll on the threshold panel. 

## Verifying Changes
<img width="407" alt="Screenshot 2023-12-26 at 4 13 35 PM" src="https://github.com/awslabs/iot-app-kit/assets/145582655/230c4b5a-c5bc-4ae5-8374-b59bc1ce736e">

<img width="355" alt="Screenshot 2023-12-26 at 4 13 59 PM" src="https://github.com/awslabs/iot-app-kit/assets/145582655/10a6e5d2-da30-48bf-91f6-f159f3baab35">

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
