### PR TITLE
fix(dashboard): decrease width of property label in config panel to stop overflow of delete button

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.css
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.css
@@ -19,5 +19,5 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: normal;
-  width: 355px;
+  width: 350px;
 }

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
@@ -298,7 +298,7 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
 
   const YAxisHeader = (
     <div style={{ display: 'flex', width: '100%' }}>
-      <SpaceBetween size='s' direction='horizontal'>
+      <SpaceBetween size='xs' direction='horizontal'>
         {colorable && display === 'property' && (
           <ColorPicker
             color={property.color || ''}


### PR DESCRIPTION
## Overview
Change width of property label from 355 to 350px to make sure no overflow of delete button on any browser

## Verifying Changes
![Screenshot 2024-01-17 at 10 14 27 AM](https://github.com/awslabs/iot-app-kit/assets/145582655/fa8731b4-1969-47c3-a31b-eb7d0feea551)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
