### PR TITLE
fix: testing-util as devDependency of doc-site

### DIFF
--- a/packages/doc-site/package.json
+++ b/packages/doc-site/package.json
@@ -3,6 +3,7 @@
   "version": "9.11.0",
   "private": true,
   "devDependencies": {
+    "@iot-app-kit/testing-util": "^9.15.0",
     "@storybook/addon-essentials": "^7.6.6",
     "@storybook/addon-interactions": "^7.6.6",
     "@storybook/addon-links": "^7.6.6",
@@ -30,7 +31,6 @@
   },
   "dependencies": {
     "@iot-app-kit/core": "^9.15.0",
-    "@iot-app-kit/react-components": "^9.15.0",
-    "@iot-app-kit/testing-util": "^9.15.0"
+    "@iot-app-kit/react-components": "^9.15.0"
   }
 }


### PR DESCRIPTION
## Overview
This change is intended to resolve an npm package resolution issue preventing release of iot-app-kit. See https://github.com/awslabs/iot-app-kit/actions/runs/7888775192/job/21527045689?pr=2546#step:4:8 for workflow failure.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
