### PR TITLE
feat: added keyboard accessibility for create link toggle button

### DIFF
--- a/packages/dashboard/e2e/tests/widgets/text.spec.ts
+++ b/packages/dashboard/e2e/tests/widgets/text.spec.ts
@@ -263,7 +263,7 @@ test.describe('Test Text Widget', () => {
       await widget.dblclick();
       await widget.getByRole('textbox').fill(TEXT_WIDGET_CONTENT);
       await configPanel.container
-        .getByRole('button', { name: 'Link Create link' })
+        .getByTestId('text-widget-link-header')
         .click();
       await configPanel.container
         .getByText('Create link', { exact: true })

--- a/packages/dashboard/src/customization/propertiesSections/textSettings/link.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/textSettings/link.tsx
@@ -33,11 +33,22 @@ const LinkSettings: FC<LinkSettingsProps> = ({
   toggleIsUrl,
 }) => {
   const header = (
-    <div className='expandable-section-header'>
+    <div
+      className='expandable-section-header'
+      data-testid='text-widget-link-header'
+    >
       <SpaceBetween size='m' direction='horizontal'>
         <span>{defaultMessages.title}</span>
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-        <div onClick={(e) => e.stopPropagation()}>
+        <div
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === 'Enter') {
+              toggleIsUrl(!isUrl);
+            }
+          }}
+        >
           <Toggle
             checked={isUrl}
             onChange={({ detail }) => {
@@ -62,6 +73,7 @@ const LinkSettings: FC<LinkSettingsProps> = ({
     <ExpandableSection
       className='accordian-header'
       headerText={header}
+      headerAriaLabel='Text widget link settings'
       data-test-id='text-widget-link-section'
       defaultExpanded={isUrl}
       variant='footer'


### PR DESCRIPTION
We have made create link toggle button keyboard accessible as per @jmbuss comment on ticket #2363
"focusing the "Create link" toggle and pressing enter does not actually toggle the text as a link. This will need to be fixed for the entire section to be considered accessible."

Also, screen reader now announces the expandable section as 'Text widget link settings' and the toggle as "Create link".

### Verifying changes:
**Using mouse control:**
[create link toggle using mouse.webm](https://github.com/awslabs/iot-app-kit/assets/154328164/685592db-c660-4f31-8e76-67b8727ed77e)

**Using keyboard (tab focus and enter key):**
[create link toggle using keyboard.webm](https://github.com/awslabs/iot-app-kit/assets/154328164/c224d67f-a934-42e1-8fa0-f522e675af31)

**Screen reader:**
Unable to upload a video with audio on GitHub, but you will be able to see it after download on your machine.
Please download the video from this [comment](https://github.com/awslabs/iot-app-kit/pull/2607#issuecomment-1956057611) on your machine to watch it with audio

**NOTE**: After checking the "Create link" toggle, the focus shifts to text widget, this is existing behaviour for mouse control, same is replicating for keyboard control.

Question for @jmbuss 
The section seems to be screen reader accessible with just `headerAriaLabel='Text widget link settings'` so we have not added `headerDescription='Configure the text widget to be a url link. Toggle the text as a link with the button.'`
It looks like this if we add `headerDescription'
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/a658a57d-3186-4430-b878-af64285d2476)

