### PR TITLE
fix(dashboard): selected assets do not deselect on widget selection

### DIFF
--- a/packages/dashboard/e2e/tests/resourceExplorer/resourceExplorer.spec.ts
+++ b/packages/dashboard/e2e/tests/resourceExplorer/resourceExplorer.spec.ts
@@ -41,13 +41,9 @@ test('can load configure a widget with an asset model', async ({ page }) => {
   await expect(page.locator(ASSET_MODEL_TAB)).toBeVisible();
   await resourceExplorer.tabTo('assetModel');
 
-  const {
-    selectAssetModel,
-    selectAsset,
-    saveAssetModel,
-    selectProperty,
-    addToWidget,
-  } = resourceExplorer.assetModelActions;
+  const { addToWidget } = resourceExplorer.generalActions;
+  const { selectAssetModel, selectAsset, saveAssetModel, selectProperty } =
+    resourceExplorer.assetModelActions;
   // configure asset model and default asset and select
   await selectAssetModel('Site');
   await selectAsset('Africa site');
@@ -101,4 +97,200 @@ test('properties are disabled and enabled according to their data type', async (
   // check that string property is disabled
   const invalidProperty = findProperty('Coordinates');
   await expect(invalidProperty).toBeDisabled();
+});
+
+//modeled data streams tests
+test('properties are disabled and enabled according to their data type (modeled)', async ({
+  page,
+}) => {
+  await page.goto(TEST_PAGE);
+
+  const grid = gridUtil(page);
+  const resourceExplorer = resourceExplorerUtil(page);
+
+  // add line widget
+  const location1 = await grid.cellLocation(0, 0);
+  const lineWidget = await grid.addWidget('line', () => location1);
+
+  // select line widget
+  await grid.clickWidget(lineWidget);
+
+  // check that widget is in empty state
+  await expect(page.getByText(WIDGET_EMPTY_STATE_TEXT)).toBeVisible();
+
+  // open resource explorer and tab to Modeled
+  await resourceExplorer.open();
+  await expect(page.locator(MODELED_TAB)).toBeVisible();
+  await resourceExplorer.tabTo('modeled');
+
+  const {
+    findAsset,
+    selectAsset,
+    findProperty,
+    selectProperty,
+    findDisabledProperty,
+  } = resourceExplorer.modeledActions;
+
+  //find and click asset
+  await findAsset('Africa Site');
+  await selectAsset('Africa Site');
+
+  //find string property and check disabled (double click to move screen down)
+  await selectProperty('Production Rate');
+  await selectProperty('Production Rate');
+
+  // check that number property is not disabled
+  const validProperty = findProperty('Production Rate');
+  await expect(validProperty).not.toBeDisabled();
+
+  // check that string property is disabled
+  const invalidProperty = findDisabledProperty('STRING');
+  await expect(invalidProperty).toBeDisabled();
+});
+
+test('changing selected asset and returning back to old asset resets selection (modeled)', async ({
+  page,
+}) => {
+  await page.goto(TEST_PAGE);
+
+  const grid = gridUtil(page);
+  const resourceExplorer = resourceExplorerUtil(page);
+
+  // add line widget
+  const location1 = await grid.cellLocation(0, 0);
+  const lineWidget = await grid.addWidget('line', () => location1);
+
+  // select line widget
+  await grid.clickWidget(lineWidget);
+
+  // check that widget is in empty state
+  await expect(page.getByText(WIDGET_EMPTY_STATE_TEXT)).toBeVisible();
+
+  // open resource explorer and tab to Modeled
+  await resourceExplorer.open();
+  await expect(page.locator(MODELED_TAB)).toBeVisible();
+  await resourceExplorer.tabTo('modeled');
+
+  const { findAsset, selectAsset, findProperty, selectProperty } =
+    resourceExplorer.modeledActions;
+
+  //find and click asset
+  await findAsset('Africa Site');
+  await selectAsset('Africa Site');
+
+  //select property and see if it is selected
+  await selectProperty('Production Rate');
+  const checkedProperty = findProperty('Production Rate');
+  await expect(checkedProperty).toBeChecked();
+
+  //find another asset and click
+  await findAsset('Asia Site');
+  await selectAsset('Asia Site');
+
+  //find and click original asset
+  await findAsset('Africa Site');
+  await selectAsset('Africa Site');
+
+  await expect(checkedProperty).not.toBeChecked();
+});
+
+test(' adding properties to widget clears selection on resource explorer (modeled)', async ({
+  page,
+}) => {
+  await page.goto(TEST_PAGE);
+
+  const grid = gridUtil(page);
+  const resourceExplorer = resourceExplorerUtil(page);
+
+  // add line widget
+  const location1 = await grid.cellLocation(0, 0);
+  const lineWidget = await grid.addWidget('line', () => location1);
+
+  // select line widget
+  await grid.clickWidget(lineWidget);
+
+  // check that widget is in empty state
+  await expect(page.getByText(WIDGET_EMPTY_STATE_TEXT)).toBeVisible();
+
+  // open resource explorer and tab to Modeled
+  await resourceExplorer.open();
+  await expect(page.locator(MODELED_TAB)).toBeVisible();
+  await resourceExplorer.tabTo('modeled');
+
+  const { addToWidget } = resourceExplorer.generalActions;
+
+  const { findAsset, selectAsset, findProperty, selectProperty } =
+    resourceExplorer.modeledActions;
+
+  //find and click asset
+  await findAsset('Africa Site');
+  await selectAsset('Africa Site');
+
+  //select property
+  await selectProperty('Production Rate');
+  const checkedProperty = findProperty('Production Rate');
+  await expect(checkedProperty).toBeChecked();
+
+  //add selected properties to widget
+  await addToWidget();
+
+  // check that widget is not in empty state
+  await expect(page.getByText(WIDGET_EMPTY_STATE_TEXT)).not.toBeVisible();
+  // check that property is visible in legend
+  await expect(grid.gridArea().getByText('Production Rate')).toBeVisible();
+
+  //properties are not selected anymore
+  await expect(checkedProperty).not.toBeChecked();
+});
+
+test(' changing widgets filters properties correctly (modeled)', async ({
+  page,
+}) => {
+  await page.goto(TEST_PAGE);
+
+  const grid = gridUtil(page);
+  const resourceExplorer = resourceExplorerUtil(page);
+
+  // add line widget
+  const location1 = await grid.cellLocation(0, 0);
+  const location2 = await grid.cellLocation(0, 0);
+  const lineWidget = await grid.addWidget('line', () => location1);
+  const kpiWidget = await grid.addWidget('kpi', () => location2);
+
+  // select line widget
+  await grid.clickWidget(lineWidget);
+
+  // check that widget is in empty state
+  await expect(page.getByText(WIDGET_EMPTY_STATE_TEXT)).toBeVisible();
+
+  // open resource explorer and tab to Modeled
+  await resourceExplorer.open();
+  await expect(page.locator(MODELED_TAB)).toBeVisible();
+  await resourceExplorer.tabTo('modeled');
+
+  const { findAsset, selectAsset, findProperty, findDisabledProperty } =
+    resourceExplorer.modeledActions;
+
+  //find and click asset
+  await findAsset('Africa Site');
+  await selectAsset('Africa Site');
+
+  // check integer property not disabled
+  const validProperty = findProperty('Production Rate');
+  await expect(validProperty).not.toBeDisabled();
+
+  //find string property and check disabled
+  const invalidProperty = findDisabledProperty('STRING');
+  await expect(invalidProperty).toBeDisabled();
+
+  // select kpi widget
+  await grid.clickWidget(kpiWidget);
+
+  const validProperty2 = findProperty('Coordinates');
+
+  // check integer property is not disabled
+  await expect(validProperty).not.toBeDisabled();
+
+  //find string property is not disabled
+  await expect(validProperty2).not.toBeDisabled();
 });

--- a/packages/dashboard/e2e/tests/utils/resourceExplorer.ts
+++ b/packages/dashboard/e2e/tests/utils/resourceExplorer.ts
@@ -17,6 +17,21 @@ export const resourceExplorerUtil = (page: Page) => {
   const frame = page.locator(RESOURCE_EXPLORER_FRAME);
 
   /**
+   * general RE specific actions
+   */
+  const generalActions = {
+    /**
+     * click the add button
+     * will add the asset model configuration to the selection.
+     *
+     * @returns void
+     */
+    addToWidget: async () => {
+      await frame.getByRole('button', { name: 'Add', exact: true }).click();
+    },
+  };
+
+  /**
    * asset model tab specific actions
    */
   const assetModelActions = {
@@ -66,14 +81,57 @@ export const resourceExplorerUtil = (page: Page) => {
     selectProperty: async (label: string) => {
       await frame.getByLabel(`Select asset model property ${label}`).click();
     },
+  };
+
+  /**
+   * modeled tab specific actions
+   */
+  const modeledActions = {
     /**
-     * click the add button
-     * will add the asset model configuration to the selection.
+     * finds an asset
+     *
+     * @returns Locator
+     *
+     */
+    findAsset: (label: string) => {
+      return frame.getByLabel(`Select asset ${label}`);
+    },
+
+    /**
+     * select asset from table
      *
      * @returns void
      */
-    addToWidget: async () => {
-      await frame.getByRole('button', { name: 'Add', exact: true }).click();
+    selectAsset: (label: string) => {
+      return frame.getByLabel(`Select asset ${label}`).click();
+    },
+
+    /**
+     * finds an asset property
+     *
+     * @returns Locator
+     *
+     */
+    findProperty: (label: string) => {
+      return frame.getByLabel(`Select modeled data stream ${label}`);
+    },
+    /**
+     * select asset property from table
+     *
+     * @returns void
+     */
+    selectProperty: async (label: string) => {
+      await frame.getByLabel(`Select modeled data stream ${label}`).click();
+    },
+    /**
+     * select a disabled asset property from table
+     *
+     * @returns void
+     */
+    findDisabledProperty: (label: string) => {
+      return frame.getByLabel(
+        `${label} data not supported for the selected widget`
+      );
     },
   };
 
@@ -94,6 +152,8 @@ export const resourceExplorerUtil = (page: Page) => {
     tabTo: async (tab: Tabs) => {
       await frame.locator(tabMap[tab]).click();
     },
+    generalActions,
     assetModelActions,
+    modeledActions,
   };
 };


### PR DESCRIPTION
## Overview
- changed current useEffect hook that resets selected items to depend on selectedAsset asset id primitive instead of selected asset object.

- added useEffect hook that deselects already selected options that are not compatible with widget type 

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/0fab202f-5281-4d66-8025-1b54b416df13


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
