### PR TITLE
feat: move dashboard playwright tests to docker

### DIFF
--- a/.github/workflows/ui-test-for-commit.yml
+++ b/.github/workflows/ui-test-for-commit.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: test UI
         run:
-          npm run test:ui -w @iot-app-kit/dashboard --filter=[HEAD~1] && npm run test:ui -w @iot-app-kit/react-components --filter=[HEAD~1] --production && npm run test:ui -w @iot-app-kit/scene-composer --filter=[HEAD~1] --production
+          npm run test:ui -w @iot-app-kit/dashboard --filter=[HEAD~1] --production && npm run test:ui -w @iot-app-kit/react-components --filter=[HEAD~1] --production && npm run test:ui -w @iot-app-kit/scene-composer --filter=[HEAD~1] --production
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/ui-test-full-suite.yml
+++ b/.github/workflows/ui-test-full-suite.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: test UI
         run:
-          npm run test:ui -w @iot-app-kit/dashboard && npm run test:ui -w @iot-app-kit/react-components --production && npm run test:ui -w @iot-app-kit/scene-composer --production
+          npm run test:ui --production
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fix:stylelint": "stylelint '**/*.css' --fix",
     "test": "turbo run test",
     "test:ui": "turbo run test:ui",
-    "test:reliability": "turbo run test:ui:reliability",
+    "test:reliability": "PW_TEST_HTML_REPORT_OPEN=never turbo run test:ui:reliability",
     "test:stylelint": "stylelint '**/*.css' --max-warnings 0",
     "test:git": "git diff --exit-code",
     "release": "npm run build",

--- a/packages/dashboard/docker-compose.yml
+++ b/packages/dashboard/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.0'
 
-name: iot-app-kit-react-components
+name: iot-app-kit-dashboard
 
 services:
   playwright:
@@ -10,6 +10,6 @@ services:
       - ../../:/iot-app-kit
     ports:
       - 9323:9323/tcp
-      - 6007:6007/tcp
-    working_dir: '/iot-app-kit/packages/react-components'
+      - 6006:6006/tcp
+    working_dir: '/iot-app-kit/packages/dashboard'
     command: sh -c "npx playwright install chromium"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -32,7 +32,15 @@
     "test:watch": "jest --watch",
     "lint": "eslint . --max-warnings=0",
     "fix": "eslint --fix .",
-    "test:ui": "npx playwright test",
+    "playwright": "docker compose run playwright",
+    "test:ui": "if test \"$NODE_ENV\" = \"production\"; then npm run _test:ui:ci ; else npm run _test:ui:local ; fi",
+    "test:ui:reliability": "if test \"$NODE_ENV\" = \"production\"; then npm run _test:ui:reliability:ci ; else npm run _test:ui:reliability:local ; fi",
+    "_test:ui:ci": "npx playwright test",
+    "_test:ui:local": "npm run playwright -- npx playwright test",
+    "_test:ui:reliability:ci": "npx playwright test --repeat-each 5 --workers=1",
+    "_test:ui:reliability:local": "npm run playwright -- npx playwright test --repeat-each 5 --workers=1",
+    "test:ui:update": "npm run playwright -- npx playwright test --update-snapshots",
+    "test:ui:dev": "npx playwright test --ui",
     "watch-dependencies": "npm exec turbowatch ./turbowatch.ts"
   },
   "devDependencies": {

--- a/packages/dashboard/playwright.config.ts
+++ b/packages/dashboard/playwright.config.ts
@@ -24,8 +24,9 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  reporter: [
+    ['html', { host: '0.0.0.0' }],
+  ] /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */,
   use: {
     viewport: { height: 1500, width: 1028 },
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
@@ -35,7 +36,7 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    baseURL: 'http://localhost:6006/',
+    baseURL: 'http://0.0.0.0:6006/',
   },
 
   /* Configure projects for major browsers */

--- a/packages/scene-composer/docker-compose.yml
+++ b/packages/scene-composer/docker-compose.yml
@@ -1,7 +1,10 @@
 version: '3.0'
 
+name: iot-app-kit-scene-composer
+
 services:
   playwright:
+    container_name: iot-app-kit-scene-composer
     image: mcr.microsoft.com/playwright:v1.39.0-focal
     build: .
     volumes:

--- a/turbo.json
+++ b/turbo.json
@@ -27,6 +27,11 @@
       "env": ["CI"],
       "outputMode": "new-only"
     },
+    "test:ui:reliability": {
+      "dependsOn": ["build"],
+      "env": ["CI"],
+      "outputMode": "new-only"
+    },
     "start": {
       "dependsOn": ["^build"],
       "env": [


### PR DESCRIPTION
## Overview
UI Tests for Dashboard package will now be run in a docker image locally by default to ensure snapshot and run consistency with CI server.

## Verifying Changes
Tests run locally, and the workflows in this PR.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
