### PR TITLE
feat: auto select previously selected workspace or first workspace from options

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/dataStreamSearch/workspaceSelector/workspaceSelector.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/dataStreamSearch/workspaceSelector/workspaceSelector.tsx
@@ -1,9 +1,11 @@
 import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import FormField from '@cloudscape-design/components/form-field';
 import Select, { type SelectProps } from '@cloudscape-design/components/select';
+import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
 import { type useQuery } from '@tanstack/react-query';
 import React, { useEffect } from 'react';
 import { Controller, type Control } from 'react-hook-form';
+import { useLocalStorage } from 'react-use';
 
 import { useWorkspaces } from './useWorkspaces';
 import { WorkspaceOptionFactory } from './workspaceOptionFactory';
@@ -26,10 +28,33 @@ export const WorkspaceSelector = ({
   const { workspaces, status } = useWorkspaces({ client });
   const workspaceOptions = createWorkspaceOptions(workspaces);
 
+  const [storedWorkspace, setStoredWorkspace] =
+    useLocalStorage<OptionDefinition | null>('storedWorkspace', null);
+
   useEffect(() => {
     OnGettingError(status === 'error');
   }, [status, OnGettingError]);
 
+  useEffect(() => {
+    if (workspaceOptions.length) {
+      const isStoredValueInOptions =
+        storedWorkspace &&
+        workspaceOptions.some(
+          (option: OptionDefinition) => option.value === storedWorkspace.value
+        );
+      if (!isStoredValueInOptions) {
+        setStoredWorkspace(workspaceOptions[0]);
+      }
+    }
+  }, [storedWorkspace, setStoredWorkspace, workspaceOptions]);
+
+  const onChangeHandler = (
+    detail: SelectProps.ChangeDetail,
+    onChange: (...event: unknown[]) => void
+  ) => {
+    setStoredWorkspace(detail.selectedOption);
+    onChange(detail.selectedOption);
+  };
   return (
     <Controller
       control={control}
@@ -44,8 +69,8 @@ export const WorkspaceSelector = ({
           <Select
             disabled={status == 'error'}
             options={workspaceOptions}
-            selectedOption={field.value}
-            onChange={({ detail }) => field.onChange(detail.selectedOption)}
+            selectedOption={storedWorkspace ?? null}
+            onChange={({ detail }) => onChangeHandler(detail, field.onChange)}
             placeholder='Select a workspace'
             loadingText='Loading workspaces...'
             errorText='Failed to load workspaces.'


### PR DESCRIPTION
This PR adds below functionality to the workspace dropdown in resource explorer #2384 
1. Automatically selects first available workspace from the options list, if nothing was selected previously
2. If some workspace option was selected previously, it is stored in localStorage, and on next load, the same option is set as default(i.e. automatically selected)
3. If Previously selected option which is stored in localStorage is no longer present in the workspace options list, it will not be selected automatically, instead first option from the list will be selected.

### Verifying changes:
First time load:
[Screencast from 05-01-24 05:31:06 PM IST.webm](https://github.com/awslabs/iot-app-kit/assets/154328164/4ec97422-7430-4325-88e1-939130f3af0b)

Next renders:
[Screencast from 05-01-24 05:32:01 PM IST.webm](https://github.com/awslabs/iot-app-kit/assets/154328164/19da88e3-30b2-455c-92e7-ec241d646817)


In video - 
1. By default first option from list is selected automatially
2. User selects second option, which is then stored to localStorage
3. The value in localStorage is not present in current options list, so by defautl first option from list is selected

