### PR TITLE
fix: relative month test

### DIFF
--- a/packages/react-components/global-jest-setup.js
+++ b/packages/react-components/global-jest-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.TZ = 'UTC';
+};

--- a/packages/react-components/jest.config.ts
+++ b/packages/react-components/jest.config.ts
@@ -16,6 +16,7 @@ const config = {
     '^.+\\.svg$': '<rootDir>/svgTransform.js',
   },
   setupFilesAfterEnv: [...reactConfig.setupFilesAfterEnv, '<rootDir>/jest-setup.js'],
+  globalSetup: './global-jest-setup.js',
   coveragePathIgnorePatterns: [
     '<rootDir>/src/components/knowledge-graph/KnowledgeGraphPanel.tsx',
     '<rootDir>/src/components/chart/trendCursor/mouseEvents/useTrendCursorsEvents.ts',

--- a/packages/react-components/src/components/time-sync/viewportAdapter.spec.ts
+++ b/packages/react-components/src/components/time-sync/viewportAdapter.spec.ts
@@ -144,7 +144,13 @@ describe('viewportToDateRange', () => {
 });
 
 describe('getViewportStartOnBackwardRelative', () => {
-  jest.useFakeTimers().setSystemTime(new Date(2023, 11, 24).getTime());
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 11, 24).getTime());
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
   it('can get the new start date when going back from a relative duration', () => {
     let currentDate = new Date();
@@ -203,7 +209,13 @@ describe('getViewportStartOnBackwardRelative', () => {
 });
 
 describe('getViewportStartOnBackwardRelative on first backward click', () => {
-  jest.useFakeTimers().setSystemTime(new Date(2023, 11, 24).getTime());
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 11, 24).getTime());
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
   it('can get the new start date from current range when going back from a relative duration', () => {
     let currentDate = new Date();
@@ -273,11 +285,6 @@ describe('getViewportStartOnBackwardRelative on first backward click', () => {
       },
       true
     );
-
-    const previousMonthDays = new Date(newDate.getFullYear(), newDate.getMonth() - 1, 0).getDate(); //calculating no of days for previous month of current range
-    const timeGap = previousMonthDays === 30 ? 5184000000 : 5270400000;
-    expect(currentDate.getTime() - newDate.getTime()).toEqual(timeGap);
-
-    jest.useRealTimers();
+    expect(currentDate.getTime() - newDate.getTime()).toEqual(5270400000);
   });
 });

--- a/turbo.json
+++ b/turbo.json
@@ -2,12 +2,8 @@
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "dist/**"
-      ],
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
       "outputMode": "new-only"
     },
     "pack": {
@@ -23,24 +19,16 @@
       "outputMode": "new-only"
     },
     "test": {
-      "dependsOn": [
-        "build"
-      ],
+      "dependsOn": ["build"],
       "outputMode": "new-only"
     },
     "test:ui": {
-      "dependsOn": [
-        "build"
-      ],
-      "env": [
-        "CI"
-      ],
+      "dependsOn": ["build"],
+      "env": ["CI"],
       "outputMode": "new-only"
     },
     "start": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "env": [
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
@@ -51,7 +39,8 @@
         "PROPERTY_ID_1",
         "PROPERTY_ID_2",
         "PROPERTY_ID_3",
-        "REGION"
+        "REGION",
+        "TZ"
       ]
     },
     "version": {


### PR DESCRIPTION
## Overview
This change mirrors what was done in https://github.com/awslabs/iot-app-kit/pull/2438 to unblock `main`. It may be another day or two before `rc` is merged into `main`, so we want to go ahead and unblock the CI.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
