### PR TITLE
fix(scene-composer): fix sub-model selection

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/components/SceneHierarchyTree/SceneHierarchyTreeItem.tsx
@@ -47,7 +47,7 @@ const SceneHierarchyTreeItem: FC<SceneHierarchyTreeItemProps> = ({
   const componentRef = component?.ref;
   const showSubModel = useMemo(() => {
     return component && !!model && !isViewing();
-  }, [component]);
+  }, [component, model]);
   const isSubModel = !!findComponentByType(node, KnownComponentType.SubModelRef);
   const isDynamic = isDynamicNode(node);
 


### PR DESCRIPTION
## Overview
Scene Composer component does not have the sub-model selection feature enabled by default. Needed to update the `useMemo` variable dependency list with the `model` variable.

## Verifying Changes
Tested on storybook.

Image before - no sub-model selection tree:
<img width="1023" alt="Screenshot 2024-01-30 at 4 25 36 PM" src="https://github.com/awslabs/iot-app-kit/assets/87385528/d1ecc241-c923-4096-9ec8-699f705147c8">

Image after - sub-model selection tree shows up and I am able to add a sub-model to the scene hierarchy:
<img width="1300" alt="Screenshot 2024-01-30 at 4 25 19 PM" src="https://github.com/awslabs/iot-app-kit/assets/87385528/7c0721c6-1744-4b61-a821-f76557d8a3fc">

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
