### PR TITLE
chore(scene-composer): remove old feature flags part 1

### DIFF
--- a/packages/scene-composer/src/SceneViewer.tsx
+++ b/packages/scene-composer/src/SceneViewer.tsx
@@ -71,10 +71,6 @@ export const SceneViewer: React.FC<SceneViewerProps> = ({ sceneComposerId, confi
             // Allow beta users to override feature config
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             ...((config as any)?.featureConfig || {}),
-            [COMPOSER_FEATURES.SceneHierarchySearch]: true,
-            [COMPOSER_FEATURES.SceneHierarchyReorder]: true,
-            [COMPOSER_FEATURES.SubModelSelection]: true,
-            [COMPOSER_FEATURES.ENHANCED_EDITING]: true,
             [COMPOSER_FEATURES.CameraView]: true,
             [COMPOSER_FEATURES.OpacityRule]: true,
             [COMPOSER_FEATURES.Overlay]: true,

--- a/packages/scene-composer/src/__snapshots__/SceneViewer.spec.tsx.snap
+++ b/packages/scene-composer/src/__snapshots__/SceneViewer.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`SceneViewer should render correctly 1`] = `
   data-testid="webgl-root"
 >
   <div
-    config="{\\"mode\\":\\"Viewing\\",\\"featureConfig\\":{\\"SceneHierarchySearch\\":true,\\"SceneHierarchyReorder\\":true,\\"SubModelSelection\\":true,\\"ENHANCED_EDITING\\":true,\\"CameraView\\":true,\\"OpacityRule\\":true,\\"Overlay\\":true,\\"TagResize\\":true,\\"Matterport\\":true,\\"TagStyle\\":true,\\"AutoQuery\\":true,\\"SceneAppearance\\":true}}"
+    config="{\\"mode\\":\\"Viewing\\",\\"featureConfig\\":{\\"CameraView\\":true,\\"OpacityRule\\":true,\\"Overlay\\":true,\\"TagResize\\":true,\\"Matterport\\":true,\\"TagStyle\\":true,\\"AutoQuery\\":true,\\"SceneAppearance\\":true}}"
     data-mocked="SceneComposerInternal"
     onSceneLoaded={[Function]}
     sceneComposerId="123"

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyPanel.tsx
@@ -21,21 +21,17 @@ const strings = defineMessages({
 const SceneHierarchyPanel = () => {
   const { formatMessage } = useIntl();
 
-  const [{ variation: canSearchHierarchy }] = useFeature(COMPOSER_FEATURES[COMPOSER_FEATURES.SceneHierarchySearch]);
-  const [{ variation: canReorderHierarchy }] = useFeature(COMPOSER_FEATURES[COMPOSER_FEATURES.SceneHierarchyReorder]);
   const [{ variation: canSelectMultiple }] = useFeature(COMPOSER_FEATURES[COMPOSER_FEATURES.SceneHierarchyMultiSelect]);
 
   return (
     <LogProvider namespace='SceneHierarchyPanel'>
       <SceneHierarchyDataProvider selectionMode={canSelectMultiple === 'T1' ? 'multi' : 'single'}>
         <Layout>
-          {canSearchHierarchy === 'T1' && (
-            <Toolbar>
-              <Typeahead placeholder={formatMessage(strings.searchPlaceholder)} />
-            </Toolbar>
-          )}
+          <Toolbar>
+            <Typeahead placeholder={formatMessage(strings.searchPlaceholder)} />
+          </Toolbar>
           <Main>
-            <SceneHierarchyTree enableDragAndDrop={canReorderHierarchy === 'T1'} />
+            <SceneHierarchyTree enableDragAndDrop={true} />
           </Main>
         </Layout>
       </SceneHierarchyDataProvider>

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/__snapshots__/SceneHierarchyPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/__snapshots__/SceneHierarchyPanel.spec.tsx.snap
@@ -6,6 +6,15 @@ exports[`SceneHierarchyPanel should render search hierarchy correctly when enabl
     class="tm-hierarchy-panel"
   >
     <div
+      class="tm-toolbar"
+    >
+      <div
+        data-mocked="Autosuggest"
+        placeholder="Find resources"
+        value=""
+      />
+    </div>
+    <div
       class="tm-main"
       id="tm-main"
       role="radioGroup"

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
@@ -5,10 +5,9 @@ import ISceneHierarchyNode from '../../model/ISceneHierarchyNode';
 import { useChildNodes, useSceneHierarchyData } from '../../SceneHierarchyDataProvider';
 import { DropHandler } from '../../../../../hooks/useDropMonitor';
 import SubModelTree from '../SubModelTree';
-import { COMPOSER_FEATURES, KnownComponentType } from '../../../../../interfaces';
+import { KnownComponentType } from '../../../../../interfaces';
 import { IModelRefComponentInternal, useSceneDocument } from '../../../../../store';
 import { ModelType } from '../../../../../models/SceneModels';
-import useFeature from '../../../../../hooks/useFeature';
 import { findComponentByType } from '../../../../../utils/nodeUtils';
 import { sceneComposerIdContext } from '../../../../../common/sceneComposerIdContext';
 import { isDynamicNode } from '../../../../../utils/entityModelUtils/sceneUtils';
@@ -50,8 +49,7 @@ const SceneHierarchyTreeItem: FC<SceneHierarchyTreeItemProps> = ({
   const isValidModelRef = useMemo(() => {
     return component && component?.modelType !== ModelType.Environment;
   }, [component]);
-  const [{ variation: subModelSelectionEnabled }] = useFeature(COMPOSER_FEATURES[COMPOSER_FEATURES.SubModelSelection]);
-  const showSubModel = subModelSelectionEnabled === 'T1' && isValidModelRef && !!model && !isViewing();
+  const showSubModel = isValidModelRef && !!model && !isViewing();
   const isSubModel = !!findComponentByType(node, KnownComponentType.SubModelRef);
   const isDynamic = isDynamicNode(node);
 

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
@@ -147,7 +147,7 @@ describe('AddObjectMenu', () => {
     expect(mockMetricRecorder.recordClick).toBeCalledWith('add-object-view-camera');
   });
 
-  it('should call appendSceneNode when adding a tag', () => {
+  it('should call setAddingWidget when adding a tag', () => {
     const anchorComponent: IAnchorComponent = {
       icon: 'Info',
       type: 'Tag',
@@ -156,10 +156,13 @@ describe('AddObjectMenu', () => {
     render(<AddObjectMenu canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-object-tag');
     fireEvent.pointerUp(sut);
-    expect(appendSceneNode).toBeCalledWith({
-      name: 'Tag',
-      components: [anchorComponent],
-      parentRef: selectedSceneNodeRef,
+    expect(setAddingWidget).toBeCalledWith({
+      type: KnownComponentType.Tag,
+      node: {
+        name: 'Tag',
+        components: [anchorComponent],
+        parentRef: selectedSceneNodeRef,
+      },
     });
     expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
     expect(mockMetricRecorder.recordClick).toBeCalledWith('add-object-tag');
@@ -177,7 +180,7 @@ describe('AddObjectMenu', () => {
     expect(mockMetricRecorder.recordClick).toBeCalledWith('add-object-empty');
   });
 
-  it('should call appendSceneNode when adding a model', () => {
+  it('should call setAddingWidget when adding a model', () => {
     const gltfComponent: IModelRefComponent = {
       type: 'ModelRef',
       uri: 'modelUri',
@@ -188,16 +191,19 @@ describe('AddObjectMenu', () => {
     render(<AddObjectMenu canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-object-model');
     fireEvent.pointerUp(sut);
-    expect(appendSceneNode).toBeCalledWith({
-      name: 'filename',
-      components: [gltfComponent],
-      parentRef: selectedSceneNodeRef,
+    expect(setAddingWidget).toBeCalledWith({
+      type: KnownComponentType.ModelRef,
+      node: {
+        name: 'filename',
+        components: [gltfComponent],
+        parentRef: selectedSceneNodeRef,
+      },
     });
     expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
     expect(mockMetricRecorder.recordClick).toBeCalledWith('add-object-model');
   });
 
-  it('should call appendSceneNode when adding an environment model', () => {
+  it('should call setAddingWidget when adding an environment model', () => {
     const gltfComponent: IModelRefComponent = {
       type: 'ModelRef',
       uri: 'modelUri',
@@ -208,10 +214,13 @@ describe('AddObjectMenu', () => {
     render(<AddObjectMenu canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-environment-model');
     fireEvent.pointerUp(sut);
-    expect(appendSceneNode).toBeCalledWith({
-      name: 'filename',
-      components: [gltfComponent],
-      parentRef: undefined,
+    expect(setAddingWidget).toBeCalledWith({
+      type: KnownComponentType.ModelRef,
+      node: {
+        name: 'filename',
+        components: [gltfComponent],
+        parentRef: undefined,
+      },
     });
     expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
     expect(mockMetricRecorder.recordClick).toBeCalledWith('add-environment-model');
@@ -231,7 +240,7 @@ describe('AddObjectMenu', () => {
     expect(mockMetricRecorder.recordClick).toBeCalledWith('add-effect-model-shader');
   });
 
-  it('should call appendSceneNode when adding a motion indicator', () => {
+  it('should call setAddingWidget when adding a motion indicator', () => {
     const motionIndicatorComponent: IMotionIndicatorComponent = {
       type: KnownComponentType.MotionIndicator,
       valueDataBindings: {},
@@ -245,10 +254,13 @@ describe('AddObjectMenu', () => {
     render(<AddObjectMenu canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />);
     const sut = screen.getByTestId('add-object-motion-indicator');
     fireEvent.pointerUp(sut);
-    expect(appendSceneNode).toBeCalledWith({
-      name: 'MotionIndicator',
-      components: [motionIndicatorComponent],
-      parentRef: selectedSceneNodeRef,
+    expect(setAddingWidget).toBeCalledWith({
+      type: KnownComponentType.MotionIndicator,
+      node: {
+        name: 'MotionIndicator',
+        components: [motionIndicatorComponent],
+        parentRef: selectedSceneNodeRef,
+      },
     });
     expect(mockMetricRecorder.recordClick).toBeCalledTimes(1);
     expect(mockMetricRecorder.recordClick).toBeCalledWith('add-object-motion-indicator');
@@ -263,7 +275,7 @@ describe('AddObjectMenu', () => {
   });
 
   it('should call setAddingWidget when adding a annotation', () => {
-    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true, [COMPOSER_FEATURES.ENHANCED_EDITING]: true });
+    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
     const component: IDataOverlayComponent = {
       type: KnownComponentType.DataOverlay,
       valueDataBindings: [],

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -92,7 +92,6 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
   const nodeMap = useStore(sceneComposerId)((state) => state.document.nodeMap);
   const { setAddingWidget, getObject3DBySceneNodeRef } = useEditorState(sceneComposerId);
   const { enableMatterportViewer } = useMatterportViewer();
-  const enhancedEditingEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.ENHANCED_EDITING];
   const { formatMessage } = useIntl();
   const { activeCameraSettings, mainCameraObject } = useActiveCamera();
   const dynamicSceneEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.DynamicScene];
@@ -185,17 +184,15 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
       icon: getSceneResourceDefaultValue(type),
       type: 'Tag',
     };
+
     const node = {
       name: 'Tag',
       components: [anchorComponent],
       parentRef: getRefForParenting(),
     } as ISceneNodeInternal;
-    if (enhancedEditingEnabled) {
-      setAddingWidget({ type: KnownComponentType.Tag, node });
-    } else {
-      appendSceneNode(node);
-    }
-  }, [enhancedEditingEnabled, getRefForParenting, appendSceneNode, setAddingWidget]);
+
+    setAddingWidget({ type: KnownComponentType.Tag, node });
+  }, [getRefForParenting, appendSceneNode, setAddingWidget]);
 
   const handleAddColorOverlay = () => {
     // Requires a selected scene node
@@ -292,16 +289,14 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
           uri: modelUri,
           modelType: modelType ?? ext.toUpperCase(),
         };
+
         const node = {
           name: filename,
           components: [gltfComponent],
           parentRef: mustBeRoot ? undefined : getRefForParenting(),
         } as unknown as ISceneNodeInternal;
-        if (enhancedEditingEnabled && !modelType) {
-          setAddingWidget({ type: KnownComponentType.ModelRef, node });
-        } else {
-          appendSceneNode(node);
-        }
+
+        setAddingWidget({ type: KnownComponentType.ModelRef, node });
       });
     }
   };
@@ -323,11 +318,7 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
       parentRef: getRefForParenting(),
     } as unknown as ISceneNodeInternal;
 
-    if (enhancedEditingEnabled) {
-      setAddingWidget({ type: KnownComponentType.MotionIndicator, node });
-    } else {
-      appendSceneNode(node);
-    }
+    setAddingWidget({ type: KnownComponentType.MotionIndicator, node });
   };
 
   const handleAddOverlay = useCallback(
@@ -350,13 +341,9 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
         parentRef: getRefForParenting(),
       } as unknown as ISceneNodeInternal;
 
-      if (enhancedEditingEnabled) {
-        setAddingWidget({ type: KnownComponentType.DataOverlay, node });
-      } else {
-        appendSceneNode(node);
-      }
+      setAddingWidget({ type: KnownComponentType.DataOverlay, node });
     },
-    [getRefForParenting, enhancedEditingEnabled, setAddingWidget, appendSceneNode],
+    [getRefForParenting, setAddingWidget, appendSceneNode],
   );
 
   return (

--- a/packages/scene-composer/src/interfaces/feature.ts
+++ b/packages/scene-composer/src/interfaces/feature.ts
@@ -1,12 +1,7 @@
 export enum COMPOSER_FEATURES {
   FOR_TESTS = 'FOR_TESTS', // Feature flags may come and go, as things launch, this one is used for automated testing, so please don't remove it.
-  i18n = 'i18n',
-  SceneHierarchySearch = 'SceneHierarchySearch',
-  SceneHierarchyReorder = 'SceneHierarchyReorder',
   SceneHierarchyMultiSelect = 'SceneHierarchyMultiSelect',
-  SubModelSelection = 'SubModelSelection',
   OpacityRule = 'OpacityRule',
-  ENHANCED_EDITING = 'ENHANCED_EDITING',
   CameraView = 'CameraView',
   Matterport = 'Matterport',
   TagResize = 'TagResize',

--- a/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
@@ -13,10 +13,6 @@ export const defaultArgs = {
   mode: 'Editing',
   density: 'comfortable',
   features: [
-    COMPOSER_FEATURES.SceneHierarchyReorder,
-    COMPOSER_FEATURES.SceneHierarchySearch,
-    COMPOSER_FEATURES.SubModelSelection,
-    COMPOSER_FEATURES.ENHANCED_EDITING,
     COMPOSER_FEATURES.CameraView,
     COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.Overlay,

--- a/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
@@ -8,14 +8,10 @@ import { COMPOSER_FEATURES } from '../../src/interfaces/feature';
 
 export const defaultArgs = {
   source: 'local',
-  scene: 'scene1',
+  scene: 'scene_1',
   theme: 'dark',
   density: 'comfortable',
   features: [
-    COMPOSER_FEATURES.SceneHierarchyReorder,
-    COMPOSER_FEATURES.SceneHierarchySearch,
-    COMPOSER_FEATURES.SubModelSelection,
-    COMPOSER_FEATURES.ENHANCED_EDITING,
     COMPOSER_FEATURES.CameraView,
     COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.Matterport,

--- a/packages/scene-composer/stories/FirstPerson.stories.mdx
+++ b/packages/scene-composer/stories/FirstPerson.stories.mdx
@@ -13,10 +13,6 @@ export const defaultArgs = {
   mode: 'Viewing',
   density: 'comfortable',
   features: [
-    COMPOSER_FEATURES.SceneHierarchyReorder,
-    COMPOSER_FEATURES.SceneHierarchySearch,
-    COMPOSER_FEATURES.SubModelSelection,
-    COMPOSER_FEATURES.ENHANCED_EDITING,
     COMPOSER_FEATURES.CameraView,
     COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.FirstPerson,

--- a/packages/scene-composer/stories/Highlight.stories.mdx
+++ b/packages/scene-composer/stories/Highlight.stories.mdx
@@ -14,10 +14,6 @@ export const defaultArgs = {
   mode: 'Viewing',
   density: 'comfortable',
   features: [
-    COMPOSER_FEATURES.SceneHierarchyReorder,
-    COMPOSER_FEATURES.SceneHierarchySearch,
-    COMPOSER_FEATURES.SubModelSelection,
-    COMPOSER_FEATURES.ENHANCED_EDITING,
     COMPOSER_FEATURES.CameraView,
     COMPOSER_FEATURES.OpacityRule,
   ]

--- a/packages/scene-composer/stories/Matterport.stories.mdx
+++ b/packages/scene-composer/stories/Matterport.stories.mdx
@@ -15,10 +15,6 @@ export const defaultArgs = {
   matterportModelId: 'cZowU1FxWEQ',
   matterportApplicationKey: '',
   features: [
-    COMPOSER_FEATURES.SceneHierarchyReorder,
-    COMPOSER_FEATURES.SceneHierarchySearch,
-    COMPOSER_FEATURES.SubModelSelection,
-    COMPOSER_FEATURES.ENHANCED_EDITING,
     COMPOSER_FEATURES.CameraView,
     COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.Matterport,

--- a/packages/scene-composer/stories/SceneViewer.stories.mdx
+++ b/packages/scene-composer/stories/SceneViewer.stories.mdx
@@ -15,10 +15,6 @@ export const defaultArgs = {
   mode: 'Viewing',
   density: 'comfortable',
   features: [
-    COMPOSER_FEATURES.SceneHierarchyReorder,
-    COMPOSER_FEATURES.SceneHierarchySearch,
-    COMPOSER_FEATURES.SubModelSelection,
-    COMPOSER_FEATURES.ENHANCED_EDITING,
     COMPOSER_FEATURES.CameraView,
     COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.Matterport,


### PR DESCRIPTION
## Overview
Removed the following feature flags that are already available to all customers:
* i18n
* SceneHierarchySearch
* SceneHierarchyReorder
* SubModelSelection
* ENHANCED_EDITING

## Verifying Changes
Ran unit tests and verified functionality of local scene composer and viewer on storybook.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
