### PR TITLE
chore(example): drop vite back to 4.5.1

### DIFF
--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -59,6 +59,6 @@
     "rollup-plugin-node-polyfills": "^0.2.1",
     "sass": "^1.63.4",
     "typescript": "^4.8.3",
-    "vite": "^4.5.2"
+    "vite": "4.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,11 +37,12 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@cloudscape-design/component-toolkit": "1.0.0-beta.26",
     "@cloudscape-design/collection-hooks": "1.0.22",
+    "@cloudscape-design/component-toolkit": "1.0.0-beta.26",
     "@cloudscape-design/components": "3.0.421",
     "@cloudscape-design/design-tokens": "3.0.15",
-    "@cloudscape-design/global-styles": "1.0.12"
+    "@cloudscape-design/global-styles": "1.0.12",
+    "vite": "^4.5.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.6.7",
@@ -70,6 +71,7 @@
   "overrides": {
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "fast-xml-parser": "^4.2.5"
+    "fast-xml-parser": "^4.2.5",
+    "vite": "$vite"
   }
 }


### PR DESCRIPTION
## Overview
undo version bump of vite 4.5.1 

## Verifying Changes
package-lock inspected

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
