### PR TITLE
fix(dashboard): disable add for kpi/status when they already have a property

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd.spec.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd.spec.tsx
@@ -1,0 +1,126 @@
+import { disableAdd } from '~/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd';
+
+describe(disableAdd, () => {
+  it('should return true if no selected widgets', () => {
+    expect(disableAdd([], 0)).toBeTruthy();
+  });
+
+  it('should return true if no results', () => {
+    expect(
+      disableAdd(
+        [
+          {
+            id: '1',
+            type: 'status',
+            x: 0,
+            y: 0,
+            z: 0,
+            properties: {},
+            height: 500,
+            width: 800,
+          },
+        ],
+        0
+      )
+    ).toBeTruthy();
+  });
+
+  it('should return true if status is selected and has a assets already added', () => {
+    expect(
+      disableAdd(
+        [
+          {
+            id: '1',
+            type: 'status',
+            x: 0,
+            y: 0,
+            z: 0,
+            properties: { queryConfig: { query: { assets: [{ id: '1' }] } } },
+            height: 500,
+            width: 800,
+          },
+        ],
+        10
+      )
+    ).toBeTruthy();
+  });
+  it('should return true if KPI is selected and has a assets already added', () => {
+    expect(
+      disableAdd(
+        [
+          {
+            id: '1',
+            type: 'kpi',
+            x: 0,
+            y: 0,
+            z: 0,
+            properties: { queryConfig: { query: { assets: [{ id: '1' }] } } },
+            height: 500,
+            width: 800,
+          },
+        ],
+        10
+      )
+    ).toBeTruthy();
+  });
+
+  it('should return false if status is selected and has NO assets already added', () => {
+    expect(
+      disableAdd(
+        [
+          {
+            id: '1',
+            type: 'status',
+            x: 0,
+            y: 0,
+            z: 0,
+            properties: { queryConfig: { query: { assets: [] } } },
+            height: 500,
+            width: 800,
+          },
+        ],
+        10
+      )
+    ).toBeFalsy();
+  });
+
+  it('should return false if KPI is selected and has NO assets already added', () => {
+    expect(
+      disableAdd(
+        [
+          {
+            id: '1',
+            type: 'kpi',
+            x: 0,
+            y: 0,
+            z: 0,
+            properties: { queryConfig: { query: { assets: [] } } },
+            height: 500,
+            width: 800,
+          },
+        ],
+        10
+      )
+    ).toBeFalsy();
+  });
+
+  it('should return false if x-y-plot is selected and has assets already added', () => {
+    expect(
+      disableAdd(
+        [
+          {
+            id: '1',
+            type: 'x-y-plot',
+            x: 0,
+            y: 0,
+            z: 0,
+            properties: { queryConfig: { query: { assets: [{ id: '1' }] } } },
+            height: 500,
+            width: 800,
+          },
+        ],
+        10
+      )
+    ).toBeFalsy();
+  });
+});

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd.ts
@@ -1,0 +1,29 @@
+import { get } from 'lodash';
+import { DashboardWidget } from '~/types';
+
+export const disableAdd = (
+  selectedWidgets: DashboardWidget<Record<string, unknown>>[],
+  collectionPropsLength?: number
+) => {
+  const selectedWidget = selectedWidgets?.at(0);
+  const currWidgetType = selectedWidget?.type;
+
+  let widgetBasedDisable = false;
+  switch (currWidgetType) {
+    case 'status':
+    case 'kpi': {
+      const assets =
+        get(selectedWidget, 'properties.queryConfig.query.assets') ?? [];
+      if (assets.length) {
+        widgetBasedDisable = true;
+      }
+      break;
+    }
+    default:
+  }
+  return (
+    collectionPropsLength === 0 ||
+    selectedWidgets.length !== 1 ||
+    widgetBasedDisable
+  );
+};

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -23,6 +23,7 @@ import { SelectedAsset } from '../../types';
 import { ResourceExplorerErrorState } from '../../components/resourceExplorerErrorState';
 import { getPlugin } from '@iot-app-kit/core';
 import { isInValidProperty } from './util/resourceExplorerTableLabels';
+import { disableAdd } from '~/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd';
 
 export interface ModeledDataStreamTableProps {
   onClickAddModeledDataStreams: (
@@ -195,10 +196,10 @@ export function ModeledDataStreamTable({
         <ResourceExplorerFooter
           resetDisabled={collectionProps.selectedItems?.length === 0}
           onReset={() => actions.setSelectedItems([])}
-          addDisabled={
-            collectionProps.selectedItems?.length === 0 ||
-            selectedWidgets.length !== 1
-          }
+          addDisabled={disableAdd(
+            selectedWidgets,
+            collectionProps?.selectedItems?.length
+          )}
           onAdd={() => {
             onClickAddModeledDataStreams(
               collectionProps.selectedItems as unknown as ModeledDataStream[]

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
@@ -19,6 +19,7 @@ import { DashboardState } from '~/store/state';
 import { getFormattedDateTimeFromEpoch } from '~/components/util/dateTimeUtil';
 import { ResourceExplorerFooter } from '../../footer/footer';
 import { getPlugin } from '@iot-app-kit/core';
+import { disableAdd } from '~/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd';
 
 export interface UnmodeledDataStreamTableProps {
   onClickAdd: (unmodeledDataStreams: UnmodeledDataStream[]) => void;
@@ -122,10 +123,10 @@ export function UnmodeledDataStreamTable({
         <ResourceExplorerFooter
           resetDisabled={collectionProps.selectedItems?.length === 0}
           onReset={() => actions.setSelectedItems([])}
-          addDisabled={
-            collectionProps.selectedItems?.length === 0 ||
-            selectedWidgets.length !== 1
-          }
+          addDisabled={disableAdd(
+            selectedWidgets,
+            collectionProps.selectedItems?.length
+          )}
           onAdd={() => {
             onClickAdd(
               collectionProps.selectedItems as unknown as UnmodeledDataStream[]


### PR DESCRIPTION
or kpi/status disable add of RE when an property is already added

## Overview
disable add for kpi/status when they already have a property 
This was previously merged but was revered due to not be able to add a property when the user copies a widget, removes the property and tries to add a property again. 


## Verifying Changes
https://github.com/awslabs/iot-app-kit/assets/135036199/606b14e5-7696-43a1-bd70-b6a9d8e3014d


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
