### PR TITLE
fix: add doc-site to release-please config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,7 @@
   "packages/components": "9.15.0",
   "packages/core": "9.15.0",
   "packages/dashboard": "9.15.0",
+  "packages/doc-site": "9.15.0",
   "packages/core-util": "9.15.0",
   "packages/react-components": "9.15.0",
   "packages/related-table": "9.15.0",

--- a/packages/doc-site/package.json
+++ b/packages/doc-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iot-app-kit/doc-site",
-  "version": "9.11.0",
+  "version": "9.15.0",
   "private": true,
   "devDependencies": {
     "@iot-app-kit/testing-util": "^9.15.0",
@@ -15,7 +15,7 @@
     "@storybook/react-webpack5": "^7.6.6",
     "@storybook/test": "^7.6.6",
     "@storybook/theming": "^7.6.6",
-    "eslint-config-iot-app-kit": "^9.11.0",
+    "eslint-config-iot-app-kit": "^9.15.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -61,6 +61,7 @@
         "components",
         "core",
         "dashboard",
+        "doc-site",
         "react-components",
         "related-table",
         "scene-composer",


### PR DESCRIPTION
## Overview
add doc-site to release-please config so that it's dependencies can be updated together with other packges

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
