### PR TITLE
fix: yAxis label collides with yAxis name #2471

### DIFF
--- a/packages/react-components/src/components/chart/chartOptions/axes/yAxis.ts
+++ b/packages/react-components/src/components/chart/chartOptions/axes/yAxis.ts
@@ -20,5 +20,6 @@ export const convertYAxis = (
     formatter: (value: number) => `${round(value, significantDigits)}`,
   },
   nameLocation: 'middle',
-  nameGap: 30,
+  //TODO: Increased nameGap to solve label collides with y-axis issue, but the issue is in echarts and waiting for this(https://github.com/apache/echarts/issues/9265) CR to be merged from echart team.
+  nameGap: 38,
 });


### PR DESCRIPTION
## Overview
This PR is for #2471 

Increased nameGap to avoid overlapping yAxis Labels with yAxis name but it supports up to 5 digits/characters only, and there is an open issue(#9265) and In-review CR(19534) in the echarts. 
TODO: Will update this nameGap once CR gets fixed from the echarts team.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/139960352/b47e7464-3c6c-4d91-afcb-b071986e9ea6


### Scene Composer
NA

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
