### PR TITLE
fix: text widget enhancement - 2429

### DIFF
--- a/packages/dashboard/src/customization/widgets/text/styledText/index.tsx
+++ b/packages/dashboard/src/customization/widgets/text/styledText/index.tsx
@@ -4,6 +4,7 @@ import { defaultFontSettings } from './defaultFontSettings';
 
 import './index.css';
 import type { TextWidget } from '../../types';
+import { spaceScaledXs } from '@cloudscape-design/design-tokens';
 
 type StyledTextProps = TextWidget & {
   onPointerDown?: PointerEventHandler;
@@ -24,6 +25,7 @@ const StyledText: React.FC<StyledTextProps> = ({ onPointerDown, onPointerUp, ...
   const style: CSSProperties = {
     fontSize,
     color: fontColor,
+    padding: spaceScaledXs,
   };
 
   const textContent = addPlaceholder ? 'Add text' : value;

--- a/packages/dashboard/src/customization/widgets/text/styledText/textArea.tsx
+++ b/packages/dashboard/src/customization/widgets/text/styledText/textArea.tsx
@@ -7,7 +7,7 @@ import { defaultFontSettings } from './defaultFontSettings';
 
 import './textArea.css';
 import type { TextWidget } from '../../types';
-import { colorTextLinkDefault } from '@cloudscape-design/design-tokens';
+import { colorTextLinkDefault, spaceScaledXs } from '@cloudscape-design/design-tokens';
 
 type StyledTextAreaProps = TextWidget & {
   handleSetEdit: (isEditing: boolean) => void;
@@ -30,6 +30,8 @@ const StyledTextArea: React.FC<StyledTextAreaProps> = ({ handleSetEdit, isUrl, .
   const style: CSSProperties = {
     fontSize,
     color: isUrl ? colorTextLinkDefault : fontColor,
+    padding: spaceScaledXs,
+    background: 'none',
   };
 
   const handleSetText = (text: string) => {


### PR DESCRIPTION
issue: #2429

as mentioned - 
- added the padding, instead of 2-4px I have added 8px because 8px gives the clear spacing for content.
- the blinking cursor is there already, it was just hiding due to no padding.
- removed the background of the textbox.

[screen-capture (3).webm](https://github.com/awslabs/iot-app-kit/assets/65999096/333513f2-306f-44a5-b5ed-5fa0a8d74684)