### PR TITLE
feat: display legend unit conditionally 

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/components/legendDisplaySection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/components/legendDisplaySection.tsx
@@ -1,0 +1,51 @@
+import type { FC } from 'react';
+import React from 'react';
+import FormField from '@cloudscape-design/components/form-field';
+import Checkbox, {
+  CheckboxProps,
+} from '@cloudscape-design/components/checkbox';
+import { NonCancelableCustomEvent } from '@cloudscape-design/components/internal/events';
+import { ChartLegend } from '~/customization/widgets/types';
+import { dropdownConsts } from '../constants';
+
+type LegendDisplaySectionProps = {
+  disabled?: boolean;
+  visibleContent?: ChartLegend['visibleContent'];
+  onChange: (visibleContent: ChartLegend['visibleContent']) => void;
+};
+
+const { legendDisplaylist } = dropdownConsts.legendDisplaySection;
+
+export const LegendDisplaySection: FC<LegendDisplaySectionProps> = ({
+  disabled = false,
+  visibleContent,
+  onChange,
+}) => {
+  const handleVisibleChange = (
+    key: string,
+    event: NonCancelableCustomEvent<CheckboxProps.ChangeDetail>
+  ) => {
+    onChange({ ...visibleContent, [key]: event.detail.checked });
+  };
+
+  return (
+    <FormField label='Display'>
+      {legendDisplaylist.map(({ label, value }) => (
+        <Checkbox
+          onChange={(e) => {
+            handleVisibleChange(value, e);
+          }}
+          checked={
+            visibleContent
+              ? visibleContent[value as keyof ChartLegend['visibleContent']]
+              : true
+          }
+          disabled={disabled}
+          key={value}
+        >
+          {label}
+        </Checkbox>
+      ))}
+    </FormField>
+  );
+};

--- a/packages/dashboard/src/customization/propertiesSections/constants.ts
+++ b/packages/dashboard/src/customization/propertiesSections/constants.ts
@@ -72,6 +72,9 @@ export const dropdownConsts = {
       { label: 'Bottom', value: 'bottom' },
     ],
   },
+  legendDisplaySection: {
+    legendDisplaylist: [{ label: 'Unit', value: 'unit' }],
+  },
 };
 
 export const LINE_RESOLUTION_OPTIONS: SelectProps.Option[] = [

--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/legendSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/legendSection.tsx
@@ -5,23 +5,34 @@ import StyleExpandableSection from '../shared/styleExpandableSection/styleExpand
 import { AlignmentDropdown } from '../components/alignmentDropdown';
 import Box from '@cloudscape-design/components/box';
 import SpaceBetween from '@cloudscape-design/components/space-between';
+import { ChartLegend } from '~/customization/widgets/types';
+import { LegendDisplaySection } from '../components/legendDisplaySection';
 
 type LegendSectionOptions = {
   disabled?: boolean;
   visible?: boolean;
   position?: string;
+  visibleContent?: ChartLegend['visibleContent'];
   setVisible: (visible: boolean) => void;
   setAlignment: (position: string) => void;
+  setVisibleContent: (visibleContent: ChartLegend['visibleContent']) => void;
 };
 
 export const LegendSection: FC<LegendSectionOptions> = ({
   visible,
   position,
+  visibleContent,
   setVisible,
   setAlignment,
+  setVisibleContent,
 }) => {
   const handleType = (position: string) => {
     setAlignment(position);
+  };
+  const handleVisibleChange = (
+    visibleContent: ChartLegend['visibleContent']
+  ) => {
+    setVisibleContent(visibleContent);
   };
 
   return (
@@ -35,6 +46,11 @@ export const LegendSection: FC<LegendSectionOptions> = ({
           <AlignmentDropdown
             position={position}
             onTypeChange={handleType}
+            disabled={!visible}
+          />
+          <LegendDisplaySection
+            visibleContent={visibleContent}
+            onChange={handleVisibleChange}
             disabled={!visible}
           />
         </SpaceBetween>

--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
+import { ChartLegend } from '~/customization/widgets/types';
 import { LegendSection } from './legendSection';
 import { YAxisSection } from './yAxis';
 
@@ -51,9 +52,12 @@ describe('LegendSection', () => {
       position: 'left',
       setVisible: () => {},
       setAlignment: () => {},
+      visibleContent: 'unit' as ChartLegend['visibleContent'],
+      setVisibleContent: () => {},
     };
     const { getByLabelText } = render(<LegendSection {...options} />);
     expect(getByLabelText('Alignment')).toBeDisabled();
+    expect(getByLabelText('Display')).toBeDisabled();
   });
 
   test('should not disable legend options when visible is true', () => {
@@ -62,8 +66,11 @@ describe('LegendSection', () => {
       position: 'left',
       setVisible: () => {},
       setAlignment: () => {},
+      visibleContent: 'unit' as ChartLegend['visibleContent'],
+      setVisibleContent: () => {},
     };
     const { getByLabelText } = render(<LegendSection {...options} />);
     expect(getByLabelText('Alignment')).not.toBeDisabled();
+    expect(getByLabelText('Display')).not.toBeDisabled();
   });
 });

--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
@@ -191,6 +191,17 @@ const RenderLineAndScatterStyleSettingsSection = ({
     })
   );
 
+  const [legendVisibleContentMaybe, updateLegendVisibleContent] = useProperty(
+    (properties) => properties.legend?.visibleContent,
+    (properties, updatedLegendVisibleContent) => ({
+      ...properties,
+      legend: {
+        ...properties.legend,
+        visibleContent: updatedLegendVisibleContent,
+      },
+    })
+  );
+
   const connectionStyle = maybeWithDefault(undefined, connectionStyleMaybe);
   const lineStyle = maybeWithDefault(undefined, lineStyleMaybe);
   const lineThickness = maybeWithDefault(undefined, lineThicknessMaybe);
@@ -198,6 +209,10 @@ const RenderLineAndScatterStyleSettingsSection = ({
   const axis = maybeWithDefault(undefined, axisMaybe);
   const legendVisible = maybeWithDefault(undefined, legendVisibleMaybe);
   const legendPosition = maybeWithDefault(undefined, legendPositionMaybe);
+  const legendVisibleContent = maybeWithDefault(
+    undefined,
+    legendVisibleContentMaybe
+  );
 
   const aggregationType = maybeWithDefault(undefined, aggregationMaybe);
   const resolution = maybeWithDefault(undefined, resolutionMaybe);
@@ -286,6 +301,12 @@ const RenderLineAndScatterStyleSettingsSection = ({
         setAlignment={(position) =>
           updateLegendPosition(position as ChartLegend['position'])
         }
+        setVisibleContent={(visibleContent) => {
+          updateLegendVisibleContent(
+            visibleContent as ChartLegend['visibleContent']
+          );
+        }}
+        visibleContent={legendVisibleContent}
       />
     </>
   );

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -159,7 +159,7 @@ export type ChartAxisOptions = YAxisRange & {
   yLabel?: string;
 };
 
-type ChartLegendContent = 'unit' | 'asset';
+type ChartLegendContent = 'latestValue' | 'unit' | 'asset';
 export type ChartLegend = {
   visible?: boolean;
   position?: 'left' | 'bottom' | 'right';

--- a/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
+++ b/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
@@ -10,9 +10,10 @@ import isEqual from 'lodash.isequal';
 const mapDataStreamInformation = (
   datastreams: DataStream[],
   series: SeriesOption[],
-  graphic: InternalGraphicComponentGroupOption[]
+  graphic: InternalGraphicComponentGroupOption[],
+  visibleContent: ChartLegend['visibleContent']
 ): DataStreamInformation[] =>
-  datastreams.map(({ id, name }) => {
+  datastreams.map(({ id, name, unit }) => {
     const foundSeries = series.find((series) => series.id === id);
     const graphicIndex = series.findIndex((series) => series.id === id);
     const trendCursorValues = graphic.reduce<
@@ -22,10 +23,11 @@ const mapDataStreamInformation = (
       valueMap[trendCursorId] = nextGraphic.yAxisMarkerValue[graphicIndex];
       return valueMap;
     }, {});
+    const unitValue = visibleContent?.unit && unit ? ` (${unit})` : '';
 
     return {
       id,
-      name,
+      name: `${name}${unitValue}`,
       color:
         ((foundSeries as LineSeriesOption)?.lineStyle?.color as string) ?? '',
       trendCursorValues,
@@ -53,6 +55,7 @@ export const ChartLegendTableAdapter = ({
   datastreams,
   series,
   graphic,
+  visibleContent,
   ...options
 }: ChartLegendTableAdapterOptions) => {
   const [datastreamInformation, setDatastreamInformation] = useState<
@@ -60,7 +63,7 @@ export const ChartLegendTableAdapter = ({
   >([]);
   const [trendCursors, setTrendCursors] = useState<TrendCursor[]>([]);
   const previousDatastreamInformation = useRef(
-    mapDataStreamInformation(datastreams, series, graphic)
+    mapDataStreamInformation(datastreams, series, graphic, visibleContent)
   );
   const previousTrendCursors = useRef(mapTrendCursors(graphic));
 
@@ -68,7 +71,8 @@ export const ChartLegendTableAdapter = ({
     const mappedDataStreamInformation = mapDataStreamInformation(
       datastreams,
       series,
-      graphic
+      graphic,
+      visibleContent
     );
     if (
       !isEqual(
@@ -84,7 +88,7 @@ export const ChartLegendTableAdapter = ({
       setTrendCursors(mappedTrendCursors);
       previousTrendCursors.current = mappedTrendCursors;
     }
-  }, [datastreams, series, graphic]);
+  }, [datastreams, series, graphic, visibleContent]);
 
   return (
     <ChartLegendTable


### PR DESCRIPTION
## Overview
This PR is for ticket #2277  and implemented display unit feature and it includes
1.  default display property units is true
2. user can toggle the display unit in the config legend section
3. for undefined unit value showing/displaying empty

## Verifying Changes
[display-unit.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/98a1738f-ca73-43b7-aabf-bbf22e8710cd)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
