### PR TITLE
fix(example):  make sure selection change uses the entity binding component index

### DIFF
--- a/examples/react-app/src/pages/Home/index.tsx
+++ b/examples/react-app/src/pages/Home/index.tsx
@@ -141,8 +141,15 @@ const ScenePage = () => {
 
   const onSelectionChanged = useCallback(
     (e: any) => {
-      if (e.additionalComponentData && e.additionalComponentData[0]?.dataBindingContext?.entityId) {
-        const entityId = e.additionalComponentData[0].dataBindingContext.entityId;
+      if (e.additionalComponentData && e.componentTypes) {
+        let entityId = selectedEntityId;
+        const entityIndex = e.componentTypes.findIndex((component: string) => component === 'EntityBinding')
+        const tagIndex = e.componentTypes.findIndex((component: string) => component === 'Tag')
+        if (e.additionalComponentData[entityIndex]?.dataBindingContext?.entityId) {
+          entityId = e.additionalComponentData[entityIndex].dataBindingContext.entityId;
+        } else if (e.additionalComponentData[tagIndex]?.dataBindingContext?.entityId) {
+          entityId = e.additionalComponentData[tagIndex].dataBindingContext.entityId;
+        }
         if (selectedEntityId !== entityId) {
           const query: IQueryData = { entityId: entityId };
           setSelectedEntityId(entityId);


### PR DESCRIPTION
## Overview
Updates to our event API mean that the sceneViewer onSelectionChange event may return multiple components.  So the exampel can no longer assume that binding information is located at index Zero. It needs to check the list of component types in the event data and then use that index to find the element of the same index in the additionalData property.

## Verifying Changes
Run the react example using a workspace with models that have Entity Binding and at least on other component like a shader etc
Click a model with a bound entity in the scene.
the models name should should show up in the knowledge graph widget
the model should turn red

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
