### PR TITLE
fix: hidden and highlighted datastreams persist correctly

### DIFF
--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -213,6 +213,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (
   return (
     <WidgetTile widget={widget} removeable title={title}>
       <Chart
+        id={widget.id}
         queries={queries}
         viewport={viewport}
         gestures={readOnly}

--- a/packages/react-components/src/components/chart/store/context.tsx
+++ b/packages/react-components/src/components/chart/store/context.tsx
@@ -10,7 +10,7 @@ import useDataStore from '../../../store';
 // Recommended usage from zustand https://docs.pmnd.rs/zustand/previous-versions/zustand-v3-create-context
 export const ChartStoreContext = createContext<
   ReturnType<typeof createChartStore>
->(createChartStore());
+>(createChartStore({ chartId: 'contextStore' }));
 
 export const ChartStoreProvider = ({
   id,

--- a/packages/react-components/src/components/chart/store/store.ts
+++ b/packages/react-components/src/components/chart/store/store.ts
@@ -3,16 +3,21 @@ import { devtools, persist } from 'zustand/middleware';
 import { createMultiYAxisSlice, MultiYAxisState } from './multiYAxis';
 import { createDataStreamsSlice, DataStreamsState } from './contextDataStreams';
 
-export type StateData = DataStreamsState & MultiYAxisState;
-export const createChartStore = () =>
+export type StateData = DataStreamsState &
+  MultiYAxisState & { chartId: string };
+
+export const createChartStore = (
+  initProps: Partial<StateData> & Required<Pick<Partial<StateData>, 'chartId'>>
+) =>
   create<StateData>()(
     devtools(
       persist(
         (...args) => ({
+          ...initProps,
           ...createMultiYAxisSlice(...args),
           ...createDataStreamsSlice(...args),
         }),
-        { name: 'chartStore' }
+        { name: `chart-store-${initProps?.chartId}` }
       )
     )
   );

--- a/packages/react-components/src/store/chartStoreSlice.ts
+++ b/packages/react-components/src/store/chartStoreSlice.ts
@@ -13,7 +13,7 @@ export interface ChartStoreState extends ChartStoreData {
 export const createChartStoresSlice: StateCreator<ChartStoreState> = (set) => ({
   chartStores: {},
   addChart: (id) => {
-    const store = createChartStore();
+    const store = createChartStore({ chartId: id }); //repopulate chart store from local storage
     set((state) => ({
       chartStores: {
         ...state.chartStores,

--- a/packages/react-components/src/store/index.ts
+++ b/packages/react-components/src/store/index.ts
@@ -1,16 +1,23 @@
 import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { devtools, persist } from 'zustand/middleware';
 import { createTrendCursorsSlice, TrendCursorsState } from './trendCusorSlice';
 import { ConfigState, createConfigSlice, Flags } from './config';
 import { ChartStoreState, createChartStoresSlice } from './chartStoreSlice';
 
 export type StateData = TrendCursorsState & ConfigState & ChartStoreState;
 const useDataStore = create<StateData>()(
-  devtools((...args) => ({
-    ...createTrendCursorsSlice(...args),
-    ...createConfigSlice(...args),
-    ...createChartStoresSlice(...args),
-  }))
+  devtools(
+    persist(
+      (...args) => ({
+        ...createTrendCursorsSlice(...args),
+        ...createConfigSlice(...args),
+        ...createChartStoresSlice(...args),
+      }),
+      {
+        name: 'global-store',
+      }
+    )
+  )
 );
 
 export default useDataStore;


### PR DESCRIPTION
## Overview
This change solves https://app.asana.com/0/1204375185707273/1206385082271207 using persist() in the Zustand library. https://docs.pmnd.rs/zustand/integrations/persisting-store-data#hashydrated

- Linked and persisted each chartStore with the widget id, so each store has its own unique store that remains populated with the correct data through edit/preview modes and refresh. 

- Persisted the global store, so that it does not reset to an empty object on edit/preview modes and refresh



## Verifying Changes

These cases are outlined in the ticket linked above. I tested more within each video to try to catch edge cases. 

Case 1:

https://github.com/awslabs/iot-app-kit/assets/145582655/3e21a6d1-318c-4411-bd47-0ebb7d1759c2

Case 2:

https://github.com/awslabs/iot-app-kit/assets/145582655/2695ea46-ddd9-48c7-a388-a60cbce60440

Case 3:

https://github.com/awslabs/iot-app-kit/assets/145582655/04bc1983-47f2-4a76-a8f7-f8b75e9568bf


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
