### PR TITLE
fix(dashboard): increase width of property label in config panel to span width of panel

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.css
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.css
@@ -19,5 +19,5 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: normal;
-  width: 288px;
+  width: 355px;
 }

--- a/packages/dashboard/src/customization/propertiesSections/settings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/settings/section.tsx
@@ -8,6 +8,7 @@ import { numberFromDetail } from '~/util/inputEvent';
 
 import './section.css';
 import { isNumeric } from '@iot-app-kit/core/dist/es/common/number';
+import { spaceScaledXs } from '@cloudscape-design/design-tokens';
 
 export const SettingsSection = ({
   significantDigits,
@@ -19,22 +20,28 @@ export const SettingsSection = ({
   const onSignificantDigitsChange: NonCancelableEventHandler<InputProps.ChangeDetail> = (event) => {
     updateSignificantDigits(isNumeric(event.detail.value) ? numberFromDetail(event) : undefined);
   };
+
+  const sectionStyle = {
+    padding: spaceScaledXs,
+  };
   return (
-    <ExpandableSection headerText='Settings' defaultExpanded>
-      <SpaceBetween size='m' direction='vertical'>
-        <div className='settings-property-label' style={{ gap: awsui.spaceScaledS }}>
-          <label htmlFor='decimal-places'>Decimal places</label>
-          <div className='settings-property-label-control'>
-            <Input
-              type='number'
-              controlId='decimal-places'
-              ariaLabel='decimal places'
-              value={significantDigits?.toFixed() ?? ''}
-              onChange={onSignificantDigitsChange}
-            />
+    <div style={sectionStyle}>
+      <ExpandableSection headerText='Settings' defaultExpanded>
+        <SpaceBetween size='m' direction='vertical'>
+          <div className='settings-property-label' style={{ gap: awsui.spaceScaledS }}>
+            <label htmlFor='decimal-places'>Decimal places</label>
+            <div className='settings-property-label-control'>
+              <Input
+                type='number'
+                controlId='decimal-places'
+                ariaLabel='decimal places'
+                value={significantDigits?.toFixed() ?? ''}
+                onChange={onSignificantDigitsChange}
+              />
+            </div>
           </div>
-        </div>
-      </SpaceBetween>
-    </ExpandableSection>
+        </SpaceBetween>
+      </ExpandableSection>
+    </div>
   );
 };


### PR DESCRIPTION
## Overview
Change property-label width from 288px to 355px to span the entire container. 
Added padding to KPI widget

## Verifying Changes

Before:
![low width](https://github.com/awslabs/iot-app-kit/assets/145582655/6b340a89-51ef-44fb-84b5-78330308e41e)

![Screenshot 2024-01-04 at 12 54 51 PM](https://github.com/awslabs/iot-app-kit/assets/145582655/98ff50d2-3f36-4d1c-8149-10bb9d98fe76)



After:
![Screenshot 2024-01-04 at 12 50 22 PM](https://github.com/awslabs/iot-app-kit/assets/145582655/b1685a7f-6a54-416b-a721-25c2d06d0d4f)

![Screenshot 2024-01-04 at 12 54 02 PM](https://github.com/awslabs/iot-app-kit/assets/145582655/b24451dd-e627-4f29-8999-477042cc91ae)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
