### PR TITLE
fix: fix filtered data on zooms

### DIFF
--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -12,7 +12,7 @@ export const DEFAULT_TOOLBOX_CONFIG: ToolboxComponentOption = {
   show: true,
   right: 30,
   feature: {
-    dataZoom: { title: { back: 'Undo\nzoom' } },
+    dataZoom: { title: { back: 'Undo\nzoom' }, filterMode: 'none' },
   },
   iconStyle: {
     borderColor: '#414d5c',
@@ -23,6 +23,7 @@ export const DEFAULT_Y_AXIS: YAXisComponentOption = {
   show: true,
   type: 'value',
   position: 'left',
+  scale: true,
 };
 
 // if you change this, please update the width calculation


### PR DESCRIPTION
## Overview
toolbox zoom on x+y would cut off data points within x range but outside y range
set filter mode to none 


https://github.com/awslabs/iot-app-kit/assets/28601414/30d47fa0-ad23-4c26-9fd2-17d0c570e8a9



similar to this issue: https://github.com/apache/echarts/issues/12247


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
