### PR TITLE
chore: update cloudscape to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,10 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@cloudscape-design/collection-hooks": "1.0.22",
-    "@cloudscape-design/component-toolkit": "1.0.0-beta.26",
-    "@cloudscape-design/components": "3.0.421",
-    "@cloudscape-design/design-tokens": "3.0.15",
-    "@cloudscape-design/global-styles": "1.0.12",
+    "@cloudscape-design/collection-hooks": "1.0.36",
+    "@cloudscape-design/components": "3.0.518",
+    "@cloudscape-design/design-tokens": "3.0.34",
+    "@cloudscape-design/global-styles": "1.0.23",
     "vite": "^4.5.2"
   },
   "devDependencies": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -99,9 +99,9 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@cloudscape-design/collection-hooks": "1.0.22",
-    "@cloudscape-design/components": "3.0.421",
-    "@cloudscape-design/design-tokens": "3.0.15",
+    "@cloudscape-design/collection-hooks": "1.0.36",
+    "@cloudscape-design/components": "3.0.518",
+    "@cloudscape-design/design-tokens": "3.0.34",
     "@iot-app-kit/charts": "2.1.2",
     "@iot-app-kit/charts-core": "2.1.2",
     "@iot-app-kit/components": "9.14.0",

--- a/packages/react-components/src/components/knowledge-graph/tests/__snapshots__/KnowledgeGraphPanel.spec.tsx.snap
+++ b/packages/react-components/src/components/knowledge-graph/tests/__snapshots__/KnowledgeGraphPanel.spec.tsx.snap
@@ -12,19 +12,19 @@ exports[`KnowledgeGraph should render correctly 1`] = `
       class="search-bar"
     >
       <div
-        class="awsui_grid_14yj0_14yem_93"
+        class="awsui_grid_14yj0_rldjy_93"
       >
         <div
-          class="awsui_grid-column_14yj0_14yem_113 awsui_colspan-9_14yj0_14yem_202"
+          class="awsui_grid-column_14yj0_rldjy_135 awsui_colspan-9_14yj0_rldjy_224"
         >
           <div
-            class="awsui_restore-pointer-events_14yj0_14yem_282"
+            class="awsui_restore-pointer-events_14yj0_rldjy_304"
           >
             <div
-              class="awsui_root_2rhyz_1l38h_93 awsui_input-container_2rhyz_1l38h_220"
+              class="awsui_root_2rhyz_62axa_93 awsui_input-container_2rhyz_62axa_242"
             >
               <span
-                class="awsui_input-icon-left_2rhyz_1l38h_225"
+                class="awsui_input-icon-left_2rhyz_62axa_247"
               >
                 <span
                   class="awsui_icon_h11ix_s5sg5_98 awsui_size-normal-mapped-height_h11ix_s5sg5_151 awsui_size-normal_h11ix_s5sg5_147 awsui_variant-subtle_h11ix_s5sg5_228"
@@ -48,7 +48,7 @@ exports[`KnowledgeGraph should render correctly 1`] = `
               </span>
               <input
                 autocomplete="on"
-                class="awsui_input_2rhyz_1l38h_97 awsui_input-type-search_2rhyz_1l38h_197 awsui_input-has-icon-left_2rhyz_1l38h_192"
+                class="awsui_input_2rhyz_62axa_97 awsui_input-type-search_2rhyz_62axa_219 awsui_input-has-icon-left_2rhyz_62axa_214"
                 type="search"
                 value=""
               />
@@ -56,19 +56,19 @@ exports[`KnowledgeGraph should render correctly 1`] = `
           </div>
         </div>
         <div
-          class="awsui_grid-column_14yj0_14yem_113 awsui_colspan-3_14yj0_14yem_142"
+          class="awsui_grid-column_14yj0_rldjy_135 awsui_colspan-3_14yj0_rldjy_164"
         >
           <div
-            class="awsui_restore-pointer-events_14yj0_14yem_282"
+            class="awsui_restore-pointer-events_14yj0_rldjy_304"
           >
             <button
-              class="awsui_button_vjswe_1u1vg_101 awsui_variant-normal_vjswe_1u1vg_125"
+              class="awsui_button_vjswe_qvh5k_101 awsui_variant-normal_vjswe_qvh5k_152"
               data-analytics-funnel-value="button:r0:"
               data-testid="search-button"
               type="submit"
             >
               <span
-                class="awsui_content_vjswe_1u1vg_97"
+                class="awsui_content_vjswe_qvh5k_97"
               >
                 Search
               </span>
@@ -96,13 +96,13 @@ exports[`KnowledgeGraph should render correctly 1`] = `
           class="iot-app-kit-graph-control-item"
         >
           <button
-            class="iot-app-kit-graph-button awsui_button_vjswe_1u1vg_101 awsui_variant-icon_vjswe_1u1vg_165 awsui_button-no-text_vjswe_1u1vg_970"
-            data-analytics-funnel-value="button:r1:"
+            class="iot-app-kit-graph-button awsui_button_vjswe_qvh5k_101 awsui_variant-icon_vjswe_qvh5k_192 awsui_button-no-text_vjswe_qvh5k_999"
+            data-analytics-funnel-value="button:r2:"
             data-testid="fit-button"
             type="submit"
           >
             <span
-              class="awsui_icon_vjswe_1u1vg_994 awsui_icon-left_vjswe_1u1vg_994 awsui_icon_h11ix_s5sg5_98 awsui_size-normal-mapped-height_h11ix_s5sg5_151 awsui_size-normal_h11ix_s5sg5_147 awsui_variant-normal_h11ix_s5sg5_219"
+              class="awsui_icon_vjswe_qvh5k_1025 awsui_icon-left_vjswe_qvh5k_1025 awsui_icon_h11ix_s5sg5_98 awsui_size-normal-mapped-height_h11ix_s5sg5_151 awsui_size-normal_h11ix_s5sg5_147 awsui_variant-normal_h11ix_s5sg5_219"
             >
               <svg
                 aria-hidden="true"
@@ -121,13 +121,13 @@ exports[`KnowledgeGraph should render correctly 1`] = `
           class="iot-app-kit-graph-control-item"
         >
           <button
-            class="iot-app-kit-graph-button awsui_button_vjswe_1u1vg_101 awsui_variant-icon_vjswe_1u1vg_165 awsui_button-no-text_vjswe_1u1vg_970"
-            data-analytics-funnel-value="button:r2:"
+            class="iot-app-kit-graph-button awsui_button_vjswe_qvh5k_101 awsui_variant-icon_vjswe_qvh5k_192 awsui_button-no-text_vjswe_qvh5k_999"
+            data-analytics-funnel-value="button:r4:"
             data-testid="center-button"
             type="submit"
           >
             <span
-              class="awsui_icon_vjswe_1u1vg_994 awsui_icon-left_vjswe_1u1vg_994 awsui_icon_h11ix_s5sg5_98 awsui_size-normal-mapped-height_h11ix_s5sg5_151 awsui_size-normal_h11ix_s5sg5_147 awsui_variant-normal_h11ix_s5sg5_219"
+              class="awsui_icon_vjswe_qvh5k_1025 awsui_icon-left_vjswe_qvh5k_1025 awsui_icon_h11ix_s5sg5_98 awsui_size-normal-mapped-height_h11ix_s5sg5_151 awsui_size-normal_h11ix_s5sg5_147 awsui_variant-normal_h11ix_s5sg5_219"
             >
               <svg
                 aria-hidden="true"
@@ -146,13 +146,13 @@ exports[`KnowledgeGraph should render correctly 1`] = `
           class="iot-app-kit-graph-control-item"
         >
           <button
-            class="iot-app-kit-graph-button awsui_button_vjswe_1u1vg_101 awsui_variant-icon_vjswe_1u1vg_165 awsui_button-no-text_vjswe_1u1vg_970"
-            data-analytics-funnel-value="button:r3:"
+            class="iot-app-kit-graph-button awsui_button_vjswe_qvh5k_101 awsui_variant-icon_vjswe_qvh5k_192 awsui_button-no-text_vjswe_qvh5k_999"
+            data-analytics-funnel-value="button:r6:"
             data-testid="zoom-in-button"
             type="submit"
           >
             <span
-              class="awsui_icon_vjswe_1u1vg_994 awsui_icon-left_vjswe_1u1vg_994 awsui_icon_h11ix_s5sg5_98 awsui_size-normal-mapped-height_h11ix_s5sg5_151 awsui_size-normal_h11ix_s5sg5_147 awsui_variant-normal_h11ix_s5sg5_219"
+              class="awsui_icon_vjswe_qvh5k_1025 awsui_icon-left_vjswe_qvh5k_1025 awsui_icon_h11ix_s5sg5_98 awsui_size-normal-mapped-height_h11ix_s5sg5_151 awsui_size-normal_h11ix_s5sg5_147 awsui_variant-normal_h11ix_s5sg5_219"
             >
               <svg
                 aria-hidden="true"
@@ -176,13 +176,13 @@ exports[`KnowledgeGraph should render correctly 1`] = `
           class="iot-app-kit-graph-control-item"
         >
           <button
-            class="iot-app-kit-graph-button awsui_button_vjswe_1u1vg_101 awsui_variant-icon_vjswe_1u1vg_165 awsui_button-no-text_vjswe_1u1vg_970"
-            data-analytics-funnel-value="button:r4:"
+            class="iot-app-kit-graph-button awsui_button_vjswe_qvh5k_101 awsui_variant-icon_vjswe_qvh5k_192 awsui_button-no-text_vjswe_qvh5k_999"
+            data-analytics-funnel-value="button:r8:"
             data-testid="zoom-out-button"
             type="submit"
           >
             <span
-              class="awsui_icon_vjswe_1u1vg_994 awsui_icon-left_vjswe_1u1vg_994 awsui_icon_h11ix_s5sg5_98 awsui_size-normal-mapped-height_h11ix_s5sg5_151 awsui_size-normal_h11ix_s5sg5_147 awsui_variant-normal_h11ix_s5sg5_219"
+              class="awsui_icon_vjswe_qvh5k_1025 awsui_icon-left_vjswe_qvh5k_1025 awsui_icon_h11ix_s5sg5_98 awsui_size-normal-mapped-height_h11ix_s5sg5_151 awsui_size-normal_h11ix_s5sg5_147 awsui_variant-normal_h11ix_s5sg5_219"
             >
               <svg
                 aria-hidden="true"
@@ -214,14 +214,14 @@ exports[`KnowledgeGraph should render correctly 1`] = `
           class="awsui_child_18582_189oq_97"
         >
           <button
-            class="awsui_button_vjswe_1u1vg_101 awsui_variant-normal_vjswe_1u1vg_125 awsui_disabled_vjswe_1u1vg_201"
-            data-analytics-funnel-value="button:r5:"
+            class="awsui_button_vjswe_qvh5k_101 awsui_variant-normal_vjswe_qvh5k_152 awsui_disabled_vjswe_qvh5k_228"
+            data-analytics-funnel-value="button:ra:"
             data-testid="explore-button"
             disabled=""
             type="submit"
           >
             <span
-              class="awsui_content_vjswe_1u1vg_97"
+              class="awsui_content_vjswe_qvh5k_97"
             >
               Explore
             </span>
@@ -231,14 +231,14 @@ exports[`KnowledgeGraph should render correctly 1`] = `
           class="awsui_child_18582_189oq_97"
         >
           <button
-            class="awsui_button_vjswe_1u1vg_101 awsui_variant-normal_vjswe_1u1vg_125 awsui_disabled_vjswe_1u1vg_201"
-            data-analytics-funnel-value="button:r6:"
+            class="awsui_button_vjswe_qvh5k_101 awsui_variant-normal_vjswe_qvh5k_152 awsui_disabled_vjswe_qvh5k_228"
+            data-analytics-funnel-value="button:rc:"
             data-testid="clear-button"
             disabled=""
             type="submit"
           >
             <span
-              class="awsui_content_vjswe_1u1vg_97"
+              class="awsui_content_vjswe_qvh5k_97"
             >
               Clear
             </span>

--- a/packages/react-components/src/components/tooltip/tooltip.tsx
+++ b/packages/react-components/src/components/tooltip/tooltip.tsx
@@ -2,7 +2,6 @@ import React, { useRef, useState } from 'react';
 import './tooltip.css';
 import {
   colorBackgroundHomeHeader,
-  colorBackgroundLayoutMain,
   spaceScaledM,
   spaceStaticS,
   spaceStaticXs,
@@ -28,7 +27,7 @@ export const Tooltip = ({
   const tooltipStyle = {
     fontSize: spaceScaledM,
     color: colorBackgroundHomeHeader,
-    backgroundColor: colorBackgroundLayoutMain,
+    backgroundColor: '#ffffff',
     padding: spaceStaticS,
     borderRadius: spaceStaticXs,
     border: `${spaceStaticXxxs} solid ${colorBackgroundHomeHeader}`,


### PR DESCRIPTION
## Overview
Bump all cloudscape packages to latest versions
`@cloudscape-design/collection-hooks: "1.0.36"`
`@cloudscape-design/components: "3.0.518"`
`@cloudscape-design/design-tokens: "3.0.34"`
`@cloudscape-design/global-styles: "1.0.23"`

And remove unused dependency:
`@cloudscape-design/component-toolkit: "1.0.0-beta.26"`

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
