### PR TITLE
feat: added label time range for viewport picker in dashboard header

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/dashboardHeader.tsx
+++ b/packages/dashboard/src/components/internalDashboard/dashboardHeader.tsx
@@ -55,8 +55,8 @@ const DashboardHeader = ({
       <Header variant='h1'>{name}</Header>
     </Box>
     <Box float='right'>
-      <SpaceBetween size='s' direction='horizontal'>
-        <TimeSelection isPaginationEnabled hideTitle />
+      <SpaceBetween size='s' direction='horizontal' alignItems='end'>
+        <TimeSelection isPaginationEnabled />
         {editable && (
           <>
             <Divider key='2' />

--- a/packages/dashboard/src/styles/variables.css
+++ b/packages/dashboard/src/styles/variables.css
@@ -37,8 +37,8 @@
   --size-asset-ghost-width: 300px;
   --radius-context-menu: 3px;
   --radius-component-palette-icon: 8px;
-  --dashboard-header-height: 72px;
-  --toolbar-overlay-height: 160px;
+  --dashboard-header-height: 88px;
+  --toolbar-overlay-height: 172px;
   --button-action-gap: 0.5rem;
   --colors-background-button: #f90;
   --colors-button-hover: #ec7211;

--- a/packages/react-components/src/components/time-sync/timeSelection.test.tsx
+++ b/packages/react-components/src/components/time-sync/timeSelection.test.tsx
@@ -12,10 +12,10 @@ import { TimeSync } from '.';
 const LAST_MINUTE = 0;
 const CUSTOM = 9;
 
-const renderViewport = () =>
+const renderViewport = ({ hideTitle }: { hideTitle?: boolean } = {}) =>
   render(
     <TimeSync group='test-group' initialViewport={{ duration: '5m' }}>
-      <TimeSelection />;
+      <TimeSelection hideTitle={hideTitle} />;
     </TimeSync>
   );
 
@@ -82,5 +82,17 @@ describe('TimeSelection', () => {
     });
 
     expect(screen.getByText('Last 15 minutes')).toBeInTheDocument();
+  });
+
+  test('title is hidden when hideTitle is true', () => {
+    const { queryByText } = renderViewport({ hideTitle: true });
+    const label = queryByText('Time range');
+    expect(label).toBeNull();
+  });
+
+  test('title is visible when hideTitle is false', () => {
+    const { queryByText } = renderViewport({ hideTitle: false });
+    const label = queryByText('Time range');
+    expect(label).toBeVisible();
   });
 });

--- a/packages/react-components/src/components/time-sync/timeSelection.tsx
+++ b/packages/react-components/src/components/time-sync/timeSelection.tsx
@@ -25,7 +25,7 @@ export type ViewportMessages = DateRangePickerProps.I18nStrings & {
   dateRangeInvalidError: string;
 };
 const messages: ViewportMessages = {
-  title: 'Time machine',
+  title: 'Time range',
   placeholder: 'Dashboard time range',
   todayAriaLabel: 'Today',
   nextMonthAriaLabel: 'Next month',
@@ -155,26 +155,25 @@ export const TimeSelection = ({
       //eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
     >
-      <FormField label={!hideTitle ? title : ''} data-testid='time-selection'>
-        <SpaceBetween direction='horizontal' size='xxs'>
-          {isPaginationEnabled && (
-            <Tooltip
-              content={`Move back ${
-                viewport && 'duration' in viewport
-                  ? viewport.duration
-                  : 'selected range'
-              }`}
-              position='bottom'
-              children={
-                <Button
-                  iconName='caret-left-filled'
-                  onClick={handlePaginateBackward}
-                  ariaLabel='Move backward'
-                />
-              }
-            />
-          )}
-
+      <SpaceBetween direction='horizontal' size='xxs' alignItems='end'>
+        {isPaginationEnabled && (
+          <Tooltip
+            content={`Move back ${
+              viewport && 'duration' in viewport
+                ? viewport.duration
+                : 'selected range'
+            }`}
+            position='bottom'
+            children={
+              <Button
+                iconName='caret-left-filled'
+                onClick={handlePaginateBackward}
+                ariaLabel='Move backward'
+              />
+            }
+          />
+        )}
+        <FormField label={!hideTitle ? title : ''} data-testid='time-selection'>
           <DateRangePicker
             expandToViewport={true}
             onChange={handleChangeDateRange}
@@ -188,25 +187,26 @@ export const TimeSelection = ({
             i18nStrings={i18nStrings}
             placeholder={placeholder}
           />
-          {isPaginationEnabled && (
-            <Tooltip
-              content={`Move forward ${
-                viewport && 'duration' in viewport
-                  ? viewport.duration
-                  : 'selected range'
-              }`}
-              position='bottom'
-              children={
-                <Button
-                  iconName='caret-right-filled'
-                  onClick={handlePaginateForward}
-                  ariaLabel='Move forward'
-                />
-              }
-            />
-          )}
-        </SpaceBetween>
-      </FormField>
+        </FormField>
+
+        {isPaginationEnabled && (
+          <Tooltip
+            content={`Move forward ${
+              viewport && 'duration' in viewport
+                ? viewport.duration
+                : 'selected range'
+            }`}
+            position='bottom'
+            children={
+              <Button
+                iconName='caret-right-filled'
+                onClick={handlePaginateForward}
+                ariaLabel='Move forward'
+              />
+            }
+          />
+        )}
+      </SpaceBetween>
     </div>
   );
 };


### PR DESCRIPTION
This PR is to add a descriptive label 'Time range' for the viewport picker in dashboard header #2559

Verifying changes:

Before:
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/8683b3cf-c578-40a9-8ee1-9a52d71dfeff)

After:
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/d155f584-2d25-4722-a410-bf33edea714c)

