### PR TITLE
feat: introduce edgeMode in source-iotsitewise

### DIFF
--- a/packages/source-iotsitewise/src/time-series-data/client/batchGetAggregatedPropertyDataPoints.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batchGetAggregatedPropertyDataPoints.ts
@@ -26,6 +26,7 @@ import type {
   RequestInformationAndRange,
 } from '@iot-app-kit/core';
 import type { AggregatedPropertyParams } from './client';
+import { flattenRequestInfoByFetch } from '../util/flattenRequestInfoByFetch';
 
 export type BatchAggregatedEntry = {
   requestInformation: RequestInformationAndRange;
@@ -195,39 +196,7 @@ export const batchGetAggregatedPropertyDataPoints = ({
       // Aggregates for raw data only (denoted by '0')
       .filter(({ resolution }) => resolution !== '0')
       // fanout on fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, fetchFromStartToEnd into dedicated request info
-      .flatMap(
-        ({
-          fetchMostRecentBeforeStart,
-          fetchMostRecentBeforeEnd,
-          fetchFromStartToEnd,
-          ...rest
-        }) => {
-          const infos: RequestInformationAndRange[] = [];
-
-          if (fetchMostRecentBeforeStart) {
-            infos.push({
-              ...rest,
-              fetchMostRecentBeforeStart,
-            });
-          }
-
-          if (fetchMostRecentBeforeEnd) {
-            infos.push({
-              ...rest,
-              fetchMostRecentBeforeEnd,
-            });
-          }
-
-          if (fetchFromStartToEnd) {
-            infos.push({
-              ...rest,
-              fetchFromStartToEnd,
-            });
-          }
-
-          return infos;
-        }
-      )
+      .flatMap(flattenRequestInfoByFetch)
       .forEach((requestInformation) => {
         // only 1 of the following options are enabled at this point:
         // fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, fetchFromStartToEnd

--- a/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.ts
@@ -25,6 +25,7 @@ import {
 } from '@iot-app-kit/core';
 import type { HistoricalPropertyParams } from './client';
 import { withinLatestPropertyDataThreshold } from './withinLatestPropertyDataThreshold';
+import { flattenRequestInfoByFetch } from '../util/flattenRequestInfoByFetch';
 
 export type BatchHistoricalEntry = {
   requestInformation: RequestInformationAndRange;
@@ -204,39 +205,7 @@ export const batchGetHistoricalPropertyDataPoints = ({
     requestInformations
       .filter(shouldAcceptRequest)
       // fanout on fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, fetchFromStartToEnd into dedicated request info
-      .flatMap(
-        ({
-          fetchMostRecentBeforeStart,
-          fetchMostRecentBeforeEnd,
-          fetchFromStartToEnd,
-          ...rest
-        }) => {
-          const infos: RequestInformationAndRange[] = [];
-
-          if (fetchMostRecentBeforeStart) {
-            infos.push({
-              ...rest,
-              fetchMostRecentBeforeStart,
-            });
-          }
-
-          if (fetchMostRecentBeforeEnd) {
-            infos.push({
-              ...rest,
-              fetchMostRecentBeforeEnd,
-            });
-          }
-
-          if (fetchFromStartToEnd) {
-            infos.push({
-              ...rest,
-              fetchFromStartToEnd,
-            });
-          }
-
-          return infos;
-        }
-      )
+      .flatMap(flattenRequestInfoByFetch)
       .forEach((requestInformation) => {
         // only 1 of the following options are enabled at this point:
         // fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, fetchFromStartToEnd

--- a/packages/source-iotsitewise/src/time-series-data/client/client.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/client.ts
@@ -30,6 +30,10 @@ export type AggregatedPropertyParams = {
   onSuccess: OnSuccessCallback;
 };
 
+export type SiteWiseClientSettings = {
+  batchDuration?: SiteWiseDataSourceSettings['batchDuration'];
+};
+
 export class SiteWiseClient {
   private siteWiseSdk: IoTSiteWiseClient;
   private settings: SiteWiseDataSourceSettings;
@@ -46,7 +50,7 @@ export class SiteWiseClient {
 
   constructor(
     siteWiseSdk: IoTSiteWiseClient,
-    settings: SiteWiseDataSourceSettings = {}
+    settings: SiteWiseClientSettings = {}
   ) {
     this.siteWiseSdk = siteWiseSdk;
     this.settings = settings;

--- a/packages/source-iotsitewise/src/time-series-data/client/edge/client.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/edge/client.spec.ts
@@ -1,0 +1,676 @@
+import {
+  AggregateType,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-iotsitewise';
+import { SiteWiseClientEdge } from './client';
+import {
+  ASSET_PROPERTY_VALUE_HISTORY,
+  ASSET_PROPERTY_DOUBLE_VALUE,
+  AGGREGATE_VALUES,
+} from '../../../__mocks__/assetPropertyValue';
+import { toId } from '../../util/dataStreamId';
+import { HOUR_IN_MS, SITEWISE_PREVIEW_DATE } from '../../util/timeConstants';
+import { createMockSiteWiseSDK } from '@iot-app-kit/testing-util';
+
+const AGGREGATE_TYPE = AggregateType.AVERAGE;
+
+describe('SiteWiseClientEdge', () => {
+  const error: Partial<ResourceNotFoundException> = {
+    name: 'ResourceNotFoundException',
+    message: 'assetId 1 not found',
+    $metadata: {
+      httpStatusCode: 404,
+    },
+  };
+
+  describe('getHistoricalPropertyDataPoints', () => {
+    it('calls onError on failure', async () => {
+      const getAssetPropertyValueHistory = jest.fn().mockRejectedValue(error);
+      const assetId = 'some-asset-id';
+      const propertyId = 'some-property-id';
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+
+      const client = new SiteWiseClientEdge(
+        createMockSiteWiseSDK({ getAssetPropertyValueHistory })
+      );
+
+      const startDate = new Date(2000, 0, 0);
+      const endDate = new Date(2001, 0, 0);
+
+      const requestInformations = [
+        {
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution: '0',
+          fetchFromStartToEnd: true,
+        },
+      ];
+
+      await client.getHistoricalPropertyDataPoints({
+        requestInformations,
+        onSuccess,
+        onError,
+      });
+
+      expect(onError).toBeCalledWith(
+        expect.objectContaining({
+          error: {
+            msg: error.message,
+            type: error.name,
+            status: error.$metadata?.httpStatusCode,
+          },
+        })
+      );
+    });
+
+    it('makes request with fetchFromStartToEnd', async () => {
+      const getAssetPropertyValueHistory = jest
+        .fn()
+        .mockResolvedValue(ASSET_PROPERTY_VALUE_HISTORY);
+      const assetId = 'some-asset-id';
+      const propertyId = 'some-property-id';
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+
+      const client = new SiteWiseClientEdge(
+        createMockSiteWiseSDK({ getAssetPropertyValueHistory })
+      );
+
+      const startDate = new Date(2000, 0, 0);
+      const endDate = new Date(2001, 0, 0);
+
+      const requestInformations = [
+        {
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution: '0',
+          fetchFromStartToEnd: true,
+        },
+      ];
+
+      await client.getHistoricalPropertyDataPoints({
+        requestInformations,
+        onSuccess,
+        onError,
+      });
+
+      expect(getAssetPropertyValueHistory).toBeCalledWith(
+        expect.objectContaining({ assetId, propertyId, startDate, endDate })
+      );
+
+      expect(onError).not.toBeCalled();
+
+      expect(onSuccess).toBeCalledWith(
+        [
+          expect.objectContaining({
+            id: toId({ assetId, propertyId }),
+            data: [
+              {
+                x: 1000099,
+                y: 10.123,
+              },
+              {
+                x: 2000000,
+                y: 12.01,
+              },
+            ],
+          }),
+        ],
+        expect.objectContaining({
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution: '0',
+          fetchFromStartToEnd: true,
+        }),
+        startDate,
+        endDate
+      );
+    });
+
+    it('makes request with fetchMostRecentBeforeEnd', async () => {
+      const getAssetPropertyValueHistory = jest
+        .fn()
+        .mockResolvedValue(ASSET_PROPERTY_VALUE_HISTORY);
+      const assetId = 'some-asset-id';
+      const propertyId = 'some-property-id';
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+
+      const client = new SiteWiseClientEdge(
+        createMockSiteWiseSDK({ getAssetPropertyValueHistory })
+      );
+
+      const startDate = new Date(2000, 0, 0);
+      const endDate = new Date(2001, 0, 0);
+
+      const requestInformations = [
+        {
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution: '0',
+          fetchMostRecentBeforeEnd: true,
+        },
+      ];
+
+      await client.getHistoricalPropertyDataPoints({
+        requestInformations,
+        onSuccess,
+        onError,
+      });
+
+      expect(getAssetPropertyValueHistory).toBeCalledWith(
+        expect.objectContaining({
+          assetId,
+          propertyId,
+          startDate: SITEWISE_PREVIEW_DATE,
+          endDate,
+        })
+      );
+
+      expect(onError).not.toBeCalled();
+
+      expect(onSuccess).toBeCalledWith(
+        [
+          expect.objectContaining({
+            id: toId({ assetId, propertyId }),
+            data: [
+              {
+                x: 1000099,
+                y: 10.123,
+              },
+              {
+                x: 2000000,
+                y: 12.01,
+              },
+            ],
+          }),
+        ],
+        expect.objectContaining({
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution: '0',
+          fetchMostRecentBeforeEnd: true,
+        }),
+        SITEWISE_PREVIEW_DATE,
+        endDate
+      );
+    });
+
+    it('makes request with fetchMostRecentBeforeStart', async () => {
+      const getAssetPropertyValueHistory = jest
+        .fn()
+        .mockResolvedValue(ASSET_PROPERTY_VALUE_HISTORY);
+      const assetId = 'some-asset-id';
+      const propertyId = 'some-property-id';
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+
+      const client = new SiteWiseClientEdge(
+        createMockSiteWiseSDK({ getAssetPropertyValueHistory })
+      );
+
+      const startDate = new Date(2000, 0, 0);
+      const endDate = new Date(2001, 0, 0);
+
+      const requestInformations = [
+        {
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution: '0',
+          fetchMostRecentBeforeStart: true,
+        },
+      ];
+
+      await client.getHistoricalPropertyDataPoints({
+        requestInformations,
+        onSuccess,
+        onError,
+      });
+
+      expect(getAssetPropertyValueHistory).toBeCalledWith(
+        expect.objectContaining({
+          assetId,
+          propertyId,
+          startDate: SITEWISE_PREVIEW_DATE,
+          endDate: startDate,
+        })
+      );
+
+      expect(onError).not.toBeCalled();
+
+      expect(onSuccess).toBeCalledWith(
+        [
+          expect.objectContaining({
+            id: toId({ assetId, propertyId }),
+            data: [
+              {
+                x: 1000099,
+                y: 10.123,
+              },
+              {
+                x: 2000000,
+                y: 12.01,
+              },
+            ],
+          }),
+        ],
+        expect.objectContaining({
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution: '0',
+          fetchMostRecentBeforeStart: true,
+        }),
+        SITEWISE_PREVIEW_DATE,
+        startDate
+      );
+    });
+  });
+
+  describe('getLatestPropertyDataPoint', () => {
+    it('calls onError when error occurs', async () => {
+      const getAssetPropertyValue = jest.fn().mockRejectedValue(error);
+      const assetId = 'some-asset-id';
+      const propertyId = 'some-property-id';
+
+      const client = new SiteWiseClientEdge(
+        createMockSiteWiseSDK({ getAssetPropertyValue })
+      );
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+
+      const requestInformations = [
+        {
+          id: toId({ assetId, propertyId }),
+          start: new Date(),
+          end: new Date(),
+          resolution: '0',
+          fetchMostRecentBeforeEnd: true,
+        },
+      ];
+
+      await client.getLatestPropertyDataPoint({
+        onSuccess,
+        onError,
+        requestInformations,
+      });
+
+      expect(onSuccess).not.toBeCalled();
+
+      expect(onError).toBeCalledWith(
+        expect.objectContaining({
+          error: {
+            msg: error.message,
+            type: error.name,
+            status: error.$metadata?.httpStatusCode,
+          },
+        })
+      );
+    });
+
+    it('makes request with fetchFromStartToEnd', async () => {
+      const getAssetPropertyValue = jest
+        .fn()
+        .mockResolvedValue(ASSET_PROPERTY_DOUBLE_VALUE);
+      const assetId = 'some-asset-id';
+      const propertyId = 'some-property-id';
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+
+      const start = new Date(1000099);
+      const end = new Date();
+
+      const requestInformations = [
+        {
+          id: toId({ assetId, propertyId }),
+          start,
+          end,
+          resolution: '0',
+          fetchMostRecentBeforeEnd: true,
+        },
+      ];
+
+      const client = new SiteWiseClientEdge(
+        createMockSiteWiseSDK({ getAssetPropertyValue })
+      );
+
+      await client.getLatestPropertyDataPoint({
+        onSuccess,
+        onError,
+        requestInformations,
+      });
+      expect(getAssetPropertyValue).toBeCalledWith({ assetId, propertyId });
+
+      expect(onError).not.toBeCalled();
+
+      expect(onSuccess).toBeCalledWith(
+        [
+          expect.objectContaining({
+            id: toId({ assetId, propertyId }),
+            data: [
+              {
+                y: ASSET_PROPERTY_DOUBLE_VALUE.propertyValue?.value
+                  ?.doubleValue,
+                x: 1000099,
+              },
+            ],
+            resolution: 0,
+          }),
+        ],
+        expect.objectContaining({
+          id: toId({ assetId, propertyId }),
+          start,
+          end,
+          resolution: '0',
+          fetchMostRecentBeforeEnd: true,
+        }),
+        start,
+        end
+      );
+    });
+  });
+
+  describe('getAggregatedPropertyDataPoints', () => {
+    it('calls onError on failure', async () => {
+      const getAssetPropertyAggregates = jest.fn().mockRejectedValue(error);
+      const assetId = 'some-asset-id';
+      const propertyId = 'some-property-id';
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+
+      const client = new SiteWiseClientEdge(
+        createMockSiteWiseSDK({ getAssetPropertyAggregates })
+      );
+
+      const startDate = new Date(2000, 0, 0);
+      const endDate = new Date(2001, 0, 0);
+      const resolution = '1h';
+
+      const requestInformations = [
+        {
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution,
+          fetchFromStartToEnd: true,
+          aggregationType: AGGREGATE_TYPE,
+        },
+      ];
+
+      await client.getAggregatedPropertyDataPoints({
+        requestInformations,
+        onSuccess,
+        onError,
+      });
+
+      expect(onSuccess).not.toBeCalled();
+
+      expect(onError).toBeCalledWith(
+        expect.objectContaining({
+          error: {
+            msg: error.message,
+            type: error.name,
+            status: error.$metadata?.httpStatusCode,
+          },
+        })
+      );
+    });
+
+    it('makes request with fetchFromStartToEnd', async () => {
+      const assetId = 'some-asset-id';
+      const propertyId = 'some-property-id';
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+      const getAssetPropertyAggregates = jest
+        .fn()
+        .mockResolvedValue(AGGREGATE_VALUES);
+
+      const client = new SiteWiseClientEdge(
+        createMockSiteWiseSDK({ getAssetPropertyAggregates })
+      );
+
+      const startDate = new Date(2000, 0, 0);
+      const endDate = new Date(2001, 0, 0);
+      const resolution = '1h';
+
+      const requestInformations = [
+        {
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution,
+          fetchFromStartToEnd: true,
+          aggregationType: AGGREGATE_TYPE,
+        },
+      ];
+
+      await client.getAggregatedPropertyDataPoints({
+        requestInformations,
+        onSuccess,
+        onError,
+      });
+
+      expect(getAssetPropertyAggregates).toBeCalledWith(
+        expect.objectContaining({
+          assetId,
+          propertyId,
+          startDate,
+          endDate,
+          resolution,
+        })
+      );
+
+      expect(onError).not.toBeCalled();
+
+      expect(onSuccess).toBeCalledWith(
+        [
+          expect.objectContaining({
+            id: toId({ assetId, propertyId }),
+            aggregationType: AggregateType.AVERAGE,
+            data: [
+              {
+                x: 946602000000,
+                y: 5,
+              },
+              {
+                x: 946605600000,
+                y: 7,
+              },
+              {
+                x: 946609200000,
+                y: 10,
+              },
+            ],
+            resolution: HOUR_IN_MS,
+          }),
+        ],
+        expect.objectContaining({
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution,
+          fetchFromStartToEnd: true,
+        }),
+        startDate,
+        endDate
+      );
+    });
+
+    it('makes request with fetchMostRecentBeforeEnd', async () => {
+      const assetId = 'some-asset-id';
+      const propertyId = 'some-property-id';
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+      const getAssetPropertyAggregates = jest
+        .fn()
+        .mockResolvedValue(AGGREGATE_VALUES);
+
+      const client = new SiteWiseClientEdge(
+        createMockSiteWiseSDK({ getAssetPropertyAggregates })
+      );
+
+      const startDate = new Date(2000, 0, 0);
+      const endDate = new Date(2001, 0, 0);
+      const resolution = '1h';
+
+      const requestInformations = [
+        {
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution,
+          fetchMostRecentBeforeEnd: true,
+          aggregationType: AGGREGATE_TYPE,
+        },
+      ];
+
+      await client.getAggregatedPropertyDataPoints({
+        requestInformations,
+        onSuccess,
+        onError,
+      });
+
+      expect(getAssetPropertyAggregates).toBeCalledWith(
+        expect.objectContaining({
+          assetId,
+          propertyId,
+          startDate: SITEWISE_PREVIEW_DATE,
+          endDate,
+          resolution,
+        })
+      );
+
+      expect(onError).not.toBeCalled();
+
+      expect(onSuccess).toBeCalledWith(
+        [
+          expect.objectContaining({
+            id: toId({ assetId, propertyId }),
+            aggregationType: AggregateType.AVERAGE,
+            data: [
+              {
+                x: 946602000000,
+                y: 5,
+              },
+              {
+                x: 946605600000,
+                y: 7,
+              },
+              {
+                x: 946609200000,
+                y: 10,
+              },
+            ],
+            resolution: HOUR_IN_MS,
+          }),
+        ],
+        expect.objectContaining({
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution,
+          fetchMostRecentBeforeEnd: true,
+        }),
+        SITEWISE_PREVIEW_DATE,
+        endDate
+      );
+    });
+
+    it('makes request with fetchMostRecentBeforeStart', async () => {
+      const assetId = 'some-asset-id';
+      const propertyId = 'some-property-id';
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+      const getAssetPropertyAggregates = jest
+        .fn()
+        .mockResolvedValue(AGGREGATE_VALUES);
+
+      const client = new SiteWiseClientEdge(
+        createMockSiteWiseSDK({ getAssetPropertyAggregates })
+      );
+
+      const startDate = new Date(2000, 0, 0);
+      const endDate = new Date(2001, 0, 0);
+      const resolution = '1h';
+
+      const requestInformations = [
+        {
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution,
+          fetchMostRecentBeforeStart: true,
+          aggregationType: AGGREGATE_TYPE,
+        },
+      ];
+
+      await client.getAggregatedPropertyDataPoints({
+        requestInformations,
+        onSuccess,
+        onError,
+      });
+
+      expect(getAssetPropertyAggregates).toBeCalledWith(
+        expect.objectContaining({
+          assetId,
+          propertyId,
+          startDate: SITEWISE_PREVIEW_DATE,
+          endDate: startDate,
+          resolution,
+        })
+      );
+
+      expect(onError).not.toBeCalled();
+
+      expect(onSuccess).toBeCalledWith(
+        [
+          expect.objectContaining({
+            id: toId({ assetId, propertyId }),
+            aggregationType: AggregateType.AVERAGE,
+            data: [
+              {
+                x: 946602000000,
+                y: 5,
+              },
+              {
+                x: 946605600000,
+                y: 7,
+              },
+              {
+                x: 946609200000,
+                y: 10,
+              },
+            ],
+            resolution: HOUR_IN_MS,
+          }),
+        ],
+        expect.objectContaining({
+          id: toId({ assetId, propertyId }),
+          start: startDate,
+          end: endDate,
+          resolution,
+          fetchMostRecentBeforeStart: true,
+        }),
+        SITEWISE_PREVIEW_DATE,
+        startDate
+      );
+    });
+  });
+});

--- a/packages/source-iotsitewise/src/time-series-data/client/edge/client.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/edge/client.ts
@@ -1,0 +1,42 @@
+import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { getAggregatedPropertyDataPoints } from './getAggregatedPropertyDataPoints';
+import { getHistoricalPropertyDataPoints } from './getHistoricalPropertyDataPoints';
+import { getLatestPropertyDataPoint } from './getLatestPropertyDataPoint';
+import {
+  AggregatedPropertyParams,
+  HistoricalPropertyParams,
+  LatestPropertyParams,
+} from '../client';
+
+export class SiteWiseClientEdge {
+  private siteWiseSdk: IoTSiteWiseClient;
+
+  constructor(siteWiseSdk: IoTSiteWiseClient) {
+    this.siteWiseSdk = siteWiseSdk;
+  }
+
+  getLatestPropertyDataPoint(params: LatestPropertyParams): Promise<void> {
+    return getLatestPropertyDataPoint({
+      client: this.siteWiseSdk,
+      ...params,
+    });
+  }
+
+  getHistoricalPropertyDataPoints(
+    params: HistoricalPropertyParams
+  ): Promise<void> {
+    return getHistoricalPropertyDataPoints({
+      client: this.siteWiseSdk,
+      ...params,
+    });
+  }
+
+  getAggregatedPropertyDataPoints(
+    params: AggregatedPropertyParams
+  ): Promise<void> {
+    return getAggregatedPropertyDataPoints({
+      client: this.siteWiseSdk,
+      ...params,
+    });
+  }
+}

--- a/packages/source-iotsitewise/src/time-series-data/client/edge/getAggregatedPropertyDataPoints.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/edge/getAggregatedPropertyDataPoints.ts
@@ -1,0 +1,177 @@
+import {
+  GetAssetPropertyAggregatesCommand,
+  IoTSiteWiseClient,
+  TimeOrdering,
+} from '@aws-sdk/client-iotsitewise';
+import { AssetId, AssetPropertyId } from '../../types';
+import { aggregateToDataPoint } from '../../util/toDataPoint';
+import { RESOLUTION_TO_MS_MAPPING } from '../../util/resolution';
+import { toId } from '../../util/dataStreamId';
+import {
+  parseDuration,
+  OnSuccessCallback,
+  ErrorCallback,
+  RequestInformationAndRange,
+  toSiteWiseAssetProperty,
+} from '@iot-app-kit/core';
+import { isDefined } from '../../../common/predicates';
+import { dataStreamFromSiteWise } from '../../dataStreamFromSiteWise';
+import { SITEWISE_PREVIEW_DATE } from '../../util/timeConstants';
+import { flattenRequestInfoByFetch } from '../../util/flattenRequestInfoByFetch';
+
+const getAggregatedPropertyDataPointsForProperty = ({
+  requestInformation,
+  assetId,
+  propertyId,
+  maxResults,
+  onSuccess,
+  onError,
+  nextToken: prevToken,
+  client,
+}: {
+  requestInformation: RequestInformationAndRange;
+  assetId: AssetId;
+  propertyId: AssetPropertyId;
+  maxResults?: number;
+  onError: ErrorCallback;
+  onSuccess: OnSuccessCallback;
+  client: IoTSiteWiseClient;
+  nextToken?: string;
+}) => {
+  let { start, end } = requestInformation;
+
+  // only 1 of the following options are enabled at this point:
+  // fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, fetchFromStartToEnd
+  const {
+    aggregationType,
+    fetchMostRecentBeforeStart,
+    fetchMostRecentBeforeEnd,
+    resolution,
+  } = requestInformation;
+
+  if (aggregationType == null) {
+    console.error(
+      'Failed to call getAggregatedPropertyDataPointsForProperty(...) due to missing `aggregationType` in the requestInformation.'
+    );
+
+    return;
+  }
+
+  const fetchMostRecent =
+    fetchMostRecentBeforeStart || fetchMostRecentBeforeEnd;
+
+  // fetch leading point without mutating requestInformation
+  if (fetchMostRecentBeforeStart) {
+    end = start;
+    // default to year of SiteWise Preview to not workload edge gateway
+    start = SITEWISE_PREVIEW_DATE;
+    maxResults = 1;
+  } else if (fetchMostRecentBeforeEnd) {
+    start = SITEWISE_PREVIEW_DATE;
+    maxResults = 1;
+  }
+
+  return client
+    .send(
+      new GetAssetPropertyAggregatesCommand({
+        assetId,
+        propertyId,
+        startDate: start,
+        endDate: end,
+        resolution,
+        aggregateTypes: [aggregationType],
+        maxResults,
+        timeOrdering: TimeOrdering.DESCENDING,
+        nextToken: prevToken,
+      })
+    )
+    .then(({ aggregatedValues, nextToken }) => {
+      if (aggregatedValues) {
+        /** Report the page of data to the data-module */
+        const dataPoints = aggregatedValues
+          .map((assetPropertyValue) => aggregateToDataPoint(assetPropertyValue))
+          .filter(isDefined);
+
+        onSuccess(
+          [
+            dataStreamFromSiteWise({
+              assetId,
+              propertyId,
+              dataPoints,
+              resolution: RESOLUTION_TO_MS_MAPPING[resolution],
+              aggregationType,
+            }),
+          ],
+          requestInformation,
+          start,
+          end
+        );
+      }
+
+      if (nextToken && !fetchMostRecent) {
+        getAggregatedPropertyDataPointsForProperty({
+          requestInformation,
+          assetId,
+          propertyId,
+          maxResults,
+          onError,
+          onSuccess,
+          nextToken,
+          client,
+        });
+      }
+    })
+    .catch((err) => {
+      const id = toId({ assetId, propertyId });
+      onError({
+        id,
+        resolution: parseDuration(resolution),
+        error: {
+          msg: err.message,
+          type: err.name,
+          status: err.$metadata?.httpStatusCode,
+        },
+      });
+    });
+};
+
+export const getAggregatedPropertyDataPoints = async ({
+  client,
+  requestInformations,
+  maxResults,
+  onSuccess,
+  onError,
+}: {
+  requestInformations: RequestInformationAndRange[];
+  maxResults?: number;
+  onError: ErrorCallback;
+  onSuccess: OnSuccessCallback;
+  client: IoTSiteWiseClient;
+}) => {
+  const requests = requestInformations
+    .filter(({ resolution }) => resolution !== '0')
+    .sort((a, b) => b.start.getTime() - a.start.getTime())
+    // fanout on fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, fetchFromStartToEnd into dedicated request info
+    .flatMap(flattenRequestInfoByFetch)
+    .map((requestInformation) => {
+      const { assetId, propertyId } = toSiteWiseAssetProperty(
+        requestInformation.id
+      );
+
+      return getAggregatedPropertyDataPointsForProperty({
+        requestInformation,
+        client,
+        assetId,
+        propertyId,
+        maxResults,
+        onSuccess,
+        onError,
+      });
+    });
+
+  try {
+    await Promise.all(requests);
+  } catch (err) {
+    // NOOP
+  }
+};

--- a/packages/source-iotsitewise/src/time-series-data/client/edge/getHistoricalPropertyDataPoints.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/edge/getHistoricalPropertyDataPoints.ts
@@ -1,0 +1,156 @@
+import {
+  GetAssetPropertyValueHistoryCommand,
+  IoTSiteWiseClient,
+  TimeOrdering,
+} from '@aws-sdk/client-iotsitewise';
+import { AssetId, AssetPropertyId } from '../../types';
+import { toDataPoint } from '../../util/toDataPoint';
+import { dataStreamFromSiteWise } from '../../dataStreamFromSiteWise';
+import {
+  OnSuccessCallback,
+  ErrorCallback,
+  RequestInformationAndRange,
+  toSiteWiseAssetProperty,
+} from '@iot-app-kit/core';
+import { toId } from '../../util/dataStreamId';
+import { isDefined } from '../../../common/predicates';
+import { SITEWISE_PREVIEW_DATE } from '../../util/timeConstants';
+import { flattenRequestInfoByFetch } from '../../util/flattenRequestInfoByFetch';
+
+const getHistoricalPropertyDataPointsForProperty = ({
+  requestInformation,
+  assetId,
+  propertyId,
+  maxResults,
+  onSuccess,
+  onError,
+  nextToken: prevToken,
+  client,
+}: {
+  requestInformation: RequestInformationAndRange;
+  assetId: AssetId;
+  propertyId: AssetPropertyId;
+  maxResults?: number;
+  onError: ErrorCallback;
+  onSuccess: OnSuccessCallback;
+  client: IoTSiteWiseClient;
+  nextToken?: string;
+}) => {
+  let { start, end } = requestInformation;
+
+  // only 1 of the following options are enabled at this point:
+  // fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, fetchFromStartToEnd
+  const { fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd } =
+    requestInformation;
+
+  const fetchMostRecent =
+    fetchMostRecentBeforeStart || fetchMostRecentBeforeEnd;
+
+  // fetch leading point without mutating requestInformation
+  if (fetchMostRecentBeforeStart) {
+    end = start;
+    // default to year of SiteWise Preview to not workload edge gateway
+    start = SITEWISE_PREVIEW_DATE;
+    maxResults = 1;
+  } else if (fetchMostRecentBeforeEnd) {
+    start = SITEWISE_PREVIEW_DATE;
+    maxResults = 1;
+  }
+
+  return client
+    .send(
+      new GetAssetPropertyValueHistoryCommand({
+        assetId,
+        propertyId,
+        startDate: start,
+        endDate: end,
+        maxResults,
+        timeOrdering: TimeOrdering.DESCENDING,
+        nextToken: prevToken,
+      })
+    )
+    .then((response) => {
+      if (response) {
+        const { assetPropertyValueHistory, nextToken } = response;
+        if (assetPropertyValueHistory) {
+          /** Report the page of data to the data-module */
+          const dataPoints = assetPropertyValueHistory
+            .map((assetPropertyValue) => toDataPoint(assetPropertyValue))
+            .filter(isDefined);
+
+          onSuccess(
+            [dataStreamFromSiteWise({ assetId, propertyId, dataPoints })],
+            requestInformation,
+            start,
+            end
+          );
+        }
+
+        if (nextToken && !fetchMostRecent) {
+          getHistoricalPropertyDataPointsForProperty({
+            requestInformation,
+            assetId,
+            propertyId,
+            maxResults,
+            onError,
+            onSuccess,
+            nextToken,
+            client,
+          });
+        }
+      }
+    })
+    .catch((err) => {
+      const id = toId({ assetId, propertyId });
+      onError({
+        id,
+        resolution: 0,
+        error: {
+          msg: err.message,
+          type: err.name,
+          status: err.$metadata?.httpStatusCode,
+        },
+      });
+    });
+};
+
+export const getHistoricalPropertyDataPoints = async ({
+  client,
+  requestInformations,
+  maxResults,
+  onSuccess,
+  onError,
+}: {
+  requestInformations: RequestInformationAndRange[];
+  maxResults?: number;
+  onError: ErrorCallback;
+  onSuccess: OnSuccessCallback;
+  client: IoTSiteWiseClient;
+}) => {
+  const requests = requestInformations
+    .filter(({ resolution }) => resolution === '0')
+    .sort((a, b) => b.start.getTime() - a.start.getTime())
+    // fanout on fetchMostRecentBeforeStart, fetchMostRecentBeforeEnd, fetchFromStartToEnd into dedicated request info
+    .flatMap(flattenRequestInfoByFetch)
+    .map((requestInformation) => {
+      const { assetId, propertyId } = toSiteWiseAssetProperty(
+        requestInformation.id
+      );
+
+      return getHistoricalPropertyDataPointsForProperty({
+        requestInformation,
+        client,
+        assetId,
+        propertyId,
+        maxResults,
+        onSuccess,
+        onError,
+      });
+    });
+
+  try {
+    await Promise.all(requests);
+  } catch (err) {
+    // NOOP
+  }
+};

--- a/packages/source-iotsitewise/src/time-series-data/client/edge/getLatestPropertyDataPoint.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/edge/getLatestPropertyDataPoint.ts
@@ -1,0 +1,85 @@
+import {
+  GetAssetPropertyValueCommand,
+  IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
+import { toDataPoint } from '../../util/toDataPoint';
+import { dataStreamFromSiteWise } from '../../dataStreamFromSiteWise';
+import {
+  OnSuccessCallback,
+  ErrorCallback,
+  RequestInformationAndRange,
+  toSiteWiseAssetProperty,
+} from '@iot-app-kit/core';
+import { toId } from '../../util/dataStreamId';
+import { isDefined } from '../../../common/predicates';
+import { SITEWISE_PREVIEW_DATE } from '../../util/timeConstants';
+
+export const getLatestPropertyDataPoint = async ({
+  onSuccess,
+  onError,
+  client,
+  requestInformations,
+}: {
+  onSuccess: OnSuccessCallback;
+  onError: ErrorCallback;
+  client: IoTSiteWiseClient;
+  requestInformations: RequestInformationAndRange[];
+}): Promise<void> => {
+  const end = new Date();
+  const requests = requestInformations
+    .filter(
+      ({ resolution, fetchMostRecentBeforeEnd }) =>
+        resolution === '0' && fetchMostRecentBeforeEnd
+    )
+    .sort((a, b) => b.start.getTime() - a.start.getTime())
+    .map((requestInformation) => {
+      const { assetId, propertyId } = toSiteWiseAssetProperty(
+        requestInformation.id
+      );
+
+      return client
+        .send(new GetAssetPropertyValueCommand({ assetId, propertyId }))
+        .then((res) => ({
+          siteWiseData: {
+            dataPoints: [toDataPoint(res.propertyValue)].filter(isDefined),
+            assetId,
+            propertyId,
+          },
+          requestInformation,
+        }))
+        .catch((err) => {
+          const dataStreamId = toId({ assetId, propertyId });
+          onError({
+            id: dataStreamId,
+            resolution: 0,
+            error: {
+              msg: err.message,
+              type: err.name,
+              status: err.$metadata?.httpStatusCode,
+            },
+          });
+          return undefined;
+        });
+    });
+
+  try {
+    await Promise.all(requests).then((results) => {
+      results
+        .filter(isDefined)
+        .map(({ siteWiseData, requestInformation }) => ({
+          dataStream: dataStreamFromSiteWise(siteWiseData),
+          requestInformation,
+        }))
+        .forEach(({ dataStream, requestInformation }) => {
+          const lastDataPoint = dataStream.data.slice(-1)[0];
+          // default to year of SiteWise Preview to not workload edge gateway
+          const start = lastDataPoint
+            ? new Date(lastDataPoint.x)
+            : SITEWISE_PREVIEW_DATE;
+          onSuccess([dataStream], requestInformation, start, end);
+        });
+    });
+  } catch {
+    // NOOP
+  }
+};

--- a/packages/source-iotsitewise/src/time-series-data/data-source.ts
+++ b/packages/source-iotsitewise/src/time-series-data/data-source.ts
@@ -13,6 +13,7 @@ import type {
   SiteWiseDataStreamQuery,
 } from './types';
 import type { ResolutionConfig, DataSource } from '@iot-app-kit/core';
+import { SiteWiseClientEdge } from './client/edge/client';
 
 const DEFAULT_RESOLUTION_MAPPING = {
   [MINUTE_IN_MS * 15]: SupportedResolutions.ONE_MINUTE,
@@ -67,9 +68,13 @@ export const determineResolution = ({
 
 export const createDataSource = (
   siteWise: IoTSiteWiseClient,
-  settings?: SiteWiseDataSourceSettings
+  settings: SiteWiseDataSourceSettings = {}
 ): DataSource<SiteWiseDataStreamQuery> => {
-  const client = new SiteWiseClient(siteWise, settings);
+  const { edgeMode } = settings;
+  const client =
+    edgeMode === 'enabled'
+      ? new SiteWiseClientEdge(siteWise)
+      : new SiteWiseClient(siteWise, settings);
   return {
     initiateRequest: ({ onSuccess, onError }, requestInformations) => {
       Promise.all([

--- a/packages/source-iotsitewise/src/time-series-data/types.ts
+++ b/packages/source-iotsitewise/src/time-series-data/types.ts
@@ -67,6 +67,9 @@ export type SiteWiseAssetModelQuery = DataStreamQuery & {
 export type SiteWiseDataStreamQuery = Partial<SiteWiseAssetQuery> &
   Partial<SiteWisePropertyAliasQuery>;
 
+export type EdgeMode = 'enabled' | 'disabled';
+
 export type SiteWiseDataSourceSettings = {
   batchDuration?: number;
+  edgeMode?: EdgeMode;
 };

--- a/packages/source-iotsitewise/src/time-series-data/util/flattenRequestInfoByFetch.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/util/flattenRequestInfoByFetch.spec.ts
@@ -1,0 +1,42 @@
+import { flattenRequestInfoByFetch } from './flattenRequestInfoByFetch';
+
+describe('flattenRequestInfoByFetch', () => {
+  it('flattens by fetchXxx fields', () => {
+    const baseRequestInfo = {
+      id: 'id',
+      resolution: '1h',
+      start: new Date(),
+      end: new Date(),
+    };
+
+    const requestInfoMostRecentBeforeStart = {
+      ...baseRequestInfo,
+      fetchMostRecentBeforeStart: true,
+    };
+
+    const requestInfoMostRecentBeforeEnd = {
+      ...baseRequestInfo,
+      fetchMostRecentBeforeEnd: true,
+    };
+
+    const requestInfoFromStartToEnd = {
+      ...baseRequestInfo,
+      fetchFromStartToEnd: true,
+    };
+
+    const requestInfo = {
+      ...baseRequestInfo,
+      fetchMostRecentBeforeStart: true,
+      fetchMostRecentBeforeEnd: true,
+      fetchFromStartToEnd: true,
+    };
+
+    expect(flattenRequestInfoByFetch(requestInfo)).toEqual(
+      expect.arrayContaining([
+        requestInfoMostRecentBeforeStart,
+        requestInfoMostRecentBeforeEnd,
+        requestInfoFromStartToEnd,
+      ])
+    );
+  });
+});

--- a/packages/source-iotsitewise/src/time-series-data/util/flattenRequestInfoByFetch.ts
+++ b/packages/source-iotsitewise/src/time-series-data/util/flattenRequestInfoByFetch.ts
@@ -1,0 +1,33 @@
+import { RequestInformationAndRange } from '@iot-app-kit/core';
+
+export const flattenRequestInfoByFetch = ({
+  fetchMostRecentBeforeStart,
+  fetchMostRecentBeforeEnd,
+  fetchFromStartToEnd,
+  ...rest
+}: RequestInformationAndRange) => {
+  const infos: RequestInformationAndRange[] = [];
+
+  if (fetchMostRecentBeforeStart) {
+    infos.push({
+      ...rest,
+      fetchMostRecentBeforeStart,
+    });
+  }
+
+  if (fetchMostRecentBeforeEnd) {
+    infos.push({
+      ...rest,
+      fetchMostRecentBeforeEnd,
+    });
+  }
+
+  if (fetchFromStartToEnd) {
+    infos.push({
+      ...rest,
+      fetchFromStartToEnd,
+    });
+  }
+
+  return infos;
+};

--- a/packages/source-iotsitewise/src/time-series-data/util/timeConstants.ts
+++ b/packages/source-iotsitewise/src/time-series-data/util/timeConstants.ts
@@ -3,3 +3,4 @@ export const SECOND_IN_MS = 1000;
 export const MINUTE_IN_MS = 60 * SECOND_IN_MS;
 export const HOUR_IN_MS = 60 * MINUTE_IN_MS;
 export const DAY_IN_MS = 24 * HOUR_IN_MS;
+export const SITEWISE_PREVIEW_DATE = new Date(2018, 0, 1);


### PR DESCRIPTION
## Overview

This PR introduce `edgeMode` in `source-iotsitewise` to serve as a stopgap missing APIs on edge. In summary, Edge Mode uses non-batching APIs for data retrievals

NOTE:
- data fetching logic `getAggregatedPropertyDataPoints.ts`, `getHistoricalPropertyDataPoints.ts`, and `getLatestPropertyDataPoint.ts` copied from previous commit https://github.com/awslabs/iot-app-kit/commit/b7a38e225199989524914b88f8da43ca77af2e54#diff-4f4c44bc9a94777afdbecc23e97e62005ceaa4e9737505657916981922ddbcfd

## Verifying Changes

Added unit tests and manual validated in dashboard connected to edge (additional changes needed)
<img width="1453" alt="Screenshot 2024-02-13 at 2 04 53 AM" src="https://github.com/awslabs/iot-app-kit/assets/50635800/92034a8a-7451-4f6e-a020-dae7359d8e07">

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
