### PR TITLE
fix: improved zoom and default values for y axis

### DIFF
--- a/packages/react-components/src/components/chart/chartOptions/axes/yAxis.ts
+++ b/packages/react-components/src/components/chart/chartOptions/axes/yAxis.ts
@@ -10,6 +10,8 @@ export const convertYAxis = (
   show: axis?.showY ?? DEFAULT_Y_AXIS.show,
   min: axis?.yMin ?? undefined,
   max: axis?.yMax ?? undefined,
+  type: 'value',
+  scale: true,
   axisLabel: {
     hideOverlap: true,
     color: '#5f6b7a',

--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -11,7 +11,7 @@ export const DEFAULT_TOOLBOX_CONFIG: ToolboxComponentOption = {
   show: true,
   right: 30,
   feature: {
-    dataZoom: { yAxisIndex: false, title: { back: 'Undo\nzoom' } },
+    dataZoom: { title: { back: 'Undo\nzoom' } },
   },
   iconStyle: {
     borderColor: '#414d5c',
@@ -57,7 +57,7 @@ export const DEFAULT_TOOLTIP: TooltipComponentOption = {
 
 export const DEFAULT_DATA_ZOOM: DataZoomComponentOption = {
   type: 'inside',
-  filterMode: 'none',
+  filterMode: 'filter',
   zoomOnMouseWheel: true,
   moveOnMouseMove: 'shift',
   moveOnMouseWheel: false,


### PR DESCRIPTION
## Overview

### **allow for the toolbox zoom to do both x and y direction zoom**

video of zoom working with default y axis:
https://github.com/awslabs/iot-app-kit/assets/28601414/97e8e9d6-eaf1-4de7-8f05-638309f59bce

video of zoom working with multiple custom y axis and NOT defaulting to 0:
https://github.com/awslabs/iot-app-kit/assets/28601414/e7712028-52f7-43b4-b2ba-907d2f37d7d5

### **y axis adjusts and doesnt default to 0**
![image](https://github.com/awslabs/iot-app-kit/assets/28601414/564dd8c0-9024-4d67-b3f0-01f1e0ef618f)

video of axis adjusting as user scrolls:
https://github.com/awslabs/iot-app-kit/assets/28601414/0ef0c9fb-d457-4091-b984-ed20d929bebe

---

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
