### PR TITLE
fix(composer): update property string length limit to 2048

### DIFF
--- a/packages/scene-composer/src/common/entityModelConstants.ts
+++ b/packages/scene-composer/src/common/entityModelConstants.ts
@@ -1,6 +1,6 @@
 import { KnownComponentType } from '../interfaces';
 
-export const MAX_PROPERTY_STRING_LENGTH = 256;
+export const MAX_PROPERTY_STRING_LENGTH = 2048;
 
 // Scene Nodes
 const SCENE_COMPONENT_TYPE_ID_PREFIX = 'com.amazon.iottwinmaker.3d';

--- a/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/overlayComponent.spec.ts
@@ -1,4 +1,4 @@
-import { componentTypeToId } from '../../common/entityModelConstants';
+import { MAX_PROPERTY_STRING_LENGTH, componentTypeToId } from '../../common/entityModelConstants';
 import { KnownComponentType } from '../../interfaces';
 import { Component } from '../../models/SceneModels';
 
@@ -65,7 +65,7 @@ describe('createOverlayEntityComponent', () => {
   });
 
   it('should return expected overlay component with data rows having long content', () => {
-    const longContent = new Array(60).fill('0123456789').join('');
+    const longContent = new Array(600).fill('0123456789').join('');
     const result = createOverlayEntityComponent({
       type: KnownComponentType.DataOverlay,
       subType: Component.DataOverlaySubType.TextAnnotation,
@@ -91,16 +91,13 @@ describe('createOverlayEntityComponent', () => {
                   stringValue: Component.DataOverlayRowType.Markdown,
                 },
                 content: {
-                  stringValue:
-                    '0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345',
+                  stringValue: expect.stringContaining('0123456789'),
                 },
                 content_1: {
-                  stringValue:
-                    '6789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901',
+                  stringValue: expect.stringContaining('0123456789'),
                 },
                 content_2: {
-                  stringValue:
-                    '2345678901234567890123456789012345678901234567890123456789012345678901234567890123456789',
+                  stringValue: expect.stringContaining('0123456789'),
                 },
               },
             },
@@ -108,10 +105,19 @@ describe('createOverlayEntityComponent', () => {
         },
       },
     });
+    expect(result.properties?.dataRows.value?.listValue?.[0].mapValue?.content.stringValue?.length).toEqual(
+      MAX_PROPERTY_STRING_LENGTH,
+    );
+    expect(result.properties?.dataRows.value?.listValue?.[0].mapValue?.content_1.stringValue?.length).toEqual(
+      MAX_PROPERTY_STRING_LENGTH,
+    );
+    expect(result.properties?.dataRows.value?.listValue?.[0].mapValue?.content_2.stringValue?.length).toEqual(
+      6000 - MAX_PROPERTY_STRING_LENGTH * 2,
+    );
   });
 
   it('should return expected overlay component with data rows having long content and split to no more than 10 parts', () => {
-    const longContent = new Array(1000).fill('0123456789').join('');
+    const longContent = new Array(3000).fill('0123456789').join('');
     const result = createOverlayEntityComponent({
       type: KnownComponentType.DataOverlay,
       subType: Component.DataOverlaySubType.TextAnnotation,


### PR DESCRIPTION
## Overview
The property string length limit has increased to 2048 in backend, therefore making this update in frontend.

Tests done:
- Overlay component with multiple pieces of contents can still be rendered properly, updating the content will split the content into pieces using the new 2048 length limit
- Overlay content splitted with the new 2048 limit can still be rendered correctly in the composer using the old 256 limit, updating the content will split the content into pieces using the old 256 length limit

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
