### PR TITLE
feat(dashboard): make component library keyboard accessible

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -185,10 +185,13 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
     cellSize,
   });
 
-  const onDrop = (e: DropEvent) => {
-    const { item, position } = e;
-    const componentTag = item.componentTag;
-
+  const onAddWidget = ({
+    componentTag,
+    position,
+  }: {
+    componentTag: string;
+    position: Position;
+  }) => {
     const widgetPresets = widgetCreator(grid)(componentTag);
 
     const { x, y } = toGridPosition(position, cellSize);
@@ -209,6 +212,19 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
       metricName: 'DashboardWidgetAdd',
       metricValue: 1,
     });
+  };
+
+  const onDrop = (e: DropEvent) => {
+    const { item, position } = e;
+    const componentTag = item.componentTag;
+
+    onAddWidget({ componentTag, position });
+  };
+
+  // Adds the widget to the start of the dashboard
+  // Provides an accessible way to add a widget
+  const onAddWidgetFromPalette = (componentTag: string) => {
+    onAddWidget({ componentTag, position: { x: 0, y: 0 } });
   };
 
   /**
@@ -314,7 +330,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
           tabIndex={0}
         >
           <Box float='left' padding='s'>
-            <ComponentPalette />
+            <ComponentPalette onAddWidget={onAddWidgetFromPalette} />
           </Box>
         </div>
         {showDashboardLayout ? (

--- a/packages/dashboard/src/components/palette/component.css
+++ b/packages/dashboard/src/components/palette/component.css
@@ -1,0 +1,8 @@
+/* reset button css */
+.palette-button {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+}

--- a/packages/dashboard/src/components/palette/index.tsx
+++ b/packages/dashboard/src/components/palette/index.tsx
@@ -25,7 +25,11 @@ const divider = {
 
 const Divider = () => <div style={divider} />;
 
-const Palette = () => {
+type PaletteOptions = {
+  onAddWidget: (componentTag: string) => void;
+};
+
+const Palette = ({ onAddWidget }: PaletteOptions) => {
   return (
     <div
       className='widget-panel'
@@ -44,6 +48,7 @@ const Palette = () => {
               componentTag={widgetType}
               name={name}
               IconComponent={iconComponent}
+              onAddWidget={onAddWidget}
             />
           );
         })}


### PR DESCRIPTION
## Overview
Updates to the component library for accessibility. 

1. Change markup to a button so that the element is focusable via the keyboard instead of directly setting the tabIndex.
2. Add click and keyboard handlers so that widgets can be added with a single action.
3. Add draggable attribute to indicate item functionality correctly

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
