### PR TITLE
fix(doc-site): canvas not recognised automatically

### DIFF
--- a/packages/doc-site/.storybook/main.js
+++ b/packages/doc-site/.storybook/main.js
@@ -10,7 +10,10 @@ function getAbsolutePath(value) {
 
 /** @type { import('@storybook/react-webpack5').StorybookConfig } */
 const config = {
-  stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  stories: [
+    '../stories/**/*.mdx',
+    '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+  ],
   addons: [
     getAbsolutePath('@storybook/addon-links'),
     getAbsolutePath('@storybook/addon-essentials'),
@@ -29,5 +32,14 @@ const config = {
   docs: {
     autodocs: 'tag',
   },
+  swc: () => ({
+    jsc: {
+      transform: {
+        react: {
+          runtime: 'automatic',
+        },
+      },
+    },
+  }),
 };
 export default config;


### PR DESCRIPTION
## Overview
canvas not recognised automatically so need to update storybook config

https://github.com/awslabs/iot-app-kit/assets/135036199/5a983df8-8364-4b27-a824-3e0de5e49a53





## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
