### PR TITLE
feat: added viewport timestamps in xy plot

### DIFF
--- a/packages/react-components/src/components/chart/chart.css
+++ b/packages/react-components/src/components/chart/chart.css
@@ -69,3 +69,15 @@
 .base-chart-left-legend {
   display: flex;
 }
+
+.base-chart-container-element {
+  position: relative;
+}
+
+.base-chart-timestamp {
+  display: flex;
+  justify-content: space-between;
+  position: absolute;
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -111,6 +111,11 @@ export const CONTEXT_MENU_Z_INDEX = 10000000;
 
 export const ECHARTS_ZOOM_DEBOUNCE_MS = 300;
 
+// viewport timestamp constants
+export const TIMESTAMP_WIDTH_FACTOR = 44;
+export const TIMESTAMP_WIDTH_FACTOR_BOTTOM = 24;
+export const TIMESTAMP_HEIGHT_FACTOR_BOTTOM = 19;
+
 // legend constants
 export const LEGEND_NAME_MIN_WIDTH_FACTOR = 3.5;
 

--- a/packages/react-components/src/components/chart/tests/baseChart.spec.tsx
+++ b/packages/react-components/src/components/chart/tests/baseChart.spec.tsx
@@ -95,6 +95,9 @@ describe('Chart slider testing', () => {
 
     const { container } = render(<Chart {...options} />);
     expect(
+      container.getElementsByClassName('base-chart-timestamp').length
+    ).toBe(1);
+    expect(
       container.getElementsByClassName('react-resizable-handle-se').length
     ).toBe(1);
   });
@@ -122,6 +125,9 @@ describe('Chart slider testing', () => {
     };
 
     const { container } = render(<Chart {...options} />);
+    expect(
+      container.getElementsByClassName('base-chart-timestamp').length
+    ).toBe(1);
     expect(
       container.getElementsByClassName('react-resizable-handle-se').length
     ).toBe(0);


### PR DESCRIPTION
## Overview
This PR is for ticket #2470 and added viewport timestamps in XY-plot and it includes
1. shows timestamps in the bottom of the widget when the legend is positioned in left/right
2. shows timestamps in the bottom of the chart and above the legend section when the legend is positioned in the bottom

## Verifying Changes
https://github.com/awslabs/iot-app-kit/assets/142866907/7c7d9dcf-9d88-4972-b0bf-0c5019248804

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
