### PR TITLE
feat(composer): show delete confirmation modal for dynamic scene

### DIFF
--- a/packages/scene-composer/__mocks__/@cloudscape-design/components.tsx
+++ b/packages/scene-composer/__mocks__/@cloudscape-design/components.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import mockComponent from '../mockComponent';
+
+const cloudscapeRaw: any = jest.createMockFromModule('@cloudscape-design/components');
+
+const cloudscape = Object.keys(cloudscapeRaw).reduce((acc, comp) => {
+  if (!comp.startsWith('_')) {
+    acc[comp] = mockComponent(comp);
+  } else {
+    acc[comp] = cloudscapeRaw[comp];
+  }
+  return acc;
+}, {});
+
+module.exports = {
+  ...cloudscape,
+  ButtonDropdown: ({ items = [], onItemClick, ...props }: any) => {
+    return (
+      <ul data-mocked='ButtonDropdown' {...props}>
+        { items.map(({ id, text, iconSvg, ...itemProps }) => {
+          return (<li id={id} {...itemProps} onClick={() => onItemClick({ detail: { id }})}>{iconSvg}{text}</li>)
+        })}
+      </ul>
+    )
+  }
+};

--- a/packages/scene-composer/src/components/modals/DeleteComponentModal.tsx
+++ b/packages/scene-composer/src/components/modals/DeleteComponentModal.tsx
@@ -1,0 +1,72 @@
+import React, { useCallback, useContext } from 'react';
+import { useIntl } from 'react-intl';
+
+import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
+import { useStore } from '../../store';
+import { getLocalizedComponentType } from '../../common/componentTypeStings';
+
+import DeleteConfirmationModal from './DeleteConfirmationModal';
+
+const DeleteComponentModal: React.FC = () => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const intl = useIntl();
+  const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
+  const setDeleteConfirmationModalVisible = useStore(sceneComposerId)(
+    (state) => state.setDeleteConfirmationModalVisible,
+  );
+  const deleteConfirmationModalParams = useStore(sceneComposerId)((state) => state.deleteConfirmationModalParams);
+  const removeComponent = useStore(sceneComposerId)((state) => state.removeComponent);
+
+  const nodeRef = deleteConfirmationModalParams?.nodeRef;
+  const node = getSceneNodeByRef(nodeRef);
+  const nodeName = node?.name ?? '';
+  const component = node?.components.find((c) => c.ref === deleteConfirmationModalParams?.componentRef);
+  const componentName = (component && getLocalizedComponentType(component, intl)) ?? '';
+
+  const title = intl.formatMessage(
+    {
+      defaultMessage: "Delete {nodeName}'s {componentName} component",
+      description: 'Delete component confirmation header text',
+    },
+    { nodeName, componentName },
+  );
+
+  const onDelete = useCallback(() => {
+    if (nodeRef && component?.ref) {
+      removeComponent(nodeRef, component.ref);
+    }
+    setDeleteConfirmationModalVisible(false);
+  }, [nodeRef, removeComponent, component?.ref]);
+
+  const contentMessage = useCallback(() => {
+    return intl.formatMessage(
+      {
+        defaultMessage:
+          "Delete {nodeName}'s {componentName} component? While this action may be undone, it may not return to its original state.",
+        description: 'Delete action confirmation message',
+      },
+      { componentName, nodeName },
+    );
+  }, [componentName, intl.formatMessage, nodeName]);
+
+  return (
+    <DeleteConfirmationModal
+      title={title}
+      contentBody={contentMessage()}
+      warningMessage={intl.formatMessage(
+        {
+          defaultMessage:
+            'If you attempt to undo this action after {componentName} is deleted, it may have issues such as some properties still being deleted or disconnection from data.',
+          description: 'Delete action confirmation warning message',
+        },
+        { componentName },
+      )}
+      deleteButtonDisabled={!nodeRef || !component?.ref}
+      onDelete={onDelete}
+    />
+  );
+};
+
+DeleteComponentModal.displayName = 'DeleteComponentModal';
+
+export default DeleteComponentModal;

--- a/packages/scene-composer/src/components/modals/DeleteComponentModalSnap.spec.tsx
+++ b/packages/scene-composer/src/components/modals/DeleteComponentModalSnap.spec.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { useStore } from '../../store';
+import { KnownComponentType } from '../../interfaces';
+
+import DeleteComponentModal from './DeleteComponentModal';
+
+jest.mock('./DeleteConfirmationModal', () => (props) => <div>{Object.values(props)}</div>);
+
+describe('DeleteComponentModal', () => {
+  const baseState = {
+    setDeleteConfirmationModalVisible: jest.fn(),
+    getSceneNodeByRef: jest.fn().mockReturnValue({
+      name: 'delete-node-name',
+      components: [{ ref: 'delete-comp-1', type: KnownComponentType.Tag }],
+    }),
+    removeComponent: jest.fn(),
+  };
+
+  it('should render correctly', () => {
+    useStore('default').setState({
+      ...baseState,
+      deleteConfirmationModalParams: {
+        type: 'deleteComponent',
+        nodeRef: 'delete-node-1',
+        componentRef: 'delete-comp-1',
+      },
+    });
+
+    const { container } = render(<DeleteComponentModal />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/modals/DeleteConfirmationModal.tsx
+++ b/packages/scene-composer/src/components/modals/DeleteConfirmationModal.tsx
@@ -1,0 +1,64 @@
+import React, { ReactNode, useCallback, useContext } from 'react';
+import { useIntl } from 'react-intl';
+import { Alert, Box, Button, Header, SpaceBetween } from '@cloudscape-design/components';
+
+import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
+import { useStore } from '../../store';
+import CenteredContainer from '../CenteredContainer';
+
+interface DeleteConfirmationModalProps {
+  title: string;
+  contentBody: ReactNode;
+  warningMessage: string;
+
+  deleteButtonDisabled?: boolean;
+  onDelete(): void;
+}
+const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
+  title,
+  contentBody,
+  warningMessage,
+  deleteButtonDisabled,
+  onDelete,
+}: DeleteConfirmationModalProps) => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const { formatMessage } = useIntl();
+  const setDeleteConfirmationModalVisible = useStore(sceneComposerId)(
+    (state) => state.setDeleteConfirmationModalVisible,
+  );
+
+  const onClose = useCallback(() => {
+    setDeleteConfirmationModalVisible(false);
+  }, [setDeleteConfirmationModalVisible]);
+
+  return (
+    <CenteredContainer
+      header={<Header variant='h2'>{title}</Header>}
+      footer={
+        <Box float='right' padding={{ bottom: 's' }}>
+          <SpaceBetween size='s' direction='horizontal'>
+            <Button data-testid='cancel-button' onClick={onClose}>
+              {formatMessage({ description: 'button label', defaultMessage: 'Cancel' })}
+            </Button>
+
+            <Button data-testid='delete-button' disabled={deleteButtonDisabled} variant='primary' onClick={onDelete}>
+              {formatMessage({ description: 'button label', defaultMessage: 'Delete' })}
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+    >
+      <SpaceBetween size='s'>
+        {contentBody}
+
+        <Alert statusIconAriaLabel='Warning' type='warning'>
+          {warningMessage}
+        </Alert>
+      </SpaceBetween>
+    </CenteredContainer>
+  );
+};
+
+DeleteConfirmationModal.displayName = 'DeleteConfirmationModal';
+
+export default DeleteConfirmationModal;

--- a/packages/scene-composer/src/components/modals/DeleteConfirmationModalSnap.spec.tsx
+++ b/packages/scene-composer/src/components/modals/DeleteConfirmationModalSnap.spec.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { useStore } from '../../store';
+
+import DeleteConfirmationModal from './DeleteConfirmationModal';
+
+describe('DeleteConfirmationModal', () => {
+  const baseState = {
+    setDeleteConfirmationModalVisible: jest.fn(),
+  };
+
+  it('should render correctly', () => {
+    useStore('default').setState(baseState);
+
+    const { container } = render(
+      <DeleteConfirmationModal
+        title='title-string'
+        contentBody='body-string'
+        warningMessage='warning-string'
+        onDelete={jest.fn()}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render correctly with delete button disabled', () => {
+    useStore('default').setState(baseState);
+
+    const { container } = render(
+      <DeleteConfirmationModal
+        deleteButtonDisabled
+        title='title-string'
+        contentBody='body-string'
+        warningMessage='warning-string'
+        onDelete={jest.fn()}
+      />,
+    );
+    const deleteButton = screen.getByTestId('delete-button');
+    expect(deleteButton.getAttribute('disabled')).not.toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/modals/DeleteNodeModal.tsx
+++ b/packages/scene-composer/src/components/modals/DeleteNodeModal.tsx
@@ -1,0 +1,117 @@
+import { isNumber } from 'lodash';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
+import { useIntl } from 'react-intl';
+import { Spinner } from '@cloudscape-design/components';
+
+import { sceneComposerIdContext } from '../../common/sceneComposerIdContext';
+import { useSceneDocument, useStore } from '../../store';
+import { getGlobalSettings } from '../../common/GlobalSettings';
+import { DEFAULT_PARENT_RELATIONSHIP_NAME, MAX_QUERY_HOP } from '../../common/entityModelConstants';
+
+import DeleteConfirmationModal from './DeleteConfirmationModal';
+
+const DeleteNodeModal: React.FC = () => {
+  const sceneComposerId = useContext(sceneComposerIdContext);
+  const { formatMessage } = useIntl();
+  const getSceneNodeByRef = useStore(sceneComposerId)((state) => state.getSceneNodeByRef);
+  const setDeleteConfirmationModalVisible = useStore(sceneComposerId)(
+    (state) => state.setDeleteConfirmationModalVisible,
+  );
+  const deleteConfirmationModalParams = useStore(sceneComposerId)((state) => state.deleteConfirmationModalParams);
+  const { removeSceneNode } = useSceneDocument(sceneComposerId);
+
+  const [childCount, setChildCount] = useState<number | undefined>();
+  const [loadChildCountError, setLoadChildCountError] = useState<Error | undefined>();
+
+  const nodeRef = deleteConfirmationModalParams?.nodeRef;
+  const node = getSceneNodeByRef(nodeRef);
+  const nodeName = node?.name ?? '';
+
+  const title = formatMessage(
+    { defaultMessage: 'Delete {nodeName}', description: 'Delete node confirmation header text' },
+    { nodeName },
+  );
+
+  useEffect(() => {
+    const executeQuery = getGlobalSettings().twinMakerSceneMetadataModule?.kgModule.executeQuery;
+    if (executeQuery && nodeRef) {
+      const statement = `SELECT COUNT(e) FROM EntityGraph MATCH (e)-[:${DEFAULT_PARENT_RELATIONSHIP_NAME}]->{1, ${MAX_QUERY_HOP}}(p) WHERE p.entityId = '${nodeRef}'`;
+
+      executeQuery({ queryStatement: statement })
+        .then((response) => {
+          const count = response.rows?.at(0)?.rowData?.at(0);
+          if (count !== undefined && isNumber(count)) {
+            setChildCount(count);
+          } else {
+            setChildCount(-1);
+          }
+        })
+        .catch((error) => {
+          setLoadChildCountError(error);
+        });
+    }
+  }, []);
+
+  const onDelete = useCallback(() => {
+    if (nodeRef) {
+      removeSceneNode(nodeRef);
+    }
+    setDeleteConfirmationModalVisible(false);
+  }, [nodeRef, removeSceneNode]);
+
+  const contentMessage = useCallback(() => {
+    if (childCount === undefined && loadChildCountError === undefined) {
+      return <Spinner />;
+    } else if (childCount !== undefined && childCount >= 0) {
+      if (childCount === 0) {
+        return formatMessage(
+          {
+            defaultMessage:
+              'Delete {nodeName}? This will delete 1 entity. While this action may be undone, it may not return to its original state.',
+            description: 'Delete action confirmation message',
+          },
+          { nodeName },
+        );
+      } else {
+        return formatMessage(
+          {
+            defaultMessage:
+              'Delete {nodeName}? This will delete 1 entity and its {childCount} children. While this action may be undone, it may not return to its original state.',
+            description: 'Delete action confirmation message',
+          },
+          { childCount, nodeName },
+        );
+      }
+    } else {
+      return formatMessage(
+        {
+          defaultMessage:
+            'Delete {nodeName}? Unable to load number of children. While this action may be undone, it may not return to its original state.',
+          description: 'Delete action confirmation message',
+        },
+        { nodeName },
+      );
+    }
+  }, [childCount, loadChildCountError, formatMessage, nodeName]);
+
+  return (
+    <DeleteConfirmationModal
+      title={title}
+      contentBody={contentMessage()}
+      warningMessage={formatMessage(
+        {
+          defaultMessage:
+            'If you attempt to undo this action after {nodeName} is deleted, it may have issues such as the children still being deleted or disconnection from data.',
+          description: 'Delete action confirmation warning message',
+        },
+        { nodeName },
+      )}
+      deleteButtonDisabled={childCount === undefined && loadChildCountError === undefined}
+      onDelete={onDelete}
+    />
+  );
+};
+
+DeleteNodeModal.displayName = 'DeleteNodeModal';
+
+export default DeleteNodeModal;

--- a/packages/scene-composer/src/components/modals/DeleteNodeModalSnap.spec.tsx
+++ b/packages/scene-composer/src/components/modals/DeleteNodeModalSnap.spec.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
+
+import { useStore } from '../../store';
+import { setTwinMakerSceneMetadataModule } from '../../common/GlobalSettings';
+
+import DeleteNodeModal from './DeleteNodeModal';
+
+jest.mock('./DeleteConfirmationModal', () => (props) => <div>{Object.values(props)}</div>);
+
+describe('DeleteNodeModal', () => {
+  const baseState = {
+    setDeleteConfirmationModalVisible: jest.fn(),
+    getSceneNodeByRef: jest.fn().mockReturnValue({ name: 'delete-node-name' }),
+    removeSceneNode: jest.fn(),
+  };
+  const mockKGModule = {
+    executeQuery: jest.fn().mockResolvedValue({}),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setTwinMakerSceneMetadataModule({ kgModule: mockKGModule } as unknown as TwinMakerSceneMetadataModule);
+  });
+
+  it('should render correctly for loading status', () => {
+    useStore('default').setState({
+      ...baseState,
+      deleteConfirmationModalParams: {
+        type: 'deleteNode',
+        nodeRef: 'delete-node-1',
+      },
+    });
+
+    const { container } = render(<DeleteNodeModal />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render correctly when query returns error', async () => {
+    useStore('default').setState({
+      ...baseState,
+      deleteConfirmationModalParams: {
+        type: 'deleteNode',
+        nodeRef: 'delete-node-1',
+      },
+    });
+    mockKGModule.executeQuery.mockRejectedValue(new Error('faield query'));
+
+    let container;
+    await act(async () => {
+      container = render(<DeleteNodeModal />).container;
+    });
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render correctly when query returns invalid number', async () => {
+    useStore('default').setState({
+      ...baseState,
+      deleteConfirmationModalParams: {
+        type: 'deleteNode',
+        nodeRef: 'delete-node-1',
+      },
+    });
+    mockKGModule.executeQuery.mockResolvedValue({ rows: [{}] });
+
+    let container;
+    await act(async () => {
+      container = render(<DeleteNodeModal />).container;
+    });
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render correctly when query returns 0 children', async () => {
+    useStore('default').setState({
+      ...baseState,
+      deleteConfirmationModalParams: {
+        type: 'deleteNode',
+        nodeRef: 'delete-node-1',
+      },
+    });
+    mockKGModule.executeQuery.mockResolvedValue({ rows: [{ rowData: [0] }] });
+
+    let container;
+    await act(async () => {
+      container = render(<DeleteNodeModal />).container;
+    });
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render correctly when query returns 1 children', async () => {
+    useStore('default').setState({
+      ...baseState,
+      deleteConfirmationModalParams: {
+        type: 'deleteNode',
+        nodeRef: 'delete-node-1',
+      },
+    });
+    mockKGModule.executeQuery.mockResolvedValue({ rows: [{ rowData: [1] }] });
+
+    let container;
+    await act(async () => {
+      container = render(<DeleteNodeModal />).container;
+    });
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/components/modals/__snapshots__/DeleteComponentModalSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/modals/__snapshots__/DeleteComponentModalSnap.spec.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeleteComponentModal should render correctly 1`] = `
+<div>
+  <div>
+    Delete delete-node-name's Tag component
+    Delete delete-node-name's Tag component? While this action may be undone, it may not return to its original state.
+    If you attempt to undo this action after Tag is deleted, it may have issues such as some properties still being deleted or disconnection from data.
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/modals/__snapshots__/DeleteConfirmationModalSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/modals/__snapshots__/DeleteConfirmationModalSnap.spec.tsx.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeleteConfirmationModal should render correctly 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        title-string
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+          direction="horizontal"
+        >
+          <div
+            data-mocked="Button"
+            data-testid="cancel-button"
+          >
+            Cancel
+          </div>
+          <div
+            data-mocked="Button"
+            data-testid="delete-button"
+            variant="primary"
+          >
+            Delete
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-mocked="SpaceBetween"
+    >
+      body-string
+      <div
+        data-mocked="Alert"
+        statusiconarialabel="Warning"
+        type="warning"
+      >
+        warning-string
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DeleteConfirmationModal should render correctly with delete button disabled 1`] = `
+.c0 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div>
+  <div
+    class="c0"
+    data-mocked="Container"
+  >
+    <div>
+      <div
+        data-mocked="Header"
+        variant="h2"
+      >
+        title-string
+      </div>
+    </div>
+    <div>
+      <div
+        data-mocked="Box"
+        float="right"
+        padding="{\\"bottom\\":\\"s\\"}"
+      >
+        <div
+          data-mocked="SpaceBetween"
+          direction="horizontal"
+        >
+          <div
+            data-mocked="Button"
+            data-testid="cancel-button"
+          >
+            Cancel
+          </div>
+          <div
+            data-mocked="Button"
+            data-testid="delete-button"
+            disabled=""
+            variant="primary"
+          >
+            Delete
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-mocked="SpaceBetween"
+    >
+      body-string
+      <div
+        data-mocked="Alert"
+        statusiconarialabel="Warning"
+        type="warning"
+      >
+        warning-string
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/modals/__snapshots__/DeleteNodeModalSnap.spec.tsx.snap
+++ b/packages/scene-composer/src/components/modals/__snapshots__/DeleteNodeModalSnap.spec.tsx.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeleteNodeModal should render correctly for loading status 1`] = `
+<div>
+  <div>
+    Delete delete-node-name
+    <div
+      data-mocked="Spinner"
+    />
+    If you attempt to undo this action after delete-node-name is deleted, it may have issues such as the children still being deleted or disconnection from data.
+  </div>
+</div>
+`;
+
+exports[`DeleteNodeModal should render correctly when query returns 0 children 1`] = `
+<div>
+  <div>
+    Delete delete-node-name
+    Delete delete-node-name? This will delete 1 entity. While this action may be undone, it may not return to its original state.
+    If you attempt to undo this action after delete-node-name is deleted, it may have issues such as the children still being deleted or disconnection from data.
+  </div>
+</div>
+`;
+
+exports[`DeleteNodeModal should render correctly when query returns 1 children 1`] = `
+<div>
+  <div>
+    Delete delete-node-name
+    Delete delete-node-name? This will delete 1 entity and its 1 children. While this action may be undone, it may not return to its original state.
+    If you attempt to undo this action after delete-node-name is deleted, it may have issues such as the children still being deleted or disconnection from data.
+  </div>
+</div>
+`;
+
+exports[`DeleteNodeModal should render correctly when query returns error 1`] = `
+<div>
+  <div>
+    Delete delete-node-name
+    Delete delete-node-name? Unable to load number of children. While this action may be undone, it may not return to its original state.
+    If you attempt to undo this action after delete-node-name is deleted, it may have issues such as the children still being deleted or disconnection from data.
+  </div>
+</div>
+`;
+
+exports[`DeleteNodeModal should render correctly when query returns invalid number 1`] = `
+<div>
+  <div>
+    Delete delete-node-name
+    Delete delete-node-name? Unable to load number of children. While this action may be undone, it may not return to its original state.
+    If you attempt to undo this action after delete-node-name is deleted, it may have issues such as the children still being deleted or disconnection from data.
+  </div>
+</div>
+`;

--- a/packages/scene-composer/src/components/panels/scene-components/ColorOverlayComponentEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/ColorOverlayComponentEditor.tsx
@@ -6,6 +6,7 @@ import { IComponentEditorProps } from '../ComponentEditor';
 import { IColorOverlayComponentInternal, ISceneComponentInternal, useStore } from '../../../store';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { IValueDataBinding } from '../../../interfaces';
+import { isDynamicScene } from '../../../utils/entityModelUtils/sceneUtils';
 
 import { ValueDataBindingBuilder } from './common/ValueDataBindingBuilder';
 
@@ -23,6 +24,11 @@ export const ColorOverlayComponentEditor: React.FC<IColorOverlayComponentEditor>
   const listSceneRuleMapIds = useStore(sceneComposerId)((state) => state.listSceneRuleMapIds);
   const removeComponent = useStore(sceneComposerId)((state) => state.removeComponent);
   const intl = useIntl();
+  const document = useStore(sceneComposerId)((state) => state.document);
+  const setDeleteConfirmationModalVisible = useStore(sceneComposerId)(
+    (state) => state.setDeleteConfirmationModalVisible,
+  );
+  const isDynamic = isDynamicScene(document);
 
   const colorOverlayComponent = component as IColorOverlayComponentInternal;
 
@@ -41,7 +47,15 @@ export const ColorOverlayComponentEditor: React.FC<IColorOverlayComponentEditor>
   );
 
   const removeComponentCallback = useCallback(() => {
-    removeComponent(node.ref, component.ref);
+    if (isDynamic) {
+      setDeleteConfirmationModalVisible(true, {
+        type: 'deleteComponent',
+        nodeRef: node.ref,
+        componentRef: component.ref,
+      });
+    } else {
+      removeComponent(node.ref, component.ref);
+    }
   }, [node, component]);
 
   const ruleOptions = ruleMapIds

--- a/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.spec.tsx
+++ b/packages/scene-composer/src/components/toolbars/floatingToolbar/items/ObjectItemGroup.spec.tsx
@@ -3,14 +3,18 @@ import { render, screen, fireEvent } from '@testing-library/react';
 
 import { useStore } from '../../../../store';
 import { ToolbarOrientation } from '../../common/types';
+import { isDynamicScene } from '../../../../utils/entityModelUtils/sceneUtils';
 
 import { ObjectItemGroup } from '.';
+
+jest.mock('../../../../utils/entityModelUtils/sceneUtils');
 
 describe('ObjectItemGroup', () => {
   const removeSceneNode = jest.fn();
   const selectedSceneNodeRef = 'test-ref';
   const setTransformControlMode = jest.fn();
   const getSceneNodeByRef = jest.fn();
+  const setDeleteConfirmationModalVisible = jest.fn();
 
   beforeEach(() => {
     useStore('default').setState({
@@ -19,8 +23,11 @@ describe('ObjectItemGroup', () => {
       transformControlMode: 'translate',
       setTransformControlMode,
       getSceneNodeByRef,
+      setDeleteConfirmationModalVisible,
     });
     jest.clearAllMocks();
+
+    (isDynamicScene as jest.Mock).mockReturnValue(false);
   });
 
   it('should call removeSceneNode when clicking delete with a selected node', () => {
@@ -28,6 +35,21 @@ describe('ObjectItemGroup', () => {
     const sut = screen.getByTestId('delete');
     fireEvent.pointerUp(sut);
     expect(removeSceneNode).toBeCalledWith(selectedSceneNodeRef);
+  });
+
+  it('should call setDeleteConfirmationModalVisible when clicking delete node in dynamic scene', () => {
+    (isDynamicScene as jest.Mock).mockReturnValue(true);
+
+    render(<ObjectItemGroup canvasHeight={undefined} toolbarOrientation={ToolbarOrientation.Vertical} />);
+    const sut = screen.getByTestId('delete');
+    fireEvent.pointerUp(sut);
+
+    expect(removeSceneNode).not.toBeCalled();
+    expect(setDeleteConfirmationModalVisible).toBeCalledTimes(1);
+    expect(setDeleteConfirmationModalVisible).toBeCalledWith(true, {
+      type: 'deleteNode',
+      nodeRef: selectedSceneNodeRef,
+    });
   });
 
   it('should not call removeSceneNode when clicking delete without a selected node', () => {

--- a/packages/scene-composer/src/hooks/__snapshots__/useSceneModal.spec.tsx.snap
+++ b/packages/scene-composer/src/hooks/__snapshots__/useSceneModal.spec.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useSceneModal() hook should render with convert scene modal 1`] = `
+Object {
+  "current": <ConvertSceneModal />,
+}
+`;
+
+exports[`useSceneModal() hook should render with delete component modal 1`] = `
+Object {
+  "current": <DeleteComponentModal />,
+}
+`;
+
+exports[`useSceneModal() hook should render with delete node modal 1`] = `
+Object {
+  "current": <DeleteNodeModal />,
+}
+`;
+
+exports[`useSceneModal() hook should render with message modal 1`] = `
+Object {
+  "current": <MessageModal />,
+}
+`;
+
+exports[`useSceneModal() hook should render with no modal 1`] = `
+Object {
+  "current": null,
+}
+`;

--- a/packages/scene-composer/src/hooks/useSceneModal.spec.tsx
+++ b/packages/scene-composer/src/hooks/useSceneModal.spec.tsx
@@ -1,0 +1,82 @@
+import { renderHook } from '@testing-library/react';
+
+import { useStore } from '../store';
+
+import useSceneModal from './useSceneModal';
+
+jest.mock('../components/modals/MessageModal', () => 'MessageModal');
+jest.mock('../components/modals/ConvertSceneModal', () => 'ConvertSceneModal');
+jest.mock('../components/modals/DeleteNodeModal', () => 'DeleteNodeModal');
+jest.mock('../components/modals/DeleteComponentModal', () => 'DeleteComponentModal');
+
+describe('useSceneModal() hook', () => {
+  const baseState = {
+    getMessages: jest.fn(),
+    isViewing: jest.fn(),
+    convertSceneModalVisible: false,
+    deleteConfirmationModalVisible: false,
+    deleteConfirmationModalParams: undefined,
+  };
+
+  beforeEach(() => {
+    baseState.getMessages.mockReturnValue([]);
+  });
+
+  it('should render with no modal', () => {
+    useStore('default').setState(baseState);
+
+    const { result } = renderHook(() => useSceneModal());
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should render with message modal', () => {
+    baseState.getMessages.mockReturnValue(['message']);
+
+    const { result } = renderHook(() => useSceneModal());
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should render with convert scene modal', () => {
+    useStore('default').setState({
+      ...baseState,
+      convertSceneModalVisible: true,
+    });
+
+    const { result } = renderHook(() => useSceneModal());
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should render with delete node modal', () => {
+    useStore('default').setState({
+      ...baseState,
+      deleteConfirmationModalVisible: true,
+      deleteConfirmationModalParams: {
+        type: 'deleteNode',
+        nodeRef: 'delete-node-ref',
+      },
+    });
+
+    const { result } = renderHook(() => useSceneModal());
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should render with delete component modal', () => {
+    useStore('default').setState({
+      ...baseState,
+      deleteConfirmationModalVisible: true,
+      deleteConfirmationModalParams: {
+        type: 'deleteComponent',
+        nodeRef: 'delete-component-ref',
+        componentRef: 'comp-ref',
+      },
+    });
+
+    const { result } = renderHook(() => useSceneModal());
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/scene-composer/src/hooks/useSceneModal.tsx
+++ b/packages/scene-composer/src/hooks/useSceneModal.tsx
@@ -4,6 +4,8 @@ import MessageModal from '../components/modals/MessageModal';
 import { sceneComposerIdContext } from '../common/sceneComposerIdContext';
 import { useStore } from '../store';
 import ConvertSceneModal from '../components/modals/ConvertSceneModal';
+import DeleteNodeModal from '../components/modals/DeleteNodeModal';
+import DeleteComponentModal from '../components/modals/DeleteComponentModal';
 
 const useSceneModal = (): React.JSX.Element | null => {
   const sceneComposerId = useContext(sceneComposerIdContext);
@@ -11,6 +13,10 @@ const useSceneModal = (): React.JSX.Element | null => {
   const isViewing = useStore(sceneComposerId)((state) => state.isViewing());
 
   const convertSceneModalVisible = useStore(sceneComposerId)((state) => !!state.convertSceneModalVisible);
+  const deleteConfirmationModalVisible = useStore(sceneComposerId)((state) => !!state.deleteConfirmationModalVisible);
+  const deleteConfirmationModalVisibleParams = useStore(sceneComposerId)(
+    (state) => state.deleteConfirmationModalParams,
+  );
 
   const showMessageModal = messages.length > 0;
 
@@ -20,6 +26,14 @@ const useSceneModal = (): React.JSX.Element | null => {
 
   if (showMessageModal) {
     return <MessageModal />;
+  }
+
+  if (deleteConfirmationModalVisible) {
+    if (deleteConfirmationModalVisibleParams?.type === 'deleteNode') {
+      return <DeleteNodeModal />;
+    } else if (deleteConfirmationModalVisibleParams?.type === 'deleteComponent') {
+      return <DeleteComponentModal />;
+    }
   }
 
   return null;

--- a/packages/scene-composer/src/store/StoreOperations.ts
+++ b/packages/scene-composer/src/store/StoreOperations.ts
@@ -14,6 +14,7 @@ export type SceneComposerEditorOperation =
   | 'addMessages'
   | 'clearMessages'
   | 'setConvertSceneModalVisibility'
+  | 'setDeleteConfirmationModalVisible'
   | 'setAddingWidget'
   | 'setCursorPosition'
   | 'setCursorLookAt'
@@ -87,6 +88,7 @@ export const SceneComposerOperationTypeMap: Record<SceneComposerOperation, Opera
   addMessages: 'UPDATE_EDITOR',
   clearMessages: 'UPDATE_EDITOR',
   setConvertSceneModalVisibility: 'UPDATE_EDITOR',
+  setDeleteConfirmationModalVisible: 'UPDATE_EDITOR',
   setAddingWidget: 'UPDATE_EDITOR',
   setCursorPosition: 'UPDATE_EDITOR',
   setCursorLookAt: 'UPDATE_EDITOR',

--- a/packages/scene-composer/src/store/slices/EditorStateSlice.spec.tsx
+++ b/packages/scene-composer/src/store/slices/EditorStateSlice.spec.tsx
@@ -153,6 +153,25 @@ describe('createEditStateSlice', () => {
     expect(draft.convertSceneModalVisible).toEqual(true);
   });
 
+  it('should be able to set delete confirmation modal visibility', () => {
+    const draft = {
+      lastOperation: undefined,
+      deleteConfirmationModalVisible: false,
+      deleteConfirmationModalParams: undefined,
+    };
+    const get = jest.fn();
+    const set = jest.fn((callback) => callback(draft));
+
+    // Act
+    const { setDeleteConfirmationModalVisible } = createEditStateSlice(set, get, mockApi); // api is never used in the function, so it's not needed
+    setDeleteConfirmationModalVisible(true, { type: 'deleteNode', nodeRef: 'node-ref' });
+
+    // Assert
+    expect(draft.lastOperation!).toEqual('setDeleteConfirmationModalVisible');
+    expect(draft.deleteConfirmationModalVisible).toEqual(true);
+    expect(draft.deleteConfirmationModalParams).toEqual({ type: 'deleteNode', nodeRef: 'node-ref' });
+  });
+
   [true, false].forEach((modelLoading) => {
     it(`should be able to ${modelLoading ? 'loading' : 'not loading'} with setLoadingModelState`, () => {
       // Arrange

--- a/packages/scene-composer/src/store/slices/EditorStateSlice.ts
+++ b/packages/scene-composer/src/store/slices/EditorStateSlice.ts
@@ -39,6 +39,12 @@ class MappingWrapper {
 
 type SubModelRef = number | string;
 
+interface DeleteConfirmationModalParams {
+  type: 'deleteNode' | 'deleteComponent';
+  nodeRef: string;
+  componentRef?: string;
+}
+
 export interface IEditorStateSlice {
   /* Editor Config */
   editorConfig: IEditorConfig;
@@ -63,6 +69,10 @@ export interface IEditorStateSlice {
 
   convertSceneModalVisible?: boolean;
   setConvertSceneModalVisibility(visible: boolean): void;
+
+  deleteConfirmationModalVisible?: boolean;
+  deleteConfirmationModalParams?: DeleteConfirmationModalParams;
+  setDeleteConfirmationModalVisible(visible: boolean, params?: DeleteConfirmationModalParams): void;
 
   // Selection and highlights
   selectedSceneNodeRef?: string;
@@ -222,6 +232,14 @@ export const createEditStateSlice = (
       set((draft) => {
         draft.convertSceneModalVisible = visible;
         draft.lastOperation = 'setConvertSceneModalVisibility';
+      });
+    },
+
+    setDeleteConfirmationModalVisible(visible, params) {
+      set((draft) => {
+        draft.deleteConfirmationModalVisible = visible;
+        draft.deleteConfirmationModalParams = params;
+        draft.lastOperation = 'setDeleteConfirmationModalVisible';
       });
     },
 

--- a/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
+++ b/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
@@ -316,7 +316,13 @@ export const createSceneDocumentSlice = (set: SetState<RootState>, get: GetState
         nodeToRemove = removeNode(draft.document, nodeRef, LOG);
 
         if (isDynamicNode(nodeToRemove)) {
-          deleteNodeEntity(nodeRef);
+          deleteNodeEntity(nodeRef)?.then(() => {
+            // TODO: localize strings
+            getGlobalSettings().onFlashMessage?.({
+              type: 'success',
+              header: `Successfully deleted ${nodeToRemove.name}.`,
+            });
+          });
         }
 
         draft.lastOperation = 'removeSceneNode';
@@ -435,7 +441,13 @@ export const createSceneDocumentSlice = (set: SetState<RootState>, get: GetState
         const removedComponenet = draft.document.nodeMap[nodeRef].components.splice(componentIndex, 1).at(0);
 
         if (removedComponenet && isDynamicNode(draft.document.nodeMap[nodeRef])) {
-          updateEntity(draft.document.nodeMap[nodeRef], [removedComponenet], ComponentUpdateType.DELETE);
+          updateEntity(draft.document.nodeMap[nodeRef], [removedComponenet], ComponentUpdateType.DELETE).then(() => {
+            // TODO: localize strings
+            getGlobalSettings().onFlashMessage?.({
+              type: 'success',
+              header: `Successfully deleted ${removedComponenet.type} component from ${node.name}.`,
+            });
+          });
         }
 
         draft.lastOperation = 'removeComponent';

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -387,6 +387,10 @@
     "note": "rule Id label",
     "text": "Rule Id"
   },
+  "FgS5ks": {
+    "note": "Delete action confirmation message",
+    "text": "Delete {nodeName}? This will delete 1 entity and its {childCount} children. While this action may be undone, it may not return to its original state."
+  },
   "FvIdJC": {
     "note": "chrome picker",
     "text": "chromePicker"
@@ -406,6 +410,10 @@
   "GesjrB": {
     "note": "Rule has no statements",
     "text": "No statements"
+  },
+  "Gp31Xy": {
+    "note": "Delete action confirmation warning message",
+    "text": "If you attempt to undo this action after {componentName} is deleted, it may have issues such as some properties still being deleted or disconnection from data."
   },
   "Gv0vX8": {
     "note": "Specifies the localized string that describes an option as being selected. This is required to provide a good screen reader experience.",
@@ -518,6 +526,10 @@
   "MZtQw3": {
     "note": "75mm lens",
     "text": "75mm"
+  },
+  "MrbJ0V": {
+    "note": "Delete action confirmation message",
+    "text": "Delete {nodeName}'s {componentName} component? While this action may be undone, it may not return to its original state."
   },
   "NXP1Hm": {
     "note": "Form field errorText",
@@ -654,6 +666,10 @@
   "U5Wazx": {
     "note": "remove Button text",
     "text": "Remove"
+  },
+  "UHsPN6": {
+    "note": "Delete component confirmation header text",
+    "text": "Delete {nodeName}'s {componentName} component"
   },
   "UoOmLE": {
     "note": "Form Field label",
@@ -911,6 +927,14 @@
     "note": "Expandable Section title",
     "text": "Plane Geometry"
   },
+  "hkc541": {
+    "note": "button label",
+    "text": "Delete"
+  },
+  "hyIDNW": {
+    "note": "Delete action confirmation warning message",
+    "text": "If you attempt to undo this action after {nodeName} is deleted, it may have issues such as the children still being deleted or disconnection from data."
+  },
   "ifspRT": {
     "note": "Expandable Section title",
     "text": "Model Shader"
@@ -975,6 +999,10 @@
     "note": "Warning message",
     "text": "Warning"
   },
+  "lXOqtn": {
+    "note": "Delete node confirmation header text",
+    "text": "Delete {nodeName}"
+  },
   "lbVroy": {
     "note": "checkbox option",
     "text": "Open by default"
@@ -1014,6 +1042,10 @@
   "nGlTEq": {
     "note": "Form Field label",
     "text": "Arrow"
+  },
+  "nJP/oB": {
+    "note": "Delete action confirmation message",
+    "text": "Delete {nodeName}? Unable to load number of children. While this action may be undone, it may not return to its original state."
   },
   "nhcDIE": {
     "note": "select box option text value",
@@ -1078,6 +1110,10 @@
   "qU9dRt": {
     "note": "Form Field label",
     "text": "Scale"
+  },
+  "qYJQjk": {
+    "note": "Delete action confirmation message",
+    "text": "Delete {nodeName}? This will delete 1 entity. While this action may be undone, it may not return to its original state."
   },
   "qZiKXL": {
     "note": "ExpandableInfoSection Title",


### PR DESCRIPTION
## Overview
- show delete confirmation modal for dynamic scene when deleting a node or component
- show success bar when delete action succeeded
<img width="557" alt="delete-component" src="https://github.com/awslabs/iot-app-kit/assets/9315598/b6f33b91-2782-403c-874c-eee65cafda87">

<Note: button style shown in screenshots below is different because they were captured early before reinstalling local workspace. they will look the same as the buttons in the first screenshot>

<img width="566" alt="delete-node-no-child" src="https://github.com/awslabs/iot-app-kit/assets/9315598/4ab42ec1-9b1b-433f-af70-e449a61f8f92">
<img width="556" alt="delete-node-fail-child-query" src="https://github.com/awslabs/iot-app-kit/assets/9315598/d6692830-4b9f-433c-a9b8-dff1a25abb49">
<img width="577" alt="delete-node-with-child" src="https://github.com/awslabs/iot-app-kit/assets/9315598/dc4cc3be-89cc-410a-bfee-9d3082f4137a">


## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
