### PR TITLE
fix: source-iotsitewise batch API options

### DIFF
--- a/packages/source-iotsitewise/src/time-series-data/client/batch.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batch.spec.ts
@@ -237,6 +237,83 @@ describe('createRawHistoricalEntryBatches', () => {
     );
   });
 
+  it.each(['fetchMostRecentBeforeEnd', 'fetchMostRecentBeforeStart'])(
+    'separate all %s entries',
+    (mostRecentOption) => {
+      const onError = jest.fn();
+      const onSuccess = jest.fn();
+      const startDate = new Date(2000, 0, 0);
+      const endDate = new Date(2001, 0, 0);
+      const resolution = '0';
+
+      const batches = createRawHistoricalEntryBatches([
+        {
+          requestInformation: {
+            id: '1',
+            resolution,
+            [mostRecentOption]: true,
+          },
+          maxResults: 1,
+          onError,
+          onSuccess,
+          requestStart: startDate,
+          requestEnd: endDate,
+        },
+        {
+          requestInformation: {
+            id: '2',
+            resolution,
+            [mostRecentOption]: true,
+          },
+          maxResults: 1,
+          onError,
+          onSuccess,
+          requestStart: startDate,
+          requestEnd: endDate,
+        },
+      ]);
+
+      expect(batches).toEqual(
+        expect.arrayContaining([
+          [
+            [
+              {
+                requestInformation: {
+                  id: '1',
+                  resolution,
+                  [mostRecentOption]: true,
+                },
+                maxResults: 1,
+                onError,
+                onSuccess,
+                requestStart: startDate,
+                requestEnd: endDate,
+              },
+            ],
+            1,
+          ],
+          [
+            [
+              {
+                requestInformation: {
+                  id: '2',
+                  resolution,
+                  [mostRecentOption]: true,
+                },
+                maxResults: 1,
+                onError,
+                onSuccess,
+                requestStart: startDate,
+                requestEnd: endDate,
+              },
+            ],
+            1,
+          ],
+        ])
+      );
+    }
+  );
+
   it('handles empty input', () => {
     const batches = createRawHistoricalEntryBatches([]);
     expect(batches).toEqual([]);
@@ -349,6 +426,83 @@ describe('createAggregateEntryBatches', () => {
       ])
     );
   });
+
+  it.each(['fetchMostRecentBeforeEnd', 'fetchMostRecentBeforeStart'])(
+    'separate all %s entries',
+    (mostRecentOption) => {
+      const onError = jest.fn();
+      const onSuccess = jest.fn();
+      const startDate = new Date(2000, 0, 0);
+      const endDate = new Date(2001, 0, 0);
+      const resolution = '1h';
+
+      const batches = createAggregateEntryBatches([
+        {
+          requestInformation: {
+            id: '1',
+            resolution,
+            [mostRecentOption]: true,
+          },
+          maxResults: 1,
+          onError,
+          onSuccess,
+          requestStart: startDate,
+          requestEnd: endDate,
+        },
+        {
+          requestInformation: {
+            id: '2',
+            resolution,
+            [mostRecentOption]: true,
+          },
+          maxResults: 1,
+          onError,
+          onSuccess,
+          requestStart: startDate,
+          requestEnd: endDate,
+        },
+      ]);
+
+      expect(batches).toEqual(
+        expect.arrayContaining([
+          [
+            [
+              {
+                requestInformation: {
+                  id: '1',
+                  resolution,
+                  [mostRecentOption]: true,
+                },
+                maxResults: 1,
+                onError,
+                onSuccess,
+                requestStart: startDate,
+                requestEnd: endDate,
+              },
+            ],
+            1,
+          ],
+          [
+            [
+              {
+                requestInformation: {
+                  id: '2',
+                  resolution,
+                  [mostRecentOption]: true,
+                },
+                maxResults: 1,
+                onError,
+                onSuccess,
+                requestStart: startDate,
+                requestEnd: endDate,
+              },
+            ],
+            1,
+          ],
+        ])
+      );
+    }
+  );
 
   it('handles empty input', () => {
     const batches = createAggregateEntryBatches([]);

--- a/packages/source-iotsitewise/src/time-series-data/client/batchGetAggregatedPropertyDataPoints.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batchGetAggregatedPropertyDataPoints.spec.ts
@@ -1,0 +1,211 @@
+import { AggregateType } from '@aws-sdk/client-iotsitewise';
+import { BATCH_ASSET_PROPERTY_AGGREGATES } from '../../__mocks__/assetPropertyValue';
+import { toId } from '../util/dataStreamId';
+import flushPromises from 'flush-promises';
+import { createMockSiteWiseSDK } from '@iot-app-kit/testing-util';
+import { batchGetAggregatedPropertyDataPoints } from './batchGetAggregatedPropertyDataPoints';
+import { MAX_AGGREGATED_DATA_POINTS } from './constants';
+
+const AGGREGATE_TYPE = AggregateType.AVERAGE;
+
+const assetId1 = 'some-asset-id-1';
+const propertyId1 = 'some-property-id-1';
+
+const startDate = new Date(2000, 0, 0);
+const endDate = new Date(2001, 0, 0);
+const oldestDate = new Date(0, 0, 0);
+const resolution = '1h';
+
+const requestInformationCommon = {
+  id: toId({ assetId: assetId1, propertyId: propertyId1 }),
+  start: startDate,
+  end: endDate,
+  resolution,
+  aggregationType: AGGREGATE_TYPE,
+};
+
+const requestEntry = {
+  assetId: assetId1,
+  propertyId: propertyId1,
+  aggregateTypes: [AGGREGATE_TYPE],
+  resolution,
+  startDate,
+  endDate,
+};
+
+const batchParamForStartToEnd = expect.objectContaining({
+  entries: expect.arrayContaining([expect.objectContaining(requestEntry)]),
+  maxResults: MAX_AGGREGATED_DATA_POINTS,
+});
+
+const requestEntryForMostRecentBeforeStart = expect.objectContaining({
+  ...requestEntry,
+  startDate: oldestDate,
+  endDate: startDate,
+});
+
+const batchParamForMostRecentBeforeStart = expect.objectContaining({
+  entries: expect.arrayContaining([requestEntryForMostRecentBeforeStart]),
+  maxResults: 1,
+});
+
+const requestEntryForMostRecentBeforeEnd = expect.objectContaining({
+  ...requestEntry,
+  startDate: oldestDate,
+  endDate,
+});
+
+const batchParamForMostRecentBeforeEnd = expect.objectContaining({
+  entries: expect.arrayContaining([requestEntryForMostRecentBeforeEnd]),
+  maxResults: 1,
+});
+
+describe('batchGetAggregatedPropertyDataPoints', () => {
+  it('requests with fetchFromStartToEnd', async () => {
+    const batchGetAssetPropertyAggregates = jest
+      .fn()
+      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_AGGREGATES });
+
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+
+    const client = createMockSiteWiseSDK({ batchGetAssetPropertyAggregates });
+
+    // Set fetchFromStartToEnd
+    const requestInformation = {
+      ...requestInformationCommon,
+      fetchFromStartToEnd: true,
+    };
+    const param = {
+      requestInformations: [requestInformation],
+      onSuccess,
+      onError,
+      maxResults: MAX_AGGREGATED_DATA_POINTS,
+    };
+
+    batchGetAggregatedPropertyDataPoints({
+      params: [param],
+      client,
+    });
+
+    await flushPromises();
+
+    expect(batchGetAssetPropertyAggregates).toBeCalledTimes(1);
+    expect(batchGetAssetPropertyAggregates).toHaveBeenCalledWith(
+      batchParamForStartToEnd
+    );
+  });
+
+  it('requests with fetchMostRecentBeforeStart', async () => {
+    const batchGetAssetPropertyAggregates = jest
+      .fn()
+      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_AGGREGATES });
+
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+
+    const client = createMockSiteWiseSDK({ batchGetAssetPropertyAggregates });
+
+    // Set fetchMostRecentBeforeStart
+    const requestInformation = {
+      ...requestInformationCommon,
+      fetchMostRecentBeforeStart: true,
+    };
+    const param = {
+      requestInformations: [requestInformation],
+      onSuccess,
+      onError,
+      maxResults: MAX_AGGREGATED_DATA_POINTS,
+    };
+
+    batchGetAggregatedPropertyDataPoints({
+      params: [param],
+      client,
+    });
+
+    await flushPromises();
+
+    expect(batchGetAssetPropertyAggregates).toBeCalledTimes(1);
+    expect(batchGetAssetPropertyAggregates).toHaveBeenCalledWith(
+      batchParamForMostRecentBeforeStart
+    );
+  });
+
+  it('requests with fetchMostRecentBeforeEnd', async () => {
+    const batchGetAssetPropertyAggregates = jest
+      .fn()
+      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_AGGREGATES });
+
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+
+    const client = createMockSiteWiseSDK({ batchGetAssetPropertyAggregates });
+
+    // Set fetchMostRecentBeforeEnd
+    const requestInformation = {
+      ...requestInformationCommon,
+      fetchMostRecentBeforeEnd: true,
+    };
+    const param = {
+      requestInformations: [requestInformation],
+      onSuccess,
+      onError,
+      maxResults: MAX_AGGREGATED_DATA_POINTS,
+    };
+
+    batchGetAggregatedPropertyDataPoints({
+      params: [param],
+      client,
+    });
+
+    await flushPromises();
+
+    expect(batchGetAssetPropertyAggregates).toBeCalledTimes(1);
+    expect(batchGetAssetPropertyAggregates).toHaveBeenCalledWith(
+      batchParamForMostRecentBeforeEnd
+    );
+  });
+
+  it('requests with fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, and fetchFromStartToEnd', async () => {
+    const batchGetAssetPropertyAggregates = jest
+      .fn()
+      .mockResolvedValue({ ...BATCH_ASSET_PROPERTY_AGGREGATES });
+
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+
+    const client = createMockSiteWiseSDK({ batchGetAssetPropertyAggregates });
+
+    // set fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, and fetchFromStartToEnd
+    const requestInformation = {
+      ...requestInformationCommon,
+      fetchMostRecentBeforeStart: true,
+      fetchMostRecentBeforeEnd: true,
+      fetchFromStartToEnd: true,
+    };
+    const param = {
+      requestInformations: [requestInformation],
+      onSuccess,
+      onError,
+      maxResults: MAX_AGGREGATED_DATA_POINTS,
+    };
+
+    batchGetAggregatedPropertyDataPoints({
+      params: [param],
+      client,
+    });
+
+    await flushPromises();
+
+    expect(batchGetAssetPropertyAggregates).toBeCalledTimes(3);
+    expect(batchGetAssetPropertyAggregates).toHaveBeenCalledWith(
+      batchParamForStartToEnd
+    );
+    expect(batchGetAssetPropertyAggregates).toHaveBeenCalledWith(
+      batchParamForMostRecentBeforeEnd
+    );
+    expect(batchGetAssetPropertyAggregates).toHaveBeenCalledWith(
+      batchParamForMostRecentBeforeStart
+    );
+  });
+});

--- a/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.spec.ts
@@ -1,0 +1,205 @@
+import { BATCH_ASSET_PROPERTY_VALUE_HISTORY } from '../../__mocks__/assetPropertyValue';
+import { toId } from '../util/dataStreamId';
+import flushPromises from 'flush-promises';
+import { createMockSiteWiseSDK } from '@iot-app-kit/testing-util';
+import { batchGetHistoricalPropertyDataPoints } from './batchGetHistoricalPropertyDataPoints';
+import { MAX_AGGREGATED_DATA_POINTS } from './constants';
+
+const assetId1 = 'some-asset-id-1';
+const propertyId1 = 'some-property-id-1';
+
+const startDate = new Date(2000, 0, 0);
+const endDate = new Date(2001, 0, 0);
+const oldestDate = new Date(0, 0, 0);
+const resolution = '0';
+
+const requestInformationCommon = {
+  id: toId({ assetId: assetId1, propertyId: propertyId1 }),
+  start: startDate,
+  end: endDate,
+  resolution,
+};
+
+const requestEntry = {
+  assetId: assetId1,
+  propertyId: propertyId1,
+  startDate,
+  endDate,
+};
+
+const batchParamForStartToEnd = expect.objectContaining({
+  entries: expect.arrayContaining([expect.objectContaining(requestEntry)]),
+  maxResults: MAX_AGGREGATED_DATA_POINTS,
+});
+
+const requestEntryForMostRecentBeforeStart = expect.objectContaining({
+  ...requestEntry,
+  startDate: oldestDate,
+  endDate: startDate,
+});
+
+const batchParamForMostRecentBeforeStart = expect.objectContaining({
+  entries: expect.arrayContaining([requestEntryForMostRecentBeforeStart]),
+  maxResults: 1,
+});
+
+const requestEntryForMostRecentBeforeEnd = expect.objectContaining({
+  ...requestEntry,
+  startDate: oldestDate,
+  endDate,
+});
+
+const batchParamForMostRecentBeforeEnd = expect.objectContaining({
+  entries: expect.arrayContaining([requestEntryForMostRecentBeforeEnd]),
+  maxResults: 1,
+});
+
+describe('batchGetHistoricalPropertyDataPoints', () => {
+  it('requests with fetchFromStartToEnd', async () => {
+    const batchGetAssetPropertyValueHistory = jest
+      .fn()
+      .mockResolvedValue(BATCH_ASSET_PROPERTY_VALUE_HISTORY);
+
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+
+    const client = createMockSiteWiseSDK({ batchGetAssetPropertyValueHistory });
+
+    // Set fetchFromStartToEnd
+    const requestInformation = {
+      ...requestInformationCommon,
+      fetchFromStartToEnd: true,
+    };
+    const param = {
+      requestInformations: [requestInformation],
+      onSuccess,
+      onError,
+      maxResults: MAX_AGGREGATED_DATA_POINTS,
+    };
+
+    batchGetHistoricalPropertyDataPoints({
+      params: [param],
+      client,
+    });
+
+    await flushPromises();
+
+    expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(1);
+    expect(batchGetAssetPropertyValueHistory).toHaveBeenCalledWith(
+      batchParamForStartToEnd
+    );
+  });
+
+  it('requests with fetchMostRecentBeforeStart', async () => {
+    const batchGetAssetPropertyValueHistory = jest
+      .fn()
+      .mockResolvedValue(BATCH_ASSET_PROPERTY_VALUE_HISTORY);
+
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+
+    const client = createMockSiteWiseSDK({ batchGetAssetPropertyValueHistory });
+
+    // Set fetchMostRecentBeforeStart
+    const requestInformation = {
+      ...requestInformationCommon,
+      fetchMostRecentBeforeStart: true,
+    };
+    const param = {
+      requestInformations: [requestInformation],
+      onSuccess,
+      onError,
+      maxResults: MAX_AGGREGATED_DATA_POINTS,
+    };
+
+    batchGetHistoricalPropertyDataPoints({
+      params: [param],
+      client,
+    });
+
+    await flushPromises();
+
+    expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(1);
+    expect(batchGetAssetPropertyValueHistory).toHaveBeenCalledWith(
+      batchParamForMostRecentBeforeStart
+    );
+  });
+
+  it('requests with fetchMostRecentBeforeEnd', async () => {
+    const batchGetAssetPropertyValueHistory = jest
+      .fn()
+      .mockResolvedValue(BATCH_ASSET_PROPERTY_VALUE_HISTORY);
+
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+
+    const client = createMockSiteWiseSDK({ batchGetAssetPropertyValueHistory });
+
+    // Set fetchMostRecentBeforeEnd
+    const requestInformation = {
+      ...requestInformationCommon,
+      fetchMostRecentBeforeEnd: true,
+    };
+    const param = {
+      requestInformations: [requestInformation],
+      onSuccess,
+      onError,
+      maxResults: MAX_AGGREGATED_DATA_POINTS,
+    };
+
+    batchGetHistoricalPropertyDataPoints({
+      params: [param],
+      client,
+    });
+
+    await flushPromises();
+
+    expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(1);
+    expect(batchGetAssetPropertyValueHistory).toHaveBeenCalledWith(
+      batchParamForMostRecentBeforeEnd
+    );
+  });
+
+  it('requests with fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, and fetchFromStartToEnd', async () => {
+    const batchGetAssetPropertyValueHistory = jest
+      .fn()
+      .mockResolvedValue(BATCH_ASSET_PROPERTY_VALUE_HISTORY);
+
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+
+    const client = createMockSiteWiseSDK({ batchGetAssetPropertyValueHistory });
+
+    // set fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, and fetchFromStartToEnd
+    const requestInformation = {
+      ...requestInformationCommon,
+      fetchMostRecentBeforeStart: true,
+      fetchMostRecentBeforeEnd: true,
+      fetchFromStartToEnd: true,
+    };
+    const param = {
+      requestInformations: [requestInformation],
+      onSuccess,
+      onError,
+      maxResults: MAX_AGGREGATED_DATA_POINTS,
+    };
+
+    batchGetHistoricalPropertyDataPoints({
+      params: [param],
+      client,
+    });
+
+    await flushPromises();
+
+    expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(3);
+    expect(batchGetAssetPropertyValueHistory).toHaveBeenCalledWith(
+      batchParamForStartToEnd
+    );
+    expect(batchGetAssetPropertyValueHistory).toHaveBeenCalledWith(
+      batchParamForMostRecentBeforeEnd
+    );
+    expect(batchGetAssetPropertyValueHistory).toHaveBeenCalledWith(
+      batchParamForMostRecentBeforeStart
+    );
+  });
+});

--- a/packages/source-iotsitewise/src/time-series-data/data-source.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/data-source.spec.ts
@@ -151,7 +151,7 @@ describe('initiateRequest', () => {
 
       await flushPromises();
 
-      expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(1);
+      expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(2);
 
       expect(batchGetAssetPropertyValueHistory).toBeCalledWith(
         expect.objectContaining({
@@ -223,7 +223,7 @@ describe('initiateRequest', () => {
 
       await flushPromises();
 
-      expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(1);
+      expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(2);
 
       expect(batchGetAssetPropertyValueHistory).toBeCalledWith(
         expect.objectContaining({
@@ -232,6 +232,12 @@ describe('initiateRequest', () => {
               assetId: ASSET_1,
               propertyId: PROPERTY_1,
             }),
+          ]),
+        })
+      );
+      expect(batchGetAssetPropertyValueHistory).toBeCalledWith(
+        expect.objectContaining({
+          entries: expect.arrayContaining([
             expect.objectContaining({
               assetId: ASSET_2,
               propertyId: PROPERTY_2,
@@ -297,7 +303,7 @@ describe('initiateRequest', () => {
 
       await flushPromises();
 
-      expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(1);
+      expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(2);
 
       expect(batchGetAssetPropertyValueHistory).toBeCalledWith(
         expect.objectContaining({
@@ -308,6 +314,12 @@ describe('initiateRequest', () => {
               startDate: new Date(0, 0, 0),
               endDate: historicalRequestStart,
             }),
+          ]),
+        })
+      );
+      expect(batchGetAssetPropertyValueHistory).toBeCalledWith(
+        expect.objectContaining({
+          entries: expect.arrayContaining([
             expect.objectContaining({
               assetId: ASSET_ID,
               propertyId: PROPERTY_2,
@@ -369,7 +381,7 @@ describe('initiateRequest', () => {
 
       await flushPromises();
 
-      expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(1);
+      expect(batchGetAssetPropertyValueHistory).toBeCalledTimes(2);
 
       expect(batchGetAssetPropertyValueHistory).toBeCalledWith(
         expect.objectContaining({
@@ -380,6 +392,12 @@ describe('initiateRequest', () => {
               startDate: new Date(0, 0, 0),
               endDate: historicalRequestStart,
             }),
+          ]),
+        })
+      );
+      expect(batchGetAssetPropertyValueHistory).toBeCalledWith(
+        expect.objectContaining({
+          entries: expect.arrayContaining([
             expect.objectContaining({
               assetId: ASSET_2,
               propertyId: PROPERTY_2,
@@ -445,7 +463,7 @@ describe('initiateRequest', () => {
 
       await flushPromises();
 
-      expect(batchGetAssetPropertyAggregates).toBeCalledTimes(1);
+      expect(batchGetAssetPropertyAggregates).toBeCalledTimes(2);
 
       expect(batchGetAssetPropertyAggregates).toBeCalledWith(
         expect.objectContaining({
@@ -456,6 +474,12 @@ describe('initiateRequest', () => {
               startDate: new Date(0, 0, 0),
               endDate: historicalRequestStart,
             }),
+          ]),
+        })
+      );
+      expect(batchGetAssetPropertyAggregates).toBeCalledWith(
+        expect.objectContaining({
+          entries: expect.arrayContaining([
             expect.objectContaining({
               assetId: ASSET_ID,
               propertyId: PROPERTY_2,


### PR DESCRIPTION
## Overview

The following options could be all true at a given time `fetchMostRecentBeforeStart`, `fetchMostRecentBeforeEnd`, and `fetchFromStartToEnd`; however, the current code logic does not handle them correctly when more than 1 option at a time.

This PR fixes the issue aforementioned.

more about what the options should do, see [doc](https://awslabs.github.io/iot-app-kit/?path=/docs/core-time-series-data--docs)

## Verifying Changes

### Scene Composer

Manual testings - panning with aggregation/row data

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
