### PR TITLE
fix(react-components): add max column to legend

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/constants.ts
+++ b/packages/dashboard/src/customization/propertiesSections/constants.ts
@@ -73,7 +73,10 @@ export const dropdownConsts = {
     ],
   },
   legendDisplaySection: {
-    legendDisplaylist: [{ label: 'Unit', value: 'unit' }],
+    legendDisplaylist: [
+      { label: 'Unit', value: 'unit' },
+      { label: 'Maximum Value', value: 'max' },
+    ],
   },
 };
 

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/plugin.tsx
@@ -39,6 +39,8 @@ export const lineScatterChartPlugin: DashboardPlugin = {
           visibleContent: {
             unit: true,
             asset: true,
+            max: true,
+            min: true,
           },
         },
       }),

--- a/packages/react-components/src/components/chart/hooks/useDataStreamMinMax.ts
+++ b/packages/react-components/src/components/chart/hooks/useDataStreamMinMax.ts
@@ -1,0 +1,19 @@
+import isEqual from 'lodash.isequal';
+import { useChartStore } from '../store';
+
+export const useDataStreamMaxMin = () => {
+  const dataStreamMaxes = useChartStore(
+    (state) => state.dataStreamMaxes,
+    isEqual
+  );
+
+  const dataStreamMins = useChartStore(
+    (state) => state.dataStreamMins,
+    isEqual
+  );
+
+  return {
+    dataStreamMaxes,
+    dataStreamMins,
+  };
+};

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.spec.ts
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.spec.ts
@@ -6,6 +6,7 @@ describe('legend table column definitions', () => {
     const columnDefinitions = createTableLegendColumnDefinitions({
       trendCursors: [],
       width: 100,
+      visibleContent: {},
     });
     expect(columnDefinitions).toEqual(
       expect.arrayContaining([expect.toBeObject()])
@@ -27,6 +28,7 @@ describe('legend table column definitions', () => {
     const columnDefinitions = createTableLegendColumnDefinitions({
       trendCursors,
       width: 100,
+      visibleContent: {},
     });
     expect(columnDefinitions).toEqual(
       expect.arrayContaining([

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.tsx
@@ -3,6 +3,7 @@ import { type TableProps } from '@cloudscape-design/components/table';
 import { DataStreamInformation, TrendCursor } from '../types';
 import { DataStreamCell, DataStreamColumnHeader } from './datastream';
 import { TrendCursorCell, TrendCursorColumnHeader } from './trendCursor';
+import { MaximumColumnHeader, MaximumCell } from './maximum';
 
 type LegendTableColumnDefinitions =
   TableProps<DataStreamInformation>['columnDefinitions'];
@@ -14,6 +15,16 @@ const createDataStreamColumnDefinition = (
   sortingField: 'name',
   header: <DataStreamColumnHeader />,
   cell: (item) => <DataStreamCell {...item} width={width} />,
+  isRowHeader: true,
+});
+
+const createMaximumColumnDefinition = (): LegendTableColumnDefinitions[1] => ({
+  id: 'AssetName',
+  sortingField: 'assetName',
+  header: <MaximumColumnHeader />,
+  cell: (item) => {
+    return <MaximumCell {...item} />;
+  },
   isRowHeader: true,
 });
 
@@ -42,9 +53,11 @@ const createTrendCursorColumnDefinition = ({
 export const createTableLegendColumnDefinitions = ({
   trendCursors,
   width,
+  visibleContent,
 }: {
   trendCursors: TrendCursor[];
   width: number;
+  visibleContent: any;
 }) => {
   const trendCursorColumnDefinitions = trendCursors
     .sort((a, b) => a.date - b.date)
@@ -52,6 +65,7 @@ export const createTableLegendColumnDefinitions = ({
 
   return [
     createDataStreamColumnDefinition(width),
+    ...(visibleContent?.max ? [createMaximumColumnDefinition()] : []),
     ...trendCursorColumnDefinitions,
   ];
 };

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximum/index.ts
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximum/index.ts
@@ -1,0 +1,2 @@
+export * from './maximumHeader';
+export * from './maximumCell';

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximum/maximumCell.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximum/maximumCell.tsx
@@ -1,0 +1,23 @@
+import React, { useMemo } from 'react';
+import { DataStream } from '@iot-app-kit/core';
+import { useVisibleDataStreams } from '../../../../hooks/useVisibleDataStreams';
+import { useDataStreamMaxMin } from '../../../../hooks/useDataStreamMinMax';
+import { DataStreamInformation } from '../../types';
+
+export const MaximumCell = ({ id }: DataStreamInformation) => {
+  const { isDataStreamHidden } = useVisibleDataStreams();
+  const { dataStreamMaxes } = useDataStreamMaxMin();
+
+  const max = dataStreamMaxes[id];
+
+  const isVisible = useMemo(
+    () => !isDataStreamHidden({ id: id } as DataStream),
+    [isDataStreamHidden, id]
+  );
+
+  return (
+    <div className={!isVisible ? 'hidden-legend' : ''}>
+      {max ?? 'No data found'}
+    </div>
+  );
+};

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximum/maximumHeader.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximum/maximumHeader.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const MaximumColumnHeader = () => <div>Maximum</div>;

--- a/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
+++ b/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
@@ -63,6 +63,7 @@ export const ChartLegendTableAdapter = ({
     <ChartLegendTable
       datastreams={datastreamItems}
       trendCursors={trendCursors}
+      visibleContent={visibleContent}
       {...options}
     />
   );

--- a/packages/react-components/src/components/chart/legend/table/table.tsx
+++ b/packages/react-components/src/components/chart/legend/table/table.tsx
@@ -18,6 +18,7 @@ export const ChartLegendTable = ({
   visible,
   position,
   width,
+  visibleContent,
 }: ChartLegendTableOptions) => {
   const { items, collectionProps } = useCollection(datastreams, {
     sorting: {},
@@ -28,8 +29,9 @@ export const ChartLegendTable = ({
       createTableLegendColumnDefinitions({
         trendCursors,
         width: Number(width),
+        visibleContent,
       }),
-    [width, trendCursors]
+    [width, trendCursors, visibleContent]
   );
 
   if (!visible) return null;

--- a/packages/react-components/src/components/chart/store/dataStreamMinMaxStore.ts
+++ b/packages/react-components/src/components/chart/store/dataStreamMinMaxStore.ts
@@ -1,0 +1,32 @@
+import { StateCreator } from 'zustand';
+
+export type MinMaxMap = { [key in string]: number };
+
+export interface MinMaxData {
+  dataStreamMaxes: MinMaxMap;
+  dataStreamMins: MinMaxMap;
+}
+
+export interface MinMaxState extends MinMaxData {
+  setMax: (datastreamId: string, maxValue: number) => void;
+  setMin: (datastreamId: string, minValue: number) => void;
+}
+
+export const createMinMaxSlice: StateCreator<MinMaxState> = (set) => ({
+  dataStreamMaxes: {},
+  dataStreamMins: {},
+  setMax: (datastreamId, value) =>
+    set((state) => ({
+      dataStreamMaxes: {
+        ...state.dataStreamMaxes,
+        [datastreamId]: value,
+      },
+    })),
+  setMin: (datastreamId, value) =>
+    set((state) => ({
+      dataStreamMins: {
+        ...state.dataStreamMins,
+        [datastreamId]: value,
+      },
+    })),
+});

--- a/packages/react-components/src/components/chart/store/store.ts
+++ b/packages/react-components/src/components/chart/store/store.ts
@@ -2,9 +2,11 @@ import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 import { createMultiYAxisSlice, MultiYAxisState } from './multiYAxis';
 import { createDataStreamsSlice, DataStreamsState } from './contextDataStreams';
+import { createMinMaxSlice, MinMaxState } from './dataStreamMinMaxStore';
 
 export type StateData = DataStreamsState &
-  MultiYAxisState & { chartId: string };
+  MultiYAxisState &
+  MinMaxState & { chartId: string };
 
 export const createChartStore = (
   initProps: Partial<StateData> & Required<Pick<Partial<StateData>, 'chartId'>>
@@ -16,6 +18,7 @@ export const createChartStore = (
           ...initProps,
           ...createMultiYAxisSlice(...args),
           ...createDataStreamsSlice(...args),
+          ...createMinMaxSlice(...args),
         }),
         { name: `chart-store-${initProps?.chartId}` }
       )

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -19,7 +19,7 @@ export type ChartAxisOptions = YAxisOptions & {
   showX?: boolean;
 };
 
-type ChartLegendContent = 'unit' | 'asset' | 'visibility';
+type ChartLegendContent = 'unit' | 'asset' | 'visibility' | 'max';
 export type ChartLegend = {
   visible?: boolean;
   position?: 'left' | 'bottom' | 'right';


### PR DESCRIPTION
## Overview
Adding ability to toggle max column from config panel. The max value is pulled from the data store and displayed in a dataStreamMax cell.

## Verifying Changes



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
