### PR TITLE
fix(react-components): remove secondary selection state when using TCs or gestures

### DIFF
--- a/packages/react-components/src/components/chart/chart.css
+++ b/packages/react-components/src/components/chart/chart.css
@@ -41,6 +41,7 @@
 .base-chart-container,
 .chart-rightlegend-container {
   display: flex;
+  outline: none;
 }
 
 .base-chart-container.left-position {


### PR DESCRIPTION
## Overview
set outline property to none in chart css to remove the focus border

## Verifying Changes

Before:

https://github.com/awslabs/iot-app-kit/assets/145582655/48dc70bd-6014-4b71-9273-f18e2c72e002


After:

https://github.com/awslabs/iot-app-kit/assets/145582655/7de8c2c6-2eb6-4999-a29c-806f2bbb0aa8





## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
