### PR TITLE
fix: add signigicant digits to xy plot

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/settings/index.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/settings/index.tsx
@@ -10,8 +10,7 @@ import { PropertyLens } from '~/customization/propertiesSection';
 
 const isSettingsWidget = (
   w: DashboardWidget
-): w is DashboardWidget<CommonChartProperties> =>
-  'queryConfig' in w.properties && w.type !== 'xy-plot';
+): w is DashboardWidget<CommonChartProperties> => 'queryConfig' in w.properties;
 
 const RenderSettingsConfiguration = ({
   useProperty,

--- a/packages/react-components/src/components/chart/chartOptions/axes/yAxis.ts
+++ b/packages/react-components/src/components/chart/chartOptions/axes/yAxis.ts
@@ -1,9 +1,11 @@
 import { YAXisComponentOption } from 'echarts';
 import { ChartAxisOptions } from '../../types';
 import { DEFAULT_Y_AXIS } from '../../eChartsConstants';
+import { round } from '@iot-app-kit/core-util';
 
 export const convertYAxis = (
-  axis: ChartAxisOptions | undefined
+  axis?: ChartAxisOptions,
+  significantDigits?: number
 ): YAXisComponentOption => ({
   ...DEFAULT_Y_AXIS,
   name: axis?.yLabel,
@@ -15,6 +17,7 @@ export const convertYAxis = (
   axisLabel: {
     hideOverlap: true,
     color: '#5f6b7a',
+    formatter: (value: number) => `${round(value, significantDigits)}`,
   },
   nameLocation: 'middle',
   nameGap: 30,

--- a/packages/react-components/src/components/chart/chartOptions/seriesAndYAxis/convertSeriesAndYAxis.ts
+++ b/packages/react-components/src/components/chart/chartOptions/seriesAndYAxis/convertSeriesAndYAxis.ts
@@ -247,7 +247,9 @@ export const useSeriesAndYAxis = (
     useHighlightedDataStreams();
 
   return useMemo(() => {
-    const defaultYAxis: YAXisComponentOption[] = [convertChartYAxis(axis)];
+    const defaultYAxis: YAXisComponentOption[] = [
+      convertChartYAxis(axis, significantDigits),
+    ];
     const convertedThresholds = convertThresholds(thresholds);
 
     const shouldUseEmphasis = highlightedDataStreams.length > 0;


### PR DESCRIPTION
## Overview
Add significant digits settings to XY Plot
(style looks different but is fixed by https://github.com/awslabs/iot-app-kit/pull/2492) 

https://github.com/awslabs/iot-app-kit/assets/28601414/810866b0-42ae-48fd-8818-536be432e866


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
