### PR TITLE
feat: legend resize

### DIFF
--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -41,6 +41,7 @@ import './chart.css';
 const BaseChart = ({
   viewport,
   queries,
+  onChartOptionsChange,
   size = { width: 500, height: 500 },
   ...options
 }: ChartOptions) => {
@@ -89,8 +90,9 @@ const BaseChart = ({
   } = useResizeableEChart(
     chartRef,
     size,
-    options.legend?.visible,
-    isBottomAligned
+    options.legend,
+    isBottomAligned,
+    onChartOptionsChange
   );
 
   const {

--- a/packages/react-components/src/components/chart/chart.css
+++ b/packages/react-components/src/components/chart/chart.css
@@ -60,7 +60,7 @@
 
 .left-position .react-resizable-handle-se {
   right: unset;
-  left: -15px;
+  left: 0;
   border: unset;
   border-right: 2px solid #e9ebed;
   border-left: 1px solid #e9ebed;

--- a/packages/react-components/src/components/chart/tests/baseChart.spec.tsx
+++ b/packages/react-components/src/components/chart/tests/baseChart.spec.tsx
@@ -46,6 +46,7 @@ describe('Chart Component Testing', () => {
     const element = render(
       <Chart
         queries={[query]}
+        onChartOptionsChange={jest.fn()}
         viewport={VIEWPORT}
         size={{ width: 500, height: 500 }}
       />
@@ -57,6 +58,7 @@ describe('Chart Component Testing', () => {
     const element = render(
       <Chart
         queries={[mockQuery]}
+        onChartOptionsChange={jest.fn()}
         viewport={VIEWPORT}
         size={{ width: 500, height: 500 }}
       />
@@ -81,6 +83,7 @@ describe('Chart slider testing', () => {
           asset: true,
         },
       },
+      onChartOptionsChange: jest.fn(),
       gestures: false,
       significantDigits: 4,
       styleSettings: {},
@@ -108,6 +111,7 @@ describe('Chart slider testing', () => {
           asset: true,
         },
       },
+      onChartOptionsChange: jest.fn(),
       gestures: false,
       significantDigits: 4,
       styleSettings: {},

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -109,6 +109,7 @@ export type ChartOptions = {
   theme?: string;
   id?: string;
   titleText?: string;
+  onChartOptionsChange?: (options: Pick<ChartOptions, 'legend'>) => void;
 };
 
 export interface ViewportInMs {

--- a/packages/react-components/src/components/trend-cursor-sync/trendCursorSync.spec.tsx
+++ b/packages/react-components/src/components/trend-cursor-sync/trendCursorSync.spec.tsx
@@ -25,6 +25,7 @@ describe('TrendCursorSync', () => {
           viewport={mockViewport}
           queries={[mockQuery]}
           size={{ width: 800, height: 500 }}
+          onChartOptionsChange={jest.fn()}
           theme='light'
           id='chart1'
         />
@@ -40,6 +41,7 @@ describe('TrendCursorSync', () => {
           viewport={mockViewport}
           queries={[mockQuery]}
           size={{ width: 800, height: 500 }}
+          onChartOptionsChange={jest.fn()}
           theme='light'
           id='chart1'
         />
@@ -47,6 +49,7 @@ describe('TrendCursorSync', () => {
           viewport={mockViewport}
           queries={[mockQuery]}
           size={{ width: 800, height: 500 }}
+          onChartOptionsChange={jest.fn()}
           theme='light'
           id='chart1'
         />

--- a/packages/react-components/src/hooks/useECharts/useResizeableEchart.spec.ts
+++ b/packages/react-components/src/hooks/useECharts/useResizeableEchart.spec.ts
@@ -1,0 +1,263 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import {
+  useResizeableEChart,
+  getDecimalFromPercentage,
+  getChartHeight,
+  getChartWidth,
+  getRightLegendHeight,
+  getRightLegendWidth,
+} from './useResizeableEChart';
+import { ChartOptions } from '../../components/chart/types';
+import { ResizeCallbackData } from 'react-resizable';
+
+describe('useResizeableEChart', () => {
+  describe('render chart when legend is not visible', () => {
+    const chartRef = { current: null };
+    const size = { width: 1000, height: 500 };
+    const legend: ChartOptions['legend'] = {
+      width: '30%',
+      height: '30%',
+      visible: false,
+    };
+    const onChartOptionsChange = jest.fn();
+    const isBottomAligned = false;
+
+    it('should set initial chart width and height correctly', () => {
+      const { result } = renderHook(() =>
+        useResizeableEChart(
+          chartRef,
+          size,
+          legend,
+          isBottomAligned,
+          onChartOptionsChange
+        )
+      );
+
+      expect(result.current.chartWidth).toBe(size.width);
+      expect(result.current.chartHeight).toBe(size.height);
+    });
+  });
+
+  describe('render chart when legend is visible and not bottom aligned', () => {
+    const chartRef = { current: null };
+    const size = { width: 1000, height: 500 };
+    const legend: ChartOptions['legend'] = {
+      width: '30%',
+      height: '30%',
+      visible: true,
+    };
+    const onChartOptionsChange = jest.fn();
+    const isBottomAligned = false;
+
+    it('should set initial chart width and height correctly', () => {
+      const { result } = renderHook(() =>
+        useResizeableEChart(
+          chartRef,
+          size,
+          legend,
+          isBottomAligned,
+          onChartOptionsChange
+        )
+      );
+
+      expect(result.current.chartWidth).toBe(700);
+      expect(result.current.chartHeight).toBe(size.height);
+    });
+
+    it('should update chart width and call onChartOptionsChange when resizing horizontally', () => {
+      const { result } = renderHook(() =>
+        useResizeableEChart(
+          chartRef,
+          size,
+          legend,
+          isBottomAligned,
+          onChartOptionsChange
+        )
+      );
+
+      act(() => {
+        const event = {
+          stopPropagation: jest.fn(),
+        } as unknown as React.SyntheticEvent;
+        result.current.onResize(event, {
+          size: { width: 800, height: 400 },
+        } as unknown as ResizeCallbackData);
+      });
+
+      expect(result.current.chartWidth).toBe(800);
+      expect(onChartOptionsChange).toHaveBeenCalledWith({
+        legend: { ...legend, width: '20%' },
+      });
+    });
+  });
+
+  describe('render chart when legend is visible and bottom aligned', () => {
+    const chartRef = { current: null };
+    const size = { width: 1000, height: 500 };
+    const legend: ChartOptions['legend'] = {
+      width: '30%',
+      height: '30%',
+      visible: true,
+    };
+    const onChartOptionsChange = jest.fn();
+    const isBottomAligned = true;
+
+    it('should set initial chart width and height correctly when bottom aligned', () => {
+      const { result } = renderHook(() =>
+        useResizeableEChart(
+          chartRef,
+          size,
+          legend,
+          isBottomAligned,
+          onChartOptionsChange
+        )
+      );
+
+      expect(result.current.chartWidth).toBe(size.width);
+      expect(result.current.chartHeight).toBe(350);
+    });
+
+    it('should update chart height and call onChartOptionsChange when resizing vertically', () => {
+      const { result } = renderHook(() =>
+        useResizeableEChart(
+          chartRef,
+          size,
+          legend,
+          isBottomAligned,
+          onChartOptionsChange
+        )
+      );
+
+      act(() => {
+        const event = {
+          stopPropagation: jest.fn(),
+        } as unknown as React.SyntheticEvent;
+        result.current.onResize(event, {
+          size: { width: 800, height: 400 },
+        } as unknown as ResizeCallbackData);
+      });
+
+      expect(result.current.chartWidth).toBe(size.width);
+      expect(onChartOptionsChange).toHaveBeenCalledWith({
+        legend: { ...legend, height: '20%' },
+      });
+    });
+  });
+
+  describe('render getDecimalFromPercentage', () => {
+    it('should return 0 if the input does not contain "%" or is empty', () => {
+      expect(getDecimalFromPercentage('')).toBe(0);
+      expect(getDecimalFromPercentage('123')).toBe(0);
+      expect(getDecimalFromPercentage('123abc')).toBe(0);
+      expect(getDecimalFromPercentage('abc')).toBe(0);
+    });
+
+    it('should return the decimal value of the input', () => {
+      expect(getDecimalFromPercentage('100%')).toBe(1);
+      expect(getDecimalFromPercentage('50%')).toBe(0.5);
+      expect(getDecimalFromPercentage('25%')).toBe(0.25);
+    });
+  });
+
+  describe('render getChartWidth', () => {
+    it('should return width - staticWidth when isLegendVisible and legendWidth are falsy or isBottomAligned is true', () => {
+      expect(getChartWidth(100, 10)).toBe(90);
+      expect(getChartWidth(200, 20, false, '', true)).toBe(180);
+    });
+
+    it('should return the calculated width based on the formula when isLegendVisible and legendWidth are truthy and isBottomAligned is falsy', () => {
+      expect(getChartWidth(300, 30, true, '50%')).toBe(120);
+      expect(getChartWidth(400, 40, true, '75%')).toBe(60);
+    });
+  });
+
+  describe('render getChartHeight', () => {
+    it('should return the original height if any of the optional arguments are missing', () => {
+      const height = 100;
+      const result = getChartHeight(height);
+      expect(result).toEqual(height);
+    });
+
+    it('should return the calculated height if all optional arguments are provided', () => {
+      const height = 100;
+      const isLegendVisible = true;
+      const legendHeight = '50%';
+      const isBottomAligned = true;
+      const expected = height * (1 - getDecimalFromPercentage(legendHeight));
+      const result = getChartHeight(
+        height,
+        isLegendVisible,
+        legendHeight,
+        isBottomAligned
+      );
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('render getRightLegendWidth', () => {
+    it('should return 0 when isLegendVisible is false', () => {
+      const result = getRightLegendWidth(false, true, 100, 50, 200);
+      expect(result).toEqual(0);
+    });
+
+    it('should return width when isBottomAligned is true', () => {
+      const result = getRightLegendWidth(true, true, 100, 50, 200);
+      expect(result).toEqual(100);
+    });
+
+    it('should return width - leftLegendWidth - chartWidth when isBottomAligned is false', () => {
+      const result = getRightLegendWidth(true, false, 100, 20, 30);
+      expect(result).toEqual(50);
+    });
+  });
+
+  describe('render getRightLegendHeight', () => {
+    it('should return 0 if legend is not visible', () => {
+      const isLegendVisible = false;
+      const isBottomAligned = true;
+      const height = 100;
+      const chartHeight = 50;
+
+      const result = getRightLegendHeight(
+        isLegendVisible,
+        isBottomAligned,
+        height,
+        chartHeight
+      );
+
+      expect(result).toBe(0);
+    });
+
+    it('should return the height if legend is visible and bottom aligned', () => {
+      const isLegendVisible = true;
+      const isBottomAligned = true;
+      const height = 100;
+      const chartHeight = 50;
+
+      const result = getRightLegendHeight(
+        isLegendVisible,
+        isBottomAligned,
+        height,
+        chartHeight
+      );
+
+      expect(result).toBe(height - chartHeight);
+    });
+
+    it('should return the height if legend is visible and not bottom aligned', () => {
+      const isLegendVisible = true;
+      const isBottomAligned = false;
+      const height = 100;
+      const chartHeight = 50;
+
+      const result = getRightLegendHeight(
+        isLegendVisible,
+        isBottomAligned,
+        height,
+        chartHeight
+      );
+
+      expect(result).toBe(height);
+    });
+  });
+});

--- a/packages/react-components/src/hooks/utils/pxToPercentage.spec.ts
+++ b/packages/react-components/src/hooks/utils/pxToPercentage.spec.ts
@@ -1,0 +1,15 @@
+import { pxToPercent } from './pxToPercentage'; // Replace './file' with the correct path to the file containing the pxToPercent function
+
+describe('pxToPercent', () => {
+  it('should return the correct percentage when px is less than totalPx', () => {
+    expect(pxToPercent(10, 100)).toBe('10%');
+  });
+
+  it('should return the correct percentage when px is equal to totalPx', () => {
+    expect(pxToPercent(100, 100)).toBe('100%');
+  });
+
+  it('should return the correct percentage when px is greater than totalPx', () => {
+    expect(pxToPercent(150, 100)).toBe('150%');
+  });
+});

--- a/packages/react-components/src/hooks/utils/pxToPercentage.ts
+++ b/packages/react-components/src/hooks/utils/pxToPercentage.ts
@@ -1,0 +1,3 @@
+export const pxToPercent = (px: number, totalPx: number): string => {
+  return `${((px / totalPx) * 100).toFixed(0)}%`;
+};

--- a/packages/react-components/stories/chart/base-chart.stories.tsx
+++ b/packages/react-components/stories/chart/base-chart.stories.tsx
@@ -64,6 +64,7 @@ export const BaseChartExample: ComponentStory<FC<StoryInputs>> = ({
             defaultVisualizationType={chartType}
             significantDigits={significantDigits}
             size={size}
+            onChartOptionsChange={jest.fn()}
             styleSettings={styleSettings}
             viewport={viewport ?? VIEWPORT}
             queries={[MOCK_TIME_SERIES_DATA_QUERY]}

--- a/packages/react-components/stories/trend-cursor-sync/timesync.stories.tsx
+++ b/packages/react-components/stories/trend-cursor-sync/timesync.stories.tsx
@@ -25,6 +25,7 @@ export const Main: ComponentStory<typeof TrendCursorSync> = () => (
       viewport={VIEWPORT}
       queries={[MOCK_TIME_SERIES_DATA_QUERY]}
       size={{ width: 800, height: 500 }}
+      onChartOptionsChange={jest.fn()}
       theme='light'
     />
   </TrendCursorSync>
@@ -42,6 +43,7 @@ export const MultipleTimeSyncs: ComponentStory<typeof TrendCursorSync> = () => (
             viewport={VIEWPORT}
             queries={[MOCK_TIME_SERIES_DATA_QUERY]}
             size={{ width: 800, height: 500 }}
+            onChartOptionsChange={jest.fn()}
             theme='light'
           />
         ))}


### PR DESCRIPTION
## Overview
This PR is for ticket #2277 (Saving the legend height and width to the dashboard definition)

Made changes on resizing the legend width(In the left and right position) and height(in the bottom position) to save the legend size in redux and on clicking the save button saves the data in localStorage(db). In this PR I used percentage(%) as width and height for the calculations of legend, chart, and left legend sizes.

## Verifying Changes
Without left legend:

https://github.com/awslabs/iot-app-kit/assets/139960352/9a348446-89ed-4128-94a3-0f015dd2da2d


With left legend:

https://github.com/awslabs/iot-app-kit/assets/139960352/d6b8a039-bd59-4f8e-a4a6-953fd2819535


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
