### PR TITLE
fix(scene-composer): fix scene hierarchy in viewer mode

### DIFF
--- a/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyDataProvider.tsx
+++ b/packages/scene-composer/src/components/panels/SceneHierarchyPanel/SceneHierarchyDataProvider.tsx
@@ -111,7 +111,6 @@ const SceneHierarchyDataProvider: FC<SceneHierarchyDataProviderProps> = ({ selec
   const log = useLifecycleLogging('SceneHierarchyDataProvider');
   const sceneComposerId = useSceneComposerId();
   const { document, removeSceneNode } = useStore(sceneComposerId)((state) => state);
-  const { isEditing } = useStore(sceneComposerId)((state) => state);
   const { updateSceneNodeInternal } = useSceneDocument(sceneComposerId);
   const selectedSceneNodeRef = useStore(sceneComposerId)((state) => state.selectedSceneNodeRef);
   const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
@@ -121,7 +120,7 @@ const SceneHierarchyDataProvider: FC<SceneHierarchyDataProviderProps> = ({ selec
   const { nodeErrorMap: validationErrors } = useNodeErrorState(sceneComposerId);
 
   const rootNodeRefs = Object.values(nodeMap)
-    .filter((item) => !item.parentRef && isEditing())
+    .filter((item) => !item.parentRef)
     .map((item) => item.ref);
 
   const [searchTerms, setSearchTerms] = useState('');


### PR DESCRIPTION
## Overview
Scene hierarchy does not list nodes in viewer mode. Fixed the line that locked the hierarchy items to edit mode.

## Verifying Changes
Verified on storybook.

Before the change:
<img width="1490" alt="Screenshot 2024-01-31 at 2 11 07 PM" src="https://github.com/awslabs/iot-app-kit/assets/87385528/9cb5e472-3cfb-42d3-b4d7-aa647fc1d40d">

After the change:
<img width="1499" alt="Screenshot 2024-01-31 at 2 10 48 PM" src="https://github.com/awslabs/iot-app-kit/assets/87385528/f4f99a77-6c81-4b1e-9fe4-f48ec907c03f">


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
