### PR TITLE
fix(dashboard): fix spacing between widgets without selection box

### DIFF
--- a/packages/dashboard/src/components/widgets/widget.css
+++ b/packages/dashboard/src/components/widgets/widget.css
@@ -5,7 +5,9 @@
   height: 100%;
   overflow: hidden;
   user-select: none;
-  box-sizing: content-box;
+  box-sizing: border-box;
+  border: var(--selection-border-width) solid transparent;
+  border-radius: var(--selection-radius);
 }
 
 .widget-editable {


### PR DESCRIPTION
## Overview
Currently, when you place widgets near each other in edit mode and then preview them, the spacing between them disappears. This was due to widgets having a "selection box" that was rendering around the widgets. Rendering this border for read-only widgets solves the issue.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/90c27bd6-91d9-4920-8d5a-7aaeb1fa3432







## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
