### PR TITLE
feat: added visible labels for config panel threshold controls

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/index.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/index.spec.tsx
@@ -4,11 +4,12 @@ import { MOCK_KPI_WIDGET } from '../../../../testing/mocks';
 import { COMPARISON_OPERATOR } from '@iot-app-kit/core';
 import { Provider } from 'react-redux';
 import { configureDashboardStore } from '~/store';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { ThresholdComponent } from './thresholdComponent';
 import type { DashboardState } from '~/store/state';
 import type { ThresholdWithId } from '~/customization/settings';
 import { ThresholdSettingsConfiguration, ThresholdsWidget } from './index';
+import userEvent from '@testing-library/user-event';
 
 const MOCK_THRESHOLD_1: ThresholdWithId = {
   id: '1',
@@ -72,11 +73,35 @@ describe('thresholdsComponent', () => {
     ).toBeTruthy();
   });
 
+  it('should focus the operator select on click of label', async () => {
+    const user = userEvent.setup();
+    render(<TestThresholdComponent />);
+
+    const label = screen.getByText('Operator');
+    const input = screen.getByLabelText('Operator');
+
+    expect(input).not.toHaveFocus();
+    await user.click(label);
+    expect(input).toHaveFocus();
+  });
+
   it('renders threshold value input', () => {
     const elem = render(<TestThresholdComponent />).baseElement;
     expect(
       elem.querySelector('[data-test-id="threshold-component-value-input"]')
     ).toBeTruthy();
+  });
+
+  it('should focus the threshold value input on click of label', async () => {
+    const user = userEvent.setup();
+    render(<TestThresholdComponent />);
+
+    const label = screen.getByText('Value');
+    const input = screen.getByLabelText('Value');
+
+    expect(input).not.toHaveFocus();
+    await user.click(label);
+    expect(input).toHaveFocus();
   });
 
   it('renders color picker', () => {

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdComponent.tsx
@@ -10,6 +10,7 @@ import type { InputProps, SelectProps } from '@cloudscape-design/components';
 import {
   Box,
   Button,
+  FormField,
   Input,
   Select,
   SpaceBetween,
@@ -103,34 +104,46 @@ export const ThresholdComponent: FC<{
               className='threshold-configuration'
               style={{ gap: awsui.spaceScaledS }}
             >
-              <Box variant='span'>{defaultMessages.if}</Box>
-              <Select
-                expandToViewport={true}
-                options={comparisonOptions}
-                selectedOption={selectedOption}
-                onChange={onUpdateComparator}
-                data-test-id='threshold-component-operator-select'
-              />
-              <Input
-                value={`${displayValue}`}
-                placeholder='Threshold value'
-                onChange={onUpdateThresholdValue}
-                data-test-id='threshold-component-value-input'
-                invalid={!validValue}
-              />
-              {defaultMessages.showAs}
-              <ColorPicker
-                color={color || DEFAULT_THRESHOLD_COLOR}
-                updateColor={onUpdateColor}
-                data-test-id='threshold-component-color-picker'
-              />
-              <Button
-                ariaLabel='delete threshold'
-                iconName='remove'
-                variant='icon'
-                onClick={onDelete}
-                data-test-id='threshold-component-delete-button'
-              />
+              <Box variant='span' margin={{ top: 'l' }}>
+                {defaultMessages.if}
+              </Box>
+              <FormField label='Operator'>
+                <Select
+                  expandToViewport
+                  options={comparisonOptions}
+                  selectedOption={selectedOption}
+                  onChange={onUpdateComparator}
+                  data-test-id='threshold-component-operator-select'
+                />
+              </FormField>
+              <FormField label='Value'>
+                <Input
+                  value={`${displayValue}`}
+                  placeholder='Threshold value'
+                  onChange={onUpdateThresholdValue}
+                  data-test-id='threshold-component-value-input'
+                  invalid={!validValue}
+                />
+              </FormField>
+              <Box variant='span' margin={{ top: 'l' }}>
+                {defaultMessages.showAs}
+              </Box>
+              <Box variant='span' margin={{ top: 'l' }}>
+                <ColorPicker
+                  color={color || DEFAULT_THRESHOLD_COLOR}
+                  updateColor={onUpdateColor}
+                  data-test-id='threshold-component-color-picker'
+                />
+              </Box>
+              <Box variant='span' margin={{ top: 'l' }}>
+                <Button
+                  ariaLabel='delete threshold'
+                  iconName='remove'
+                  variant='icon'
+                  onClick={onDelete}
+                  data-test-id='threshold-component-delete-button'
+                />
+              </Box>
             </div>
           </Box>
         </SpaceBetween>


### PR DESCRIPTION
This PR addresses the accessibility issues #2512  and #2513 
1. Added visible label 'Operator' for arithmetic operator
2. Added visible label 'Value' for threshold input

### Verifying changes:
**Before (there were no visible labels):**
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/408ec2cb-0b6a-479b-b8a1-37d96ef701d8)

**After adding visible labels to arithmetic operator and threshold value input:**
**UPDATE**:
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/748f0e42-f223-4348-99cb-e0d1d7367ec0)


We have raised single PR for two tickets, as adding only one label made it look incomplete like this:
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/5b703724-8ed0-4899-8430-32a561bcfa54)

