### PR TITLE
feat: when scatter chart is selected the line style dropdown should b…

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/lineStyleSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/lineStyleSection.tsx
@@ -41,7 +41,8 @@ export const LineStyleSection: FC<LineStyleSectionOptions> = ({
         <SpaceBetween size='m'>
           <LineTypeSection type={lineType} updateType={updateType} />
           <LineStyleDropdown
-            lineStyle={lineStyle}
+            disabled={lineType === 'none'}
+            lineStyle={lineType !== 'none' ? lineStyle ?? 'solid' : undefined}
             updatelineStyle={updatelineStyle}
           />
           <LineThicknessDropdown

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
@@ -50,11 +50,16 @@ const LineStylePropertyConfig = ({
   const [connectionStyle, setConnectionStyle] = useState<
     LineStyles['connectionStyle']
   >(property.line?.connectionStyle ?? 'linear');
+
   const [lineStyle, setLineStyle] = useState<LineStyles['style']>(
-    property.line?.style ?? 'solid'
+    connectionStyle !== 'none' ? property.line?.style ?? 'solid' : undefined
   );
   const [lineThickness, setLinethickness] = useState<string | undefined>(
     property.line?.thickness?.toString() ?? '2'
+  );
+
+  const [isPrevLineStyleNone, setIsPrevLineStyleNone] = useState(
+    connectionStyle === 'none'
   );
 
   const getLineThicknessNumber = (thickness?: string) =>
@@ -87,6 +92,14 @@ const LineStylePropertyConfig = ({
   const updateConnectionStyle = (
     connectionStyle: LineStyles['connectionStyle']
   ) => {
+    if (connectionStyle === 'none') {
+      setLineStyle(undefined);
+      setIsPrevLineStyleNone(true);
+    }
+    if (isPrevLineStyleNone && connectionStyle !== 'none') {
+      setLineStyle('solid');
+      setIsPrevLineStyleNone(false);
+    }
     setConnectionStyle(connectionStyle);
     onUpdate({
       line: {
@@ -142,7 +155,7 @@ const LineStylePropertyConfig = ({
             }
           />
           <LineStyleDropdown
-            disabled={useGlobalStyle}
+            disabled={useGlobalStyle || connectionStyle === 'none'}
             lineStyle={lineStyle}
             updatelineStyle={(style) =>
               updateLineStyle(style as LineStyles['style'])


### PR DESCRIPTION
Issue: https://github.com/awslabs/iot-app-kit/issues/2427

Verification:
[x-y-chart.webm](https://github.com/awslabs/iot-app-kit/assets/81667589/c9568c6c-e34b-4ea0-b4db-e367abe269c6)

Fix:
-> when scatter chart is selected the line style dropdown should be none and disabled

