### PR TITLE
fix: template asset table disables invalid dataTypes

### DIFF
--- a/packages/dashboard/e2e/tests/resourceExplorer/resourceExplorer.spec.ts
+++ b/packages/dashboard/e2e/tests/resourceExplorer/resourceExplorer.spec.ts
@@ -54,11 +54,51 @@ test('can load configure a widget with an asset model', async ({ page }) => {
   await saveAssetModel();
 
   // select property on asset model and add to widget
-  await selectProperty('Coordinates');
+  await selectProperty('Production Rate');
   await addToWidget();
 
   // check that widget is not in empty state
   await expect(page.getByText(WIDGET_EMPTY_STATE_TEXT)).not.toBeVisible();
   // check that property is visible in legend
-  await expect(grid.gridArea().getByText('Coordinates')).toBeVisible();
+  await expect(grid.gridArea().getByText('Production Rate')).toBeVisible();
+});
+
+test('properties are disabled and enabled according to their data type', async ({
+  page,
+}) => {
+  await page.goto(TEST_PAGE);
+
+  const grid = gridUtil(page);
+  const resourceExplorer = resourceExplorerUtil(page);
+
+  // add line widget
+  const location1 = await grid.cellLocation(0, 0);
+  const lineWidget = await grid.addWidget('line', () => location1);
+
+  // select line widget
+  await grid.clickWidget(lineWidget);
+
+  // check that widget is in empty state
+  await expect(page.getByText(WIDGET_EMPTY_STATE_TEXT)).toBeVisible();
+
+  // open resource explorer and tab to asset model tab
+  await resourceExplorer.open();
+  await expect(page.locator(ASSET_MODEL_TAB)).toBeVisible();
+  await resourceExplorer.tabTo('assetModel');
+
+  const { selectAssetModel, selectAsset, saveAssetModel, findProperty } =
+    resourceExplorer.assetModelActions;
+
+  // configure asset model and default asset and select
+  await selectAssetModel('Site');
+  await selectAsset('Africa site');
+  await saveAssetModel();
+
+  // check that number property is not disabled
+  const validProperty = findProperty('Production Rate');
+  await expect(validProperty).not.toBeDisabled();
+
+  // check that string property is disabled
+  const invalidProperty = findProperty('Coordinates');
+  await expect(invalidProperty).toBeDisabled();
 });

--- a/packages/dashboard/e2e/tests/utils/resourceExplorer.ts
+++ b/packages/dashboard/e2e/tests/utils/resourceExplorer.ts
@@ -50,6 +50,15 @@ export const resourceExplorerUtil = (page: Page) => {
       await frame.getByText('Set asset model').click();
     },
     /**
+     * finds an asset property
+     *
+     * @returns Locator
+     *
+     */
+    findProperty: (label: string) => {
+      return frame.getByLabel(`Select asset model property ${label}`);
+    },
+    /**
      * select an asset model property from the table
      *
      * @returns void

--- a/packages/dashboard/src/components/queryEditor/helpers/isModeledPropertyInvalid.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/isModeledPropertyInvalid.ts
@@ -1,7 +1,7 @@
-import { ModeledDataStream } from '../../types';
+import type { PropertyDataType } from '@aws-sdk/client-iotsitewise';
 
-export const isInValidProperty = (
-  dataType: ModeledDataStream['dataType'],
+export const isModeledPropertyInvalid = (
+  dataType?: PropertyDataType,
   widgetType?: string
 ) => {
   if (!widgetType || !dataType) return false;

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesTable/assetModelPropertiesTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesTable/assetModelPropertiesTable.tsx
@@ -1,4 +1,4 @@
-import { AssetModelPropertySummary } from '@aws-sdk/client-iotsitewise';
+import type { AssetModelPropertySummary } from '@aws-sdk/client-iotsitewise';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 import Table from '@cloudscape-design/components/table';
 import React from 'react';
@@ -16,6 +16,10 @@ import { SelectedAssetModelProperties } from '../../useSelectedAssetModelPropert
 import { useCustomCompareEffect } from 'react-use';
 import { isEqual } from 'lodash';
 import { ResourceExplorerFooter } from '../../../footer/footer';
+
+import { useSelector } from 'react-redux';
+import { DashboardState } from '~/store/state';
+import { isModeledPropertyInvalid } from '~/components/queryEditor/helpers/isModeledPropertyInvalid';
 
 export interface AssetTableProps {
   onClickNextPage: () => void;
@@ -49,6 +53,10 @@ export function AssetModelPropertiesTable({
     defaultVisibleContent: ['name'],
     resourceName: 'asset model properties',
   });
+
+  const selectedWidgets = useSelector(
+    (state: DashboardState) => state.selectedWidgets
+  );
 
   const {
     items,
@@ -99,6 +107,9 @@ export function AssetModelPropertiesTable({
       loading={isLoading}
       loadingText='Loading asset model properties...'
       selectionType='multi'
+      isItemDisabled={(item) =>
+        isModeledPropertyInvalid(item.dataType, selectedWidgets?.at(0)?.type)
+      }
       onSelectionChange={(event) => {
         const selectedAssets = event.detail.selectedItems;
         onSelectAssetModelProperties(selectedAssets);

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/modeledDataStreamExplorer/modeledDataStreamTable/modeledDataStreamTable.tsx
@@ -22,8 +22,8 @@ import { ResourceExplorerFooter } from '../../../footer/footer';
 import { SelectedAsset } from '../../types';
 import { ResourceExplorerErrorState } from '../../components/resourceExplorerErrorState';
 import { getPlugin } from '@iot-app-kit/core';
-import { isInValidProperty } from './util/resourceExplorerTableLabels';
 import { disableAdd } from '~/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd';
+import { isModeledPropertyInvalid } from '~/components/queryEditor/helpers/isModeledPropertyInvalid';
 
 export interface ModeledDataStreamTableProps {
   onClickAddModeledDataStreams: (
@@ -139,7 +139,7 @@ export function ModeledDataStreamTable({
     );
 
     if (
-      isInValidProperty(
+      isModeledPropertyInvalid(
         modeledDataStream.dataType,
         selectedWidgets?.at(0)?.type
       )
@@ -174,7 +174,7 @@ export function ModeledDataStreamTable({
       wrapLines={preferences.wrapLines}
       stickyColumns={preferences.stickyColumns}
       isItemDisabled={(item) =>
-        isInValidProperty(item.dataType, selectedWidgets?.at(0)?.type)
+        isModeledPropertyInvalid(item.dataType, selectedWidgets?.at(0)?.type)
       }
       empty={
         <ModeledDataStreamTableEmptyState


### PR DESCRIPTION
Templating/Dynamic Assets table disables a property if its dataType is not supported by the chart 
---
![Screenshot 2024-01-17 at 11 13 13](https://github.com/awslabs/iot-app-kit/assets/28601414/b6a4909b-e906-4ec6-a3a4-b44b1d51b002)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
