### PR TITLE
chore(composer): clean up unused scene model fields

### DIFF
--- a/packages/scene-composer/public/overlay.scene.json
+++ b/packages/scene-composer/public/overlay.scene.json
@@ -541,6 +541,5 @@
         }
       ]
     }
-  },
-  "defaultCameraIndex": 0
+  }
 }

--- a/packages/scene-composer/public/scene_1.scene.json
+++ b/packages/scene-composer/public/scene_1.scene.json
@@ -480,6 +480,5 @@
         }
       ]
     }
-  },
-  "defaultCameraIndex": 0
+  }
 }

--- a/packages/scene-composer/public/scene_2.scene.json
+++ b/packages/scene-composer/public/scene_2.scene.json
@@ -223,7 +223,6 @@
       ]
     }
   },
-  "defaultCameraIndex": 0,
   "properties": {
     "environmentPreset": "neutral"
   }

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -92,7 +92,6 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
   const [updatedExternalLibraryConfig, setUpdatedExternalLibraryConfig] = useState<ExternalLibraryConfig | undefined>(
     externalLibraryConfig,
   );
-  const baseUrl = useStore(sceneComposerId)((state) => state.getSceneProperty<string>(KnownSceneProperty.BaseUrl));
   const messages = useStore(sceneComposerId)((state) => state.getMessages());
   const matterportModelId = useStore(sceneComposerId)((state) =>
     state.getSceneProperty<string>(KnownSceneProperty.MatterportModelId),
@@ -114,8 +113,8 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
   const { setActiveCameraSettings, setActiveCameraName } = useActiveCamera();
 
   const standardUriModifier = useMemo(
-    () => createStandardUriModifier(sceneContentUri || '', baseUrl),
-    [sceneContentUri, baseUrl],
+    () => createStandardUriModifier(sceneContentUri || '', undefined),
+    [sceneContentUri],
   );
 
   const isViewing = config.mode === 'Viewing';

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -65,7 +65,6 @@ export interface ISceneNode {
 }
 
 export enum KnownSceneProperty {
-  BaseUrl = 'baseUrl',
   EnvironmentPreset = 'environmentPreset',
   DataBindingConfig = 'dataBindingConfig',
   ComponentSettings = 'componentSettings',

--- a/packages/scene-composer/src/models/SceneModels.ts
+++ b/packages/scene-composer/src/models/SceneModels.ts
@@ -62,7 +62,6 @@ export interface Scene {
   properties?: KeyValuePair;
   rules?: Record<string, RuleBasedMap>;
   cameras?: Array<Camera>;
-  defaultCameraIndex?: number;
 }
 
 export enum CameraType {

--- a/packages/scene-composer/src/store/helpers/serializationHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/serializationHelpers.ts
@@ -762,9 +762,6 @@ function serializeDocument(document: ISceneDocumentInternal, specVersion: string
       : [],
 
     rules,
-
-    // TODO: allow picking a default camera, currently it's hard coded as the first camera
-    defaultCameraIndex: indexedObjectCollector[KnownComponentType.Camera] ? 0 : undefined,
   };
 
   return JSON.stringify(exportedScene, ...stringifyArgs);

--- a/packages/scene-composer/src/store/slices/SceneDocumentSlice.spec.ts
+++ b/packages/scene-composer/src/store/slices/SceneDocumentSlice.spec.ts
@@ -909,18 +909,18 @@ describe('createSceneDocumentSlice', () => {
 
   it('should be able to getSceneProperty', () => {
     const document = {
-      properties: { baseUrl: 'baseUrlValue' },
+      properties: { matterportModelId: 'abc' },
     };
     const get = jest.fn().mockReturnValue({ document }); // fake out get call
     const set = jest.fn();
 
     // Act
     const { getSceneProperty } = createSceneDocumentSlice(set, get);
-    const result = getSceneProperty(KnownSceneProperty.BaseUrl);
+    const result = getSceneProperty(KnownSceneProperty.MatterportModelId);
     const result2 = getSceneProperty(KnownSceneProperty.EnvironmentPreset, 'default');
 
     expect(get).toBeCalledTimes(2);
-    expect(result).toEqual(document.properties.baseUrl);
+    expect(result).toEqual(document.properties.matterportModelId);
     expect(result2).toEqual('default');
   });
 
@@ -931,13 +931,13 @@ describe('createSceneDocumentSlice', () => {
 
     // Act
     const { getSceneProperty } = createSceneDocumentSlice(set, get);
-    const result = getSceneProperty(KnownSceneProperty.BaseUrl, 'default');
+    const result = getSceneProperty(KnownSceneProperty.EnvironmentPreset, 'default');
 
     expect(get).toBeCalled();
     expect(result).toEqual('default');
   });
 
-  [{}, { properties: { baseUrl: 'original' } }].forEach((document) => {
+  [{}, { properties: { environmentPreset: 'neutral' } }].forEach((document) => {
     it(`should be able to setSceneProperty ${document.properties ? 'with' : 'without'} set properties`, () => {
       const draft = { lastOperation: undefined, document };
       const get = jest.fn(); // fake out get call
@@ -945,10 +945,10 @@ describe('createSceneDocumentSlice', () => {
 
       // Act
       const { setSceneProperty } = createSceneDocumentSlice(set, get);
-      setSceneProperty(KnownSceneProperty.BaseUrl, 'setValue');
+      setSceneProperty(KnownSceneProperty.EnvironmentPreset, 'setValue');
 
       expect(draft.lastOperation!).toEqual('setSceneProperty');
-      expect(draft.document.properties!.baseUrl).toEqual('setValue');
+      expect(draft.document.properties!.environmentPreset).toEqual('setValue');
     });
   });
 

--- a/packages/scene-composer/tests/scenes/matterport.json
+++ b/packages/scene-composer/tests/scenes/matterport.json
@@ -362,6 +362,5 @@
         }
       ]
     }
-  },
-  "defaultCameraIndex": 0
+  }
 }

--- a/packages/scene-composer/tests/scenes/scene_1.json
+++ b/packages/scene-composer/tests/scenes/scene_1.json
@@ -468,6 +468,5 @@
         }
       ]
     }
-  },
-  "defaultCameraIndex": 0
+  }
 }

--- a/packages/scene-composer/tests/scenes/scene_2.json
+++ b/packages/scene-composer/tests/scenes/scene_2.json
@@ -223,7 +223,6 @@
       ]
     }
   },
-  "defaultCameraIndex": 0,
   "properties": {
     "environmentPreset": "neutral",
     "componentSettings": {


### PR DESCRIPTION
## Overview
clean up unused scene model fields
- defaultCameraIndex
- BaseUrl

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
