### PR TITLE
fix: aws clients marked as peer dependencies

### DIFF
--- a/packages/core-util/package.json
+++ b/packages/core-util/package.json
@@ -26,8 +26,6 @@
     "test:typescript": "tsc --noEmit"
   },
   "dependencies": {
-    "@aws-sdk/client-iot-events": "3.354.0",
-    "@aws-sdk/client-iotsitewise": "3.456.0",
     "@iot-app-kit/core": "9.14.0",
     "lodash.difference": "4.5.0"
   },
@@ -40,5 +38,9 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "jest-extended": "^3.2.4"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-iot-events": "^3.354.0",
+    "@aws-sdk/client-iotsitewise": "^3.456.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,6 @@
     "pack": "npm pack"
   },
   "dependencies": {
-    "@aws-sdk/client-iotsitewise": "3.456.0",
     "d3-array": "^3.2.4",
     "intervals-fn": "^3.0.3",
     "parse-duration": "^1.0.3",
@@ -71,6 +70,9 @@
     "jest-extended": "^3.2.4",
     "npm-watch": "^0.11.0",
     "typescript": "^4.9.5"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-iotsitewise": "^3.456.0"
   },
   "bugs": {
     "url": "https://github.com/awslabs/iot-app-kit/issues"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -99,9 +99,6 @@
     "webpack": "^5.88.2"
   },
   "dependencies": {
-    "@aws-sdk/client-iot-events": "3.354.0",
-    "@aws-sdk/client-iotsitewise": "3.456.0",
-    "@aws-sdk/client-iottwinmaker": "3.354.0",
     "@iot-app-kit/charts-core": "2.1.2",
     "@iot-app-kit/components": "9.14.0",
     "@iot-app-kit/core": "9.14.0",
@@ -129,6 +126,9 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
+    "@aws-sdk/client-iot-events": "^3.354.0",
+    "@aws-sdk/client-iotsitewise": "^3.456.0",
+    "@aws-sdk/client-iottwinmaker": "^3.354.0",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/packages/source-iotsitewise/package.json
+++ b/packages/source-iotsitewise/package.json
@@ -51,8 +51,6 @@
     "pack": "npm pack"
   },
   "dependencies": {
-    "@aws-sdk/client-iot-events": "3.354.0",
-    "@aws-sdk/client-iotsitewise": "3.456.0",
     "@iot-app-kit/core": "9.14.0",
     "@iot-app-kit/core-util": "9.14.0",
     "@synchro-charts/core": "7.2.0",
@@ -78,6 +76,10 @@
     "jest-extended": "^3.2.4",
     "npm-watch": "^0.11.0",
     "typescript": "^4.9.5"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-iot-events": "^3.354.0",
+    "@aws-sdk/client-iotsitewise": "^3.456.0"
   },
   "bugs": {
     "url": "https://github.com/awslabs/iot-app-kit/issues"


### PR DESCRIPTION
## Overview

### Objective

Allows the consumer application to bring in different versions of the dependencies (than AppKit specified) while being compatible with AppKit.

### Use case

An application is using a version of AWS SDK client and want to initialize AppKit with that client. E.g. `const { query } = initialize({ iotSiteWiseClient });` in ([AppKit doc](https://awslabs.github.io/iot-app-kit/?path=/docs/overview-getting-started--docs)).

Example - [when the consumer app inits with AWS clients](https://github.com/awslabs/iot-application/blob/6b0bb7a82757ea100e44e4f59a0de39833521f7a/apps/client/src/routes/dashboards/dashboard/dashboard-page.tsx#L40-L47) and causes compatibility issue:
<img width="1768" alt="Screenshot 2024-02-05 at 8 55 43 PM" src="https://github.com/awslabs/iot-app-kit/assets/50635800/ffd44907-3e67-4f57-993f-d8463a045a01">

## Verifying Changes

1. Ran storybook on connected and mocked data, and verified functional

<img width="1768" alt="Screenshot 2024-02-05 at 2 25 44 PM" src="https://github.com/awslabs/iot-app-kit/assets/50635800/641ddeeb-972e-45ce-abe2-b789881619eb">

2. [Built and use npm package under IoT App](https://stackoverflow.com/questions/55560791/build-and-use-npm-package-locally) with different `@aws-sdk/client-xxx` versions

<img width="1771" alt="Screenshot 2024-02-05 at 4 32 18 PM" src="https://github.com/awslabs/iot-app-kit/assets/50635800/93104cd1-31f0-41c0-81aa-2e5cbc6c944f">

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
