### PR TITLE
fix: add request settings to fetchTimeSeriesData

### DIFF
--- a/packages/core/src/data-module/TimeSeriesDataModule.ts
+++ b/packages/core/src/data-module/TimeSeriesDataModule.ts
@@ -20,6 +20,7 @@ import type {
 import type { DataStreamsStore, CacheSettings } from './data-cache/types';
 import type {
   TimeSeriesDataRequest,
+  TimeSeriesDataRequestSettings,
   Viewport,
 } from './data-cache/requestTypes';
 
@@ -146,14 +147,16 @@ export class TimeSeriesDataModule<Query extends DataStreamQuery> {
     viewport,
     queries,
     emitDataStreams,
+    settings,
   }: {
     viewport: Viewport;
     queries: Query[];
     emitDataStreams: (dataStreams: DataStream[]) => void;
+    settings?: TimeSeriesDataRequestSettings;
   }) => {
     const requestedStreams = await this.dataSourceStore.getRequestsFromQueries({
       queries,
-      request: { viewport },
+      request: { viewport, settings },
     });
 
     // create request information on every dataStream requested

--- a/packages/core/src/data-module/data-cache/dataCacheWrapped.spec.ts
+++ b/packages/core/src/data-module/data-cache/dataCacheWrapped.spec.ts
@@ -209,3 +209,74 @@ describe('actions', () => {
     expect(state[DATA_STREAM.id]?.rawData).toBeUndefined();
   });
 });
+
+describe('getCachedDataForRange', () => {
+  const NUM_DATA_STREAM: DataStream<number> = {
+    id: 'some-asset-id---some-property-id',
+    resolution: 0,
+    detailedName: 'data-stream-name/detailed-name',
+    name: 'data-stream-name',
+    color: 'black',
+    dataType: DATA_TYPE.NUMBER,
+    data: [
+      { x: 1699945200000, y: 123 },
+      { x: 1699946200000, y: 20 },
+    ],
+  };
+  const REQUEST_INFO = {
+    id: NUM_DATA_STREAM.id,
+    resolution: '0',
+    start: new Date(1699945200000),
+    end: new Date(1699946200000),
+  };
+  const CACHE: DataStreamsStore = {
+    [NUM_DATA_STREAM.id]: {
+      rawData: {
+        id: NUM_DATA_STREAM.id,
+        resolution: NUM_DATA_STREAM.resolution,
+        aggregationType: AGGREGATE_TYPE,
+        dataCache: EMPTY_CACHE,
+        requestCache: EMPTY_CACHE,
+        requestHistory: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: undefined,
+      },
+    },
+  };
+  it('returns correct data if interval is already present', async () => {
+    const cache = new DataCache(CACHE);
+    cache.onSuccess(
+      [NUM_DATA_STREAM],
+      REQUEST_INFO,
+      new Date(1699945200000),
+      new Date(1699946200000)
+    );
+    const promise = new Promise((resolve) =>
+      cache.getCachedDataForRange([REQUEST_INFO], (ds) => resolve(ds))
+    );
+    const data = await promise;
+
+    expect(data).toEqual(
+      expect.arrayContaining([expect.objectContaining({ ...NUM_DATA_STREAM })])
+    );
+  });
+
+  it('returns correct data if data is added to cache after request is made', async () => {
+    const cache = new DataCache(CACHE);
+    const promise = new Promise((resolve) =>
+      cache.getCachedDataForRange([REQUEST_INFO], (ds) => resolve(ds))
+    );
+    cache.onSuccess(
+      [NUM_DATA_STREAM],
+      REQUEST_INFO,
+      new Date(1699945200000),
+      new Date(1699946200000)
+    );
+    const data = await promise;
+
+    expect(data).toEqual(
+      expect.arrayContaining([expect.objectContaining({ ...NUM_DATA_STREAM })])
+    );
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export {
   getDataBeforeDate,
   pointBisector,
 } from './common/dataFilters';
+export { toSiteWiseAssetProperty } from './common/dataStreamId';
 
 // Viewport utilities
 export { parseDuration } from './common/time';

--- a/packages/source-iotsitewise/src/initialize.ts
+++ b/packages/source-iotsitewise/src/initialize.ts
@@ -10,6 +10,7 @@ import {
   TimeSeriesDataModule,
   Viewport,
   DataStream,
+  TimeSeriesDataRequestSettings,
 } from '@iot-app-kit/core';
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
 import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
@@ -53,9 +54,11 @@ export type SiteWiseQuery = {
   fetchTimeSeriesData: ({
     query,
     viewport,
+    settings,
   }: {
     query: SiteWiseDataStreamQuery;
     viewport: Viewport;
+    settings?: TimeSeriesDataRequestSettings;
   }) => Promise<DataStream[]>;
   timeSeriesData: (query: SiteWiseDataStreamQuery) => TimeSeriesDataQuery;
   assetTree: {

--- a/packages/source-iotsitewise/src/time-series-data/fetchTimeSeriesData.ts
+++ b/packages/source-iotsitewise/src/time-series-data/fetchTimeSeriesData.ts
@@ -1,4 +1,9 @@
-import { TimeSeriesDataModule, Viewport, DataStream } from '@iot-app-kit/core';
+import {
+  TimeSeriesDataModule,
+  Viewport,
+  DataStream,
+  TimeSeriesDataRequestSettings,
+} from '@iot-app-kit/core';
 import { SiteWiseDataStreamQuery } from './types';
 
 // creates async function which requests cachedDataStreams until all the data for viewport is present
@@ -7,14 +12,17 @@ export const fetchTimeSeriesData =
   async ({
     query,
     viewport,
+    settings,
   }: {
     query: SiteWiseDataStreamQuery;
     viewport: Viewport;
+    settings?: TimeSeriesDataRequestSettings;
   }): Promise<DataStream[]> => {
     return new Promise((resolve) => {
       siteWiseTimeSeriesModule.getCachedDataStreams({
         queries: [query],
         viewport,
+        settings,
         emitDataStreams: (ds: DataStream[]) => resolve(ds),
       });
     });


### PR DESCRIPTION
## Overview
Add request settings to the async fetchTimeSeriesData function to gracefully handle bar charts and their resolution mapping.

Bar charts do not support raw data so when resolution is set to auto, the bar chart has a custom mapping of auto resolution => new resolution

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
