### PR TITLE
fix(scene-composer): 3D model selection broken on first click

### DIFF
--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/AddObjectMenu.tsx
@@ -239,38 +239,35 @@ export const AddObjectMenu = ({ canvasHeight, toolbarOrientation }: AddObjectMen
     }
   }, [selectedSceneNodeRef]);
 
-  const handleAddModel = useCallback(
-    (modelType?: string, mustBeRoot = false) => {
-      if (showAssetBrowserCallback) {
-        showAssetBrowserCallback((s3BucketArn, contentLocation) => {
-          const [filename, ext] = extractFileNameExtFromUrl(contentLocation);
+  const handleAddModel = (modelType?: string, mustBeRoot = false) => {
+    if (showAssetBrowserCallback) {
+      showAssetBrowserCallback((s3BucketArn, contentLocation) => {
+        const [filename, ext] = extractFileNameExtFromUrl(contentLocation);
 
-          let modelUri: string;
-          if (s3BucketArn === null) {
-            // This should be used for local testing only
-            modelUri = contentLocation;
-          } else {
-            modelUri = `s3://${parseS3BucketFromArn(s3BucketArn)}/${contentLocation}`;
-          }
+        let modelUri: string;
+        if (s3BucketArn === null) {
+          // This should be used for local testing only
+          modelUri = contentLocation;
+        } else {
+          modelUri = `s3://${parseS3BucketFromArn(s3BucketArn)}/${contentLocation}`;
+        }
 
-          const gltfComponent: IModelRefComponent = {
-            type: 'ModelRef',
-            uri: modelUri,
-            modelType: modelType ?? ext.toUpperCase(),
-          };
+        const gltfComponent: IModelRefComponent = {
+          type: 'ModelRef',
+          uri: modelUri,
+          modelType: modelType ?? ext.toUpperCase(),
+        };
 
-          const node = {
-            name: filename,
-            components: [gltfComponent],
-            parentRef: mustBeRoot ? undefined : selectedSceneNodeRef,
-          } as unknown as ISceneNodeInternal;
+        const node = {
+          name: filename,
+          components: [gltfComponent],
+          parentRef: mustBeRoot ? undefined : selectedSceneNodeRef,
+        } as unknown as ISceneNodeInternal;
 
-          setAddingWidget({ type: KnownComponentType.ModelRef, node });
-        }, ModelFileTypeList);
-      }
-    },
-    [selectedSceneNodeRef],
-  );
+        setAddingWidget({ type: KnownComponentType.ModelRef, node });
+      }, ModelFileTypeList);
+    }
+  };
 
   const handleAddMotionIndicator = useCallback(() => {
     const motionIndicatorComponent: IMotionIndicatorComponent = {


### PR DESCRIPTION
## Overview
Saw on the Console that the 3D model modal did not appear when first trying to click on "+" --> "Add 3D model". It only worked after trying to add another widget to the scene. This is due to making the `handleAddModel` function use a `useCallback`. Removing this fixes the issue.

Verified that adding any other widget for the first time on page load is not impacted as well.

## Verifying Changes
Verified the fix in storybook, see the videos below.

Before:

https://github.com/awslabs/iot-app-kit/assets/87385528/8fd8d253-dd45-4409-8865-3a25632014a3

After:

https://github.com/awslabs/iot-app-kit/assets/87385528/efc2ac41-21eb-4951-8392-c46bcedb43d3

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
