### PR TITLE
fix: relative month test

### DIFF
--- a/packages/react-components/global-jest-setup.js
+++ b/packages/react-components/global-jest-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.TZ = 'UTC';
+};

--- a/packages/react-components/jest.config.ts
+++ b/packages/react-components/jest.config.ts
@@ -16,6 +16,7 @@ const config = {
     '^.+\\.svg$': '<rootDir>/svgTransform.js',
   },
   setupFilesAfterEnv: [...reactConfig.setupFilesAfterEnv, '<rootDir>/jest-setup.js'],
+  globalSetup: './global-jest-setup.js',
   coveragePathIgnorePatterns: [
     '<rootDir>/src/components/knowledge-graph/KnowledgeGraphPanel.tsx',
     '<rootDir>/src/components/chart/trendCursor/mouseEvents/useTrendCursorsEvents.ts',

--- a/packages/react-components/src/components/time-sync/viewportAdapter.spec.ts
+++ b/packages/react-components/src/components/time-sync/viewportAdapter.spec.ts
@@ -285,10 +285,7 @@ describe('viewportAdapter', () => {
         },
         true
       );
-
-      const previousMonthDays = new Date(newDate.getFullYear(), newDate.getMonth() - 1, 0).getDate(); //calculating no of days for previous month of current range
-      const timeGap = previousMonthDays === 30 ? 5184000000 : 5270400000;
-      expect(currentDate.getTime() - newDate.getTime()).toEqual(timeGap);
+      expect(currentDate.getTime() - newDate.getTime()).toEqual(5270400000);
     });
   });
 });

--- a/turbo.json
+++ b/turbo.json
@@ -2,12 +2,8 @@
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "dist/**"
-      ],
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
       "outputMode": "new-only"
     },
     "pack": {
@@ -23,24 +19,16 @@
       "outputMode": "new-only"
     },
     "test": {
-      "dependsOn": [
-        "build"
-      ],
+      "dependsOn": ["build"],
       "outputMode": "new-only"
     },
     "test:ui": {
-      "dependsOn": [
-        "build"
-      ],
-      "env": [
-        "CI"
-      ],
+      "dependsOn": ["build"],
+      "env": ["CI"],
       "outputMode": "new-only"
     },
     "start": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "env": [
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
@@ -51,7 +39,8 @@
         "PROPERTY_ID_1",
         "PROPERTY_ID_2",
         "PROPERTY_ID_3",
-        "REGION"
+        "REGION",
+        "TZ"
       ]
     },
     "version": {


### PR DESCRIPTION
## Overview
This change fixes a broken test for relative month duration by explicitly setting the timezone used by Jest. The calculation for number of days was removed as the date is hard-coded and not dynamic (i.e., it's not necessary).

See https://stackoverflow.com/questions/56261381/how-do-i-set-a-timezone-in-my-jest-config for solution information.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
