### PR TITLE
fix: relative month test (main)

### DIFF
--- a/packages/react-components/src/components/time-sync/viewportAdapter.spec.ts
+++ b/packages/react-components/src/components/time-sync/viewportAdapter.spec.ts
@@ -203,7 +203,13 @@ describe('getViewportStartOnBackwardRelative', () => {
 });
 
 describe('getViewportStartOnBackwardRelative on first backward click', () => {
-  jest.useFakeTimers().setSystemTime(new Date(2023, 11, 24).getTime());
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 11, 24).getTime());
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
   it('can get the new start date from current range when going back from a relative duration', () => {
     let currentDate = new Date();
@@ -273,11 +279,6 @@ describe('getViewportStartOnBackwardRelative on first backward click', () => {
       },
       true
     );
-
-    const previousMonthDays = new Date(newDate.getFullYear(), newDate.getMonth() - 1, 0).getDate(); //calculating no of days for previous month of current range
-    const timeGap = previousMonthDays === 30 ? 5184000000 : 5270400000;
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(timeGap);
-
-    jest.useRealTimers();
+    expect(currentDate.getTime() - newDate.getTime()).toEqual(5274000000);
   });
 });


### PR DESCRIPTION
## Overview
This change fixes a broken test for relative month duration on `main`. The calculation for number of days was removed as the date is hard-coded and not dynamic (i.e., it's not necessary).

See equivalent change for the `rc` branch: https://github.com/awslabs/iot-app-kit/pull/2438.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
