### PR TITLE
feat: enable dynamic assets on edge mode

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelDataStreamExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelDataStreamExplorer.tsx
@@ -1,11 +1,16 @@
 import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 
-import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import {
+  type AssetModelPropertySummary,
+  type IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
 
 import Box from '@cloudscape-design/components/box';
 
 import { AssetModelExplorer } from './assetModelExplorer/assetModelExplorer';
 import { AssetModelPropertiesExplorer } from './assetModelPropertiesExplorer/assetModelPropertiesExplorer';
+import { AssetModelPropertiesExplorerEdge } from './assetModelPropertiesExplorer/assetModelPropertiesExplorerEdge';
 import {
   createInitialAssetModelSummary,
   useSelectedAssetModel,
@@ -22,6 +27,7 @@ import { getAssetModelQueryInformation } from './getAssetModelQueryInformation';
 import { useModelBasedQuery } from './modelBasedQuery/useModelBasedQuery';
 import { useModelBasedQuerySelection } from './modelBasedQuery/useModelBasedQuerySelection';
 import { getPlugin } from '@iot-app-kit/core';
+import type { DashboardState } from '~/store/state';
 
 export interface AssetModelDataStreamExplorerProps {
   client: IoTSiteWiseClient;
@@ -31,6 +37,9 @@ export const AssetModelDataStreamExplorer = ({
   client,
 }: AssetModelDataStreamExplorerProps) => {
   const metricsRecorder = getPlugin('metricsRecorder');
+  const isEdgeModeEnabled = useSelector(
+    (state: DashboardState) => state.isEdgeModeEnabled
+  );
   const {
     assetModelId,
     assetIds,
@@ -86,6 +95,16 @@ export const AssetModelDataStreamExplorer = ({
     }
   };
 
+  const assetModelPropertiesExplorerProps = {
+    selectedAssetModelProperties,
+    selectedAssetModel,
+    client,
+    onSave,
+    saveDisabled: !modelBasedWidgetsSelected,
+    onSelect: (assetModelProperties: AssetModelPropertySummary[]) =>
+      selectAssetModelProperties(assetModelProperties),
+  };
+
   return (
     <Box padding={{ horizontal: 's' }}>
       <AssetModelExplorer
@@ -101,16 +120,15 @@ export const AssetModelDataStreamExplorer = ({
           <Box padding={{ bottom: 's', top: 'm' }}>
             <HorizontalDivider />
           </Box>
-          <AssetModelPropertiesExplorer
-            selectedAssetModelProperties={selectedAssetModelProperties}
-            selectedAssetModel={selectedAssetModel}
-            client={client}
-            onSave={onSave}
-            saveDisabled={!modelBasedWidgetsSelected}
-            onSelect={(assetModelProperties) =>
-              selectAssetModelProperties(assetModelProperties)
-            }
-          />
+          {isEdgeModeEnabled ? (
+            <AssetModelPropertiesExplorerEdge
+              {...assetModelPropertiesExplorerProps}
+            />
+          ) : (
+            <AssetModelPropertiesExplorer
+              {...assetModelPropertiesExplorerProps}
+            />
+          )}
         </>
       )}
     </Box>

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelSelection/types.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelSelection/types.ts
@@ -1,1 +1,0 @@
-export type AssetModel = { id: string; name: string };

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesExplorerEdge.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesExplorerEdge.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import {
+  type AssetModelPropertySummary,
+  IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
+
+import { AssetModelPropertiesTable } from './assetModelPropertiesTable/assetModelPropertiesTable';
+import { type SelectedAssetModel } from '../useSelectedAssetModel';
+import { type SelectedAssetModelProperties } from '../useSelectedAssetModelProperties';
+import { useAssetModel } from '~/hooks/useAssetModel/useAssetModel';
+
+export interface AssetExplorerProps {
+  selectedAssetModel: SelectedAssetModel;
+  selectedAssetModelProperties: SelectedAssetModelProperties;
+  onSelect: (assetModelProperties: AssetModelPropertySummary[]) => void;
+  isWithoutHeader?: boolean;
+  onSave?: () => void;
+  saveDisabled?: boolean;
+  client: IoTSiteWiseClient;
+}
+
+/**
+ * This is the Edge version of the AssetModelPropertiesExplorer;
+ * The difference in the Edge version is that it is using the `useAssetModel` hook instead of `useAssetModelProperties` to mitigate the missing API ListAssetModelProperties.
+ * Can remove this component once ListAssetModelProperties is available on edge.
+ */
+export const AssetModelPropertiesExplorerEdge = ({
+  client,
+  selectedAssetModel,
+  selectedAssetModelProperties,
+  onSelect,
+  onSave,
+  saveDisabled,
+}: AssetExplorerProps) => {
+  const assetModelId = selectedAssetModel?.id ?? '';
+
+  const {
+    assetModel: assetModelPropertySummaries,
+    isFetching,
+    isLoading,
+    isError,
+    refetch,
+  } = useAssetModel({
+    assetModelId,
+    client,
+  });
+
+  const fetchNextPage = () => {}; // NOOP; all properties fetched;
+  const hasNextPage = false;
+
+  return (
+    <AssetModelPropertiesTable
+      onClickNextPage={fetchNextPage}
+      onSelectAssetModelProperties={onSelect}
+      assetModelProperties={assetModelPropertySummaries || []}
+      selectedAssetModelProperties={selectedAssetModelProperties}
+      isLoading={isLoading || isFetching}
+      isError={isError}
+      retry={refetch}
+      hasNextPage={hasNextPage}
+      onSave={onSave}
+      saveDisabled={saveDisabled}
+    />
+  );
+};

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
@@ -81,7 +81,6 @@ export function IoTSiteWiseQueryEditor({
     label: 'Dynamic assets',
     id: 'explore-asset-model-tab',
     content: <AssetModelDataStreamExplorer client={iotSiteWiseClient} />,
-    disabled: isEdgeModeEnabled,
   };
 
   const defaultTabs = [modeledTab, unmodeledTab, assetModeledTab];


### PR DESCRIPTION
## Overview

This PR enables dynamic assets on edge mode

Summary of the changes:

- Added an edge version of the AssetModelPropertiesExplorer to use the `useAssetModel` hook instead of `useAssetModelProperties` to mitigate the missing API ListAssetModelProperties.
- `useAssetModel` hook to call `DescribeAssetModel` for model properties on edge mode


## Verifying Changes

Happy flow:

https://github.com/awslabs/iot-app-kit/assets/50635800/eae81f08-964c-4161-94d1-c0144ed31694

Error retry on model props explorer:

https://github.com/awslabs/iot-app-kit/assets/50635800/5cf1b79c-ad47-44ec-b0a9-fb7c8aedea8f

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
