### PR TITLE
feat(react-components): add max column to legend

### DIFF
--- a/packages/dashboard/e2e/tests/constants.ts
+++ b/packages/dashboard/e2e/tests/constants.ts
@@ -21,3 +21,6 @@ export const REMOVE_TREND_CURSOR = 'Delete trend cursor';
 export const TREND_CURSOR_TABLE_HEADER =
   '.base-chart-legend-tc-header-container';
 export const TREND_CURSOR_TABLE_CELL = '.trend-cursor-value';
+
+export const MAX_VALUE_TABLE_HEADER = 'base-chart-legend-max-header-container';
+export const MAX_TABLE_CELL = 'max-value';

--- a/packages/dashboard/e2e/tests/dataStreamMinMax/dataStreamMaxes.spec.ts
+++ b/packages/dashboard/e2e/tests/dataStreamMinMax/dataStreamMaxes.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect, Page } from '@playwright/test';
+import {
+  MODELED_TAB,
+  TEST_PAGE,
+  WIDGET_EMPTY_STATE_TEXT,
+  MAX_VALUE_TABLE_HEADER,
+  MAX_TABLE_CELL,
+} from '../constants';
+import { gridUtil } from '../utils/grid';
+import { resourceExplorerUtil } from '../utils/resourceExplorer';
+
+const setupTest = async (page: Page) => {
+  await page.goto(TEST_PAGE);
+
+  const grid = gridUtil(page);
+  const resourceExplorer = resourceExplorerUtil(page);
+
+  // add line widget
+  const location1 = await grid.cellLocation(0, 0);
+  const lineWidget = await grid.addWidget('line', () => location1);
+
+  // select line widget
+  await grid.clickWidget(lineWidget);
+
+  // check that widget is in empty state
+  await expect(page.getByText(WIDGET_EMPTY_STATE_TEXT)).toBeVisible();
+
+  // open resource explorer and tab to asset model tab
+  await resourceExplorer.open();
+  await expect(page.locator(MODELED_TAB)).toBeVisible();
+  await resourceExplorer.tabTo('modeled');
+
+  const { selectAsset, selectProperty } = resourceExplorer.modeledActions;
+  const { addToWidget } = resourceExplorer.generalActions;
+  await selectAsset('Africa site');
+  // select property on asset model and add to widget
+  await selectProperty('Production Rate');
+  await addToWidget();
+
+  await expect(grid.gridArea().getByText('Production Rate')).toBeVisible();
+  return lineWidget;
+};
+
+test('max value is present', async ({ page }) => {
+  const lineWidget = await setupTest(page);
+
+  const bounds = await lineWidget.boundingBox();
+
+  if (!bounds) {
+    throw new Error('Line widget has no bounds');
+  }
+
+  // cloudscape table makes 2 instances of the header
+  await expect(page.getByTestId(MAX_VALUE_TABLE_HEADER)).toHaveCount(2);
+
+  const initialMaxValueString = await page
+    .getByTestId(MAX_TABLE_CELL)
+    .first()
+    .innerText();
+
+  expect(initialMaxValueString).not.toEqual('-');
+
+  // pause for data load + echarts lifecycle to re-render
+  await page.waitForTimeout(2000);
+
+  const updatedMaxValueString = await page
+    .getByTestId(MAX_TABLE_CELL)
+    .first()
+    .innerText();
+
+  expect(updatedMaxValueString).not.toEqual('-');
+});

--- a/packages/dashboard/src/customization/propertiesSections/constants.ts
+++ b/packages/dashboard/src/customization/propertiesSections/constants.ts
@@ -73,7 +73,10 @@ export const dropdownConsts = {
     ],
   },
   legendDisplaySection: {
-    legendDisplaylist: [{ label: 'Unit', value: 'unit' }],
+    legendDisplaylist: [
+      { label: 'Unit', value: 'unit' },
+      { label: 'Maximum Value', value: 'maxValue' },
+    ],
   },
 };
 

--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.spec.tsx
@@ -55,9 +55,12 @@ describe('LegendSection', () => {
       visibleContent: 'unit' as ChartLegend['visibleContent'],
       setVisibleContent: () => {},
     };
-    const { getByLabelText } = render(<LegendSection {...options} />);
+    const { getByLabelText, getAllByLabelText } = render(
+      <LegendSection {...options} />
+    );
     expect(getByLabelText('Alignment')).toBeDisabled();
-    expect(getByLabelText('Display')).toBeDisabled();
+    expect(getAllByLabelText('Display')[0]).toBeDisabled();
+    expect(getAllByLabelText('Display')[1]).toBeDisabled();
   });
 
   test('should not disable legend options when visible is true', () => {
@@ -69,8 +72,11 @@ describe('LegendSection', () => {
       visibleContent: 'unit' as ChartLegend['visibleContent'],
       setVisibleContent: () => {},
     };
-    const { getByLabelText } = render(<LegendSection {...options} />);
+    const { getByLabelText, getAllByLabelText } = render(
+      <LegendSection {...options} />
+    );
     expect(getByLabelText('Alignment')).not.toBeDisabled();
-    expect(getByLabelText('Display')).not.toBeDisabled();
+    expect(getAllByLabelText('Display')[0]).not.toBeDisabled();
+    expect(getAllByLabelText('Display')[1]).not.toBeDisabled();
   });
 });

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/plugin.tsx
@@ -39,6 +39,8 @@ export const lineScatterChartPlugin: DashboardPlugin = {
           visibleContent: {
             unit: true,
             asset: true,
+            maxValue: true,
+            minValue: true,
           },
         },
       }),

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -159,7 +159,7 @@ export type ChartAxisOptions = YAxisRange & {
   yLabel?: string;
 };
 
-type ChartLegendContent = 'latestValue' | 'unit' | 'asset';
+type ChartLegendContent = 'latestValue' | 'unit' | 'asset' | 'maxValue';
 export type ChartLegend = {
   visible?: boolean;
   position?: 'left' | 'bottom' | 'right';

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.spec.ts
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.spec.ts
@@ -6,6 +6,7 @@ describe('legend table column definitions', () => {
     const columnDefinitions = createTableLegendColumnDefinitions({
       trendCursors: [],
       width: 100,
+      visibleContent: {},
     });
     expect(columnDefinitions).toEqual(
       expect.arrayContaining([expect.toBeObject()])
@@ -27,6 +28,7 @@ describe('legend table column definitions', () => {
     const columnDefinitions = createTableLegendColumnDefinitions({
       trendCursors,
       width: 100,
+      visibleContent: {},
     });
     expect(columnDefinitions).toEqual(
       expect.arrayContaining([

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.tsx
@@ -3,6 +3,8 @@ import { type TableProps } from '@cloudscape-design/components/table';
 import { DataStreamInformation, TrendCursor } from '../types';
 import { DataStreamCell, DataStreamColumnHeader } from './datastream';
 import { TrendCursorCell, TrendCursorColumnHeader } from './trendCursor';
+import { MaximumColumnHeader, MaximumCell } from './maximumValue';
+import { ChartLegend } from '../../../types';
 
 type LegendTableColumnDefinitions =
   TableProps<DataStreamInformation>['columnDefinitions'];
@@ -16,6 +18,17 @@ const createDataStreamColumnDefinition = (
   cell: (item) => <DataStreamCell {...item} width={width} />,
   isRowHeader: true,
 });
+
+const createMaximumColumnDefinition =
+  (): LegendTableColumnDefinitions[number] => ({
+    id: 'AssetName',
+    sortingField: 'assetName',
+    header: <MaximumColumnHeader />,
+    cell: (item) => {
+      return <MaximumCell {...item} />;
+    },
+    isRowHeader: true,
+  });
 
 const createTrendCursorColumnDefinition = ({
   id: trendCursorId,
@@ -42,9 +55,11 @@ const createTrendCursorColumnDefinition = ({
 export const createTableLegendColumnDefinitions = ({
   trendCursors,
   width,
+  visibleContent,
 }: {
   trendCursors: TrendCursor[];
   width: number;
+  visibleContent: ChartLegend['visibleContent'];
 }) => {
   const trendCursorColumnDefinitions = trendCursors
     .sort((a, b) => a.date - b.date)
@@ -52,6 +67,7 @@ export const createTableLegendColumnDefinitions = ({
 
   return [
     createDataStreamColumnDefinition(width),
+    ...(visibleContent?.maxValue ? [createMaximumColumnDefinition()] : []),
     ...trendCursorColumnDefinitions,
   ];
 };

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximumValue/index.ts
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximumValue/index.ts
@@ -1,0 +1,2 @@
+export * from './maximumHeader';
+export * from './maximumCell';

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximumValue/maximumCell.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximumValue/maximumCell.tsx
@@ -1,0 +1,23 @@
+import React, { useMemo } from 'react';
+import { DataStream } from '@iot-app-kit/core';
+import { useVisibleDataStreams } from '../../../../hooks/useVisibleDataStreams';
+import { useDataStreamMaxMin } from '../../../../hooks/useDataStreamMaxMin';
+import { DataStreamInformation } from '../../types';
+
+export const MaximumCell = ({ id }: DataStreamInformation) => {
+  const { isDataStreamHidden } = useVisibleDataStreams();
+  const { dataStreamMaxes } = useDataStreamMaxMin();
+
+  const max = dataStreamMaxes[id];
+
+  const isVisible = useMemo(
+    () => !isDataStreamHidden({ id: id } as DataStream),
+    [isDataStreamHidden, id]
+  );
+
+  return (
+    <div data-testid='max-value' className={!isVisible ? 'hidden-legend' : ''}>
+      {max ?? '-'}
+    </div>
+  );
+};

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximumValue/maximumHeader.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/maximumValue/maximumHeader.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const MaximumColumnHeader = () => (
+  <div data-testid='base-chart-legend-max-header-container'>Maximum</div>
+);

--- a/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
+++ b/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
@@ -63,6 +63,7 @@ export const ChartLegendTableAdapter = ({
     <ChartLegendTable
       datastreams={datastreamItems}
       trendCursors={trendCursors}
+      visibleContent={visibleContent}
       {...options}
     />
   );

--- a/packages/react-components/src/components/chart/legend/table/table.tsx
+++ b/packages/react-components/src/components/chart/legend/table/table.tsx
@@ -18,6 +18,7 @@ export const ChartLegendTable = ({
   visible,
   position,
   width,
+  visibleContent,
 }: ChartLegendTableOptions) => {
   const { items, collectionProps } = useCollection(datastreams, {
     sorting: {},
@@ -28,8 +29,9 @@ export const ChartLegendTable = ({
       createTableLegendColumnDefinitions({
         trendCursors,
         width: Number(width),
+        visibleContent,
       }),
-    [width, trendCursors]
+    [width, trendCursors, visibleContent]
   );
 
   if (!visible) return null;

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -19,7 +19,7 @@ export type ChartAxisOptions = YAxisOptions & {
   showX?: boolean;
 };
 
-type ChartLegendContent = 'unit' | 'asset' | 'visibility';
+type ChartLegendContent = 'unit' | 'asset' | 'visibility' | 'maxValue';
 export type ChartLegend = {
   visible?: boolean;
   position?: 'left' | 'bottom' | 'right';


### PR DESCRIPTION
## Overview
Adding ability to toggle max column from config panel. The max value is pulled from the data store and displayed in a dataStreamMax cell.

## Verifying Changes
https://github.com/awslabs/iot-app-kit/assets/145582655/1fc6534b-5b20-4422-abbf-6334a8f99bd0

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
