### PR TITLE
fix: kpi add prop bug

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesTable/assetModelPropertiesTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesTable/assetModelPropertiesTable.tsx
@@ -20,6 +20,7 @@ import { ResourceExplorerFooter } from '../../../footer/footer';
 import { useSelector } from 'react-redux';
 import { DashboardState } from '~/store/state';
 import { isModeledPropertyInvalid } from '~/components/queryEditor/helpers/isModeledPropertyInvalid';
+import { disableAdd } from '~/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd';
 
 export interface AssetTableProps {
   onClickNextPage: () => void;
@@ -132,7 +133,8 @@ export function AssetModelPropertiesTable({
       footer={
         <ResourceExplorerFooter
           addDisabled={
-            saveDisabled || collectionProps.selectedItems?.length === 0
+            saveDisabled ||
+            disableAdd(selectedWidgets, collectionProps.selectedItems?.length)
           }
           onAdd={onSave}
           onReset={() => actions.setSelectedItems([])}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd.spec.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd.spec.tsx
@@ -1,11 +1,14 @@
 import { disableAdd } from '~/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd';
+import { SiteWiseQueryConfig } from '~/customization/widgets/types';
 
-describe(disableAdd, () => {
-  it('should return true if no selected widgets', () => {
-    expect(disableAdd([], 0)).toBeTruthy();
-  });
-
-  it('should return true if no results', () => {
+const commonTests = ({
+  objectWithoutProperties,
+  objectWithProperties,
+}: {
+  objectWithoutProperties: { queryConfig: SiteWiseQueryConfig };
+  objectWithProperties: { queryConfig: SiteWiseQueryConfig };
+}) => {
+  it('should return true if no results, with or without properties', () => {
     expect(
       disableAdd(
         [
@@ -15,7 +18,24 @@ describe(disableAdd, () => {
             x: 0,
             y: 0,
             z: 0,
-            properties: {},
+            properties: objectWithoutProperties,
+            height: 500,
+            width: 800,
+          },
+        ],
+        0
+      )
+    ).toBeTruthy();
+    expect(
+      disableAdd(
+        [
+          {
+            id: '1',
+            type: 'status',
+            x: 0,
+            y: 0,
+            z: 0,
+            properties: objectWithProperties,
             height: 500,
             width: 800,
           },
@@ -25,7 +45,7 @@ describe(disableAdd, () => {
     ).toBeTruthy();
   });
 
-  it('should return true if status is selected and has a assets already added', () => {
+  it('should return true if status/kpi is selected and has a property already added', () => {
     expect(
       disableAdd(
         [
@@ -35,7 +55,7 @@ describe(disableAdd, () => {
             x: 0,
             y: 0,
             z: 0,
-            properties: { queryConfig: { query: { assets: [{ id: '1' }] } } },
+            properties: objectWithProperties,
             height: 500,
             width: 800,
           },
@@ -43,8 +63,6 @@ describe(disableAdd, () => {
         10
       )
     ).toBeTruthy();
-  });
-  it('should return true if KPI is selected and has a assets already added', () => {
     expect(
       disableAdd(
         [
@@ -54,7 +72,7 @@ describe(disableAdd, () => {
             x: 0,
             y: 0,
             z: 0,
-            properties: { queryConfig: { query: { assets: [{ id: '1' }] } } },
+            properties: objectWithProperties,
             height: 500,
             width: 800,
           },
@@ -64,7 +82,7 @@ describe(disableAdd, () => {
     ).toBeTruthy();
   });
 
-  it('should return false if status is selected and has NO assets already added', () => {
+  it('should return false if status/kpi is selected and has NO property already added', () => {
     expect(
       disableAdd(
         [
@@ -74,17 +92,15 @@ describe(disableAdd, () => {
             x: 0,
             y: 0,
             z: 0,
-            properties: { queryConfig: { query: { assets: [] } } },
+            properties: objectWithoutProperties,
             height: 500,
             width: 800,
           },
         ],
-        10
+        1
       )
     ).toBeFalsy();
-  });
 
-  it('should return false if KPI is selected and has NO assets already added', () => {
     expect(
       disableAdd(
         [
@@ -94,17 +110,17 @@ describe(disableAdd, () => {
             x: 0,
             y: 0,
             z: 0,
-            properties: { queryConfig: { query: { assets: [] } } },
+            properties: objectWithoutProperties,
             height: 500,
             width: 800,
           },
         ],
-        10
+        1
       )
     ).toBeFalsy();
   });
 
-  it('should return false if x-y-plot is selected and has assets already added', () => {
+  it('should return false if x-y-plot is selected and has property already added', () => {
     expect(
       disableAdd(
         [
@@ -114,7 +130,7 @@ describe(disableAdd, () => {
             x: 0,
             y: 0,
             z: 0,
-            properties: { queryConfig: { query: { assets: [{ id: '1' }] } } },
+            properties: objectWithoutProperties,
             height: 500,
             width: 800,
           },
@@ -122,5 +138,115 @@ describe(disableAdd, () => {
         10
       )
     ).toBeFalsy();
+  });
+
+  it('should return true if KPI(with or without property) is selected and more than 1 property selected', () => {
+    expect(
+      disableAdd(
+        [
+          {
+            id: '1',
+            type: 'kpi',
+            x: 0,
+            y: 0,
+            z: 0,
+            properties: {},
+            height: 500,
+            width: 800,
+          },
+        ],
+        10
+      )
+    ).toBeTruthy();
+    expect(
+      disableAdd(
+        [
+          {
+            id: '1',
+            type: 'kpi',
+            x: 0,
+            y: 0,
+            z: 0,
+            properties: objectWithProperties,
+            height: 500,
+            width: 800,
+          },
+        ],
+        10
+      )
+    ).toBeTruthy();
+  });
+
+  it('should return false if x-y-plot(with or without properties) is selected and more than 1 property selected', () => {
+    expect(
+      disableAdd(
+        [
+          {
+            id: '1',
+            type: 'x-y-plot',
+            x: 0,
+            y: 0,
+            z: 0,
+            properties: objectWithoutProperties,
+            height: 500,
+            width: 800,
+          },
+        ],
+        10
+      )
+    ).toBeFalsy();
+
+    expect(
+      disableAdd(
+        [
+          {
+            id: '1',
+            type: 'x-y-plot',
+            x: 0,
+            y: 0,
+            z: 0,
+            properties: objectWithProperties,
+            height: 500,
+            width: 800,
+          },
+        ],
+        10
+      )
+    ).toBeFalsy();
+  });
+};
+describe(disableAdd, () => {
+  it('should return true if no selected widgets', () => {
+    expect(disableAdd([], 0)).toBeTruthy();
+  });
+
+  describe('For modeled data', () => {
+    const objectWithoutProperties = {
+      queryConfig: { query: { assets: [] } },
+    } as unknown as { queryConfig: SiteWiseQueryConfig };
+    const objectWithProperties = {
+      queryConfig: { query: { assets: [{ id: '1' }] } },
+    } as unknown as { queryConfig: SiteWiseQueryConfig };
+
+    commonTests({ objectWithoutProperties, objectWithProperties });
+  });
+
+  describe('For unmodeled data', () => {
+    const objectWithoutProperties = {
+      queryConfig: { query: { properties: [] } },
+    } as unknown as { queryConfig: SiteWiseQueryConfig };
+    const objectWithProperties = {
+      queryConfig: { query: { properties: [{ id: '1' }] } },
+    } as unknown as { queryConfig: SiteWiseQueryConfig };
+    commonTests({ objectWithoutProperties, objectWithProperties });
+  });
+  describe('For asset model data', () => {
+    const objectWithoutProperties = {
+      queryConfig: { query: { assetModels: [] } },
+    } as unknown as { queryConfig: SiteWiseQueryConfig };
+    const objectWithProperties = {
+      queryConfig: { query: { assetModels: [{ id: '1' }] } },
+    } as unknown as { queryConfig: SiteWiseQueryConfig };
+    commonTests({ objectWithoutProperties, objectWithProperties });
   });
 });

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/disableAdd.ts
@@ -12,9 +12,18 @@ export const disableAdd = (
   switch (currWidgetType) {
     case 'status':
     case 'kpi': {
-      const assets =
+      const modeledProperties =
         get(selectedWidget, 'properties.queryConfig.query.assets') ?? [];
-      if (assets.length) {
+      const unmodeledProperties =
+        get(selectedWidget, 'properties.queryConfig.query.properties') ?? [];
+      const assetModelProperties =
+        get(selectedWidget, 'properties.queryConfig.query.assetModels') ?? [];
+      if (
+        modeledProperties.length ||
+        unmodeledProperties.length ||
+        assetModelProperties.length ||
+        collectionPropsLength !== 1
+      ) {
         widgetBasedDisable = true;
       }
       break;
@@ -22,6 +31,7 @@ export const disableAdd = (
     default:
   }
   return (
+    collectionPropsLength === undefined ||
     collectionPropsLength === 0 ||
     selectedWidgets.length !== 1 ||
     widgetBasedDisable


### PR DESCRIPTION
## Overview
The issue was that we were not checking the selection properties count
when we add  a kPI / status, we are allowing the user to add more than 1 property

this particular bug was becasue, when we selected kpi, we check if it already has properties added but did not check if more than 1 is selected. given for other widget type we can add more than one, the logic was obviously wrong.

Also, this was done only for modeled data and had missed unmodeled and asset models
## Verification


https://github.com/awslabs/iot-app-kit/assets/135036199/68a9f83f-1734-49ea-a5b7-aab9c5683827


## Legal
This project is available under the [Apache 2.0 License](http://www.apache


.org/licenses/LICENSE-2.0.html).
