### PR TITLE
feat(composer): save scene level data to scene root entity

### DIFF
--- a/packages/scene-composer/src/common/entityModelConstants.ts
+++ b/packages/scene-composer/src/common/entityModelConstants.ts
@@ -4,6 +4,7 @@ export const MAX_PROPERTY_STRING_LENGTH = 2048;
 
 // Scene Nodes
 const SCENE_COMPONENT_TYPE_ID_PREFIX = 'com.amazon.iottwinmaker.3d';
+export const SCENE_COMPONENT_TYPE_ID = `${SCENE_COMPONENT_TYPE_ID_PREFIX}.scene`;
 export const NODE_COMPONENT_TYPE_ID = `${SCENE_COMPONENT_TYPE_ID_PREFIX}.node`;
 export const LAYER_COMPONENT_TYPE_ID = `${SCENE_COMPONENT_TYPE_ID_PREFIX}.layer`;
 export const componentTypeToId: Record<KnownComponentType, string> = {
@@ -24,6 +25,7 @@ export const DEFAULT_PARENT_RELATIONSHIP_NAME = 'isChildOf';
 export const SUB_MODEL_REF_PARENT_RELATIONSHIP_NAME = 'parentRef';
 export const DEFAULT_NODE_COMPONENT_NAME = 'Node';
 export const SCENE_ROOT_ENTITY_ID = 'SCENES_EntityId';
+export const SCENE_ROOT_ENTITY_COMPONENT_NAME = 'Scene';
 export const SCENE_ROOT_ENTITY_NAME = '$SCENES';
 
 // Matterport

--- a/packages/scene-composer/src/interfaces/feature.ts
+++ b/packages/scene-composer/src/interfaces/feature.ts
@@ -6,6 +6,7 @@ export enum COMPOSER_FEATURES {
   SubModelChildren = 'SubModelChildren',
   Animations = 'Animations',
   DynamicScene = 'DynamicScene',
+  DynamicSceneAlpha = 'DynamicSceneAlpha', // gate changes pending backend prod deployment and integrated testing
   FirstPerson = 'FirstPerson',
   SceneAppearance = 'SceneAppearance',
   Textures = 'Textures',

--- a/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
+++ b/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
@@ -39,7 +39,7 @@ import {
 } from '../internalInterfaces';
 import { deleteNodeEntity } from '../../utils/entityModelUtils/deleteNodeEntity';
 import { updateEntity } from '../../utils/entityModelUtils/updateNodeEntity';
-import { isDynamicNode, isDynamicScene } from '../../utils/entityModelUtils/sceneUtils';
+import { isDynamicNode, isDynamicScene, updateSceneRootEntity } from '../../utils/entityModelUtils/sceneUtils';
 import { createNodeEntity } from '../../utils/entityModelUtils/createNodeEntity';
 import { findComponentByType, getFinalNodeScale } from '../../utils/nodeUtils';
 import { getGlobalSettings } from '../../common/GlobalSettings';
@@ -273,6 +273,12 @@ export const createSceneDocumentSlice = (set: SetState<RootState>, get: GetState
       set((draft) => {
         mergeDeep(draft.document, partial);
 
+        const sceneRootEntityId = draft.document.properties?.sceneRootEntityId;
+        const dynamicSceneAlphaEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.DynamicSceneAlpha];
+        if (dynamicSceneAlphaEnabled && sceneRootEntityId) {
+          updateSceneRootEntity(sceneRootEntityId, draft.document);
+        }
+
         draft.lastOperation = 'updateDocumentInternal';
       });
     },
@@ -334,6 +340,12 @@ export const createSceneDocumentSlice = (set: SetState<RootState>, get: GetState
       set((draft) => {
         draft.document.ruleMap[id] = ruleMap;
 
+        const sceneRootEntityId = draft.document.properties?.sceneRootEntityId;
+        const dynamicSceneAlphaEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.DynamicSceneAlpha];
+        if (dynamicSceneAlphaEnabled && sceneRootEntityId) {
+          updateSceneRootEntity(sceneRootEntityId, draft.document);
+        }
+
         draft.lastOperation = 'updateSceneRuleMapById';
       });
     },
@@ -341,6 +353,12 @@ export const createSceneDocumentSlice = (set: SetState<RootState>, get: GetState
     removeSceneRuleMapById: (id: string) => {
       set((draft) => {
         delete draft.document.ruleMap[id];
+
+        const sceneRootEntityId = draft.document.properties?.sceneRootEntityId;
+        const dynamicSceneAlphaEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.DynamicSceneAlpha];
+        if (dynamicSceneAlphaEnabled && sceneRootEntityId) {
+          updateSceneRootEntity(sceneRootEntityId, draft.document);
+        }
 
         draft.lastOperation = 'removeSceneRuleMapById';
       });
@@ -466,6 +484,13 @@ export const createSceneDocumentSlice = (set: SetState<RootState>, get: GetState
               });
             });
         }
+
+        const sceneRootEntityId = draft.document.properties?.sceneRootEntityId;
+        const dynamicSceneAlphaEnabled = getGlobalSettings().featureConfig[COMPOSER_FEATURES.DynamicSceneAlpha];
+        if (dynamicSceneAlphaEnabled && sceneRootEntityId) {
+          updateSceneRootEntity(sceneRootEntityId, draft.document);
+        }
+
         draft.lastOperation = 'setSceneProperty';
       });
     },

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneComponent.spec.ts
@@ -1,0 +1,224 @@
+import { SCENE_COMPONENT_TYPE_ID } from '../../common/entityModelConstants';
+import { KnownComponentType, KnownSceneProperty } from '../../interfaces';
+
+import { createSceneEntityComponent, updateSceneEntityComponent } from './sceneComponent';
+
+describe('createSceneEntityComponent', () => {
+  it('should return expected scene component with basic fields', () => {
+    const result = createSceneEntityComponent({
+      specVersion: '1.0',
+      version: '1',
+      ruleMap: {},
+    });
+
+    expect(result.properties).toEqual({
+      specVersion: {
+        value: { stringValue: '1.0' },
+      },
+      version: {
+        value: { stringValue: '1' },
+      },
+    });
+  });
+
+  it('should return expected scene component with all fields', () => {
+    const result = createSceneEntityComponent({
+      specVersion: '1.0',
+      version: '1',
+      ruleMap: {
+        alarmRule: {
+          statements: [
+            {
+              expression: "alarm_status == 'ACTIVE'",
+              target: 'iottwinmaker.common.icon:Error',
+            },
+            {
+              expression: "alarm_status == 'ACKNOWLEDGED'",
+              target: 'iottwinmaker.common.icon:Warning',
+            },
+            {
+              expression: "alarm_status == 'SNOOZE_DISABLED'",
+              target: 'iottwinmaker.common.icon:Warning',
+            },
+            {
+              expression: "alarm_status == 'NORMAL'",
+              target: 'iottwinmaker.common.icon:Info',
+            },
+          ],
+        },
+        tagRule: {
+          statements: [
+            {
+              expression: "alarm_status == 'NORMAL'",
+              target: 'iottwinmaker.common.icon:Info',
+              targetMetadata: {
+                color: '#d13313',
+                iconName: 'file-lines',
+                iconPrefix: 'fas',
+              },
+            },
+          ],
+        },
+      },
+      unit: 'meters',
+      properties: {
+        [KnownSceneProperty.ComponentSettings]: {
+          [KnownComponentType.Tag]: {
+            scale: 2.5,
+            autoRescale: true,
+            enableOcclusion: false,
+          },
+          [KnownComponentType.DataOverlay]: {
+            overlayPanelVisible: false,
+          },
+        },
+        [KnownSceneProperty.DataBindingConfig]: {
+          fieldMapping: {
+            entityId: ['sel_entity'],
+            componentName: ['sel_comp'],
+          },
+          template: {
+            sel_entity: 'room1',
+            sel_comp: 'temperatureSensor2',
+          },
+        },
+        [KnownSceneProperty.EnvironmentPreset]: 'neutral',
+        [KnownSceneProperty.LayerDefaultRefreshInterval]: 4000,
+        [KnownSceneProperty.LayerIds]: ['layer-1111', 'layer-2222'],
+        [KnownSceneProperty.MatterportModelId]: 'matterport-id',
+        [KnownSceneProperty.TagCustomColors]: ['#FFFFFF', '#123456'],
+      },
+    });
+
+    expect(result.properties).toEqual({
+      specVersion: {
+        value: { stringValue: '1.0' },
+      },
+      version: {
+        value: { stringValue: '1' },
+      },
+      rule_statements: {
+        value: {
+          mapValue: {
+            alarmRule: {
+              listValue: [
+                {
+                  stringValue: `{"expression":"alarm_status == 'ACTIVE'","target":"iottwinmaker.common.icon:Error"}`,
+                },
+                {
+                  stringValue: `{"expression":"alarm_status == 'ACKNOWLEDGED'","target":"iottwinmaker.common.icon:Warning"}`,
+                },
+                {
+                  stringValue: `{"expression":"alarm_status == 'SNOOZE_DISABLED'","target":"iottwinmaker.common.icon:Warning"}`,
+                },
+                {
+                  stringValue: `{"expression":"alarm_status == 'NORMAL'","target":"iottwinmaker.common.icon:Info"}`,
+                },
+              ],
+            },
+            tagRule: {
+              listValue: [
+                {
+                  stringValue: `{"expression":"alarm_status == 'NORMAL'","target":"iottwinmaker.common.icon:Info","targetMetadata":{"color":"#d13313","iconName":"file-lines","iconPrefix":"fas"}}`,
+                },
+              ],
+            },
+          },
+        },
+      },
+      unit: {
+        value: { stringValue: 'meters' },
+      },
+      properties_componentSettings: {
+        value: {
+          mapValue: {
+            Tag: {
+              mapValue: {
+                scale: { stringValue: '2.5' },
+                autoRescale: { stringValue: 'true' },
+                enableOcclusion: { stringValue: 'false' },
+              },
+            },
+            DataOverlay: {
+              mapValue: {
+                overlayPanelVisible: { stringValue: 'false' },
+              },
+            },
+          },
+        },
+      },
+      properties_dataBindingConfig: {
+        value: {
+          mapValue: {
+            fieldMapping: {
+              mapValue: {
+                entityId: { stringValue: JSON.stringify(['sel_entity']) },
+                componentName: { stringValue: JSON.stringify(['sel_comp']) },
+              },
+            },
+            template: {
+              mapValue: {
+                sel_entity: { stringValue: 'room1' },
+                sel_comp: { stringValue: 'temperatureSensor2' },
+              },
+            },
+          },
+        },
+      },
+      properties_environmentPreset: {
+        value: { stringValue: 'neutral' },
+      },
+      properties_layerDefaultRefreshInterval: {
+        value: { integerValue: 4000 },
+      },
+      connectedToLayers: {
+        value: {
+          listValue: [
+            {
+              relationshipValue: {
+                targetEntityId: 'layer-1111',
+              },
+            },
+            {
+              relationshipValue: {
+                targetEntityId: 'layer-2222',
+              },
+            },
+          ],
+        },
+      },
+      properties_tagCustomColors: {
+        value: {
+          listValue: [{ stringValue: '#FFFFFF' }, { stringValue: '#123456' }],
+        },
+      },
+      properties_matterportModelId: {
+        value: {
+          stringValue: 'matterport-id',
+        },
+      },
+    });
+  });
+});
+
+describe('updateSceneEntityComponent', () => {
+  it('should update a model ref component', () => {
+    expect(
+      updateSceneEntityComponent({
+        specVersion: '1.0',
+        version: '1',
+        ruleMap: {},
+      }),
+    ).toEqual({
+      componentTypeId: SCENE_COMPONENT_TYPE_ID,
+      propertyUpdates: {
+        specVersion: {
+          value: { stringValue: '1.0' },
+        },
+        version: {
+          value: { stringValue: '1' },
+        },
+      },
+    });
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneComponent.ts
@@ -1,0 +1,172 @@
+import { ComponentRequest, ComponentUpdateRequest, DataValue } from '@aws-sdk/client-iottwinmaker';
+import { isEmpty } from 'lodash';
+
+import { IComponentSettingsMap, IDataBindingConfig, ISceneDocument } from '../../interfaces';
+import { SCENE_COMPONENT_TYPE_ID } from '../../common/entityModelConstants';
+import { CURRENT_VERSION } from '../../common/constants';
+
+enum SceneComponentProperty {
+  SpecVersion = 'specVersion',
+  Version = 'version',
+  Unit = 'unit',
+  RuleStatements = 'rule_statements',
+  PropertiesEnvironmentPreset = 'properties_environmentPreset',
+  PropertiesDataBindingConfig = 'properties_dataBindingConfig',
+  PropertiesComponentSettings = 'properties_componentSettings',
+  PropertiesMatterportModelId = 'properties_matterportModelId',
+  ConnectedToLayers = 'connectedToLayers',
+  PropertiesTagCustomColors = 'properties_tagCustomColors',
+  PropertiesLayerDefaultRefreshInterval = 'properties_layerDefaultRefreshInterval',
+}
+
+enum DataBindingConfigPropertyKey {
+  FieldMapping = 'fieldMapping',
+  Template = 'template',
+}
+
+export const createSceneEntityComponent = (
+  scene: Omit<ISceneDocument, 'nodeMap' | 'rootNodeRefs'>,
+): ComponentRequest => {
+  const comp: ComponentRequest = {
+    componentTypeId: SCENE_COMPONENT_TYPE_ID,
+    properties: {
+      [SceneComponentProperty.SpecVersion]: {
+        value: {
+          stringValue: scene.specVersion ?? CURRENT_VERSION,
+        },
+      },
+      [SceneComponentProperty.Version]: {
+        value: {
+          stringValue: scene.version,
+        },
+      },
+    },
+  };
+
+  if (scene.unit) {
+    comp.properties![SceneComponentProperty.Unit] = {
+      value: {
+        stringValue: scene.unit,
+      },
+    };
+  }
+  if (!isEmpty(scene.ruleMap)) {
+    const ruleMap = scene.ruleMap;
+    const value: DataValue = {
+      mapValue: {},
+    };
+
+    Object.keys(ruleMap).forEach((ruleId) => {
+      const statements: DataValue = {
+        listValue: ruleMap[ruleId].statements.map((statement) => ({ stringValue: JSON.stringify(statement) })),
+      };
+
+      value.mapValue![ruleId] = statements;
+    });
+
+    comp.properties![SceneComponentProperty.RuleStatements] = {
+      value,
+    };
+  }
+  if (scene.properties?.environmentPreset) {
+    comp.properties![SceneComponentProperty.PropertiesEnvironmentPreset] = {
+      value: {
+        stringValue: scene.properties.environmentPreset,
+      },
+    };
+  }
+  if (scene.properties?.dataBindingConfig !== undefined) {
+    const config = scene.properties.dataBindingConfig as IDataBindingConfig;
+    const fieldMapping: DataValue = { mapValue: {} };
+    Object.keys(config.fieldMapping).forEach((k) => {
+      fieldMapping.mapValue![k] = {
+        stringValue: JSON.stringify(config.fieldMapping[k]),
+      };
+    });
+    const value: DataValue = {
+      mapValue: {
+        [DataBindingConfigPropertyKey.FieldMapping]: fieldMapping,
+      },
+    };
+
+    if (config.template) {
+      const template: DataValue = { mapValue: {} };
+      Object.keys(config.template).forEach((k) => {
+        template.mapValue![k] = {
+          stringValue: config.template![k],
+        };
+      });
+      value.mapValue![DataBindingConfigPropertyKey.Template] = template;
+    }
+
+    comp.properties![SceneComponentProperty.PropertiesDataBindingConfig] = {
+      value,
+    };
+  }
+  if (scene.properties?.componentSettings !== undefined && !isEmpty(scene.properties?.componentSettings)) {
+    const settings = scene.properties.componentSettings as IComponentSettingsMap;
+
+    const value: DataValue = {
+      mapValue: {},
+    };
+
+    Object.keys(settings).forEach((type) => {
+      const settingsValue: DataValue = {
+        mapValue: {},
+      };
+      Object.keys(settings[type]).forEach((k) => {
+        settingsValue.mapValue![k] = {
+          stringValue: String(settings[type][k]),
+        };
+      });
+
+      if (!isEmpty(settingsValue.mapValue)) {
+        value.mapValue![type] = settingsValue;
+      }
+    });
+
+    comp.properties![SceneComponentProperty.PropertiesComponentSettings] = {
+      value,
+    };
+  }
+  if (scene.properties?.matterportModelId) {
+    comp.properties![SceneComponentProperty.PropertiesMatterportModelId] = {
+      value: {
+        stringValue: scene.properties.matterportModelId,
+      },
+    };
+  }
+  if (scene.properties?.layerIds && !isEmpty(scene.properties?.layerIds)) {
+    comp.properties![SceneComponentProperty.ConnectedToLayers] = {
+      value: {
+        listValue: (scene.properties.layerIds as string[]).map((id) => ({ relationshipValue: { targetEntityId: id } })),
+      },
+    };
+  }
+  if (scene.properties?.tagCustomColors) {
+    comp.properties![SceneComponentProperty.PropertiesTagCustomColors] = {
+      value: {
+        listValue: (scene.properties.tagCustomColors as string[]).map((color) => ({ stringValue: color })),
+      },
+    };
+  }
+  if (scene.properties?.layerDefaultRefreshInterval) {
+    comp.properties![SceneComponentProperty.PropertiesLayerDefaultRefreshInterval] = {
+      value: {
+        integerValue: scene.properties.layerDefaultRefreshInterval,
+      },
+    };
+  }
+
+  return comp;
+};
+
+export const updateSceneEntityComponent = (
+  scene: Omit<ISceneDocument, 'nodeMap' | 'rootNodeRefs'>,
+): ComponentUpdateRequest => {
+  const request = createSceneEntityComponent(scene);
+  return {
+    componentTypeId: request.componentTypeId,
+    propertyUpdates: request.properties,
+  };
+};

--- a/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
@@ -16,6 +16,7 @@ export const defaultArgs = {
     COMPOSER_FEATURES.Matterport,
     COMPOSER_FEATURES.SceneAppearance,
     COMPOSER_FEATURES.DynamicScene,
+    COMPOSER_FEATURES.DynamicSceneAlpha,
     COMPOSER_FEATURES.Textures,
   ],
 };


### PR DESCRIPTION
## Overview
Save scene level data to scene root entity if exists and gated by a new feature flag DynamicSceneAlpha.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
