### PR TITLE
fix(react-components): clear ymin and ymax was getting emitted on eve…

### DIFF
--- a/packages/react-components/src/components/time-sync/viewportAdapter.spec.ts
+++ b/packages/react-components/src/components/time-sync/viewportAdapter.spec.ts
@@ -4,280 +4,291 @@ import {
   relativeOptions,
   getViewportDateRelativeToAbsolute,
 } from './viewportAdapter';
+import { beforeEach } from '@jest/globals';
 
-describe('dateRangeToViewport', () => {
-  it('can convert a relative date range option to the correct viewport', () => {
-    expect(dateRangeToViewport(relativeOptions[0])).toEqual({ duration: '1 minute' });
+describe('viewportAdapter', () => {
+  describe('dateRangeToViewport', () => {
+    it('can convert a relative date range option to the correct viewport', () => {
+      expect(dateRangeToViewport(relativeOptions[0])).toEqual({ duration: '1 minute' });
 
-    expect(dateRangeToViewport(relativeOptions[1])).toEqual({ duration: '5 minute' });
+      expect(dateRangeToViewport(relativeOptions[1])).toEqual({ duration: '5 minute' });
 
-    expect(dateRangeToViewport(relativeOptions[2])).toEqual({ duration: '10 minute' });
+      expect(dateRangeToViewport(relativeOptions[2])).toEqual({ duration: '10 minute' });
 
-    expect(dateRangeToViewport(relativeOptions[3])).toEqual({ duration: '30 minute' });
+      expect(dateRangeToViewport(relativeOptions[3])).toEqual({ duration: '30 minute' });
 
-    expect(dateRangeToViewport(relativeOptions[4])).toEqual({ duration: '1 hour' });
+      expect(dateRangeToViewport(relativeOptions[4])).toEqual({ duration: '1 hour' });
 
-    expect(dateRangeToViewport(relativeOptions[5])).toEqual({ duration: '1 day' });
+      expect(dateRangeToViewport(relativeOptions[5])).toEqual({ duration: '1 day' });
 
-    expect(dateRangeToViewport(relativeOptions[6])).toEqual({ duration: '7 day' });
+      expect(dateRangeToViewport(relativeOptions[6])).toEqual({ duration: '7 day' });
 
-    expect(dateRangeToViewport(relativeOptions[7])).toEqual({ duration: '30 day' });
+      expect(dateRangeToViewport(relativeOptions[7])).toEqual({ duration: '30 day' });
 
-    expect(dateRangeToViewport(relativeOptions[8])).toEqual({ duration: '90 day' });
-  });
-
-  it('can convert a relative custom date range option to the correct viewport', () => {
-    expect(
-      dateRangeToViewport({
-        amount: 20,
-        unit: 'minute',
-        type: 'relative',
-      })
-    ).toEqual({ duration: '20 minute' });
-
-    expect(
-      dateRangeToViewport({
-        amount: 3,
-        unit: 'month',
-        type: 'relative',
-      })
-    ).toEqual({ duration: '3 month' });
-  });
-
-  it('can convert an absolute date range to the correct viewport', () => {
-    expect(
-      dateRangeToViewport({
-        startDate: '2023-01-11T00:00:00Z',
-        endDate: '2023-01-13T23:59:59Z',
-        type: 'absolute',
-      })
-    ).toEqual({
-      start: new Date('2023-01-11T00:00:00Z'),
-      end: new Date('2023-01-13T23:59:59Z'),
+      expect(dateRangeToViewport(relativeOptions[8])).toEqual({ duration: '90 day' });
     });
 
-    expect(
-      dateRangeToViewport({
-        startDate: '2023-01-01T00:00:00Z',
-        endDate: '2023-02-28T23:59:59Z',
-        type: 'absolute',
-      })
-    ).toEqual({
-      start: new Date('2023-01-01T00:00:00Z'),
-      end: new Date('2023-02-28T23:59:59Z'),
-    });
-  });
-});
+    it('can convert a relative custom date range option to the correct viewport', () => {
+      expect(
+        dateRangeToViewport({
+          amount: 20,
+          unit: 'minute',
+          type: 'relative',
+        })
+      ).toEqual({ duration: '20 minute' });
 
-describe('viewportToDateRange', () => {
-  it('can convert a relative duration to a date range', () => {
-    expect(viewportToDateRange({ duration: '1 minute' })).toEqual(relativeOptions[0]);
-
-    expect(viewportToDateRange({ duration: '1m' })).toEqual(relativeOptions[0]);
-
-    expect(viewportToDateRange({ duration: '5 minute' })).toEqual(relativeOptions[1]);
-
-    expect(viewportToDateRange({ duration: '5m' })).toEqual(relativeOptions[1]);
-
-    expect(viewportToDateRange({ duration: '10 minute' })).toEqual(relativeOptions[2]);
-
-    expect(viewportToDateRange({ duration: '10m' })).toEqual(relativeOptions[2]);
-
-    expect(viewportToDateRange({ duration: '1m 60s' })).toEqual({
-      amount: 120,
-      unit: 'second',
-      type: 'relative',
+      expect(
+        dateRangeToViewport({
+          amount: 3,
+          unit: 'month',
+          type: 'relative',
+        })
+      ).toEqual({ duration: '3 month' });
     });
 
-    expect(viewportToDateRange({ duration: 6000 })).toEqual({
-      amount: 6,
-      unit: 'second',
-      type: 'relative',
-    });
-  });
-
-  it('can convert an absolute duration to a date range', () => {
-    expect(
-      viewportToDateRange({
+    it('can convert an absolute date range to the correct viewport', () => {
+      expect(
+        dateRangeToViewport({
+          startDate: '2023-01-11T00:00:00Z',
+          endDate: '2023-01-13T23:59:59Z',
+          type: 'absolute',
+        })
+      ).toEqual({
         start: new Date('2023-01-11T00:00:00Z'),
         end: new Date('2023-01-13T23:59:59Z'),
-      })
-    ).toEqual({
-      startDate: '2023-01-11T00:00:00.000Z',
-      endDate: '2023-01-13T23:59:59.000Z',
-      type: 'absolute',
-    });
+      });
 
-    expect(
-      viewportToDateRange({
+      expect(
+        dateRangeToViewport({
+          startDate: '2023-01-01T00:00:00Z',
+          endDate: '2023-02-28T23:59:59Z',
+          type: 'absolute',
+        })
+      ).toEqual({
         start: new Date('2023-01-01T00:00:00Z'),
         end: new Date('2023-02-28T23:59:59Z'),
-      })
-    ).toEqual({
-      startDate: '2023-01-01T00:00:00.000Z',
-      endDate: '2023-02-28T23:59:59.000Z',
-      type: 'absolute',
-    });
-
-    expect(
-      viewportToDateRange({
-        start: new Date('2023-01-11T00:00:00Z'),
-        end: new Date('2023-01-13T23:59:59.00Z'),
-      })
-    ).toEqual({
-      startDate: '2023-01-11T00:00:00.000Z',
-      endDate: '2023-01-13T23:59:59.000Z',
-      type: 'absolute',
-    });
-
-    expect(
-      viewportToDateRange({
-        start: new Date('2023-01-01T00:00:00Z'),
-        end: new Date('2023-02-28T23:59:59.00Z'),
-      })
-    ).toEqual({
-      startDate: '2023-01-01T00:00:00.000Z',
-      endDate: '2023-02-28T23:59:59.000Z',
-      type: 'absolute',
+      });
     });
   });
-});
 
-describe('getViewportStartOnBackwardRelative', () => {
-  jest.useFakeTimers().setSystemTime(new Date(2023, 11, 24).getTime());
+  describe('viewportToDateRange', () => {
+    it('can convert a relative duration to a date range', () => {
+      expect(viewportToDateRange({ duration: '1 minute' })).toEqual(relativeOptions[0]);
 
-  it('can get the new start date when going back from a relative duration', () => {
-    let currentDate = new Date();
-    let newDate = getViewportDateRelativeToAbsolute({
-      amount: 5,
-      unit: 'minute',
-      type: 'relative',
+      expect(viewportToDateRange({ duration: '1m' })).toEqual(relativeOptions[0]);
+
+      expect(viewportToDateRange({ duration: '5 minute' })).toEqual(relativeOptions[1]);
+
+      expect(viewportToDateRange({ duration: '5m' })).toEqual(relativeOptions[1]);
+
+      expect(viewportToDateRange({ duration: '10 minute' })).toEqual(relativeOptions[2]);
+
+      expect(viewportToDateRange({ duration: '10m' })).toEqual(relativeOptions[2]);
+
+      expect(viewportToDateRange({ duration: '1m 60s' })).toEqual({
+        amount: 120,
+        unit: 'second',
+        type: 'relative',
+      });
+
+      expect(viewportToDateRange({ duration: 6000 })).toEqual({
+        amount: 6,
+        unit: 'second',
+        type: 'relative',
+      });
     });
 
-    const result = currentDate.getTime() - newDate.getTime();
-    expect(result).toEqual(300000);
+    it('can convert an absolute duration to a date range', () => {
+      expect(
+        viewportToDateRange({
+          start: new Date('2023-01-11T00:00:00Z'),
+          end: new Date('2023-01-13T23:59:59Z'),
+        })
+      ).toEqual({
+        startDate: '2023-01-11T00:00:00.000Z',
+        endDate: '2023-01-13T23:59:59.000Z',
+        type: 'absolute',
+      });
 
-    currentDate = new Date();
-    newDate = getViewportDateRelativeToAbsolute({
-      amount: 1,
-      unit: 'hour',
-      type: 'relative',
+      expect(
+        viewportToDateRange({
+          start: new Date('2023-01-01T00:00:00Z'),
+          end: new Date('2023-02-28T23:59:59Z'),
+        })
+      ).toEqual({
+        startDate: '2023-01-01T00:00:00.000Z',
+        endDate: '2023-02-28T23:59:59.000Z',
+        type: 'absolute',
+      });
+
+      expect(
+        viewportToDateRange({
+          start: new Date('2023-01-11T00:00:00Z'),
+          end: new Date('2023-01-13T23:59:59.00Z'),
+        })
+      ).toEqual({
+        startDate: '2023-01-11T00:00:00.000Z',
+        endDate: '2023-01-13T23:59:59.000Z',
+        type: 'absolute',
+      });
+
+      expect(
+        viewportToDateRange({
+          start: new Date('2023-01-01T00:00:00Z'),
+          end: new Date('2023-02-28T23:59:59.00Z'),
+        })
+      ).toEqual({
+        startDate: '2023-01-01T00:00:00.000Z',
+        endDate: '2023-02-28T23:59:59.000Z',
+        type: 'absolute',
+      });
     });
-
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(3600000);
-
-    currentDate = new Date();
-    newDate = getViewportDateRelativeToAbsolute({
-      amount: 30,
-      unit: 'second',
-      type: 'relative',
-    });
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(30000);
-
-    currentDate = new Date();
-    newDate = getViewportDateRelativeToAbsolute({
-      amount: 1,
-      unit: 'day',
-      type: 'relative',
-    });
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(86400000);
-
-    currentDate = new Date();
-    newDate = getViewportDateRelativeToAbsolute({
-      amount: 1,
-      unit: 'week',
-      type: 'relative',
-    });
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(604800000);
-
-    currentDate = new Date();
-    newDate = getViewportDateRelativeToAbsolute({
-      amount: 1,
-      unit: 'month',
-      type: 'relative',
-    });
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(2592000000); //previous month is 30 days
-
-    jest.useRealTimers();
   });
-});
 
-describe('getViewportStartOnBackwardRelative on first backward click', () => {
-  jest.useFakeTimers().setSystemTime(new Date(2023, 11, 24).getTime());
+  describe('getViewportStartOnBackwardRelative', () => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date(2023, 11, 24).getTime());
+    });
 
-  it('can get the new start date from current range when going back from a relative duration', () => {
-    let currentDate = new Date();
-    let newDate = getViewportDateRelativeToAbsolute(
-      {
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    it('can get the new start date when going back from a relative duration', () => {
+      let currentDate = new Date();
+      let newDate = getViewportDateRelativeToAbsolute({
         amount: 5,
         unit: 'minute',
         type: 'relative',
-      },
-      true
-    );
+      });
 
-    const result = currentDate.getTime() - newDate.getTime();
-    expect(result).toEqual(600000);
+      const result = currentDate.getTime() - newDate.getTime();
+      expect(result).toEqual(300000);
 
-    currentDate = new Date();
-    newDate = getViewportDateRelativeToAbsolute(
-      {
+      currentDate = new Date();
+      newDate = getViewportDateRelativeToAbsolute({
         amount: 1,
         unit: 'hour',
         type: 'relative',
-      },
-      true
-    );
+      });
 
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(7200000);
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(3600000);
 
-    currentDate = new Date();
-    newDate = getViewportDateRelativeToAbsolute(
-      {
+      currentDate = new Date();
+      newDate = getViewportDateRelativeToAbsolute({
         amount: 30,
         unit: 'second',
         type: 'relative',
-      },
-      true
-    );
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(60000);
+      });
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(30000);
 
-    currentDate = new Date();
-    newDate = getViewportDateRelativeToAbsolute(
-      {
+      currentDate = new Date();
+      newDate = getViewportDateRelativeToAbsolute({
         amount: 1,
         unit: 'day',
         type: 'relative',
-      },
-      true
-    );
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(172800000);
+      });
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(86400000);
 
-    currentDate = new Date();
-    newDate = getViewportDateRelativeToAbsolute(
-      {
+      currentDate = new Date();
+      newDate = getViewportDateRelativeToAbsolute({
         amount: 1,
         unit: 'week',
         type: 'relative',
-      },
-      true
-    );
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(1209600000);
+      });
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(604800000);
 
-    currentDate = new Date();
-    newDate = getViewportDateRelativeToAbsolute(
-      {
+      currentDate = new Date();
+      newDate = getViewportDateRelativeToAbsolute({
         amount: 1,
         unit: 'month',
         type: 'relative',
-      },
-      true
-    );
+      });
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(2592000000); //previous month is 30 days
+    });
+  });
 
-    const previousMonthDays = new Date(newDate.getFullYear(), newDate.getMonth() - 1, 0).getDate(); //calculating no of days for previous month of current range
-    const timeGap = previousMonthDays === 30 ? 5184000000 : 5270400000;
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(timeGap);
+  describe('getViewportStartOnBackwardRelative on first backward click', () => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date(2023, 11, 24).getTime());
+    });
 
-    jest.useRealTimers();
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    it('can get the new start date from current range when going back from a relative duration', () => {
+      let currentDate = new Date();
+      let newDate = getViewportDateRelativeToAbsolute(
+        {
+          amount: 5,
+          unit: 'minute',
+          type: 'relative',
+        },
+        true
+      );
+
+      const result = currentDate.getTime() - newDate.getTime();
+      expect(result).toEqual(600000);
+
+      currentDate = new Date();
+      newDate = getViewportDateRelativeToAbsolute(
+        {
+          amount: 1,
+          unit: 'hour',
+          type: 'relative',
+        },
+        true
+      );
+
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(7200000);
+
+      currentDate = new Date();
+      newDate = getViewportDateRelativeToAbsolute(
+        {
+          amount: 30,
+          unit: 'second',
+          type: 'relative',
+        },
+        true
+      );
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(60000);
+
+      currentDate = new Date();
+      newDate = getViewportDateRelativeToAbsolute(
+        {
+          amount: 1,
+          unit: 'day',
+          type: 'relative',
+        },
+        true
+      );
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(172800000);
+
+      currentDate = new Date();
+      newDate = getViewportDateRelativeToAbsolute(
+        {
+          amount: 1,
+          unit: 'week',
+          type: 'relative',
+        },
+        true
+      );
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(1209600000);
+
+      currentDate = new Date();
+      newDate = getViewportDateRelativeToAbsolute(
+        {
+          amount: 1,
+          unit: 'month',
+          type: 'relative',
+        },
+        true
+      );
+
+      const previousMonthDays = new Date(newDate.getFullYear(), newDate.getMonth() - 1, 0).getDate(); //calculating no of days for previous month of current range
+      const timeGap = previousMonthDays === 30 ? 5184000000 : 5270400000;
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(timeGap);
+    });
   });
 });

--- a/packages/react-components/src/echarts/extensions/yAxisSync/updateYAxis.ts
+++ b/packages/react-components/src/echarts/extensions/yAxisSync/updateYAxis.ts
@@ -1,5 +1,6 @@
 import minBy from 'lodash.minby';
 import maxBy from 'lodash.maxby';
+import isEqual from 'lodash.isequal';
 
 import LineSeriesModel from 'echarts/types/src/chart/line/LineSeries';
 import { hasCustomYAxis } from './yAxisPredicates';
@@ -20,6 +21,10 @@ export const handleSetYAxis = (model: LineSeriesModel) => {
 
   if (!store) return;
 
+  const state = store.getState();
+
+  if (!state) return;
+
   if (hasCustomYAxis(option)) {
     const significantDigits = (option as GenericSeries).appKitSignificantDigits;
     const color = (option as GenericSeries).appKitColor;
@@ -35,9 +40,19 @@ export const handleSetYAxis = (model: LineSeriesModel) => {
       significantDigits,
     };
 
-    store.getState().setYMax(id, { ...valuePartial, value: max });
-    store.getState().setYMin(id, { ...valuePartial, value: min });
+    const newMax = { ...valuePartial, value: max };
+    const newMin = { ...valuePartial, value: min };
+
+    // set state only if something has changed
+    if (!isEqual(newMax, state.yMaxes[id])) {
+      state.setYMax(id, newMax);
+    }
+    if (!isEqual(newMin, state.yMins[id])) {
+      state.setYMin(id, newMin);
+    }
   } else {
-    store.getState().clearYAxis(id);
+    if (!isEqual(undefined, state.yMaxes[id]) || !isEqual(undefined, state.yMins[id])) {
+      store.getState().clearYAxis(id);
+    }
   }
 };


### PR DESCRIPTION
clear ymin and ymax was getting emitted on every loop

## Overview
The per chart state was getting updated on every loop

BEFORE:


https://github.com/awslabs/iot-app-kit/assets/135036199/32a34816-fecb-4ada-8d85-18e8fa637940


AFTER :


https://github.com/awslabs/iot-app-kit/assets/135036199/532162a9-d388-4fe7-b491-9b3eefcb2356


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
