### PR TITLE
feat: updated KPI style (gated)

### DIFF
--- a/packages/react-components/src/components/kpi/kpi.css
+++ b/packages/react-components/src/components/kpi/kpi.css
@@ -1,0 +1,41 @@
+.updated-kpi {
+  box-sizing: border-box;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+  overflow: hidden;
+}
+
+.updated-kpi .property-name {
+  font-weight: bold;
+  color: #000716;
+  padding: 2px 0;
+}
+
+.updated-kpi .asset-name {
+  color: #414d5c;
+  padding: 2px 0;
+}
+
+.updated-kpi .value {
+  font-weight: bold;
+  padding: 4px 0;
+}
+
+.updated-kpi .timestamp-container {
+  color: "#414D5C";
+}
+
+.updated-kpi .timestamp-border {
+  position: relative;
+  width: calc(100% + 16px);
+  height: 2px;
+  left: -8px;
+  background-color: #e9ebed;
+}
+
+.updated-kpi .timestamp {
+  margin-top: 6px;
+}

--- a/packages/react-components/src/components/kpi/kpi.tsx
+++ b/packages/react-components/src/components/kpi/kpi.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { KpiBase } from './kpiBase';
 import { useTimeSeriesData } from '../../hooks/useTimeSeriesData';
 import { useViewport } from '../../hooks/useViewport';
 import { widgetPropertiesFromInputs } from '../../common/widgetPropertiesFromInputs';
@@ -11,6 +10,8 @@ import type {
   TimeSeriesDataQuery,
 } from '@iot-app-kit/core';
 import type { KPISettings } from './types';
+import { UpdatedKpiBase } from './updatedKpiBase';
+import { KpiBase } from './kpiBase';
 
 export const KPI = ({
   query,
@@ -62,6 +63,25 @@ export const KPI = ({
   const isLoading =
     alarmStream?.isLoading || propertyStream?.isLoading || false;
   const error = alarmStream?.error || propertyStream?.error;
+
+  const hasNewKPI = !!localStorage?.getItem('USE_UPDATED_KPI');
+
+  if (hasNewKPI)
+    return (
+      <UpdatedKpiBase
+        propertyPoint={propertyPoint}
+        alarmPoint={alarmPoint}
+        settings={settings}
+        aggregationType={aggregationType}
+        resolution={propertyResolution}
+        name={name}
+        unit={unit}
+        color={color}
+        isLoading={isLoading}
+        error={error?.msg}
+        significantDigits={significantDigits}
+      />
+    );
 
   return (
     <KpiBase

--- a/packages/react-components/src/components/kpi/updatedKpiBase.tsx
+++ b/packages/react-components/src/components/kpi/updatedKpiBase.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import Alert from '@cloudscape-design/components/alert';
+import Spinner from '@cloudscape-design/components/spinner';
+import Box from '@cloudscape-design/components/box';
+import omitBy from 'lodash.omitby';
+
+import {
+  DEFAULT_KPI_SETTINGS,
+  DEFAULT_KPI_COLOR,
+  KPI_ICON_SHRINK_FACTOR,
+} from './constants';
+import { StatusIcon, Value } from '../shared-components';
+import type { KPIProperties, KPISettings } from './types';
+import './kpi.css';
+
+export const UpdatedKpiBase: React.FC<KPIProperties> = ({
+  icon,
+  propertyPoint,
+  error,
+  unit,
+  name,
+  isLoading,
+  color = DEFAULT_KPI_COLOR,
+  settings = {},
+  significantDigits,
+}) => {
+  const {
+    showUnit,
+    showIcon,
+    showName,
+    showTimestamp,
+    fontSize,
+    secondaryFontSize,
+  }: KPISettings = {
+    ...DEFAULT_KPI_SETTINGS,
+    ...omitBy(settings, (x) => x == null),
+  };
+
+  const point = propertyPoint;
+
+  if (error) {
+    return (
+      <div
+        className='kpi'
+        data-testid='kpi-base-component'
+        style={{ fontSize: `${secondaryFontSize}px` }}
+      >
+        {error && (
+          <Box margin={{ vertical: 's' }}>
+            <Alert statusIconAriaLabel='Error' type='error'>
+              {error}
+            </Alert>
+          </Box>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className='updated-kpi' data-testid='kpi-base-component'>
+      <div>
+        {showIcon && icon && (
+          <StatusIcon
+            name={icon}
+            size={fontSize * KPI_ICON_SHRINK_FACTOR}
+            color={color}
+          />
+        )}
+        <div
+          className='property-name'
+          style={{ fontSize: `${secondaryFontSize}px` }}
+        >
+          {isLoading ? '-' : showName && name}{' '}
+          {showUnit && !isLoading && `(${unit})`}
+        </div>
+        {/* <div
+          className='asset-name'
+          style={{ fontSize: `${secondaryFontSize}px` }}
+        >
+          {isLoading ? '-' : assetName && assetName}
+        </div> */}
+        <div
+          className='value'
+          data-testid='kpi-value'
+          style={{ fontSize: `${fontSize}px` }}
+        >
+          {isLoading ? (
+            <Spinner data-testid='loading' />
+          ) : (
+            <Value value={point?.y} precision={significantDigits} />
+          )}
+        </div>
+      </div>
+      {point && showTimestamp && (
+        <div
+          className='timestamp-container'
+          style={{ fontSize: `${secondaryFontSize}px` }}
+        >
+          <div className='timestamp-border' />
+          {isLoading ? (
+            '-'
+          ) : (
+            <div className='timestamp'>
+              {new Date(point.x).toLocaleString()}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/react-components/stories/kpi/kpiBaseUpdated.tsx
+++ b/packages/react-components/stories/kpi/kpiBaseUpdated.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { STATUS_ICON_TYPE } from '@iot-app-kit/core';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { KpiBase } from '../../src/components/kpi/kpiBase';
+import { KPISettings } from '../../src/components/kpi/types';
+import type { DataPoint } from '@iot-app-kit/core';
+import type { FC } from 'react';
+import { UpdatedKpiBase } from '../../src/components/kpi/updatedKpiBase';
+
+export default {
+  title: 'Widgets/KPI/Updated KPI Base',
+  component: UpdatedKpiBase,
+  argTypes: {
+    name: { control: { type: 'text' }, defaultValue: 'Windmill' },
+    error: { control: { type: 'text' } },
+    color: { control: { type: 'color' } },
+    unit: { control: { type: 'text' } },
+    icon: {
+      control: { type: 'radio' },
+      options: [...Object.values(STATUS_ICON_TYPE), undefined],
+      defaultValue: undefined,
+    },
+    showName: { control: { type: 'boolean' } },
+    showTimestamp: { control: { type: 'boolean' } },
+    showUnit: { control: { type: 'boolean' } },
+    isLoading: { control: { type: 'boolean' } },
+    propertyPoint: {
+      control: { type: 'object' },
+      defaultValue: { x: 123123213, y: 100 },
+    },
+    alarmPoint: { control: { type: 'object' } },
+    fontSize: { control: { type: 'number' } },
+    secondaryFontSize: { control: { type: 'number' } },
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof KpiBase>;
+
+type StoryInputs = KPISettings & {
+  alarmPoint?: DataPoint;
+  propertyPoint?: DataPoint;
+};
+
+export const Main: ComponentStory<FC<StoryInputs>> = ({
+  showName,
+  showUnit,
+  showTimestamp,
+  fontSize,
+  secondaryFontSize,
+  ...args
+}) => (
+  <div style={{ background: 'grey', padding: '25px' }}>
+    <div style={{ margin: '5px 0' }}>Current KPI:</div>
+    <div
+      style={{
+        background: 'white',
+        width: '250px',
+        height: '150px',
+        marginBottom: '24px',
+      }}
+    >
+      <KpiBase
+        {...args}
+        unit='MPH'
+        name='Wind speed'
+        settings={{
+          showName,
+          showUnit,
+          showTimestamp,
+          fontSize,
+          secondaryFontSize,
+        }}
+      />
+    </div>
+    <div style={{ margin: '5px 0' }}>
+      New (gated under localStorage 'USE_UPDATED_KPI'):
+    </div>
+    <div
+      style={{
+        background: 'white',
+        width: '250px',
+        height: '150px',
+        marginBottom: '24px',
+      }}
+    >
+      <UpdatedKpiBase
+        {...args}
+        unit='MPH'
+        name='Wind speed'
+        settings={{
+          showName,
+          showUnit,
+          showTimestamp,
+          fontSize,
+          secondaryFontSize,
+        }}
+      />
+    </div>
+  </div>
+);


### PR DESCRIPTION
## Overview
Updated KPI style gated behind localStorage `USE_UPDATED_KPI`

current:
![image](https://github.com/awslabs/iot-app-kit/assets/28601414/6a162369-a21a-441c-94e4-cb221c9b6bb2)


new:
![Screenshot 2024-02-15 at 13 07 04](https://github.com/awslabs/iot-app-kit/assets/28601414/b367b99c-4d82-47cf-aace-50ac301085c0)

feature gate working in dashboard:
https://github.com/awslabs/iot-app-kit/assets/28601414/d7b7bd96-b93b-4702-91c3-dbded0479d0a


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

