### PR TITLE
feat: conditionally display latest value in legend table

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/constants.ts
+++ b/packages/dashboard/src/customization/propertiesSections/constants.ts
@@ -77,6 +77,7 @@ export const dropdownConsts = {
       { label: 'Unit', value: 'unit' },
       { label: 'Maximum Value', value: 'maxValue' },
       { label: 'Minimum Value', value: 'minValue' },
+      { label: 'Latest Value', value: 'latestValue' },
     ],
   },
 };

--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.spec.tsx
@@ -61,6 +61,7 @@ describe('LegendSection', () => {
     expect(getByLabelText('Alignment')).toBeDisabled();
     expect(getAllByLabelText('Display')[0]).toBeDisabled();
     expect(getAllByLabelText('Display')[1]).toBeDisabled();
+    expect(getAllByLabelText('Display')[2]).toBeDisabled();
   });
 
   test('should not disable legend options when visible is true', () => {
@@ -78,5 +79,6 @@ describe('LegendSection', () => {
     expect(getByLabelText('Alignment')).not.toBeDisabled();
     expect(getAllByLabelText('Display')[0]).not.toBeDisabled();
     expect(getAllByLabelText('Display')[1]).not.toBeDisabled();
+    expect(getAllByLabelText('Display')[2]).not.toBeDisabled();
   });
 });

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/plugin.tsx
@@ -41,6 +41,7 @@ export const lineScatterChartPlugin: DashboardPlugin = {
             asset: true,
             maxValue: true,
             minValue: true,
+            latestValue: true,
           },
         },
       }),

--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -207,6 +207,7 @@ const BaseChart = ({
             trendCursors={trendCursors}
             trendCursorValues={trendCursorValues}
             width={rightLegendWidth.toString()}
+            significantDigits={options.significantDigits}
           />
         </div>
       )}

--- a/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
+++ b/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
@@ -39,7 +39,7 @@ const useTitle = ({
 
 const toDataStreamIdentifiers = (dataStreams: DataStream[]) =>
   dataStreams.map(
-    ({ id, name, color, refId, dataType, detailedName, unit }) => ({
+    ({ id, name, color, refId, dataType, detailedName, unit, data }) => ({
       id,
       name,
       color,
@@ -47,6 +47,7 @@ const toDataStreamIdentifiers = (dataStreams: DataStream[]) =>
       dataType,
       detailedName,
       unit,
+      latestValue: data.at(-1)?.y,
     })
   );
 
@@ -55,7 +56,7 @@ const toDataStreamMetaData = (
   series: SeriesOption[]
 ) => {
   return datastreams.map(
-    ({ id, name, color, dataType, refId, detailedName, unit }) => {
+    ({ id, name, color, dataType, refId, detailedName, unit, latestValue }) => {
       const foundSeries = series.find(
         ({ id: seriesId }) => seriesId === id
       ) ?? { appKitColor: color };
@@ -68,6 +69,7 @@ const toDataStreamMetaData = (
         dataType,
         detailedName,
         unit,
+        latestValue,
       };
     }
   );

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.spec.ts
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.spec.ts
@@ -7,11 +7,13 @@ describe('legend table column definitions', () => {
       trendCursors: [],
       width: 100,
       visibleContent: {},
+      significantDigits: 0,
     });
     expect(columnDefinitions).toEqual(
       expect.arrayContaining([expect.toBeObject()])
     );
   });
+
   it('correctly orders trendcurors', () => {
     const trendCursors: TrendCursor[] = [
       {
@@ -29,6 +31,7 @@ describe('legend table column definitions', () => {
       trendCursors,
       width: 100,
       visibleContent: {},
+      significantDigits: 0,
     });
     expect(columnDefinitions).toEqual(
       expect.arrayContaining([
@@ -38,6 +41,44 @@ describe('legend table column definitions', () => {
         }),
         expect.objectContaining({
           id: 'trendcursor-2',
+        }),
+      ])
+    );
+  });
+
+  it('latest value column is added when latestvalue visible is true', () => {
+    const columnDefinitions = createTableLegendColumnDefinitions({
+      trendCursors: [],
+      width: 100,
+      visibleContent: {
+        latestValue: true,
+      },
+      significantDigits: 0,
+    });
+    expect(columnDefinitions).toEqual(
+      expect.arrayContaining([
+        expect.toBeObject(),
+        expect.objectContaining({
+          id: 'Latest Value',
+        }),
+      ])
+    );
+  });
+
+  it('latest value column is not added when latestvalue visible is false', () => {
+    const columnDefinitions = createTableLegendColumnDefinitions({
+      trendCursors: [],
+      width: 100,
+      visibleContent: {
+        latestValue: false,
+      },
+      significantDigits: 0,
+    });
+    expect(columnDefinitions).toEqual(
+      expect.arrayContaining([
+        expect.toBeObject(),
+        expect.not.objectContaining({
+          id: 'Latest Value',
         }),
       ])
     );

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/latestValue/index.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/latestValue/index.tsx
@@ -1,0 +1,2 @@
+export * from './latestValueHeader';
+export * from './latestValueCell';

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/latestValue/latestValueCell.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/latestValue/latestValueCell.tsx
@@ -1,0 +1,15 @@
+import React, { useMemo } from 'react';
+import { DataStream } from '@iot-app-kit/core';
+import { useVisibleDataStreams } from '../../../../hooks/useVisibleDataStreams';
+import { DataStreamInformation } from '../../types';
+
+export const LatestValueCell = ({ id, latestValue }: DataStreamInformation) => {
+  const { isDataStreamHidden } = useVisibleDataStreams();
+
+  const isVisible = useMemo(
+    () => !isDataStreamHidden({ id: id } as DataStream),
+    [isDataStreamHidden, id]
+  );
+
+  return <div className={!isVisible ? 'hidden-legend' : ''}>{latestValue}</div>;
+};

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/latestValue/latestValueHeader.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/latestValue/latestValueHeader.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const LatestValueColumnHeader = () => <div>Latest Value</div>;

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/trendCursor/trendCursorCell.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/trendCursor/trendCursorCell.tsx
@@ -5,7 +5,7 @@ import { DataStream } from '@iot-app-kit/core';
 
 type TrendCursorCellOptions = Omit<
   DataStreamInformation,
-  'trendCursorValues'
+  'trendCursorValues' | 'latestValue'
 > & { trendCursorValue?: number };
 
 export const TrendCursorCell = ({

--- a/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
+++ b/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { DataStream } from '@iot-app-kit/core';
-import { ChartLegend } from '../../types';
+import { DataStream, Primitive } from '@iot-app-kit/core';
+import { ChartLegend, ChartOptions } from '../../types';
 import { ChartLegendTable } from './table';
 import { DataStreamInformation, TrendCursor } from './types';
 import { TrendCursorValues } from '../../../../echarts/extensions/trendCursors/store';
@@ -11,12 +11,14 @@ const mapDataStreamInformation = ({
   chartId,
   visibleContent,
 }: {
-  datastreams: Pick<DataStream, 'id' | 'color' | 'name' | 'unit'>[];
+  datastreams: (Pick<DataStream, 'id' | 'color' | 'name' | 'unit'> & {
+    latestValue: Primitive | undefined;
+  })[];
   trendCursorValues: TrendCursorValues[];
   chartId: string;
   visibleContent: ChartLegend['visibleContent'];
 }): DataStreamInformation[] =>
-  datastreams.map(({ id, name, color, unit }) => {
+  datastreams.map(({ id, name, color, unit, latestValue }) => {
     const values = trendCursorValues.reduce<
       DataStreamInformation['trendCursorValues']
     >((valueMap, next) => {
@@ -33,15 +35,19 @@ const mapDataStreamInformation = ({
       id,
       name: dataStreamName,
       color,
+      latestValue,
       trendCursorValues: values,
     };
   });
 
 type ChartLegendTableAdapterOptions = ChartLegend & {
-  datastreams: Pick<DataStream, 'id' | 'color' | 'name'>[];
+  datastreams: (Pick<DataStream, 'id' | 'color' | 'name' | 'unit'> & {
+    latestValue: Primitive | undefined;
+  })[];
   trendCursorValues: TrendCursorValues[];
   trendCursors: TrendCursor[];
   chartId?: string;
+  significantDigits: ChartOptions['significantDigits'];
 };
 
 export const ChartLegendTableAdapter = ({
@@ -50,6 +56,7 @@ export const ChartLegendTableAdapter = ({
   trendCursorValues,
   chartId = '',
   visibleContent,
+  significantDigits,
   ...options
 }: ChartLegendTableAdapterOptions) => {
   const datastreamItems = mapDataStreamInformation({
@@ -64,6 +71,7 @@ export const ChartLegendTableAdapter = ({
       datastreams={datastreamItems}
       trendCursors={trendCursors}
       visibleContent={visibleContent}
+      significantDigits={significantDigits}
       {...options}
     />
   );

--- a/packages/react-components/src/components/chart/legend/table/table.spec.tsx
+++ b/packages/react-components/src/components/chart/legend/table/table.spec.tsx
@@ -24,12 +24,14 @@ describe('legend table', () => {
         name: 'fake datastream',
         color: 'black',
         trendCursorValues: {},
+        latestValue: 111,
       },
       {
         id: 'datastream-2',
         name: 'fake datastream 2',
         color: 'black',
         trendCursorValues: {},
+        latestValue: 222,
       },
     ];
     const table = render(
@@ -37,6 +39,7 @@ describe('legend table', () => {
         visible={true}
         datastreams={datastreams}
         trendCursors={[]}
+        significantDigits={2}
       />
     );
 
@@ -55,6 +58,7 @@ describe('legend table', () => {
           'trendcursor-1': 111,
           'trendcursor-2': 333,
         },
+        latestValue: 111,
       },
     ];
     const trendCursors: TrendCursor[] = [
@@ -74,6 +78,7 @@ describe('legend table', () => {
         visible={true}
         datastreams={datastreams}
         trendCursors={trendCursors}
+        significantDigits={2}
       />
     );
 

--- a/packages/react-components/src/components/chart/legend/table/table.tsx
+++ b/packages/react-components/src/components/chart/legend/table/table.tsx
@@ -3,13 +3,14 @@ import { DataStreamInformation, TrendCursor } from './types';
 import Table from '@cloudscape-design/components/table';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 import { createTableLegendColumnDefinitions } from './columnDefinitions/factory';
-import { ChartLegend } from '../../types';
+import { ChartLegend, ChartOptions } from '../../types';
 
 import './table.css';
 
 type ChartLegendTableOptions = ChartLegend & {
   datastreams: DataStreamInformation[];
   trendCursors: TrendCursor[];
+  significantDigits: ChartOptions['significantDigits'];
 };
 
 export const ChartLegendTable = ({
@@ -19,6 +20,7 @@ export const ChartLegendTable = ({
   position,
   width,
   visibleContent,
+  significantDigits,
 }: ChartLegendTableOptions) => {
   const { items, collectionProps } = useCollection(datastreams, {
     sorting: {},
@@ -30,8 +32,9 @@ export const ChartLegendTable = ({
         trendCursors,
         width: Number(width),
         visibleContent,
+        significantDigits,
       }),
-    [width, trendCursors, visibleContent]
+    [width, trendCursors, visibleContent, significantDigits]
   );
 
   if (!visible) return null;

--- a/packages/react-components/src/components/chart/legend/table/types.ts
+++ b/packages/react-components/src/components/chart/legend/table/types.ts
@@ -1,9 +1,12 @@
-import { DataStream } from '@iot-app-kit/core';
+import { DataStream, Primitive } from '@iot-app-kit/core';
 
 export type TrendCursorValues = { [id in string]?: number };
 export type DataStreamInformation = Pick<
   DataStream,
   'id' | 'name' | 'color'
-> & { trendCursorValues: TrendCursorValues };
+> & {
+  trendCursorValues: TrendCursorValues;
+  latestValue: Primitive | undefined;
+};
 
 export type TrendCursor = { id: string; date: number; color?: string };

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -24,7 +24,8 @@ type ChartLegendContent =
   | 'asset'
   | 'visibility'
   | 'maxValue'
-  | 'minValue';
+  | 'minValue'
+  | 'latestValue';
 export type ChartLegend = {
   visible?: boolean;
   position?: 'left' | 'bottom' | 'right';


### PR DESCRIPTION
## Overview
This PR is for ticket #2277  and implemented display latest value feature and it includes
1. default display property latest value is true
2. user can toggle the display latest value in the config legend section

## Verifying Changes
[latestvalue-in-legend.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/98c17ee0-c639-41a4-a912-c2a6bb62afdd)

for a few properties latest value is showing in specific point:
[latestvalue-display.webm](https://github.com/awslabs/iot-app-kit/assets/142866907/77a8f207-447f-4b3d-9618-f8510322da66)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
