### PR TITLE
feat(scene-composer): enable accelerated raycasting for 3D Tiles

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/ModelRefComponent/TilesModelComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/ModelRefComponent/TilesModelComponent.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { ThreeEvent, useFrame } from '@react-three/fiber';
+import { Object3D } from 'three';
 
 import { MAX_CLICK_DISTANCE } from '../../../common/constants';
 import useLifecycleLogging from '../../../logger/react-logger/hooks/useLifecycleLogging';
 import { IModelRefComponentInternal, ISceneNodeInternal, useEditorState, useStore } from '../../../store';
-import { getComponentGroupName } from '../../../utils/objectThreeUtils';
+import { acceleratedRaycasting, getComponentGroupName } from '../../../utils/objectThreeUtils';
 import {
   findComponentByType,
   createNodeWithPositionAndNormal,
@@ -33,6 +34,14 @@ export const TilesModelComponent: React.FC<TilesModelProps> = ({ node, component
   //       to clone the model like what we did in GLTFModelComponent. However, if we found this assumption is
   //       wrong in the future, let's optimize from here.
   const tilesRenderer = useTiles(component.uri, uriModifier);
+
+  // Enable optimized raycasting
+  tilesRenderer.onLoadModel = (scene: Object3D) => {
+    scene.traverse((obj: Object3D) => {
+      acceleratedRaycasting(obj);
+    });
+  };
+
   useFrame(() => {
     tilesRenderer.update();
   });

--- a/packages/scene-composer/src/three/tiles3d/TilesRenderer.js
+++ b/packages/scene-composer/src/three/tiles3d/TilesRenderer.js
@@ -7,10 +7,10 @@ import { CMPTLoader } from '3d-tiles-renderer/src/three/CMPTLoader.js';
 import { GLTFExtensionLoader } from '3d-tiles-renderer/src/three/GLTFExtensionLoader.js';
 import { TilesGroup } from '3d-tiles-renderer/src/three/TilesGroup.js';
 import { Matrix4, Box3, Sphere, Vector3, Vector2, Frustum, LoadingManager } from 'three';
-import { raycastTraverse, raycastTraverseFirstHit } from '3d-tiles-renderer/src/three/raycastTraverse.js';
 import { readMagicBytes } from '3d-tiles-renderer/src/utilities/readMagicBytes.js';
 
 import { TilesRendererBase } from './TilesRendererBase.js';
+import { raycastTraverse, raycastTraverseFirstHit } from './raycastTraverse.js';
 
 const INITIAL_FRUSTUM_CULLED = Symbol('INITIAL_FRUSTUM_CULLED');
 const tempMat = new Matrix4();

--- a/packages/scene-composer/src/three/tiles3d/raycastTraverse.js
+++ b/packages/scene-composer/src/three/tiles3d/raycastTraverse.js
@@ -1,0 +1,237 @@
+import { Matrix4, Sphere, Ray, Vector3 } from 'three';
+
+const _sphere = new Sphere();
+const _mat = new Matrix4();
+const _vec = new Vector3();
+const _vec2 = new Vector3();
+const _ray = new Ray();
+
+const _hitArray = [];
+
+function distanceSort( a, b ) {
+
+	return a.distance - b.distance;
+
+}
+
+function intersectTileScene( scene, raycaster, intersects ) {
+
+  // + Amazon --------
+  // Call the object's overridden raycast method
+	scene.traverse(c => c.raycast.call(c, raycaster, intersects));
+  // - Amazon --------
+
+}
+
+// Returns the closest hit when traversing the tree
+export function raycastTraverseFirstHit( root, group, activeTiles, raycaster ) {
+
+	// If the root is active make sure we've checked it
+	if ( activeTiles.has( root ) ) {
+
+		intersectTileScene( root.cached.scene, raycaster, _hitArray );
+
+		if ( _hitArray.length > 0 ) {
+
+			if ( _hitArray.length > 1 ) {
+
+				_hitArray.sort( distanceSort );
+
+			}
+
+			const res = _hitArray[ 0 ];
+			_hitArray.length = 0;
+			return res;
+
+		} else {
+
+			return null;
+
+		}
+
+	}
+
+	// TODO: can we avoid creating a new array here every time to save on memory?
+	const array = [];
+	const children = root.children;
+	for ( let i = 0, l = children.length; i < l; i ++ ) {
+
+		const tile = children[ i ];
+		const cached = tile.cached;
+		const groupMatrixWorld = group.matrixWorld;
+
+		_mat.copy( groupMatrixWorld );
+
+		// if we don't hit the sphere then early out
+		const sphere = cached.sphere;
+		if ( sphere ) {
+
+			_sphere.copy( sphere );
+			_sphere.applyMatrix4( _mat );
+			if ( ! raycaster.ray.intersectsSphere( _sphere ) ) {
+
+				continue;
+
+			}
+
+		}
+
+		// TODO: check region?
+
+		const boundingBox = cached.box;
+		const obbMat = cached.boxTransform;
+		if ( boundingBox ) {
+
+			_mat.multiply( obbMat ).invert();
+			_ray.copy( raycaster.ray );
+			_ray.applyMatrix4( _mat );
+			if ( _ray.intersectBox( boundingBox, _vec ) ) {
+
+				// account for tile scale
+				_vec2.setFromMatrixScale( _mat );
+				const invScale = _vec2.x;
+
+				if ( Math.abs( Math.max( _vec2.x - _vec2.y, _vec2.x - _vec2.z ) ) > 1e-6 ) {
+
+					console.warn( 'ThreeTilesRenderer : Non uniform scale used for tile which may cause issues when raycasting.' );
+
+				}
+
+				// if we intersect the box save the distance to the tile bounds
+				const data = {
+					distance: Infinity,
+					tile: null
+				};
+				array.push( data );
+
+				data.distance = _vec.distanceToSquared( _ray.origin ) * invScale * invScale;
+				data.tile = tile;
+
+			} else {
+
+				continue;
+
+			}
+
+		}
+
+	}
+
+	// sort them by ascending distance
+	array.sort( distanceSort );
+
+	// traverse until we find the best hit and early out if a tile bounds
+	// couldn't possible include a best hit
+	let bestDistanceSquared = Infinity;
+	let bestHit = null;
+	for ( let i = 0, l = array.length; i < l; i ++ ) {
+
+		const data = array[ i ];
+		const distanceSquared = data.distance;
+		if ( distanceSquared > bestDistanceSquared ) {
+
+			break;
+
+		} else {
+
+			const tile = data.tile;
+			const scene = tile.cached.scene;
+
+			let hit = null;
+			if ( activeTiles.has( tile ) ) {
+
+				// save the hit if it's closer
+				intersectTileScene( scene, raycaster, _hitArray );
+				if ( _hitArray.length > 0 ) {
+
+					if ( _hitArray.length > 1 ) {
+
+						_hitArray.sort( distanceSort );
+
+					}
+
+					hit = _hitArray[ 0 ];
+
+				}
+
+			} else {
+
+				hit = raycastTraverseFirstHit( tile, group, activeTiles, raycaster );
+
+			}
+
+			if ( hit ) {
+
+				const hitDistanceSquared = hit.distance * hit.distance;
+				if ( hitDistanceSquared < bestDistanceSquared ) {
+
+					bestDistanceSquared = hitDistanceSquared;
+					bestHit = hit;
+
+				}
+				_hitArray.length = 0;
+
+			}
+
+		}
+
+	}
+
+	return bestHit;
+
+}
+
+export function raycastTraverse( tile, group, activeTiles, raycaster, intersects ) {
+
+	const cached = tile.cached;
+	const groupMatrixWorld = group.matrixWorld;
+
+	_mat.copy( groupMatrixWorld );
+
+	// Early out if we don't hit this tile sphere
+	const sphere = cached.sphere;
+	if ( sphere ) {
+
+		_sphere.copy( sphere );
+		_sphere.applyMatrix4( _mat );
+		if ( ! raycaster.ray.intersectsSphere( _sphere ) ) {
+
+			return;
+
+		}
+
+	}
+
+	// Early out if we don't this this tile box
+	const boundingBox = cached.box;
+	const obbMat = cached.boxTransform;
+	if ( boundingBox ) {
+
+		_mat.multiply( obbMat ).invert();
+		_ray.copy( raycaster.ray ).applyMatrix4( _mat );
+		if ( ! _ray.intersectsBox( boundingBox ) ) {
+
+			return;
+
+		}
+
+	}
+
+	// TODO: check region
+
+	const scene = cached.scene;
+	if ( activeTiles.has( tile ) ) {
+
+		intersectTileScene( scene, raycaster, intersects );
+		return;
+
+	}
+
+	const children = tile.children;
+	for ( let i = 0, l = children.length; i < l; i ++ ) {
+
+		raycastTraverse( children[ i ], group, activeTiles, raycaster, intersects );
+
+	}
+
+}

--- a/packages/scene-composer/src/utils/objectThreeUtils.ts
+++ b/packages/scene-composer/src/utils/objectThreeUtils.ts
@@ -49,6 +49,7 @@ export function cloneMaterials(obj: THREE.Object3D) {
   }
 }
 
+// Only run once on model load
 export function acceleratedRaycasting(obj: THREE.Object3D) {
   if (obj instanceof THREE.Mesh) {
     const mesh = obj;


### PR DESCRIPTION
## Overview
The raycasting for 3D Tiles has not been optimized like other GLTF models. This PR enables three-mesh-bvh `acceleratedRaycasting` to improve the calculation of intersections for raycasting in the scene.

The [3D Tiles renderer](https://github.com/NASA-AMMOS/3DTilesRendererJS) that we use calls a couple raycast methods `raycastTraverse()` and `raycastTraverseFirstHit()`. These methods use the helper `intersectTileScene()` which forces the built-in `raycast` method of the Object3D / Mesh class. This helper must be overwritten to use the object instance's `raycast` method, which we overwrite in `TilesModelComponent`.

I copied over the version of the `raycastTraverse.js` script that AppKit uses, version `0.3.16`.
* [Reference](https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/fada8f7394b7a98c5ab259afb793d3353b13e555/src/three/raycastTraverse.js)

## Verifying Changes

Can see the clear difference between the scene composer on prod Console vs with this change on storybook:

https://github.com/awslabs/iot-app-kit/assets/87385528/b7dd291e-e326-4776-916c-34f13bb55a74

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
