### PR TITLE
fix: make context menu appear on top of chart tooltip

### DIFF
--- a/packages/react-components/src/components/chart/contextMenu/ChartContextMenu.tsx
+++ b/packages/react-components/src/components/chart/contextMenu/ChartContextMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Menu, MenuOption } from '../../menu';
 
+import { CONTEXT_MENU_Z_INDEX } from '../eChartsConstants';
 import { MAX_TREND_CURSORS } from '../trendCursor/constants';
 import { InternalGraphicComponentGroupOption } from '../trendCursor/types';
 
@@ -29,6 +30,7 @@ const ChartContextMenu = ({
         position: 'absolute',
         top: `${position.y}px`,
         left: `${position.x}px`,
+        zIndex: CONTEXT_MENU_Z_INDEX,
       }}
       onClickOutside={onOutSideClickHandler}
     >

--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -100,6 +100,12 @@ export const MULTI_Y_AXIS_LEGEND_WIDTH = 170;
 export const EMPHASIZE_SCALE_CONSTANT = 2;
 export const DEEMPHASIZE_OPACITY = 0.25;
 
+/**
+ * Echarts tooltip has z-index of 9999999.
+ * Must set context menu above this so its always displayed on top.
+ */
+export const CONTEXT_MENU_Z_INDEX = 10000000;
+
 // Zoom constants
 
 export const ECHARTS_ZOOM_DEBOUNCE_MS = 300;


### PR DESCRIPTION
## Overview
* Fix for an issue where chart tooltips will overlap and display on top of a charts context menu, which makes it harder to use the context menu since it should always be on top
* This change increases the z-index for the context menu such that it appears on top of the tooltip
* I wasn't sure of a better solution than just hardcoding z-index greater than the tooltip, so let me know if you have any other ideas

## Verifying Changes
1. Create any chart
2. Hover mouse over chart to see tooltip
3. Right click to see context menu
4. Validate context menu displays on top of tooltip

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

## Demo


https://github.com/awslabs/iot-app-kit/assets/66272633/b39c68b4-9558-4618-bf5f-24506234a7a3


