### PR TITLE
fix: set npm-publish node version to v16

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install and Build


### PR DESCRIPTION
## Overview
Set the node version to match all the other yml files with v16.x.x

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
