### PR TITLE
fix(react-components): performance fixes for chart component

### DIFF
--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -22,12 +22,12 @@ import { MultiYAxisLegend } from './multiYAxis/multiYAxis';
 
 import './chart.css';
 import { useContextMenu } from './contextMenu/useContextMenu';
-// import { useViewportToMS } from './hooks/useViewportToMS';
-import { DEFAULT_CHART_VISUALIZATION, DEFAULT_TOOLBOX_CONFIG, PERFORMANCE_MODE_THRESHOLD } from './eChartsConstants';
+import { DEFAULT_CHART_VISUALIZATION, DEFAULT_TOOLBOX_CONFIG } from './eChartsConstants';
 import { useDataZoom } from './hooks/useDataZoom';
 import { useViewport } from '../../hooks/useViewport';
 import { getXAxis } from './chartOptions/axes/xAxis';
 import { useHandleChartEvents } from './events/useHandleChartEvents';
+import { TREND_CURSOR_KEY_MAP } from './trendCursor/constants';
 
 /**
  * Developer Notes:
@@ -59,8 +59,9 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
     dataStreams,
     thresholds: queryThresholds,
     utilizedViewport,
-    visibleData,
+    performanceMode,
   } = useVisualizedDataStreams(queries, viewport);
+
   const allThresholds = [...queryThresholds, ...(options.thresholds ?? [])];
 
   const isBottomAligned = options.legend?.position === 'bottom';
@@ -86,7 +87,6 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
   // calculate style settings for all datastreams
   const [styleSettingsMap] = useChartStyleSettings(dataStreams, options);
 
-  const performanceMode = visibleData.length > PERFORMANCE_MODE_THRESHOLD;
   // adapt datastreams into echarts series and yAxis data
   const { series, yAxis } = useSeriesAndYAxis(dataStreams, {
     styleSettings: styleSettingsMap,
@@ -103,7 +103,7 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
   const xAxis = getXAxis(options.axis);
 
   // this will handle all the Trend Cursors operations
-  const { onContextMenuClickHandler, trendCursors, trendCursorKeyMap, trendCursorHandlers } = useTrendCursors({
+  const { onContextMenuClickHandler, trendCursors, trendCursorHandlers } = useTrendCursors({
     chartRef,
     initialGraphic: options.graphic,
     size: { width: chartWidth, height: chartHeight },
@@ -154,13 +154,12 @@ const BaseChart = ({ viewport, queries, size = { width: 500, height: 500 }, ...o
       xAxis,
       graphic: trendCursors,
       animation: false,
-      appKitChartId: options.id,
     },
     settings
   );
 
   const hotKeyMap = {
-    ...trendCursorKeyMap,
+    ...TREND_CURSOR_KEY_MAP,
     ...chartEventsKeyMap,
   };
 

--- a/packages/react-components/src/components/chart/chartOptions/convertOptions.ts
+++ b/packages/react-components/src/components/chart/chartOptions/convertOptions.ts
@@ -23,8 +23,9 @@ export const useConvertedOptions = ({
   options: ConvertChartOptions;
   series: SeriesOption[];
 }): EChartsOption => {
-  const { backgroundColor, significantDigits, titleText } = options;
+  const { backgroundColor, significantDigits, titleText, legend } = options;
   const text = series.length === 0 ? 'No data present' : titleText ?? '';
+
   return useMemo(
     () => ({
       aria: {
@@ -35,9 +36,9 @@ export const useConvertedOptions = ({
         top: 10,
       },
       backgroundColor,
-      grid: convertGrid(options.legend),
+      grid: convertGrid(legend),
       tooltip: convertTooltip(significantDigits),
     }),
-    [backgroundColor, significantDigits, text, options.legend]
+    [backgroundColor, significantDigits, text, legend]
   );
 };

--- a/packages/react-components/src/components/chart/hooks/useVisualizedDataStreams.ts
+++ b/packages/react-components/src/components/chart/hooks/useVisualizedDataStreams.ts
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import { DataStream, TimeSeriesDataQuery, Viewport, getVisibleData } from '@iot-app-kit/core';
 import { useTimeSeriesData } from '../../../hooks/useTimeSeriesData';
 import { useViewport } from '../../../hooks/useViewport';
 import { DEFAULT_VIEWPORT, StreamType } from '../../../common/constants';
+import { PERFORMANCE_MODE_THRESHOLD } from '../eChartsConstants';
 
 const isNotAlarmStream = ({ streamType }: DataStream) => streamType !== StreamType.ALARM;
 const dataStreamIsLoading = ({ isLoading }: DataStream) => isLoading;
@@ -22,17 +23,38 @@ export const useVisualizedDataStreams = (queries: TimeSeriesDataQuery[], passedI
     },
   });
 
-  // Line | Scatter | Bar charts do not support alarm streams.
-  const dataStreamsWithoutAlarms = dataStreams.filter(isNotAlarmStream);
+  // dependencies converted to string
+  // useEffect performs an equal check on the previous and current values , for object it check the reference
+  // if the reference has changed i.e. new element but has the same value, the useEffect is triggered, to avoid this
+  // strings are used to compare
+  const dataString = JSON.stringify(dataStreams);
+  const thresholdsString = JSON.stringify(thresholds);
+  const utilizedString = JSON.stringify(utilizedViewport);
 
-  const hasError = useMemo(() => dataStreamsWithoutAlarms.some(dataStreamHasError), [dataStreamsWithoutAlarms]);
+  // utilizing state to make sure these values are updated only on change else
+  // creating a new object will trigger the useEffect in every cycle
+  const [dataStreamsWithoutAlarms, setDataStreamsWithoutAlarms] = useState(dataStreams);
+  const [hasError, setHasError] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [performanceMode, setPerformanceMode] = useState(false);
 
-  const isLoading = useMemo(
-    () => !hasError && dataStreamsWithoutAlarms.some(dataStreamIsLoading),
-    [hasError, dataStreamsWithoutAlarms]
-  );
+  useEffect(() => {
+    const dataWOAlarms = dataStreams.filter(isNotAlarmStream) as DataStream[];
+    setDataStreamsWithoutAlarms(dataWOAlarms);
 
-  const visibleData = dataStreamsWithoutAlarms.flatMap(({ data }) => getVisibleData(data, utilizedViewport, false));
+    const hasErrorLocal = dataWOAlarms.some(dataStreamHasError);
+    const isLoadingLocal = !hasErrorLocal && dataWOAlarms.some(dataStreamIsLoading);
+    setHasError(hasErrorLocal);
+    setIsLoading(isLoadingLocal);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataString, thresholdsString]);
+
+  useEffect(() => {
+    const visibleData = dataStreamsWithoutAlarms.flatMap(({ data }) => getVisibleData(data, utilizedViewport, false));
+    const performanceModeLocal = visibleData.length > PERFORMANCE_MODE_THRESHOLD;
+    setPerformanceMode(performanceModeLocal);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataStreamsWithoutAlarms, utilizedString]);
 
   return {
     hasError,
@@ -40,6 +62,6 @@ export const useVisualizedDataStreams = (queries: TimeSeriesDataQuery[], passedI
     dataStreams: dataStreamsWithoutAlarms,
     thresholds,
     utilizedViewport,
-    visibleData,
+    performanceMode,
   };
 };

--- a/packages/react-components/src/components/chart/trendCursor/constants/index.ts
+++ b/packages/react-components/src/components/chart/trendCursor/constants/index.ts
@@ -1,4 +1,6 @@
 // Trend Cursor constants
+import { KeyMap } from 'react-hotkeys';
+
 export const DEBUG_TREND_CURSORS = localStorage.getItem('DEBUG_TREND_CURSORS') ?? false;
 export const TREND_CURSOR_HEADER_COLORS = ['#DA7596', '#2EA597', '#688AE8', '#A783E1', '#E07941'];
 export const TREND_CURSOR_HEADER_WIDTH = 120;
@@ -19,3 +21,8 @@ export const TREND_CURSOR_LINE_MARKERS_GRAPHIC_INDEX = 3;
 export const TREND_CURSOR_DRAG_RECT_WIDTH = 60;
 
 export const FRAMES_TO_SKIP = 2;
+
+export const TREND_CURSOR_KEY_MAP: KeyMap = {
+  commandDown: { sequence: 't', action: 'keydown' },
+  commandUp: { sequence: 't', action: 'keyup' },
+};

--- a/packages/react-components/src/hooks/useECharts/useEChartOptions.ts
+++ b/packages/react-components/src/hooks/useECharts/useEChartOptions.ts
@@ -15,7 +15,11 @@ export const useEChartOptions = (
   option: EChartsOption,
   settings?: SetOptionOpts
 ) => {
+  const optionString = JSON.stringify(option);
+  const settingsString = JSON.stringify(settings);
+
   useEffect(() => {
     chartRef.current?.setOption(option, settings);
-  }, [chartRef, option, settings]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chartRef, optionString, settingsString]);
 };

--- a/packages/react-components/src/hooks/useECharts/useGroupableEchart.ts
+++ b/packages/react-components/src/hooks/useECharts/useGroupableEchart.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { connect, disconnect, type ECharts } from 'echarts';
 
 /**
@@ -15,6 +15,5 @@ export const useGroupableEChart = (chartRef: React.MutableRefObject<ECharts | nu
       disconnect(groupId);
       connect(groupId);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [groupId]);
+  }, [chartRef, groupId]);
 };

--- a/packages/react-components/src/hooks/useECharts/useLoadableEChart.ts
+++ b/packages/react-components/src/hooks/useECharts/useLoadableEChart.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import type { ECharts } from 'echarts';
 
 /**

--- a/packages/react-components/src/utils/useEffectDebugger.ts
+++ b/packages/react-components/src/utils/useEffectDebugger.ts
@@ -1,0 +1,39 @@
+import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
+
+const usePrevious = (value: DependencyList, initialValue: DependencyList) => {
+  const ref = useRef(initialValue);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+export const useEffectDebugger = (
+  effectHook: EffectCallback,
+  dependencies: DependencyList = [],
+  dependencyNames = []
+) => {
+  const previousDeps = usePrevious(dependencies, []);
+
+  const changedDeps: unknown = dependencies.reduce((accum: object, dependency, index) => {
+    if (dependency !== previousDeps[index]) {
+      const keyName = dependencyNames[index] || index;
+
+      return {
+        ...accum,
+        [keyName]: {
+          before: previousDeps[index],
+          after: dependency,
+        },
+      };
+    }
+
+    return accum;
+  }, {});
+
+  if (Object.keys(changedDeps as NonNullable<unknown>).length) {
+    console.log('[use-effect-debugger] ', changedDeps);
+  }
+
+  useEffect(effectHook, [effectHook, ...dependencies]);
+};


### PR DESCRIPTION
## Overview
1. to avoid unnecessary calculations on change of certain input props, adding appropriate memo and useEffect with dependencies converted into string using JSON.stringify 
This should helps us save some cycles and stop unnecessary setting of echart options.

2. added a utility debugger useEffect which can used to debug useEffect when required. 


## Verifying Changes


https://github.com/awslabs/iot-app-kit/assets/135036199/ae322030-91ed-438f-99a8-9a37f9ab0498


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
