### PR TITLE
fix: realistic dev experience on storybook

### DIFF
--- a/packages/dashboard/src/components/dashboard/view.tsx
+++ b/packages/dashboard/src/components/dashboard/view.tsx
@@ -13,12 +13,14 @@ import type {
   DashboardConfiguration,
 } from '~/types';
 import { ClientContext } from './clientContext';
+import { queryClient } from '~/data/query-client';
 import { QueryContext } from './queryContext';
 import { getClients } from './getClients';
 import { getQueries } from './getQueries';
 
 import '@cloudscape-design/global-styles/index.css';
 import '../../styles/variables.css';
+import { QueryClientProvider } from '@tanstack/react-query';
 
 export type DashboardViewProperties = {
   clientConfiguration: DashboardClientConfiguration;
@@ -35,22 +37,24 @@ const DashboardView: React.FC<DashboardViewProperties> = ({
   return (
     <ClientContext.Provider value={getClients(clientConfiguration)}>
       <QueryContext.Provider value={getQueries(clientConfiguration)}>
-        <Provider
-          store={configureDashboardStore({
-            ...toDashboardState(dashboardConfiguration),
-            readOnly: true,
-          })}
-        >
-          <DndProvider
-            backend={TouchBackend}
-            options={{
-              enableMouseEvents: true,
-              enableKeyboardEvents: true,
-            }}
+        <QueryClientProvider client={queryClient}>
+          <Provider
+            store={configureDashboardStore({
+              ...toDashboardState(dashboardConfiguration),
+              readOnly: true,
+            })}
           >
-            <InternalDashboard />
-          </DndProvider>
-        </Provider>
+            <DndProvider
+              backend={TouchBackend}
+              options={{
+                enableMouseEvents: true,
+                enableKeyboardEvents: true,
+              }}
+            >
+              <InternalDashboard />
+            </DndProvider>
+          </Provider>
+        </QueryClientProvider>
       </QueryContext.Provider>
     </ClientContext.Provider>
   );


### PR DESCRIPTION
## Overview
fix: view only mode did not work since it did not have a tanstack provider 
fix: main mode storybook now saves dashboard config to localStorage and makes the dashboard reload with new config, making the dev experience match the centurion implementation


better storybook dev: 
![fixed](https://github.com/awslabs/iot-app-kit/assets/28601414/dbe1bd4c-f963-4760-b1d7-2ea1b762d5fc)


fixed view mode:
<img width="1274" alt="Screenshot 2024-01-24 at 10 33 09" src="https://github.com/awslabs/iot-app-kit/assets/28601414/5d81eac2-9cdc-4739-81a0-8447bd092c63">



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
