### PR TITLE
fix: empty state overflow

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/dashboardEmptyState.css
+++ b/packages/dashboard/src/components/internalDashboard/dashboardEmptyState.css
@@ -1,8 +1,6 @@
 .dashboard-empty-state {
   position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  margin: 32px;
   border: dashed;
   height: 200px;
   width: 350px;


### PR DESCRIPTION
## Overview
fix the dashboard's empty state overflowing into the nav area by adding a margin and removing the transform/positioning

temporary fix until nischay's rework of the entire panel/layout system 

issue was due to a mixed use of `overflow: hidden` and `position: fixed` with a transform which do not work together

---

before: 
<img width="500" alt="image" src="https://github.com/awslabs/iot-app-kit/assets/28601414/9c337d19-ec4f-41ef-bbcf-7f419d60f78b">

after:
<img width="583" alt="image" src="https://github.com/awslabs/iot-app-kit/assets/28601414/2d13011e-f57d-4826-bf56-1fd796635d77">
[video](https://github.com/awslabs/iot-app-kit/assets/28601414/e7bde06a-14a2-45eb-b76b-0cc847d80384)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
