### PR TITLE
fix(dashboard): spacing issues on editable grid

### DIFF
--- a/packages/dashboard/src/components/widgets/widget.css
+++ b/packages/dashboard/src/components/widgets/widget.css
@@ -5,7 +5,7 @@
   height: 100%;
   overflow: hidden;
   user-select: none;
-  box-sizing: border-box;
+  box-sizing: content-box;
 }
 
 .widget-editable {


### PR DESCRIPTION
## Overview
Currently, when you place widgets near each other in edit mode and then preview them, the spacing between them disappears. This was due to widgets having a "selection box" that was rendering around the widgets.

![selection state](https://github.com/awslabs/iot-app-kit/assets/145582655/3301e20a-7f97-474b-9c11-f2b80071dab4)

The widget positions in the dashboard defintion were correct. We can see that because one of the placed widget starts at 0,0 and has width 18. The next widget starts at 0,18. 

![DC](https://github.com/awslabs/iot-app-kit/assets/145582655/f2117910-e48f-4475-adfc-4d6c6f727f36)

To fix this, we changed the widget box-sizing property to be "content-box" from "border-box" to limit the selection state within the widget border. 

![selection state 2](https://github.com/awslabs/iot-app-kit/assets/145582655/e04af32d-ea7c-4cbc-b9fc-af83960ab0eb)


## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/357a7111-300a-4537-a226-fd572b454f86



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
