### PR TITLE
fix: update public API for status and KPI

### DIFF
--- a/packages/react-components/src/common/dataTypes.ts
+++ b/packages/react-components/src/common/dataTypes.ts
@@ -63,6 +63,9 @@ export type WidgetSettings = {
   name?: string;
   detailedName?: string;
   aggregationType?: string;
+  resolution?: number;
   isLoading?: boolean;
   significantDigits?: number;
+  assetName?: string;
+  propertyName?: string;
 };

--- a/packages/react-components/src/components/kpi/constants.ts
+++ b/packages/react-components/src/components/kpi/constants.ts
@@ -7,10 +7,12 @@ export const KPI_ICON_SHRINK_FACTOR = 0.7;
 export const DEFAULT_KPI_SETTINGS: Required<KPISettings> = {
   showTimestamp: true,
   showUnit: true,
-  color: 'black',
+  color: '#000000',
   showIcon: true,
   showName: true,
   fontSize: 30,
   secondaryFontSize: 15,
   aggregationFontSize: 12,
+  backgroundColor: '#ffffff',
+  showAssetName: true,
 };

--- a/packages/react-components/src/components/kpi/kpi.css
+++ b/packages/react-components/src/components/kpi/kpi.css
@@ -1,10 +1,9 @@
 .updated-kpi {
-  box-sizing: border-box;
   padding: 8px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100%;
+  height: calc(100% - 16px);
   overflow: hidden;
 }
 

--- a/packages/react-components/src/components/kpi/kpi.tsx
+++ b/packages/react-components/src/components/kpi/kpi.tsx
@@ -33,9 +33,10 @@ export const KPI = ({
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
     queries: [query],
-    // Currently set to only fetch raw data.
-    // TODO: Support all resolutions and aggregation types
-    settings: { fetchMostRecentBeforeEnd: true, resolution: '0' },
+    settings: {
+      fetchMostRecentBeforeEnd: true,
+      fetchMostRecentBeforeStart: true,
+    },
     styles,
   });
   const { viewport } = useViewport();

--- a/packages/react-components/src/components/kpi/types.ts
+++ b/packages/react-components/src/components/kpi/types.ts
@@ -2,8 +2,6 @@ import type { WidgetSettings } from '../../common/dataTypes';
 
 export type KPIProperties = WidgetSettings & {
   settings?: Partial<KPISettings>;
-  resolution?: number;
-  aggregationType?: string;
 };
 
 export type KPISettings = {
@@ -15,4 +13,6 @@ export type KPISettings = {
   secondaryFontSize: number; // pixels
   aggregationFontSize: number; // pixels
   color: string; // hex string
+  backgroundColor: string; // hex string
+  showAssetName: boolean;
 };

--- a/packages/react-components/src/components/kpi/updatedKpiBase.tsx
+++ b/packages/react-components/src/components/kpi/updatedKpiBase.tsx
@@ -4,31 +4,25 @@ import Spinner from '@cloudscape-design/components/spinner';
 import Box from '@cloudscape-design/components/box';
 import omitBy from 'lodash.omitby';
 
-import {
-  DEFAULT_KPI_SETTINGS,
-  DEFAULT_KPI_COLOR,
-  KPI_ICON_SHRINK_FACTOR,
-} from './constants';
-import { StatusIcon, Value } from '../shared-components';
+import { DEFAULT_KPI_SETTINGS } from './constants';
+import { Value } from '../shared-components';
 import type { KPIProperties, KPISettings } from './types';
 import './kpi.css';
 
 export const UpdatedKpiBase: React.FC<KPIProperties> = ({
-  icon,
   propertyPoint,
   error,
   unit,
   name,
   isLoading,
-  color = DEFAULT_KPI_COLOR,
   settings = {},
   significantDigits,
 }) => {
   const {
     showUnit,
-    showIcon,
     showName,
     showTimestamp,
+    backgroundColor,
     fontSize,
     secondaryFontSize,
   }: KPISettings = {
@@ -57,28 +51,19 @@ export const UpdatedKpiBase: React.FC<KPIProperties> = ({
   }
 
   return (
-    <div className='updated-kpi' data-testid='kpi-base-component'>
+    <div
+      className='updated-kpi'
+      data-testid='kpi-base-component'
+      style={{ backgroundColor }}
+    >
       <div>
-        {showIcon && icon && (
-          <StatusIcon
-            name={icon}
-            size={fontSize * KPI_ICON_SHRINK_FACTOR}
-            color={color}
-          />
-        )}
         <div
           className='property-name'
           style={{ fontSize: `${secondaryFontSize}px` }}
         >
           {isLoading ? '-' : showName && name}{' '}
-          {showUnit && !isLoading && `(${unit})`}
+          {showUnit && !isLoading && unit && `(${unit})`}
         </div>
-        {/* <div
-          className='asset-name'
-          style={{ fontSize: `${secondaryFontSize}px` }}
-        >
-          {isLoading ? '-' : assetName && assetName}
-        </div> */}
         <div
           className='value'
           data-testid='kpi-value'

--- a/packages/react-components/src/components/status/constants.ts
+++ b/packages/react-components/src/components/status/constants.ts
@@ -13,4 +13,7 @@ export const DEFAULT_STATUS_SETTINGS: Required<StatusSettings> = {
   fontSize: 20,
   secondaryFontSize: 20,
   aggregationFontSize: 12,
+  showTimestamp: true,
+  backgroundColor: 'white',
+  showAssetName: true,
 };

--- a/packages/react-components/src/components/status/status.tsx
+++ b/packages/react-components/src/components/status/status.tsx
@@ -13,7 +13,7 @@ import type {
 } from '@iot-app-kit/core';
 import type { StatusSettings } from './types';
 import { DEFAULT_VIEWPORT } from '../../common/constants';
-import { UpdatedKpiBase } from '../kpi/updatedKpiBase';
+import { KPI } from '../kpi/kpi';
 
 export const Status = ({
   query,
@@ -73,17 +73,13 @@ export const Status = ({
 
   if (hasNewKPI)
     return (
-      <UpdatedKpiBase
+      <KPI
+        query={query}
+        viewport={passedInViewport}
+        styles={styles}
+        thresholds={thresholds}
         aggregationType={aggregationType}
-        propertyPoint={propertyPoint}
-        resolution={propertyResolution}
-        alarmPoint={alarmPoint}
         settings={settings}
-        name={name}
-        unit={unit}
-        color={color}
-        isLoading={isLoading}
-        error={error?.msg}
         significantDigits={significantDigits}
       />
     );

--- a/packages/react-components/src/components/status/types.ts
+++ b/packages/react-components/src/components/status/types.ts
@@ -3,7 +3,6 @@ import type { WidgetSettings } from '../../common/dataTypes';
 export type StatusProperties = WidgetSettings & {
   settings?: Partial<StatusSettings>;
   aggregationType?: string;
-  resolution?: number;
 };
 
 export type StatusSettings = {
@@ -15,4 +14,7 @@ export type StatusSettings = {
   fontSize: number; // pixels
   secondaryFontSize: number; // pixels
   aggregationFontSize: number; // pixels
+  backgroundColor: string; // hex string
+  showTimestamp: boolean;
+  showAssetName: boolean;
 };

--- a/packages/react-components/stories/kpi/kpi.stories.tsx
+++ b/packages/react-components/stories/kpi/kpi.stories.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { KPI } from '../../src/components/kpi/kpi';
-import { initialize } from '@iot-app-kit/source-iotsitewise';
+import {
+  getSingleValueTimeSeriesDataQuery,
+  queryConfigured,
+} from '../utils/query';
+import {
+  MOCK_TIME_SERIES_DATA_AGGREGATED_QUERY,
+  MOCK_TIME_SERIES_DATA_QUERY,
+} from './mock-data';
 
 const ASSET_ID = '587295b6-e0d0-4862-b7db-b905afd7c514';
 const PROPERTY_ID = '16d45cb7-bb8b-4a1e-8256-55276f261d93';
@@ -21,28 +28,53 @@ export default {
   },
 } as ComponentMeta<typeof KPI>;
 
-const { query } = initialize({
-  awsCredentials: {
-    accessKeyId: 'xxxx',
-    secretAccessKey: 'xxxx',
-    sessionToken: 'xxxx',
-  },
-});
+export const MockDataKPI: ComponentStory<typeof KPI> = () => {
+  return (
+    <div style={{ background: 'grey' }}>
+      <div style={{ height: '200px', width: '250px', padding: '20px' }}>
+        <KPI
+          viewport={{ duration: '5m' }}
+          query={MOCK_TIME_SERIES_DATA_QUERY}
+        />
+      </div>
+      <div style={{ height: '200px', width: '250px', padding: '20px' }}>
+        <KPI
+          viewport={{ duration: '5m' }}
+          query={MOCK_TIME_SERIES_DATA_AGGREGATED_QUERY}
+        />
+      </div>
+    </div>
+  );
+};
 
-export const Main: ComponentStory<typeof KPI> = () => (
-  <KPI
-    viewport={{ duration: '5m' }}
-    query={query.timeSeriesData({
-      assets: [
-        {
-          assetId: ASSET_ID,
-          properties: [
-            {
-              propertyId: PROPERTY_ID,
-            },
-          ],
-        },
-      ],
-    })}
-  />
-);
+export const ConnectedKPIWidget: ComponentStory<typeof KPI> = () => {
+  if (!queryConfigured()) {
+    return (
+      <div>
+        <h1>All required Env variables not set</h1>
+        <p>Required:</p>
+        <ul>
+          <li>AWS_ACCESS_KEY_ID</li>
+          <li>AWS_SECRET_ACCESS_KEY</li>
+          <li>AWS_SESSION_TOKEN</li>
+          <li>AWS_REGION</li>
+          <li>ASSET_ID_1</li>
+          <li>PROPERTY_ID_1</li>
+          <li>PROPERTY_ID_2</li>
+          <li>PROPERTY_ID_3</li>
+        </ul>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ background: 'grey' }}>
+      <div style={{ height: '200px', width: '250px', padding: '20px' }}>
+        <KPI
+          viewport={{ duration: '5m' }}
+          query={getSingleValueTimeSeriesDataQuery()}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/react-components/stories/kpi/mock-data.ts
+++ b/packages/react-components/stories/kpi/mock-data.ts
@@ -1,0 +1,53 @@
+import { mockTimeSeriesDataQuery } from '@iot-app-kit/testing-util';
+import { DATA_TYPE, DAY_IN_MS } from '@iot-app-kit/core';
+import type { DataStream } from '@iot-app-kit/core';
+
+export const VIEWPORT = {
+  start: new Date(2000, 0, 0),
+  end: new Date(2010, 0, 0),
+};
+
+const DATA_STREAM: DataStream = {
+  id: 'some-asset-id---some-property-id',
+  resolution: 0,
+  detailedName: 'data-stream-name/detailed-name',
+  name: 'data-stream-name',
+  color: 'black',
+  dataType: DATA_TYPE.NUMBER,
+  data: [],
+};
+
+export const MOCK_TIME_SERIES_DATA_QUERY = mockTimeSeriesDataQuery([
+  {
+    dataStreams: [
+      {
+        ...DATA_STREAM,
+        data: [{ x: new Date(2005, 6, 13).getTime(), y: (2 * (10 * 13)) ^ 2 }],
+        unit: 'Minutes',
+        name: `stream-1`,
+        refId: `stream-1`,
+        id: '1',
+      },
+    ],
+    thresholds: [],
+    viewport: VIEWPORT,
+  },
+]);
+
+export const MOCK_TIME_SERIES_DATA_AGGREGATED_QUERY = mockTimeSeriesDataQuery([
+  {
+    dataStreams: [
+      {
+        ...DATA_STREAM,
+        name: `stream-2`,
+        id: '2',
+        resolution: DAY_IN_MS * 300,
+        aggregationType: 'AVERAGE',
+        unit: 'MPH',
+        data: [{ x: new Date(2000, 5, 13).getTime(), y: (10 * 14) ^ 2 }],
+      },
+    ],
+    thresholds: [],
+    viewport: VIEWPORT,
+  },
+]);

--- a/packages/react-components/stories/utils/query.ts
+++ b/packages/react-components/stories/utils/query.ts
@@ -98,6 +98,32 @@ export const getTimeSeriesDataQuery = (
   });
 };
 
+export const getSingleValueTimeSeriesDataQuery = (
+  dataStreamQuery?: SiteWiseDataStreamQuery
+) => {
+  if (dataStreamQuery) {
+    return getIotSiteWiseQuery().timeSeriesData(dataStreamQuery);
+  }
+
+  const { assetId, propertyId1 } = getAssetQuery();
+
+  return getIotSiteWiseQuery().timeSeriesData({
+    assets: [
+      {
+        assetId,
+        properties: [
+          {
+            refId: '1',
+            propertyId: propertyId1,
+            aggregationType: 'AVERAGE',
+            resolution: '1m',
+          },
+        ],
+      },
+    ],
+  });
+};
+
 export const queryConfigured = () => {
   try {
     getEnvCredentials();


### PR DESCRIPTION
## Overview
- some minor style fixes and 
- add new API values to KPI and Status settings includes: 
   - showTimestamp
   - showAssetName
   - backgroundColor
values not yet configurable in dashboard


<img width="1035" alt="image" src="https://github.com/awslabs/iot-app-kit/assets/28601414/caf114b9-d01f-4e56-9c1d-b27ed69eda96">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
