### PR TITLE
fix(composer): cannot delete scene node of a child and then its parent

### DIFF
--- a/packages/scene-composer/src/store/helpers/__tests__/sceneDocumentHelpers.spec.ts
+++ b/packages/scene-composer/src/store/helpers/__tests__/sceneDocumentHelpers.spec.ts
@@ -75,11 +75,14 @@ describe('sceneDocumentHelpers', () => {
         ruleMap: {},
       } as ISceneDocumentInternal;
 
-      removeNode(document, 'testNode', logger);
-      expect(document.nodeMap.testNode).toBeUndefined();
+      removeNode(document, 'childNode', logger);
+      expect(document.nodeMap.testNode.childRefs).toEqual([]);
       expect(document.nodeMap.childNode).toBeUndefined();
       expect(document.nodeMap.grandchildNode).toBeUndefined();
-      expect(document.componentNodeMap).toEqual({ abc: { root: ['root-comp'] }, def: {} });
+      expect(document.componentNodeMap).toEqual({
+        abc: { root: ['root-comp'], testNode: ['test-comp-1'] },
+        def: { testNode: ['test-comp-2'] },
+      });
     });
   });
 

--- a/packages/scene-composer/src/store/helpers/sceneDocumentHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/sceneDocumentHelpers.ts
@@ -49,7 +49,7 @@ export const removeNode = (document: ISceneDocumentInternal, nodeRef: string, lo
     const indexOfNodeInParent = document.nodeMap[nodeToRemove.parentRef]!.childRefs.findIndex(
       (ref) => ref === nodeToRemove.ref,
     );
-    indexOfNodeInParent >= 0 ?? document.nodeMap[nodeToRemove.parentRef]?.childRefs.splice(indexOfNodeInParent, 1);
+    indexOfNodeInParent >= 0 && document.nodeMap[nodeToRemove.parentRef]?.childRefs.splice(indexOfNodeInParent, 1);
   }
 
   return nodeToRemove;


### PR DESCRIPTION
## Overview
Fix cannot delete scene node of a child and then its parent.

https://github.com/awslabs/iot-app-kit/assets/9315598/e630525e-19b5-49fd-83ca-0468dc41b023



## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
