### PR TITLE
chore(scene-composer): remove old feature flags part 2

### DIFF
--- a/packages/scene-composer/src/SceneViewer.tsx
+++ b/packages/scene-composer/src/SceneViewer.tsx
@@ -71,10 +71,6 @@ export const SceneViewer: React.FC<SceneViewerProps> = ({ sceneComposerId, confi
             // Allow beta users to override feature config
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             ...((config as any)?.featureConfig || {}),
-            [COMPOSER_FEATURES.CameraView]: true,
-            [COMPOSER_FEATURES.OpacityRule]: true,
-            [COMPOSER_FEATURES.Overlay]: true,
-            [COMPOSER_FEATURES.TagResize]: true,
             [COMPOSER_FEATURES.Matterport]: true,
             [COMPOSER_FEATURES.TagStyle]: true,
             [COMPOSER_FEATURES.AutoQuery]: true,

--- a/packages/scene-composer/src/__snapshots__/SceneViewer.spec.tsx.snap
+++ b/packages/scene-composer/src/__snapshots__/SceneViewer.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`SceneViewer should render correctly 1`] = `
   data-testid="webgl-root"
 >
   <div
-    config="{\\"mode\\":\\"Viewing\\",\\"featureConfig\\":{\\"CameraView\\":true,\\"OpacityRule\\":true,\\"Overlay\\":true,\\"TagResize\\":true,\\"Matterport\\":true,\\"TagStyle\\":true,\\"AutoQuery\\":true,\\"SceneAppearance\\":true}}"
+    config="{\\"mode\\":\\"Viewing\\",\\"featureConfig\\":{\\"Matterport\\":true,\\"TagStyle\\":true,\\"AutoQuery\\":true,\\"SceneAppearance\\":true}}"
     data-mocked="SceneComposerInternal"
     onSceneLoaded={[Function]}
     sceneComposerId="123"

--- a/packages/scene-composer/src/components/panels/AddComponentMenu.spec.tsx
+++ b/packages/scene-composer/src/components/panels/AddComponentMenu.spec.tsx
@@ -1,8 +1,8 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { setFeatureConfig, setMetricRecorder } from '../../common/GlobalSettings';
-import { COMPOSER_FEATURES, KnownComponentType } from '../../interfaces';
+import { setMetricRecorder } from '../../common/GlobalSettings';
+import { KnownComponentType } from '../../interfaces';
 import { Component } from '../../models/SceneModels';
 import { useStore } from '../../store';
 
@@ -27,7 +27,6 @@ describe('AddComponentMenu', () => {
       updateComponentInternal,
       getSceneNodeByRef,
     });
-    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
   });
 
   it('should show add overlay for Tag node without overlay and call addComponentInternal when clicked', () => {

--- a/packages/scene-composer/src/components/panels/AddComponentMenu.tsx
+++ b/packages/scene-composer/src/components/panels/AddComponentMenu.tsx
@@ -81,7 +81,6 @@ export const AddComponentMenu: React.FC<AddComponentMenuProps> = ({ onSelect }) 
           {
             uuid: ObjectTypes.Overlay,
             isDisabled: isOverlayComponent,
-            feature: { name: COMPOSER_FEATURES.Overlay },
           },
         ]
       : [];

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyPanel.spec.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyPanel.spec.tsx
@@ -9,7 +9,7 @@ jest.mock('../../../hooks/useFeature');
 
 describe('SceneHierarchyPanel', () => {
   ['T1', 'C'].forEach((treatment) => {
-    it(`should render search hierarchy correctly when enabled is "${treatment}"`, () => {
+    it(`should render hierarchy correctly when enabled is "${treatment}"`, () => {
       (useFeature as unknown as jest.Mock).mockImplementation(() => [{ variation: treatment }]);
 
       const { container } = render(<SceneHierarchyPanel />);

--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/__snapshots__/SceneHierarchyPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/__snapshots__/SceneHierarchyPanel.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SceneHierarchyPanel should render search hierarchy correctly when enabled is "C" 1`] = `
+exports[`SceneHierarchyPanel should render hierarchy correctly when enabled is "C" 1`] = `
 <div>
   <div
     class="tm-hierarchy-panel"
@@ -28,7 +28,7 @@ exports[`SceneHierarchyPanel should render search hierarchy correctly when enabl
 </div>
 `;
 
-exports[`SceneHierarchyPanel should render search hierarchy correctly when enabled is "T1" 1`] = `
+exports[`SceneHierarchyPanel should render hierarchy correctly when enabled is "T1" 1`] = `
 <div>
   <div
     class="tm-hierarchy-panel"

--- a/packages/scene-composer/src/components/panels/SettingsPanel.spec.tsx
+++ b/packages/scene-composer/src/components/panels/SettingsPanel.spec.tsx
@@ -3,7 +3,6 @@ import { render } from '@testing-library/react';
 
 import { useStore } from '../../store';
 import { setFeatureConfig } from '../../common/GlobalSettings';
-import { COMPOSER_FEATURES } from '../../interfaces';
 import { mockProvider } from '../../../tests/components/panels/scene-components/MockComponents';
 import useDynamicScene from '../../hooks/useDynamicScene';
 
@@ -47,7 +46,6 @@ describe('SettingsPanel contains expected elements.', () => {
   });
 
   it('should contains default elements in editing mode.', async () => {
-    setFeatureConfig({ [COMPOSER_FEATURES.TagResize]: false });
     useStore('default').setState({
       isEditing: jest.fn().mockReturnValue(true),
     });
@@ -56,7 +54,7 @@ describe('SettingsPanel contains expected elements.', () => {
 
     expect(queryByTitle('Current View Settings')).toBeTruthy();
     expect(queryByTitle('Scene Settings')).toBeTruthy();
-    expect(queryByTitle('Tag Settings')).toBeFalsy();
+    expect(queryByTitle('Tag Settings')).toBeTruthy();
     expect(queryByTitle('Data Binding Template')).toBeTruthy();
     expect(container).toMatchSnapshot();
   });
@@ -70,22 +68,12 @@ describe('SettingsPanel contains expected elements.', () => {
 
     expect(queryByTitle('Current View Settings')).toBeTruthy();
     expect(queryByTitle('Scene Settings')).toBeFalsy();
-    expect(queryByTitle('Tag Settings')).toBeFalsy();
+    expect(queryByTitle('Tag Settings')).toBeTruthy();
     expect(queryByTitle('Data Binding Template')).toBeFalsy();
     expect(container).toMatchSnapshot();
   });
 
-  it('should contains tag settings element.', async () => {
-    setFeatureConfig({ [COMPOSER_FEATURES.TagResize]: true });
-
-    const { container, queryByTitle } = render(<SettingsPanel />);
-
-    expect(queryByTitle('Tag Settings')).toBeTruthy();
-    expect(container).toMatchSnapshot();
-  });
-
   it('should contains settings element for overlay in editing.', async () => {
-    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
     useStore('default').setState({
       isEditing: jest.fn().mockReturnValue(true),
     });
@@ -100,7 +88,6 @@ describe('SettingsPanel contains expected elements.', () => {
   });
 
   it('should contains settings element for overlay in viewing.', async () => {
-    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
     useStore('default').setState({
       isEditing: jest.fn().mockReturnValue(false),
     });

--- a/packages/scene-composer/src/components/panels/SettingsPanel.tsx
+++ b/packages/scene-composer/src/components/panels/SettingsPanel.tsx
@@ -34,9 +34,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
   const isEditing = useStore(sceneComposerId)((state) => state.isEditing());
   const intl = useIntl();
 
-  const tagResizeEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagResize];
   const matterportEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Matterport];
-  const overlayEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Overlay];
   const sceneAppearanceEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.SceneAppearance];
   const animationComponentEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.Animations];
   const dynamicSceneEnabled = useDynamicScene();
@@ -137,24 +135,16 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
             componentType={KnownComponentType.Tag}
             label={intl.formatMessage(visibilityToggleLabels[KnownComponentType.Tag])}
           />
-          {overlayEnabled && (
-            <>
-              <Divider />
-              <ComponentVisibilityToggle
-                componentType={Component.DataOverlaySubType.OverlayPanel}
-                label={intl.formatMessage(visibilityToggleLabels[Component.DataOverlaySubType.OverlayPanel])}
-              />
-            </>
-          )}
-          {overlayEnabled && (
-            <>
-              <Divider />
-              <ComponentVisibilityToggle
-                componentType={Component.DataOverlaySubType.TextAnnotation}
-                label={intl.formatMessage(visibilityToggleLabels[Component.DataOverlaySubType.TextAnnotation])}
-              />
-            </>
-          )}
+          <Divider />
+          <ComponentVisibilityToggle
+            componentType={Component.DataOverlaySubType.OverlayPanel}
+            label={intl.formatMessage(visibilityToggleLabels[Component.DataOverlaySubType.OverlayPanel])}
+          />
+          <Divider />
+          <ComponentVisibilityToggle
+            componentType={Component.DataOverlaySubType.TextAnnotation}
+            label={intl.formatMessage(visibilityToggleLabels[Component.DataOverlaySubType.TextAnnotation])}
+          />
         </FormField>
       </ExpandableInfoSection>
 
@@ -197,15 +187,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ valueDataBindingPr
         </ExpandableInfoSection>
       )}
 
-      {(tagResizeEnabled || overlayEnabled) && (
-        <ExpandableInfoSection
-          title={intl.formatMessage({ description: 'ExpandableInfoSection Title', defaultMessage: 'Tag Settings' })}
-          defaultExpanded={false}
-        >
-          {tagResizeEnabled && <SceneTagSettingsEditor />}
-          {overlayEnabled && isEditing && <OverlayPanelVisibilityToggle />}
-        </ExpandableInfoSection>
-      )}
+      <ExpandableInfoSection
+        title={intl.formatMessage({ description: 'ExpandableInfoSection Title', defaultMessage: 'Tag Settings' })}
+        defaultExpanded={false}
+      >
+        <SceneTagSettingsEditor />
+        {isEditing && <OverlayPanelVisibilityToggle />}
+      </ExpandableInfoSection>
 
       {valueDataBindingProvider && isEditing && (
         <ExpandableInfoSection

--- a/packages/scene-composer/src/components/panels/__snapshots__/SettingsPanel.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/__snapshots__/SettingsPanel.spec.tsx.snap
@@ -70,6 +70,56 @@ exports[`SettingsPanel contains expected elements. should contains default eleme
           />
         </div>
       </div>
+      <hr
+        class="c0"
+      />
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Overlay
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
+      <hr
+        class="c0"
+      />
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Annotation
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -91,6 +141,33 @@ exports[`SettingsPanel contains expected elements. should contains default eleme
           selectedoption="{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"}"
         />
       </div>
+    </div>
+  </div>
+  <div
+    data-mocked="ExpandableInfoSection"
+    title="Tag Settings"
+  >
+    <scenetagsettingseditor />
+    <div
+      data-mocked="Box"
+      font-weight="bold"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+      variant="p"
+    >
+      Overlay
+    </div>
+    <div
+      data-mocked="Box"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+      variant="p"
+    >
+      Visibility settings
+    </div>
+    <div
+      data-mocked="Toggle"
+      disabled=""
+    >
+      Always on
     </div>
   </div>
   <div
@@ -174,7 +251,63 @@ exports[`SettingsPanel contains expected elements. should contains default eleme
           />
         </div>
       </div>
+      <hr
+        class="c0"
+      />
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Overlay
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
+      <hr
+        class="c0"
+      />
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Annotation
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
     </div>
+  </div>
+  <div
+    data-mocked="ExpandableInfoSection"
+    title="Tag Settings"
+  >
+    <scenetagsettingseditor />
   </div>
 </div>
 `;
@@ -249,6 +382,56 @@ exports[`SettingsPanel contains expected elements. should contains settings elem
           />
         </div>
       </div>
+      <hr
+        class="c0"
+      />
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Overlay
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
+      <hr
+        class="c0"
+      />
+      <div
+        data-mocked="Box"
+        margin="{\\"vertical\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="Box"
+          display="inline"
+          margin="{\\"bottom\\":\\"xxs\\"}"
+          variant="p"
+        >
+          Annotation
+        </div>
+        <div
+          data-mocked="Box"
+          float="right"
+        >
+          <div
+            data-mocked="Toggle"
+            disabled=""
+          />
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -270,6 +453,33 @@ exports[`SettingsPanel contains expected elements. should contains settings elem
           selectedoption="{\\"label\\":\\"Neutral\\",\\"value\\":\\"neutral\\"}"
         />
       </div>
+    </div>
+  </div>
+  <div
+    data-mocked="ExpandableInfoSection"
+    title="Tag Settings"
+  >
+    <scenetagsettingseditor />
+    <div
+      data-mocked="Box"
+      font-weight="bold"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+      variant="p"
+    >
+      Overlay
+    </div>
+    <div
+      data-mocked="Box"
+      margin="{\\"bottom\\":\\"xxs\\"}"
+      variant="p"
+    >
+      Visibility settings
+    </div>
+    <div
+      data-mocked="Toggle"
+      disabled=""
+    >
+      Always on
     </div>
   </div>
   <div
@@ -430,6 +640,7 @@ exports[`SettingsPanel contains expected elements. should contains settings elem
     data-mocked="ExpandableInfoSection"
     title="Tag Settings"
   >
+    <scenetagsettingseditor />
     <div
       data-mocked="Box"
       font-weight="bold"
@@ -564,85 +775,6 @@ exports[`SettingsPanel contains expected elements. should contains settings elem
           variant="p"
         >
           Annotation
-        </div>
-        <div
-          data-mocked="Box"
-          float="right"
-        >
-          <div
-            data-mocked="Toggle"
-            disabled=""
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    data-mocked="ExpandableInfoSection"
-    title="Tag Settings"
-  />
-</div>
-`;
-
-exports[`SettingsPanel contains expected elements. should contains tag settings element. 1`] = `
-.c0 {
-  height: 1px;
-  border-width: 0px;
-  background-color: colorBorderDividerDefault;
-}
-
-<div>
-  <div
-    data-mocked="ExpandableInfoSection"
-    title="Current View Settings"
-  >
-    <div
-      data-mocked="FormField"
-    >
-      <div>
-        <div
-          data-mocked="Box"
-          font-weight="bold"
-        >
-          Toggle visibility
-        </div>
-      </div>
-      <div
-        data-mocked="Box"
-        margin="{\\"vertical\\":\\"s\\"}"
-      >
-        <div
-          data-mocked="Box"
-          display="inline"
-          margin="{\\"bottom\\":\\"xxs\\"}"
-          variant="p"
-        >
-          Motion indicator
-        </div>
-        <div
-          data-mocked="Box"
-          float="right"
-        >
-          <div
-            data-mocked="Toggle"
-            disabled=""
-          />
-        </div>
-      </div>
-      <hr
-        class="c0"
-      />
-      <div
-        data-mocked="Box"
-        margin="{\\"vertical\\":\\"s\\"}"
-      >
-        <div
-          data-mocked="Box"
-          display="inline"
-          margin="{\\"bottom\\":\\"xxs\\"}"
-          variant="p"
-        >
-          Tag
         </div>
         <div
           data-mocked="Box"

--- a/packages/scene-composer/src/components/panels/__tests__/SceneNodeInspectorPanel.spec.tsx
+++ b/packages/scene-composer/src/components/panels/__tests__/SceneNodeInspectorPanel.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import { SceneNodeInspectorPanel } from '../SceneNodeInspectorPanel';
-import { COMPOSER_FEATURES, KnownComponentType } from '../../../interfaces';
+import { KnownComponentType } from '../../../interfaces';
 import { Component, ModelType } from '../../../models/SceneModels';
 import { ISceneNodeInternal, useStore } from '../../../store';
 import { setFeatureConfig } from '../../../common/GlobalSettings';
@@ -119,7 +119,6 @@ describe('SceneNodeInspectorPanel returns expected elements.', () => {
   });
 
   it('disable rotation, hide scale and render correct overlay section when selected scene node is Tag.', async () => {
-    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
     getSceneNodeByRef.mockReturnValue({
       ...baseNode,
       components: [
@@ -144,7 +143,6 @@ describe('SceneNodeInspectorPanel returns expected elements.', () => {
   });
 
   it('disable scale and rotation when selected scene node is Annotation.', async () => {
-    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
     getSceneNodeByRef.mockReturnValue({
       ...baseNode,
       components: [
@@ -173,7 +171,6 @@ describe('SceneNodeInspectorPanel returns expected elements.', () => {
   });
 
   it('disable rotation, hide scale and render correct overlay section when selected scene node is Tag with Overlay panel.', async () => {
-    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
     getSceneNodeByRef.mockReturnValue({
       ...baseNode,
       components: [

--- a/packages/scene-composer/src/components/panels/__tests__/TopBar.spec.tsx
+++ b/packages/scene-composer/src/components/panels/__tests__/TopBar.spec.tsx
@@ -4,13 +4,7 @@ import * as THREE from 'three';
 
 import { TopBar } from '../TopBar';
 import { useStore } from '../../../store';
-import {
-  COMPOSER_FEATURES,
-  DEFAULT_CAMERA_OPTIONS,
-  DEFAULT_CAMERA_POSITION,
-  KnownComponentType,
-  setFeatureConfig,
-} from '../../..';
+import { DEFAULT_CAMERA_OPTIONS, DEFAULT_CAMERA_POSITION, KnownComponentType } from '../../..';
 import useActiveCamera from '../../../hooks/useActiveCamera';
 
 jest.mock('../../../hooks/useActiveCamera', () => jest.fn().mockReturnValue({ setActiveCameraSettings: jest.fn() }));
@@ -91,7 +85,6 @@ describe('<TopBar />', () => {
     };
 
     useStore('default').setState({ ...baseState, document });
-    setFeatureConfig({ [COMPOSER_FEATURES.CameraView]: true });
     const { setActiveCameraSettings } = useActiveCamera();
 
     const { getByTestId } = render(<TopBar />);

--- a/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/SceneRuleTargetEditor.tsx
@@ -4,7 +4,6 @@ import { defineMessages, useIntl } from 'react-intl';
 
 import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
-import useFeature from '../../../hooks/useFeature';
 import { COMPOSER_FEATURES, KnownSceneProperty, SceneResourceType, TargetMetadata } from '../../../interfaces';
 import { IIconLookup } from '../../../models/SceneModels';
 import { useSceneDocument, useStore } from '../../../store';
@@ -54,21 +53,16 @@ export const SceneRuleTargetEditor: React.FC<ISceneRuleTargetEditorProps> = ({
   const targetInfo = getSceneResourceInfo(target);
   const { formatMessage } = useIntl();
   const sceneComposerId = useContext(sceneComposerIdContext);
-  const [{ variation: opacityRuleEnabled }] = useFeature(COMPOSER_FEATURES[COMPOSER_FEATURES.OpacityRule]);
   const tagStyle = getGlobalSettings().featureConfig[COMPOSER_FEATURES.TagStyle];
   const [chosenColor, setChosenColor] = useState<string>(targetMetadata?.color ?? colors.customBlue);
   const [icon, setIcon] = useState<IIconLookup>({
     prefix: targetMetadata?.iconPrefix as string,
     iconName: targetMetadata?.iconName as string,
   });
-  const options = Object.values(SceneResourceType)
-    .filter((type) => {
-      return opacityRuleEnabled === 'C' ? type !== SceneResourceType.Opacity : true;
-    })
-    .map((type) => ({
-      label: formatMessage(i18nSceneResourceTypeStrings[SceneResourceType[type]]) || SceneResourceType[type],
-      value: SceneResourceType[type],
-    }));
+  const options = Object.values(SceneResourceType).map((type) => ({
+    label: formatMessage(i18nSceneResourceTypeStrings[SceneResourceType[type]]) || SceneResourceType[type],
+    value: SceneResourceType[type],
+  }));
   const { getSceneProperty } = useSceneDocument(sceneComposerId);
 
   const tagStyleColors = getSceneProperty<string[]>(KnownSceneProperty.TagCustomColors, []);
@@ -156,7 +150,7 @@ export const SceneRuleTargetEditor: React.FC<ISceneRuleTargetEditorProps> = ({
           onChange={(targetValue) => onChange(convertToIotTwinMakerNamespace(targetInfo.type, targetValue))}
         />
       )}
-      {opacityRuleEnabled === 'T1' && targetInfo.type === SceneResourceType.Opacity && (
+      {targetInfo.type === SceneResourceType.Opacity && (
         <SceneRuleTargetOpacityEditor
           targetValue={targetInfo.value}
           onChange={(targetValue) => onChange(convertToIotTwinMakerNamespace(targetInfo.type, targetValue))}

--- a/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/SceneRuleTargetEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/SceneRuleTargetEditor.spec.tsx
@@ -5,7 +5,6 @@ import { useIntl } from 'react-intl';
 import { SceneRuleTargetEditor } from '../SceneRuleTargetEditor';
 import { DefaultAnchorStatus, SceneResourceType } from '../../../../';
 import { getSceneResourceInfo } from '../../../../utils/sceneResourceUtils';
-import useFeature from '../../../../hooks/useFeature';
 
 jest.mock('../SceneRuleTargetColorEditor', () => ({
   SceneRuleTargetColorEditor: () => 'SceneRuleTargetColorEditor',
@@ -28,26 +27,20 @@ jest.mock('react-intl', () => ({
 jest.mock('../../../../hooks/useFeature', () => jest.fn());
 
 describe('SceneRuleTargetEditor', () => {
-  [
-    { opacityRuleFeature: 'T1', type: SceneResourceType.Icon },
-    { opacityRuleFeature: 'C', type: SceneResourceType.Icon },
-    { opacityRuleFeature: 'T1', type: SceneResourceType.Color },
-    { opacityRuleFeature: 'C', type: SceneResourceType.Color },
-    { opacityRuleFeature: 'T1', type: SceneResourceType.Opacity },
-    { opacityRuleFeature: 'C', type: SceneResourceType.Opacity },
-  ].forEach(({ opacityRuleFeature, type }) => {
-    it(`should render a drop down with appropriate options: { opacityRuleFeature: ${opacityRuleFeature}, type: ${type} }`, () => {
-      (useIntl as jest.Mock).mockReturnValue({
-        formatMessage: jest.fn(() => 'test message'),
-      });
-      (useFeature as jest.Mock).mockReturnValue([{ variation: opacityRuleFeature }]);
-      (getSceneResourceInfo as jest.Mock).mockReturnValue({
-        type,
-      });
+  [{ type: SceneResourceType.Icon }, { type: SceneResourceType.Color }, { type: SceneResourceType.Opacity }].forEach(
+    ({ type }) => {
+      it(`should render a drop down with appropriate resource type: ${type}`, () => {
+        (useIntl as jest.Mock).mockReturnValue({
+          formatMessage: jest.fn(() => 'test message'),
+        });
+        (getSceneResourceInfo as jest.Mock).mockReturnValue({
+          type,
+        });
 
-      const { container } = render(<SceneRuleTargetEditor target={DefaultAnchorStatus.Info} onChange={jest.fn()} />);
+        const { container } = render(<SceneRuleTargetEditor target={DefaultAnchorStatus.Info} onChange={jest.fn()} />);
 
-      expect(container).toMatchSnapshot();
-    });
-  });
+        expect(container).toMatchSnapshot();
+      });
+    },
+  );
 });

--- a/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/__snapshots__/SceneRuleTargetEditor.spec.tsx.snap
+++ b/packages/scene-composer/src/components/panels/scene-rule-components/__tests__/__snapshots__/SceneRuleTargetEditor.spec.tsx.snap
@@ -1,56 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SceneRuleTargetEditor should render a drop down with appropriate options: { opacityRuleFeature: C, type: Color } 1`] = `
-<div>
-  <div
-    data-mocked="Grid"
-    griddefinition="[{\\"colspan\\":4},{\\"colspan\\":8}]"
-  >
-    <div
-      data-mocked="Select"
-      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"}]"
-      selectedarialabel="test message"
-      selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"}"
-    />
-    SceneRuleTargetColorEditor
-  </div>
-</div>
-`;
-
-exports[`SceneRuleTargetEditor should render a drop down with appropriate options: { opacityRuleFeature: C, type: Icon } 1`] = `
-<div>
-  <div
-    data-mocked="Grid"
-    griddefinition="[{\\"colspan\\":4},{\\"colspan\\":8}]"
-  >
-    <div
-      data-mocked="Select"
-      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"}]"
-      selectedarialabel="test message"
-      selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"}"
-    />
-    SceneRuleTargetIconEditor
-  </div>
-</div>
-`;
-
-exports[`SceneRuleTargetEditor should render a drop down with appropriate options: { opacityRuleFeature: C, type: Opacity } 1`] = `
-<div>
-  <div
-    data-mocked="Grid"
-    griddefinition="[{\\"colspan\\":4},{\\"colspan\\":8}]"
-  >
-    <div
-      data-mocked="Select"
-      options="[{\\"label\\":\\"test message\\",\\"value\\":\\"Icon\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Color\\"},{\\"label\\":\\"test message\\",\\"value\\":\\"Number\\"}]"
-      selectedarialabel="test message"
-      selectedoption="{\\"label\\":\\"test message\\",\\"value\\":\\"Opacity\\"}"
-    />
-  </div>
-</div>
-`;
-
-exports[`SceneRuleTargetEditor should render a drop down with appropriate options: { opacityRuleFeature: T1, type: Color } 1`] = `
+exports[`SceneRuleTargetEditor should render a drop down with appropriate resource type: Color 1`] = `
 <div>
   <div
     data-mocked="Grid"
@@ -67,7 +17,7 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
 </div>
 `;
 
-exports[`SceneRuleTargetEditor should render a drop down with appropriate options: { opacityRuleFeature: T1, type: Icon } 1`] = `
+exports[`SceneRuleTargetEditor should render a drop down with appropriate resource type: Icon 1`] = `
 <div>
   <div
     data-mocked="Grid"
@@ -84,7 +34,7 @@ exports[`SceneRuleTargetEditor should render a drop down with appropriate option
 </div>
 `;
 
-exports[`SceneRuleTargetEditor should render a drop down with appropriate options: { opacityRuleFeature: T1, type: Opacity } 1`] = `
+exports[`SceneRuleTargetEditor should render a drop down with appropriate resource type: Opacity 1`] = `
 <div>
   <div
     data-mocked="Grid"

--- a/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/index.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ColorOverlayComponent/index.tsx
@@ -2,13 +2,12 @@ import React, { useMemo, useEffect } from 'react';
 import { Material, Mesh } from 'three';
 import { isEmpty } from 'lodash';
 
-import { COMPOSER_FEATURES, SceneResourceType } from '../../../interfaces';
+import { SceneResourceType } from '../../../interfaces';
 import { ISceneNodeInternal, IColorOverlayComponentInternal, useStore } from '../../../store';
 import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
 import { getSceneResourceInfo, parseColorWithAlpha } from '../../../utils/sceneResourceUtils';
 import useMaterialEffect from '../../../hooks/useMaterialEffect';
 import useRuleResult from '../../../hooks/useRuleResult';
-import useFeature from '../../../hooks/useFeature';
 
 interface IColorOverlayComponentProps {
   node: ISceneNodeInternal;
@@ -22,7 +21,6 @@ const ColorOverlayComponent: React.FC<IColorOverlayComponentProps> = ({
   const { ruleBasedMapId, valueDataBinding } = component;
   const sceneComposerId = useSceneComposerId();
   const entityObject3D = useStore(sceneComposerId)((state) => state.getObject3DBySceneNodeRef(node.ref));
-  const [{ variation: opacityRuleEnabled }] = useFeature(COMPOSER_FEATURES[COMPOSER_FEATURES.OpacityRule]);
 
   const ruleResult = useRuleResult({ ruleMapId: ruleBasedMapId, dataBinding: valueDataBinding });
 
@@ -72,7 +70,7 @@ const ColorOverlayComponent: React.FC<IColorOverlayComponentProps> = ({
     return () => {
       restore();
     };
-  }, [ruleResult, entityObject3D, opacityRuleEnabled]);
+  }, [ruleResult, entityObject3D]);
 
   // This component relies on side effects to update the rendering of the entity's mesh. Returning an empty fragment.
   return <React.Fragment></React.Fragment>;

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.spec.tsx
@@ -67,7 +67,6 @@ describe('AddObjectMenu', () => {
     jest.clearAllMocks();
 
     setFeatureConfig({
-      [COMPOSER_FEATURES.CameraView]: true,
       [COMPOSER_FEATURES.EnvironmentModel]: true,
       [COMPOSER_FEATURES.DynamicScene]: true,
     });
@@ -266,16 +265,7 @@ describe('AddObjectMenu', () => {
     expect(mockMetricRecorder.recordClick).toBeCalledWith('add-object-motion-indicator');
   });
 
-  it('should not see add overlay item when feature is not enabled', () => {
-    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: false });
-
-    render(<AddObjectMenu canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />);
-
-    expect(screen.queryByTestId('add-overlay-menu')).toBeNull();
-  });
-
   it('should call setAddingWidget when adding a annotation', () => {
-    setFeatureConfig({ [COMPOSER_FEATURES.Overlay]: true });
     const component: IDataOverlayComponent = {
       type: KnownComponentType.DataOverlay,
       valueDataBindings: [],

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -147,7 +147,6 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
         },
         {
           uuid: ObjectTypes.ViewCamera,
-          feature: { name: COMPOSER_FEATURES.CameraView },
           isDisabled: enableMatterportViewer,
         },
         {
@@ -155,7 +154,6 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
         },
         {
           uuid: ObjectTypes.Annotation,
-          feature: { name: COMPOSER_FEATURES.Overlay },
         },
         {
           uuid: ObjectTypes.ModelShader,

--- a/packages/scene-composer/src/interfaces/feature.ts
+++ b/packages/scene-composer/src/interfaces/feature.ts
@@ -1,13 +1,9 @@
 export enum COMPOSER_FEATURES {
   FOR_TESTS = 'FOR_TESTS', // Feature flags may come and go, as things launch, this one is used for automated testing, so please don't remove it.
   SceneHierarchyMultiSelect = 'SceneHierarchyMultiSelect',
-  OpacityRule = 'OpacityRule',
-  CameraView = 'CameraView',
   Matterport = 'Matterport',
-  TagResize = 'TagResize',
   SubModelMovement = 'SubModelMovement',
   SubModelChildren = 'SubModelChildren',
-  Overlay = 'Overlay',
   DataBinding = 'DataBinding',
   TagStyle = 'TagStyle',
   AutoQuery = 'AutoQuery',

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.spec.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.spec.tsx
@@ -5,9 +5,8 @@ import { create } from 'react-test-renderer';
 
 import { SceneLayout } from '.';
 import { useStore } from '../../store';
-import { COMPOSER_FEATURES, KnownComponentType } from '../../interfaces';
+import { KnownComponentType } from '../../interfaces';
 import useSelectedNode from '../../hooks/useSelectedNode';
-import { setFeatureConfig } from '../../common/GlobalSettings';
 
 jest.mock('.', () => {
   const originalModule = jest.requireActual('.');
@@ -58,8 +57,6 @@ describe('SceneLayout', () => {
         ],
       },
     });
-
-    setFeatureConfig({ [COMPOSER_FEATURES.CameraView]: true });
   });
 
   [

--- a/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
@@ -13,10 +13,6 @@ export const defaultArgs = {
   mode: 'Editing',
   density: 'comfortable',
   features: [
-    COMPOSER_FEATURES.CameraView,
-    COMPOSER_FEATURES.OpacityRule,
-    COMPOSER_FEATURES.Overlay,
-    COMPOSER_FEATURES.TagResize,
     COMPOSER_FEATURES.Matterport,
     COMPOSER_FEATURES.TagStyle,
     COMPOSER_FEATURES.AutoQuery,

--- a/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneViewer.stories.mdx
@@ -12,8 +12,6 @@ export const defaultArgs = {
   theme: 'dark',
   density: 'comfortable',
   features: [
-    COMPOSER_FEATURES.CameraView,
-    COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.Matterport,
     COMPOSER_FEATURES.SceneAppearance,
     COMPOSER_FEATURES.Textures,

--- a/packages/scene-composer/stories/FirstPerson.stories.mdx
+++ b/packages/scene-composer/stories/FirstPerson.stories.mdx
@@ -13,10 +13,7 @@ export const defaultArgs = {
   mode: 'Viewing',
   density: 'comfortable',
   features: [
-    COMPOSER_FEATURES.CameraView,
-    COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.FirstPerson,
-    COMPOSER_FEATURES.Overlay
   ]
 }
 

--- a/packages/scene-composer/stories/Highlight.stories.mdx
+++ b/packages/scene-composer/stories/Highlight.stories.mdx
@@ -13,10 +13,7 @@ export const defaultArgs = {
   theme: 'dark',
   mode: 'Viewing',
   density: 'comfortable',
-  features: [
-    COMPOSER_FEATURES.CameraView,
-    COMPOSER_FEATURES.OpacityRule,
-  ]
+  features: []
 }
 
 export const Template = (args) => {

--- a/packages/scene-composer/stories/Matterport.stories.mdx
+++ b/packages/scene-composer/stories/Matterport.stories.mdx
@@ -15,10 +15,7 @@ export const defaultArgs = {
   matterportModelId: 'cZowU1FxWEQ',
   matterportApplicationKey: '',
   features: [
-    COMPOSER_FEATURES.CameraView,
-    COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.Matterport,
-    COMPOSER_FEATURES.Overlay
   ]
 }
 

--- a/packages/scene-composer/stories/SceneViewer.stories.mdx
+++ b/packages/scene-composer/stories/SceneViewer.stories.mdx
@@ -15,8 +15,6 @@ export const defaultArgs = {
   mode: 'Viewing',
   density: 'comfortable',
   features: [
-    COMPOSER_FEATURES.CameraView,
-    COMPOSER_FEATURES.OpacityRule,
     COMPOSER_FEATURES.Matterport,
   ]
 }


### PR DESCRIPTION
## Overview
Removed the following feature flags that are already available to all customers:

* CameraView
* OpacityRule
* TagResize
* Overlay

## Verifying Changes

Ran unit tests and verified functionality of local scene composer and viewer on storybook.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
