### PR TITLE
feat: widget tool box on mouse hover and selection state

### DIFF
--- a/packages/dashboard/e2e/tests/dashboard/DashboardPage.ts
+++ b/packages/dashboard/e2e/tests/dashboard/DashboardPage.ts
@@ -39,6 +39,7 @@ export class DashboardPage {
     this.gridArea = page.locator('#container');
     this.confirmModalDeleteButton = this.page.getByRole('button', {
       name: 'Delete',
+      exact: true,
     });
     this.contextMenuDeleteButton = this.gridArea.getByText('Delete');
   }

--- a/packages/dashboard/src/components/csvDownloadButton/index.tsx
+++ b/packages/dashboard/src/components/csvDownloadButton/index.tsx
@@ -18,9 +18,14 @@ import {
 } from './constants';
 import { convertViewportToHistoricalViewport } from '../util/dateTimeUtil';
 
-const canOnlyDownloadLiveMode: readonly string[] = ['table', 'kpi', 'status'];
+export const canOnlyDownloadLiveMode: readonly string[] = [
+  'table',
+  'kpi',
+  'status',
+  'text',
+];
 
-const isQueryEmpty = (queryConfig: StyledSiteWiseQueryConfig) => {
+export const isQueryEmpty = (queryConfig: StyledSiteWiseQueryConfig) => {
   const query = queryConfig.query;
   return (
     !query?.assets?.length &&

--- a/packages/dashboard/src/components/widgets/selectionBoxAnchor.tsx
+++ b/packages/dashboard/src/components/widgets/selectionBoxAnchor.tsx
@@ -5,6 +5,8 @@ import {
 } from '../internalDashboard/gestures/determineTargetGestures';
 import './selectionBoxAnchor.css';
 import type { Anchor } from '~/store/actions';
+import WidgetActions from './widgetActions';
+import { useSelectedWidgets } from '~/hooks/useSelectedWidgets';
 
 const CORNERS: Anchor[] = [
   'top-left',
@@ -19,6 +21,9 @@ export type SelectionBoxAnchorProps = {
 };
 
 const SelectionBoxAnchor: React.FC<SelectionBoxAnchorProps> = ({ anchor }) => {
+  const selectedWidgets = useSelectedWidgets();
+  const widget = selectedWidgets[0];
+
   const isCorner = CORNERS.includes(anchor);
   const isSide = SIDES.includes(anchor);
   const cornerClass = isCorner
@@ -29,12 +34,19 @@ const SelectionBoxAnchor: React.FC<SelectionBoxAnchorProps> = ({ anchor }) => {
     : '';
   const anchorClass = `${cornerClass} ${sideClass}`;
 
+  const isTop = anchor === 'top';
+
   return (
-    <div
-      {...gestureable('resize')}
-      {...anchorable(anchor)}
-      className={anchorClass}
-    />
+    <>
+      {isTop && selectedWidgets?.length === 1 && (
+        <WidgetActions widget={widget} />
+      )}
+      <div
+        {...gestureable('resize')}
+        {...anchorable(anchor)}
+        className={anchorClass}
+      />
+    </>
   );
 };
 

--- a/packages/dashboard/src/components/widgets/tile/tile.css
+++ b/packages/dashboard/src/components/widgets/tile/tile.css
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  overflow: hidden;
 }
 
 .widget-tile-body {
@@ -17,10 +18,6 @@
 }
 
 .widget-tile-header {
-  overflow: hidden;
-}
-
-.widget-tile-header h1 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/dashboard/src/components/widgets/tile/tile.spec.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.spec.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import wrapper from '@cloudscape-design/components/test-utils/dom';
-
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { screen } from '@testing-library/dom';
 
 import WidgetTile from './tile';
 import { configureDashboardStore } from '~/store';
-import { MOCK_LINE_CHART_WIDGET } from '../../../../testing/mocks';
+import {
+  MOCK_BAR_WIDGET,
+  MOCK_LINE_CHART_WIDGET,
+} from '../../../../testing/mocks';
 
 describe('WidgetTile', () => {
   it('should render widget content', function () {
@@ -31,65 +32,27 @@ describe('WidgetTile', () => {
     expect(screen.getByText('test-content')).toBeInTheDocument();
   });
 
-  it('should render a title', function () {
-    render(
-      <Provider
-        store={configureDashboardStore({
-          dashboardConfiguration: {
-            widgets: [MOCK_LINE_CHART_WIDGET],
-          },
-        })}
-      >
-        <WidgetTile title='test-title' widget={MOCK_LINE_CHART_WIDGET}>
-          <div>test-content</div>
-        </WidgetTile>
-        ;
-      </Provider>
+  it('displays titlewhen widget type is "bar-chart"', () => {
+    const { getByText } = render(
+      <WidgetTile widget={MOCK_BAR_WIDGET} title='Test Title'>
+        Test Children
+      </WidgetTile>
     );
-
-    expect(screen.getByText('test-title')).toBeInTheDocument();
+    const titleElement = getByText('Test Title');
+    expect(titleElement).toBeInTheDocument();
   });
 
-  it('can remove a widget', function () {
-    const store = configureDashboardStore({
-      dashboardConfiguration: {
-        widgets: [MOCK_LINE_CHART_WIDGET],
-      },
-    });
-    const { container } = render(
-      <Provider store={store}>
-        <WidgetTile removeable widget={MOCK_LINE_CHART_WIDGET}>
-          <div>test-content</div>
-        </WidgetTile>
-        ;
-      </Provider>
-    );
-
-    const removeButton = wrapper(container).findButton();
-
-    act(() => {
-      removeButton?.click();
-    });
-
-    const deleteBtn = screen.getByText('Delete');
-    expect(deleteBtn).toBeInTheDocument();
-    act(() => {
-      deleteBtn?.click();
-    });
-    expect(store.getState().dashboardConfiguration.widgets).toEqual([]);
-  });
-
-  it('does not show delete in readonly mode', function () {
+  it('does not show download CSV in readonly mode', function () {
     const { container } = render(
       <Provider
         store={configureDashboardStore({
           dashboardConfiguration: {
             widgets: [MOCK_LINE_CHART_WIDGET],
           },
-          readOnly: true,
+          isEdgeModeEnabled: true,
         })}
       >
-        <WidgetTile removeable widget={MOCK_LINE_CHART_WIDGET}>
+        <WidgetTile widget={MOCK_LINE_CHART_WIDGET}>
           <div>test-content</div>
         </WidgetTile>
         ;
@@ -97,7 +60,7 @@ describe('WidgetTile', () => {
     );
 
     expect(
-      container.querySelector('[aria-label="delete widget"]')
+      container.querySelector('[aria-label="download CSV"]')
     ).not.toBeInTheDocument();
   });
 
@@ -111,7 +74,7 @@ describe('WidgetTile', () => {
           isEdgeModeEnabled: true,
         })}
       >
-        <WidgetTile removeable widget={MOCK_LINE_CHART_WIDGET}>
+        <WidgetTile widget={MOCK_LINE_CHART_WIDGET}>
           <div>test-content</div>
         </WidgetTile>
         ;

--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -1,112 +1,26 @@
-import React, { PropsWithChildren, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-
-import Box from '@cloudscape-design/components/box';
-import Button from '@cloudscape-design/components/button';
+import React, { PropsWithChildren } from 'react';
 import {
   colorBorderDividerDefault,
   borderRadiusBadge,
   colorBackgroundContainerContent,
-  spaceScaledXxs,
-  spaceScaledXs,
-  spaceScaledM,
 } from '@cloudscape-design/design-tokens';
-import {
-  CancelableEventHandler,
-  ClickDetail,
-} from '@cloudscape-design/components/internal/events';
-import { getPlugin } from '@iot-app-kit/core';
+import { Box } from '@cloudscape-design/components';
 
 import { DashboardWidget } from '~/types';
-import { useDeleteWidgets } from '~/hooks/useDeleteWidgets';
-import ConfirmDeleteModal from '~/components/confirmDeleteModal';
-import { DashboardState } from '~/store/state';
 
 import './tile.css';
-import { onChangeDashboardGridEnabledAction } from '~/store/actions';
-import { CSVDownloadButton } from '~/components/csvDownloadButton';
-import { StyledSiteWiseQueryConfig } from '~/customization/widgets/types';
-import { useClients } from '~/components/dashboard/clientContext';
-
-type DeletableTileActionProps = {
-  handleDelete: CancelableEventHandler<ClickDetail>;
-};
-
-const DeletableTileAction = ({ handleDelete }: DeletableTileActionProps) => {
-  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation();
-  };
-
-  return (
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-    <div onMouseDown={handleMouseDown}>
-      <Button
-        onClick={handleDelete}
-        ariaLabel='delete widget'
-        variant='icon'
-        iconName='close'
-      />
-    </div>
-  );
-};
 
 export type WidgetTileProps = PropsWithChildren<{
   widget: DashboardWidget;
   title?: string;
-  removeable?: boolean;
 }>;
 
 /**
  *
  * Component to add functionality to the widget container
- * Allows a user to title a widget, add click remove
+ * Allows a user to title a widget for bar and status-timeline
  */
-const WidgetTile: React.FC<WidgetTileProps> = ({
-  children,
-  widget,
-  title,
-  removeable,
-}) => {
-  const isEdgeModeEnabled = useSelector(
-    (state: DashboardState) => state.isEdgeModeEnabled
-  );
-  const isReadOnly = useSelector((state: DashboardState) => state.readOnly);
-  const dispatch = useDispatch();
-  const [visible, setVisible] = useState(false);
-  const { onDelete } = useDeleteWidgets();
-  const metricsRecorder = getPlugin('metricsRecorder');
-  const { iotSiteWiseClient } = useClients();
-
-  const isRemoveable = !isReadOnly && removeable;
-  const headerVisible = !isReadOnly || widget.type !== 'text';
-
-  const handleDelete: CancelableEventHandler<ClickDetail> = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    dispatch(onChangeDashboardGridEnabledAction({ enabled: false }));
-    setVisible(true);
-  };
-
-  const handleCloseModal = () => {
-    dispatch(onChangeDashboardGridEnabledAction({ enabled: true }));
-    setVisible(false);
-  };
-
-  const handleSubmit = () => {
-    const widgetType = widget.type;
-    onDelete(widget);
-    dispatch(onChangeDashboardGridEnabledAction({ enabled: true }));
-    setVisible(false);
-
-    metricsRecorder?.record({
-      contexts: {
-        widgetType,
-      },
-      metricName: 'DashboardWidgetDelete',
-      metricValue: 1,
-    });
-  };
-
+const WidgetTile: React.FC<WidgetTileProps> = ({ widget, title, children }) => {
   return (
     <div
       aria-description='widget tile'
@@ -117,58 +31,15 @@ const WidgetTile: React.FC<WidgetTileProps> = ({
         backgroundColor: colorBackgroundContainerContent,
       }}
     >
-      {headerVisible && (
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            padding: `${spaceScaledXs} ${spaceScaledXs} ${spaceScaledXxs} ${spaceScaledM}`,
-            borderBottom: `2px solid ${colorBorderDividerDefault}`,
-          }}
+      {(widget.type === 'bar-chart' || widget.type === 'status-timeline') && (
+        <Box
+          padding={{ horizontal: 's', top: 'xs' }}
+          color='text-body-secondary'
+          fontSize='heading-m'
+          fontWeight='bold'
         >
-          <div className='widget-tile-header' title={title}>
-            <Box variant='h1' fontSize='body-m'>
-              {title}
-            </Box>
-          </div>
-          <div className='tile-button-contianer'>
-            {!isEdgeModeEnabled &&
-              widget.type !== 'text' &&
-              iotSiteWiseClient && (
-                <CSVDownloadButton
-                  fileName={`${widget.properties.title ?? widget.type}`}
-                  client={iotSiteWiseClient}
-                  widgetType={widget.type}
-                  queryConfig={
-                    widget.properties.queryConfig as StyledSiteWiseQueryConfig
-                  }
-                />
-              )}
-            {isRemoveable && (
-              <DeletableTileAction handleDelete={handleDelete} />
-            )}
-            <ConfirmDeleteModal
-              visible={visible}
-              headerTitle='Delete selected widget?'
-              cancelTitle='Cancel'
-              submitTitle='Delete'
-              description={
-                <Box>
-                  <Box variant='p'>
-                    Are you sure you want to delete the selected widget? You'll
-                    lose all the progress you made to the widget
-                  </Box>
-                  <Box variant='p' padding={{ top: 'm' }}>
-                    You cannot undo this action.
-                  </Box>
-                </Box>
-              }
-              handleDismiss={handleCloseModal}
-              handleCancel={handleCloseModal}
-              handleSubmit={handleSubmit}
-            />
-          </div>
-        </div>
+          <div className='widget-tile-header'>{title}</div>
+        </Box>
       )}
       <div className='widget-tile-body'>{children}</div>
     </div>

--- a/packages/dashboard/src/components/widgets/widget.css
+++ b/packages/dashboard/src/components/widgets/widget.css
@@ -3,7 +3,6 @@
 .widget {
   position: absolute;
   height: 100%;
-  overflow: hidden;
   user-select: none;
   box-sizing: border-box;
   border: var(--selection-border-width) solid transparent;

--- a/packages/dashboard/src/components/widgets/widget.tsx
+++ b/packages/dashboard/src/components/widgets/widget.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   gestureable,
   idable,
 } from '../internalDashboard/gestures/determineTargetGestures';
 import DynamicWidgetComponent from './dynamicWidget';
+import WidgetActions from './widgetActions';
 
 import './widget.css';
 import type { SiteWiseQuery } from '@iot-app-kit/source-iotsitewise';
@@ -29,9 +30,19 @@ const WidgetComponent: React.FC<WidgetProps> = ({
   cellSize,
   widget,
   messageOverrides,
+  isSelected,
   readOnly,
 }) => {
   const { x, y, z, width, height } = widget;
+  const [showActionButtons, setShowActionButtons] = useState(false);
+
+  const handleShowActionButtons = (show: boolean) => {
+    if (isSelected) {
+      setShowActionButtons(false);
+      return;
+    }
+    setShowActionButtons(show);
+  };
 
   return (
     <div
@@ -45,7 +56,10 @@ const WidgetComponent: React.FC<WidgetProps> = ({
         width: `${cellSize * width}px`,
         height: `${cellSize * height}px`,
       }}
+      onMouseEnter={() => handleShowActionButtons(true)}
+      onMouseLeave={() => handleShowActionButtons(false)}
     >
+      {showActionButtons && <WidgetActions widget={widget} />}
       <DynamicWidgetComponent
         widget={widget}
         widgetsMessages={messageOverrides.widgets}

--- a/packages/dashboard/src/components/widgets/widgetActions.css
+++ b/packages/dashboard/src/components/widgets/widgetActions.css
@@ -1,0 +1,7 @@
+.widget-actions-container {
+  display: flex;
+  align-items: center;
+  position: absolute;
+  top: -20px;
+  z-index: 999; /* Widget actions toolbox should be above the widget container */
+}

--- a/packages/dashboard/src/components/widgets/widgetActions.test.tsx
+++ b/packages/dashboard/src/components/widgets/widgetActions.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import WidgetActions from './widgetActions';
+import { configureDashboardStore } from '~/store';
+import {
+  MOCK_KPI_WIDGET,
+  MOCK_LINE_CHART_WIDGET,
+} from '../../../testing/mocks';
+import { Provider } from 'react-redux';
+import wrapper from '@cloudscape-design/components/test-utils/dom';
+import { act } from 'react-dom/test-utils';
+import { screen } from '@testing-library/dom';
+
+describe('WidgetActions', () => {
+  it('can remove a widget', function () {
+    const store = configureDashboardStore({
+      dashboardConfiguration: {
+        widgets: [MOCK_LINE_CHART_WIDGET],
+      },
+    });
+    const { container } = render(
+      <Provider store={store}>
+        <WidgetActions widget={MOCK_LINE_CHART_WIDGET} />
+      </Provider>
+    );
+
+    const removeButton = wrapper(container).findButton();
+
+    act(() => {
+      removeButton?.click();
+    });
+
+    const deleteBtn = screen.getByText('Delete');
+    expect(deleteBtn).toBeInTheDocument();
+    act(() => {
+      deleteBtn?.click();
+    });
+    expect(store.getState().dashboardConfiguration.widgets).toEqual([]);
+  });
+
+  it('does not show delete in readonly mode', function () {
+    const { container } = render(
+      <Provider
+        store={configureDashboardStore({
+          dashboardConfiguration: {
+            widgets: [MOCK_LINE_CHART_WIDGET],
+          },
+          readOnly: true,
+        })}
+      >
+        <WidgetActions widget={MOCK_LINE_CHART_WIDGET} />;
+      </Provider>
+    );
+
+    expect(
+      container.querySelector('[aria-label="delete widget"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show widget actions in readonly mode for kpi widget', function () {
+    const { container } = render(
+      <Provider
+        store={configureDashboardStore({
+          dashboardConfiguration: {
+            widgets: [MOCK_KPI_WIDGET],
+          },
+          readOnly: true,
+        })}
+      >
+        <WidgetActions widget={MOCK_KPI_WIDGET} />;
+      </Provider>
+    );
+
+    expect(
+      container.querySelector('[aria-label="widget-actions-container"]')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/components/widgets/widgetActions.tsx
+++ b/packages/dashboard/src/components/widgets/widgetActions.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { getPlugin } from '@iot-app-kit/core';
+
+import {
+  colorBackgroundButtonPrimaryDefault,
+  colorBackgroundButtonNormalDefault,
+  spaceStaticXl,
+  spaceStaticL,
+  spaceStaticXxs,
+  spaceStaticXs,
+  borderRadiusBadge,
+} from '@cloudscape-design/design-tokens';
+import {
+  CancelableEventHandler,
+  ClickDetail,
+} from '@cloudscape-design/components/internal/events';
+import { Box, Button, ButtonProps } from '@cloudscape-design/components';
+
+import {
+  CSVDownloadButton,
+  canOnlyDownloadLiveMode,
+  isQueryEmpty,
+} from '../csvDownloadButton';
+import { StyledSiteWiseQueryConfig } from '~/customization/widgets/types';
+import ConfirmDeleteModal from '../confirmDeleteModal';
+import { useClients } from '../dashboard/clientContext';
+import { useDeleteWidgets } from '~/hooks/useDeleteWidgets';
+import { DashboardWidget } from '~/types';
+
+import {
+  onChangeDashboardGridEnabledAction,
+  onSelectWidgetsAction,
+} from '~/store/actions';
+import { DashboardState } from '~/store/state';
+
+import './widgetActions.css';
+
+type DeletableTileActionProps = {
+  handleDelete: CancelableEventHandler<ClickDetail>;
+};
+
+const DeletableTileAction = ({
+  handleDelete,
+  variant,
+}: DeletableTileActionProps & ButtonProps) => {
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+  };
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div onMouseDown={handleMouseDown}>
+      <Button
+        onClick={handleDelete}
+        ariaLabel='delete widget'
+        variant={variant ?? 'icon'}
+        iconName='close'
+      />
+    </div>
+  );
+};
+
+const WidgetActions = ({ widget }: { widget: DashboardWidget }) => {
+  const dispatch = useDispatch();
+  const { iotSiteWiseClient } = useClients();
+  const { onDelete } = useDeleteWidgets();
+  const metricsRecorder = getPlugin('metricsRecorder');
+  const readOnly = useSelector((state: DashboardState) => state.readOnly);
+
+  const [visible, setVisible] = useState(false);
+
+  const handleDelete: CancelableEventHandler<ClickDetail> = (e) => {
+    e.stopPropagation();
+    dispatch(onChangeDashboardGridEnabledAction({ enabled: false }));
+    dispatch(onSelectWidgetsAction({ widgets: [widget], union: false }));
+    setVisible(true);
+  };
+
+  const handleCloseModal = () => {
+    dispatch(onChangeDashboardGridEnabledAction({ enabled: true }));
+    setVisible(false);
+  };
+
+  const handleSubmit = () => {
+    const widgetType = widget.type;
+    onDelete(widget);
+    dispatch(onChangeDashboardGridEnabledAction({ enabled: true }));
+    setVisible(false);
+
+    metricsRecorder?.record({
+      contexts: {
+        widgetType,
+      },
+      metricName: 'DashboardWidgetDelete',
+      metricValue: 1,
+    });
+  };
+
+  const isEmptyQuery =
+    widget.type !== 'text' &&
+    isQueryEmpty(widget.properties.queryConfig as StyledSiteWiseQueryConfig);
+  const cannotDownload = canOnlyDownloadLiveMode.some((t) => t === widget.type);
+
+  if (readOnly && (isEmptyQuery || cannotDownload)) return <></>;
+
+  return (
+    <div
+      className='widget-actions-container'
+      aria-label='widget-actions-container'
+      style={{
+        padding: `${spaceStaticXxs} ${spaceStaticXs}`,
+        height: `${spaceStaticXl}`,
+        right: `${spaceStaticL}`,
+        borderRadius: `${borderRadiusBadge}`,
+        border: `2px solid ${colorBackgroundButtonPrimaryDefault}`,
+        backgroundColor: `${colorBackgroundButtonNormalDefault}`,
+        pointerEvents: 'auto',
+      }}
+    >
+      {widget.type !== 'text' && iotSiteWiseClient && (
+        <CSVDownloadButton
+          variant='inline-icon'
+          fileName={`${widget.properties.title ?? widget.type}`}
+          client={iotSiteWiseClient}
+          widgetType={widget.type}
+          queryConfig={
+            widget.properties.queryConfig as StyledSiteWiseQueryConfig
+          }
+        />
+      )}
+      {!readOnly && (
+        <DeletableTileAction
+          variant='inline-icon'
+          handleDelete={handleDelete}
+        />
+      )}
+      <ConfirmDeleteModal
+        visible={visible}
+        headerTitle='Delete selected widget?'
+        cancelTitle='Cancel'
+        submitTitle='Delete'
+        description={
+          <Box>
+            <Box variant='p'>
+              Are you sure you want to delete the selected widget? You'll lose
+              all the progress you made to the widget
+            </Box>
+            <Box variant='p' padding={{ top: 'm' }}>
+              You cannot undo this action.
+            </Box>
+          </Box>
+        }
+        handleDismiss={handleCloseModal}
+        handleCancel={handleCloseModal}
+        handleSubmit={handleSubmit}
+      />
+    </div>
+  );
+};
+
+export default WidgetActions;

--- a/packages/dashboard/src/customization/widgets/barChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/component.tsx
@@ -41,13 +41,10 @@ const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
   const aggregation = getAggregation(widget);
   const significantDigits =
     widgetSignificantDigits ?? dashboardSignificantDigits;
-  // there may be better ways to fix this, i.e. not have -44 and let the chart container  take its parent height,
-  // the problem is that the Resizable component needs a "height" to be provided,
-  // so not entirely sure if we can have a mechanism where the container auto adjusts the height
-  // the 44 is from the widget tile header's height
-  const size = { width: chartSize.width, height: chartSize.height - 44 };
+
+  const size = { width: chartSize.width, height: chartSize.height };
   return (
-    <WidgetTile widget={widget} removeable title={title}>
+    <WidgetTile widget={widget} title={title}>
       <BarChart
         chartSize={size}
         key={key}

--- a/packages/dashboard/src/customization/widgets/components/no-chart-data.spec.tsx
+++ b/packages/dashboard/src/customization/widgets/components/no-chart-data.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { act, render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import NoChartData from './no-chart-data';
 import { default as lineSvgDark } from '../lineScatterChart/line-dark.svg';
 import WidgetTile from '~/components/widgets/tile/tile';
@@ -18,9 +18,9 @@ describe('NoChartData', () => {
         widgets: [MOCK_LINE_CHART_WIDGET],
       },
     });
-    const { getByText, getByAltText, getByTitle } = render(
+    const { getByText, getByAltText } = render(
       <Provider store={store}>
-        <WidgetTile widget={MOCK_LINE_CHART_WIDGET} removeable>
+        <WidgetTile widget={MOCK_LINE_CHART_WIDGET}>
           <NoChartData
             icon={lineSvgDark}
             emptyStateText='Browse and select to add your asset properties in your line widget.'
@@ -34,22 +34,9 @@ describe('NoChartData', () => {
     const emptyStateText = getByText(
       'Browse and select to add your asset properties in your line widget.'
     );
-    const deleteButton = getByTitle('delete widget');
 
     expect(icon).toBeInTheDocument();
     expect(emptyStateText).toBeInTheDocument();
-    expect(deleteButton).toBeInTheDocument();
-
-    act(() => {
-      deleteButton?.click();
-    });
-
-    const deleteBtn = screen.getByText('Delete');
-    expect(deleteBtn).toBeInTheDocument();
-    act(() => {
-      deleteBtn?.click();
-    });
-    expect(store.getState().dashboardConfiguration.widgets).toEqual([]);
   });
 
   it('renders the correct text widget with delete option', () => {
@@ -58,9 +45,9 @@ describe('NoChartData', () => {
         widgets: [MOCK_TEXT_WIDGET],
       },
     });
-    const { getByText, getByTitle } = render(
+    const { getByText } = render(
       <Provider store={store}>
-        <WidgetTile widget={MOCK_TEXT_WIDGET} removeable>
+        <WidgetTile widget={MOCK_TEXT_WIDGET}>
           <StyledTextArea {...MOCK_TEXT_WIDGET} handleSetEdit={() => {}} />
         </WidgetTile>
         ;
@@ -68,20 +55,7 @@ describe('NoChartData', () => {
     );
 
     const textValue = getByText('text content');
-    const deleteButton = getByTitle('delete widget');
 
     expect(textValue).toBeInTheDocument();
-    expect(deleteButton).toBeInTheDocument();
-
-    act(() => {
-      deleteButton?.click();
-    });
-
-    const deleteBtn = screen.getByText('Delete');
-    expect(deleteBtn).toBeInTheDocument();
-    act(() => {
-      deleteBtn?.click();
-    });
-    expect(store.getState().dashboardConfiguration.widgets).toEqual([]);
   });
 });

--- a/packages/dashboard/src/customization/widgets/kpi/component.tsx
+++ b/packages/dashboard/src/customization/widgets/kpi/component.tsx
@@ -42,7 +42,7 @@ const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
 
   if (shouldShowEmptyState) {
     return (
-      <WidgetTile widget={widget} removeable>
+      <WidgetTile widget={widget}>
         <KPIWidgetEmptyStateComponent />
       </WidgetTile>
     );
@@ -66,7 +66,7 @@ const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
     widgetSignificantDigits ?? dashboardSignificantDigits;
 
   return (
-    <WidgetTile widget={widget} removeable key={key}>
+    <WidgetTile widget={widget} key={key}>
       <KPI
         query={queries[0]}
         viewport={viewport}

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -175,12 +175,9 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (
 
   const convertedAxis = useConvertedAxis(axis);
 
-  // there may be better ways to fix this, i.e. not have -44 and let the chart container  take its parent height,
-  // the problem is that the Resizable component needs a "height" to be provided,
-  // so not entirely sure if we can have a mechanism where the container auto adjusts the height
-  // the 52 is from the widget tile header's height and top, bottom boder lines height
+  // the 4 is from the widget tile top, bottom boder lines height
   // the 8 is from the left and right border lines width
-  const size = { width: chartSize.width - 8, height: chartSize.height - 52 };
+  const size = { width: chartSize.width - 8, height: chartSize.height - 4 };
 
   const onChartOptionsChange = (options: Pick<ChartOptions, 'legend'>) => {
     dispatch(
@@ -201,7 +198,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (
   const isEmptyWidget = queries.length === 0;
   if (isEmptyWidget) {
     return (
-      <WidgetTile widget={widget} removeable title={title}>
+      <WidgetTile widget={widget}>
         <NoChartData
           icon={lineSvgDark}
           emptyStateText='Browse and select to add your asset properties in your line widget.'
@@ -211,7 +208,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (
   }
 
   return (
-    <WidgetTile widget={widget} removeable title={title}>
+    <WidgetTile widget={widget}>
       <Chart
         id={widget.id}
         queries={queries}
@@ -223,6 +220,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (
         thresholds={thresholds}
         significantDigits={significantDigits}
         size={size}
+        titleText={title}
         legend={legend}
         onChartOptionsChange={onChartOptionsChange}
         defaultVisualizationType={mapConnectionStyleToVisualizationType(

--- a/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
+++ b/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
@@ -39,7 +39,7 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (
   const isEmptyWidget = queries.length === 0;
   if (isEmptyWidget) {
     return (
-      <WidgetTile widget={widget} removeable title={title}>
+      <WidgetTile widget={widget}>
         <NoChartData
           icon={timelineSvgDark}
           emptyStateText='Browse and select to add your asset properties in your status timeline widget.'
@@ -49,7 +49,7 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (
   }
 
   return (
-    <WidgetTile widget={widget} removeable title={title} key={key}>
+    <WidgetTile widget={widget} title={title} key={key}>
       <StatusTimeline
         queries={queries}
         viewport={viewport}

--- a/packages/dashboard/src/customization/widgets/status/component.tsx
+++ b/packages/dashboard/src/customization/widgets/status/component.tsx
@@ -39,7 +39,7 @@ const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
 
   if (shouldShowEmptyState) {
     return (
-      <WidgetTile widget={widget} removeable>
+      <WidgetTile widget={widget}>
         <StatusWidgetEmptyStateComponent />
       </WidgetTile>
     );

--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -96,7 +96,7 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
   };
 
   return (
-    <WidgetTile widget={widget} removeable>
+    <WidgetTile widget={widget}>
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div
         data-testid='table-widget-component'

--- a/packages/dashboard/testing/mocks.ts
+++ b/packages/dashboard/testing/mocks.ts
@@ -2,6 +2,7 @@ import type { DataPoint, TimeSeriesData } from '@iot-app-kit/core';
 import { DATA_TYPE } from '@iot-app-kit/core';
 import random from 'lodash/random';
 import {
+  BarChartWidget,
   KPIWidget,
   LineScatterChartWidget,
   LineWidget,
@@ -138,6 +139,32 @@ export const MOCK_STATUS_TIMELINE_WIDGET: StatusWidget = {
     },
     primaryFont: {},
     secondaryFont: {},
+  },
+};
+
+export const MOCK_BAR_WIDGET: BarChartWidget = {
+  id: 'mock-status-timeline-widget',
+  type: 'bar-chart',
+  x: 2,
+  y: 2,
+  z: 1,
+  width: 8,
+  height: 5,
+  properties: {
+    queryConfig: {
+      source: 'iotsitewise',
+      query: {
+        assets: [
+          {
+            assetId: DEMO_TURBINE_ASSET_1,
+            properties: [
+              { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_2 },
+              { propertyId: DEMO_TURBINE_ASSET_1_PROPERTY_1 },
+            ],
+          },
+        ],
+      },
+    },
   },
 };
 

--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -86,19 +86,6 @@ const BaseChart = ({
   //handle dataZoom updates, which are dependent on user events and viewportInMS changes
   useDataZoom(chartRef, utilizedViewport);
 
-  const { dataStreamMetaData } = useChartConfiguration(chartRef, {
-    group,
-    isLoading,
-    dataStreams,
-    thresholds,
-    visibleData,
-    ...options,
-  });
-
-  useChartDataset(chartRef, dataStreams);
-
-  useChartStoreDataStreamsSync(dataStreamMetaData);
-
   const isBottomAligned = options.legend?.position === 'bottom';
 
   // Setup resize container and calculate size for echarts
@@ -142,6 +129,20 @@ const BaseChart = ({
     fontSize: `10px`,
     color: `${colorBackgroundLayoutToggleActive}`,
   };
+
+  const { dataStreamMetaData } = useChartConfiguration(chartRef, {
+    group,
+    isLoading,
+    dataStreams,
+    thresholds,
+    visibleData,
+    chartWidth,
+    ...options,
+  });
+
+  useChartDataset(chartRef, dataStreams);
+
+  useChartStoreDataStreamsSync(dataStreamMetaData);
 
   // handle chart event updates
   const { chartEventsKeyMap, chartEventsHandlers } =

--- a/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
+++ b/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
@@ -23,17 +23,24 @@ import { SeriesOption } from 'echarts';
 import { GenericSeries } from '../../../echarts/types';
 
 const useTitle = ({
+  chartWidth,
   titleText,
   hasSeries,
 }: {
+  chartWidth: number;
   titleText?: string;
   hasSeries: boolean;
 }) => {
   return useMemo(
     () => ({
       text: hasSeries ? titleText ?? '' : 'No data present',
+      padding: [0, 12],
+      textStyle: {
+        width: chartWidth - 90, // Decreased 90px width from chart width for title to avoid overlapping with the title and zoom in and out buttons
+        overflow: 'truncate',
+      },
     }),
-    [hasSeries, titleText]
+    [hasSeries, titleText, chartWidth]
   );
 };
 
@@ -89,7 +96,7 @@ type ChartConfigurationOptions = Pick<
   dataStreams: DataStream[];
 } & { visibleData: DataPoint[] } & {
   thresholds: Threshold<ThresholdValue>[];
-};
+} & { chartWidth: number };
 
 export type DataStreamMetaData = ReturnType<
   typeof useChartConfiguration
@@ -114,6 +121,7 @@ export const useChartConfiguration = (
     axis,
     backgroundColor,
     significantDigits,
+    chartWidth,
     styleSettings,
     thresholds,
     defaultVisualizationType,
@@ -174,7 +182,11 @@ export const useChartConfiguration = (
     performanceMode,
   });
 
-  const title = useTitle({ hasSeries: series.length > 0, titleText });
+  const title = useTitle({
+    chartWidth,
+    hasSeries: series.length > 0,
+    titleText,
+  });
 
   /*
    * Setup all of the changeable chart configuration options


### PR DESCRIPTION
## Overview
This PR is for the ticket #2439 

- Removed widget header from widgetTile component.
- Added functionality to display remove and download buttons on hover and widget selected state.
- Moved widget title for line-scatter to echart component and for bar and timeline to inside widget tile and truncated the title when widget was resized.
- Displayed only the download button on hover in live mode for line-scatter(xy-plot), bar-chart, and status-timeline widgets and hidden widget actions toolbox for the rest of all widgets.

## Verifying Changes


https://github.com/awslabs/iot-app-kit/assets/139960352/b9a0b94f-b4cd-4584-84c4-1f9b3f5fe6cb



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
