### PR TITLE
feat(react-components): add min column to legend

### DIFF
--- a/packages/dashboard/e2e/tests/constants.ts
+++ b/packages/dashboard/e2e/tests/constants.ts
@@ -24,3 +24,5 @@ export const TREND_CURSOR_TABLE_CELL = '.trend-cursor-value';
 
 export const MAX_VALUE_TABLE_HEADER = 'base-chart-legend-max-header-container';
 export const MAX_TABLE_CELL = 'max-value';
+export const MIN_VALUE_TABLE_HEADER = 'base-chart-legend-min-header-container';
+export const MIN_TABLE_CELL = 'min-value';

--- a/packages/dashboard/e2e/tests/dataStreamMinMax/dataStreamMins.spec.ts
+++ b/packages/dashboard/e2e/tests/dataStreamMinMax/dataStreamMins.spec.ts
@@ -3,8 +3,8 @@ import {
   MODELED_TAB,
   TEST_PAGE,
   WIDGET_EMPTY_STATE_TEXT,
-  MAX_VALUE_TABLE_HEADER,
-  MAX_TABLE_CELL,
+  MIN_VALUE_TABLE_HEADER,
+  MIN_TABLE_CELL,
 } from '../constants';
 import { gridUtil } from '../utils/grid';
 import { resourceExplorerUtil } from '../utils/resourceExplorer';
@@ -41,7 +41,7 @@ const setupTest = async (page: Page) => {
   return lineWidget;
 };
 
-test('max value is present', async ({ page }) => {
+test('min value is present', async ({ page }) => {
   const lineWidget = await setupTest(page);
 
   const bounds = await lineWidget.boundingBox();
@@ -51,15 +51,15 @@ test('max value is present', async ({ page }) => {
   }
 
   // cloudscape table makes 2 instances of the header
-  await expect(page.getByTestId(MAX_VALUE_TABLE_HEADER)).toHaveCount(2);
+  await expect(page.getByTestId(MIN_VALUE_TABLE_HEADER)).toHaveCount(2);
 
   // pause for data load + echarts lifecycle to re-render
   await page.waitForTimeout(2000);
 
-  const updatedMaxValueString = await page
-    .getByTestId(MAX_TABLE_CELL)
+  const updatedMinValueString = await page
+    .getByTestId(MIN_TABLE_CELL)
     .first()
     .innerText();
 
-  expect(updatedMaxValueString).not.toEqual('-');
+  expect(updatedMinValueString).not.toEqual('-');
 });

--- a/packages/dashboard/src/customization/propertiesSections/constants.ts
+++ b/packages/dashboard/src/customization/propertiesSections/constants.ts
@@ -76,6 +76,7 @@ export const dropdownConsts = {
     legendDisplaylist: [
       { label: 'Unit', value: 'unit' },
       { label: 'Maximum Value', value: 'maxValue' },
+      { label: 'Minimum Value', value: 'minValue' },
     ],
   },
 };

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -159,7 +159,12 @@ export type ChartAxisOptions = YAxisRange & {
   yLabel?: string;
 };
 
-type ChartLegendContent = 'latestValue' | 'unit' | 'asset' | 'maxValue';
+type ChartLegendContent =
+  | 'latestValue'
+  | 'unit'
+  | 'asset'
+  | 'minValue'
+  | 'maxValue';
 export type ChartLegend = {
   visible?: boolean;
   position?: 'left' | 'bottom' | 'right';

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/factory.tsx
@@ -5,6 +5,7 @@ import { DataStreamCell, DataStreamColumnHeader } from './datastream';
 import { TrendCursorCell, TrendCursorColumnHeader } from './trendCursor';
 import { MaximumColumnHeader, MaximumCell } from './maximumValue';
 import { ChartLegend } from '../../../types';
+import { MinimumColumnHeader, MinimumCell } from './minimumValue';
 
 type LegendTableColumnDefinitions =
   TableProps<DataStreamInformation>['columnDefinitions'];
@@ -26,6 +27,17 @@ const createMaximumColumnDefinition =
     header: <MaximumColumnHeader />,
     cell: (item) => {
       return <MaximumCell {...item} />;
+    },
+    isRowHeader: true,
+  });
+
+const createMinimumColumnDefinition =
+  (): LegendTableColumnDefinitions[number] => ({
+    id: 'AssetName',
+    sortingField: 'assetName',
+    header: <MinimumColumnHeader />,
+    cell: (item) => {
+      return <MinimumCell {...item} />;
     },
     isRowHeader: true,
   });
@@ -68,6 +80,7 @@ export const createTableLegendColumnDefinitions = ({
   return [
     createDataStreamColumnDefinition(width),
     ...(visibleContent?.maxValue ? [createMaximumColumnDefinition()] : []),
+    ...(visibleContent?.minValue ? [createMinimumColumnDefinition()] : []),
     ...trendCursorColumnDefinitions,
   ];
 };

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/minimumValue/index.ts
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/minimumValue/index.ts
@@ -1,0 +1,2 @@
+export * from './minimumHeader';
+export * from './minimumCell';

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/minimumValue/minimumCell.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/minimumValue/minimumCell.tsx
@@ -1,0 +1,23 @@
+import React, { useMemo } from 'react';
+import { DataStream } from '@iot-app-kit/core';
+import { useVisibleDataStreams } from '../../../../hooks/useVisibleDataStreams';
+import { useDataStreamMaxMin } from '../../../../hooks/useDataStreamMaxMin';
+import { DataStreamInformation } from '../../types';
+
+export const MinimumCell = ({ id }: DataStreamInformation) => {
+  const { isDataStreamHidden } = useVisibleDataStreams();
+  const { dataStreamMins } = useDataStreamMaxMin();
+
+  const min = dataStreamMins[id];
+
+  const isVisible = useMemo(
+    () => !isDataStreamHidden({ id: id } as DataStream),
+    [isDataStreamHidden, id]
+  );
+
+  return (
+    <div data-testid='min-value' className={!isVisible ? 'hidden-legend' : ''}>
+      {min ?? '-'}
+    </div>
+  );
+};

--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/minimumValue/minimumHeader.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/minimumValue/minimumHeader.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const MinimumColumnHeader = () => (
+  <div data-testid='base-chart-legend-min-header-container'>Minimum</div>
+);

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -19,7 +19,12 @@ export type ChartAxisOptions = YAxisOptions & {
   showX?: boolean;
 };
 
-type ChartLegendContent = 'unit' | 'asset' | 'visibility' | 'maxValue';
+type ChartLegendContent =
+  | 'unit'
+  | 'asset'
+  | 'visibility'
+  | 'maxValue'
+  | 'minValue';
 export type ChartLegend = {
   visible?: boolean;
   position?: 'left' | 'bottom' | 'right';


### PR DESCRIPTION
## Overview
Adding ability to toggle min column from config panel. The max value is pulled from the data store and displayed in a dataStreamMin cell.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/a70eb845-8c2d-4d20-8c13-f7b5f2bc69f6



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
