### PR TITLE
feat: kpi and status gated config panel (gated) 

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/aggregationSettings/helpers.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/aggregationSettings/helpers.tsx
@@ -1,38 +1,5 @@
-import type { SelectProps } from '@cloudscape-design/components';
-import { AggregateType } from '@aws-sdk/client-iotsitewise';
-import {
-  LINE_AGGREGATION_OPTIONS,
-  LINE_RESOLUTION_OPTIONS,
-} from '../constants';
-
-export const NONE_AGGREGATION = { label: 'No aggregation', value: undefined };
-
 // replacing the underscore in aggregate names with a space
 // ex: "STANDARD_DEVIATION" => "standard deviation"
 export const aggregateToString = (aggregate?: string): string => {
   return aggregate ? aggregate.replace(/_/g, ' ').toLowerCase() : 'auto';
-};
-
-export const getAggregationOptions = (
-  supportsRawData: boolean,
-  dataTypes: Set<string>,
-  resolution?: string
-) => {
-  const dataTypeAggregations =
-    dataTypes.has('STRING') || dataTypes.has('BOOLEAN')
-      ? [{ label: 'Count', value: AggregateType.COUNT }]
-      : LINE_AGGREGATION_OPTIONS;
-
-  if (!supportsRawData) return dataTypeAggregations;
-  return !resolution || resolution === '0'
-    ? [...dataTypeAggregations, NONE_AGGREGATION]
-    : dataTypeAggregations;
-};
-
-export const getResolutionOptions = (supportsRawData: boolean) => {
-  if (!supportsRawData)
-    return LINE_RESOLUTION_OPTIONS.filter(
-      (option: SelectProps.Option) => option.value !== '0'
-    );
-  return LINE_RESOLUTION_OPTIONS;
 };

--- a/packages/dashboard/src/customization/propertiesSections/constants.ts
+++ b/packages/dashboard/src/customization/propertiesSections/constants.ts
@@ -82,7 +82,7 @@ export const dropdownConsts = {
   },
 };
 
-export const LINE_RESOLUTION_OPTIONS: SelectProps.Option[] = [
+export const ALL_RESOLUTION_OPTIONS: SelectProps.Option[] = [
   { label: '1 min', value: '1m' },
   { label: '15 min', value: '15m' },
   { label: '1 hour', value: '1h' },
@@ -91,7 +91,7 @@ export const LINE_RESOLUTION_OPTIONS: SelectProps.Option[] = [
   { label: 'Autoselect', value: undefined },
 ];
 
-export const LINE_AGGREGATION_OPTIONS: SelectProps.Option[] = [
+export const ALL_AGGREGATION_OPTIONS: SelectProps.Option[] = [
   { label: 'Average', value: AggregateType.AVERAGE },
   { label: 'Count', value: AggregateType.COUNT },
   { label: 'Maximum', value: AggregateType.MAXIMUM },
@@ -100,7 +100,7 @@ export const LINE_AGGREGATION_OPTIONS: SelectProps.Option[] = [
   { label: 'Sum', value: AggregateType.SUM },
 ];
 
-export const BAR_RESOLUTION_OPTIONS: SelectProps.Option[] = [
+export const AGGREGATE_ONLY_RESOLUTION_OPTIONS: SelectProps.Option[] = [
   { label: '1 min', value: '1m' },
   { label: '15 min', value: '15m' },
   { label: '1 hour', value: '1h' },
@@ -108,7 +108,7 @@ export const BAR_RESOLUTION_OPTIONS: SelectProps.Option[] = [
   { label: 'Autoselect', value: undefined },
 ];
 
-export const BAR_AGGREGATION_OPTIONS: SelectProps.Option[] = [
+export const AGGREGATE_ONLY_AGGREGATION_OPTIONS: SelectProps.Option[] = [
   { label: 'Average', value: AggregateType.AVERAGE },
   { label: 'Count', value: AggregateType.COUNT },
   { label: 'Maximum', value: AggregateType.MAXIMUM },

--- a/packages/dashboard/src/customization/propertiesSections/displaySettingsSection/index.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/displaySettingsSection/index.tsx
@@ -1,0 +1,99 @@
+import {
+  Box,
+  Checkbox,
+  ExpandableSection,
+  FormField,
+} from '@cloudscape-design/components';
+import React from 'react';
+import { PropertyLens } from '~/customization/propertiesSection';
+import { PropertiesSection } from '~/customization/propertiesSectionComponent';
+import {
+  KPIProperties,
+  KPIWidget,
+  StatusProperties,
+} from '~/customization/widgets/types';
+import { DashboardWidget } from '~/types';
+import { maybeWithDefault } from '~/util/maybe';
+
+const widgetWithCustomDisplaySettings: readonly string[] = ['kpi', 'status'];
+
+export const isDisplaySettingsWidget = (
+  widget: DashboardWidget
+): widget is KPIWidget =>
+  !!localStorage?.getItem('USE_UPDATED_KPI') &&
+  widgetWithCustomDisplaySettings.some((t) => t === widget.type);
+
+const RenderDisplaySettingsSection = ({
+  useProperty,
+}: {
+  useProperty: PropertyLens<DashboardWidget<KPIProperties | StatusProperties>>;
+}) => {
+  const [maybeShowName, updateShowName] = useProperty(
+    (properties) => properties.showName,
+    (properties, updatedShowName) => ({
+      ...properties,
+      showName: updatedShowName,
+    })
+  );
+
+  const [maybeShowTimestamp, updateShowTimestamp] = useProperty(
+    (properties) => properties.showTimestamp,
+    (properties, updatedShowTimestamp) => ({
+      ...properties,
+      showTimestamp: updatedShowTimestamp,
+    })
+  );
+
+  const [maybeShowUnit, updateShowUnit] = useProperty(
+    (properties) => properties.showUnit,
+    (properties, updatedShowUnit) => ({
+      ...properties,
+      showUnit: updatedShowUnit,
+    })
+  );
+
+  const showName = maybeWithDefault(undefined, maybeShowName);
+  const showTimestamp = maybeWithDefault(undefined, maybeShowTimestamp);
+  const showUnit = maybeWithDefault(undefined, maybeShowUnit);
+
+  return (
+    <ExpandableSection
+      className='accordian-header'
+      headerText='Display'
+      defaultExpanded
+      variant='footer'
+    >
+      <Box padding='s'>
+        <FormField label='Display primary values'>
+          <Checkbox
+            onChange={(event) => updateShowName(event.detail.checked)}
+            checked={!!showName}
+          >
+            Show name
+          </Checkbox>
+          <Checkbox
+            onChange={(event) => updateShowTimestamp(event.detail.checked)}
+            checked={!!showTimestamp}
+          >
+            Show timestamp
+          </Checkbox>
+          <Checkbox
+            onChange={(event) => updateShowUnit(event.detail.checked)}
+            checked={!!showUnit}
+          >
+            Show unit
+          </Checkbox>
+        </FormField>
+      </Box>
+    </ExpandableSection>
+  );
+};
+
+export const DisplaySettingsSection: React.FC = () => (
+  <PropertiesSection
+    isVisible={isDisplaySettingsWidget}
+    render={({ useProperty }) => (
+      <RenderDisplaySettingsSection useProperty={useProperty} />
+    )}
+  />
+);

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/index.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/index.tsx
@@ -12,6 +12,7 @@ import { StyledPropertiesAlarmsSection } from './styledSection';
 import { PropertyLens } from '~/customization/propertiesSection';
 import { useClients } from '~/components/dashboard/clientContext';
 import { spaceScaledXs } from '@cloudscape-design/design-tokens';
+import { Maybe, maybeWithDefault } from '~/util/maybe';
 
 // exclude table because it is handled specially
 const isQueryWidgetExcludesTable = (w: DashboardWidget): w is QueryWidget =>
@@ -49,8 +50,10 @@ const RenderPropertiesSectionWithStyledQuery = ({
 
 const RenderPropertiesSectionWithoutTable = ({
   useProperty,
+  maybeType,
 }: {
   useProperty: PropertyLens<QueryWidget>;
+  maybeType: Maybe<string>;
 }) => {
   const { iotSiteWiseClient } = useClients();
 
@@ -69,6 +72,13 @@ const RenderPropertiesSectionWithoutTable = ({
     })
   );
 
+  const hasNewKPI = !!localStorage?.getItem('USE_UPDATED_KPI');
+  const type = maybeWithDefault(undefined, maybeType);
+  const canColorProperty = !(
+    hasNewKPI &&
+    (type === 'kpi' || type === 'status')
+  );
+
   if (!iotSiteWiseClient) return null;
 
   return (
@@ -78,6 +88,7 @@ const RenderPropertiesSectionWithoutTable = ({
       styleSettings={styleSettings}
       updateStyleSettings={updateStyleSettings}
       client={iotSiteWiseClient}
+      colorable={canColorProperty}
     />
   );
 };
@@ -132,8 +143,11 @@ export const PropertiesAndAlarmsSettingsConfiguration: React.FC = () => (
     />
     <PropertiesSection
       isVisible={isQueryWidgetExcludesTable}
-      render={({ useProperty }) => (
-        <RenderPropertiesSectionWithoutTable useProperty={useProperty} />
+      render={({ useProperty, type }) => (
+        <RenderPropertiesSectionWithoutTable
+          maybeType={type}
+          useProperty={useProperty}
+        />
       )}
     />
     <PropertiesSection

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/styleTab.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/styleTab.tsx
@@ -1,23 +1,21 @@
 import React from 'react';
 
-import SpaceBetween from '@cloudscape-design/components/space-between';
-
 import { AggregationsSettingsConfiguration } from '../aggregationSettings';
 import { AxisSettingsConfiguration } from '../axisSettings';
 import { SettingsConfiguration } from '../settings';
 import { TextSettingsConfiguration } from '../textSettings';
 import { LineAndScatterStyleSettingsSection } from '../lineAndScatterStyleSettings/section';
 import { WidgetTitle } from '../widgetTitle';
+import { DisplaySettingsSection } from '../displaySettingsSection';
 
 export const StylesSection = () => (
   <div>
-    <SpaceBetween size='s' direction='vertical'>
-      <WidgetTitle />
-      <LineAndScatterStyleSettingsSection />
-      <AggregationsSettingsConfiguration />
-      <AxisSettingsConfiguration />
-      <SettingsConfiguration />
-      <TextSettingsConfiguration />
-    </SpaceBetween>
+    <WidgetTitle />
+    <LineAndScatterStyleSettingsSection />
+    <DisplaySettingsSection />
+    <AggregationsSettingsConfiguration />
+    <AxisSettingsConfiguration />
+    <SettingsConfiguration />
+    <TextSettingsConfiguration />
   </div>
 );

--- a/packages/dashboard/src/customization/widgets/kpi/component.tsx
+++ b/packages/dashboard/src/customization/widgets/kpi/component.tsx
@@ -30,6 +30,7 @@ const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
     showIcon,
     showName,
     showTimestamp,
+    backgroundColor,
     thresholds,
     significantDigits: widgetSignificantDigits,
   } = widget.properties;
@@ -55,6 +56,7 @@ const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
       showValue,
       showUnit,
       showTimestamp,
+      backgroundColor,
       fontSize: primaryFont.fontSize,
       color: primaryFont.fontColor,
       secondaryFontSize: secondaryFont.fontSize,

--- a/packages/dashboard/src/customization/widgets/kpi/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/kpi/plugin.tsx
@@ -17,12 +17,16 @@ export const kpiPlugin: DashboardPlugin = {
         icon: KPIIcon,
       },
       properties: () => ({
+        resolution: '0',
         queryConfig: {
           source: 'iotsitewise',
           query: undefined,
         },
         primaryFont: {},
         secondaryFont: {},
+        showName: true,
+        showTimestamp: true,
+        showUnit: true,
       }),
       initialSize: {
         height: KPI_WIDGET_INITIAL_HEIGHT,

--- a/packages/dashboard/src/customization/widgets/status/component.tsx
+++ b/packages/dashboard/src/customization/widgets/status/component.tsx
@@ -28,7 +28,9 @@ const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
     showUnit,
     showIcon,
     showName,
+    showTimestamp,
     thresholds,
+    backgroundColor,
     significantDigits: widgetSignificantDigits,
   } = widget.properties;
 
@@ -51,8 +53,10 @@ const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
       showIcon,
       showValue,
       showUnit,
+      showTimestamp,
       fontSize: primaryFont.fontSize,
       color: primaryFont.fontColor,
+      backgroundColor,
       secondaryFontSize: secondaryFont.fontSize,
     },
     isDefined

--- a/packages/dashboard/src/customization/widgets/status/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/status/plugin.tsx
@@ -17,12 +17,16 @@ export const statusPlugin: DashboardPlugin = {
         icon: StatusIcon,
       },
       properties: () => ({
+        resolution: '0',
         queryConfig: {
           source: 'iotsitewise',
           query: undefined,
         },
         primaryFont: {},
         secondaryFont: {},
+        showName: true,
+        showTimestamp: true,
+        showUnit: true,
       }),
       initialSize: {
         height: STATUS_WIDGET_INITIAL_HEIGHT,

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -50,6 +50,7 @@ export type KPIProperties = QueryProperties & {
   showName?: boolean;
   showTimestamp?: boolean;
   thresholds?: ThresholdWithId[];
+  backgroundColor?: string;
   significantDigits?: number;
 };
 
@@ -64,6 +65,7 @@ export type StatusProperties = QueryProperties & {
   showIcon?: boolean;
   showName?: boolean;
   thresholds?: ThresholdWithId[];
+  showTimestamp?: boolean;
   backgroundColor?: string;
   significantDigits?: number;
 };

--- a/packages/react-components/src/components/kpi/kpi.tsx
+++ b/packages/react-components/src/components/kpi/kpi.tsx
@@ -4,7 +4,6 @@ import { useViewport } from '../../hooks/useViewport';
 import { widgetPropertiesFromInputs } from '../../common/widgetPropertiesFromInputs';
 import { DEFAULT_VIEWPORT } from '../../common/constants';
 import type {
-  Threshold,
   StyleSettingsMap,
   Viewport,
   TimeSeriesDataQuery,
@@ -12,6 +11,7 @@ import type {
 import type { KPISettings } from './types';
 import { UpdatedKpiBase } from './updatedKpiBase';
 import { KpiBase } from './kpiBase';
+import { StyledThreshold } from '../chart/types';
 
 export const KPI = ({
   query,
@@ -24,7 +24,7 @@ export const KPI = ({
 }: {
   query: TimeSeriesDataQuery;
   viewport?: Viewport;
-  thresholds?: Threshold[];
+  thresholds?: StyledThreshold[];
   styles?: StyleSettingsMap;
   aggregationType?: string;
   settings?: Partial<KPISettings>;
@@ -60,7 +60,10 @@ export const KPI = ({
   const name = propertyStream?.name || alarmStream?.name;
   const unit = propertyStream?.unit || alarmStream?.unit;
   const color =
-    alarmThreshold?.color || propertyThreshold?.color || settings?.color;
+    alarmThreshold?.color ||
+    propertyThreshold?.color ||
+    settings?.color ||
+    settings?.backgroundColor;
   const isLoading =
     alarmStream?.isLoading || propertyStream?.isLoading || false;
   const error = alarmStream?.error || propertyStream?.error;
@@ -72,12 +75,11 @@ export const KPI = ({
       <UpdatedKpiBase
         propertyPoint={propertyPoint}
         alarmPoint={alarmPoint}
-        settings={settings}
+        settings={{ ...settings, backgroundColor: color }}
         aggregationType={aggregationType}
         resolution={propertyResolution}
         name={name}
         unit={unit}
-        color={color}
         isLoading={isLoading}
         error={error?.msg}
         significantDigits={significantDigits}

--- a/packages/react-components/src/components/kpi/updatedKpiBase.tsx
+++ b/packages/react-components/src/components/kpi/updatedKpiBase.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_KPI_SETTINGS } from './constants';
 import { Value } from '../shared-components';
 import type { KPIProperties, KPISettings } from './types';
 import './kpi.css';
+import { highContrastColor } from '../status/highContrastColor';
 
 export const UpdatedKpiBase: React.FC<KPIProperties> = ({
   propertyPoint,
@@ -31,6 +32,8 @@ export const UpdatedKpiBase: React.FC<KPIProperties> = ({
   };
 
   const point = propertyPoint;
+  const fontColor =
+    backgroundColor === '#ffffff' ? '' : highContrastColor(backgroundColor);
 
   if (error) {
     return (
@@ -59,7 +62,7 @@ export const UpdatedKpiBase: React.FC<KPIProperties> = ({
       <div>
         <div
           className='property-name'
-          style={{ fontSize: `${secondaryFontSize}px` }}
+          style={{ fontSize: `${secondaryFontSize}px`, color: fontColor }}
         >
           {isLoading ? '-' : showName && name}{' '}
           {showUnit && !isLoading && unit && `(${unit})`}
@@ -67,7 +70,7 @@ export const UpdatedKpiBase: React.FC<KPIProperties> = ({
         <div
           className='value'
           data-testid='kpi-value'
-          style={{ fontSize: `${fontSize}px` }}
+          style={{ fontSize: `${fontSize}px`, color: fontColor }}
         >
           {isLoading ? (
             <Spinner data-testid='loading' />
@@ -79,9 +82,12 @@ export const UpdatedKpiBase: React.FC<KPIProperties> = ({
       {point && showTimestamp && (
         <div
           className='timestamp-container'
-          style={{ fontSize: `${secondaryFontSize}px` }}
+          style={{ fontSize: `${secondaryFontSize}px`, color: fontColor }}
         >
-          <div className='timestamp-border' />
+          <div
+            className='timestamp-border'
+            style={{ backgroundColor: fontColor }}
+          />
           {isLoading ? (
             '-'
           ) : (

--- a/packages/react-components/src/components/status/status.tsx
+++ b/packages/react-components/src/components/status/status.tsx
@@ -35,9 +35,10 @@ export const Status = ({
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
     queries: [query],
-    // Currently set to only fetch raw data.
-    // TODO: Support all resolutions and aggregation types
-    settings: { fetchMostRecentBeforeEnd: true, resolution: '0' },
+    settings: {
+      fetchMostRecentBeforeEnd: true,
+      fetchMostRecentBeforeStart: true,
+    },
     styles,
   });
 

--- a/packages/react-components/stories/kpi/kpi.stories.tsx
+++ b/packages/react-components/stories/kpi/kpi.stories.tsx
@@ -33,12 +33,28 @@ export const MockDataKPI: ComponentStory<typeof KPI> = () => {
     <div style={{ background: 'grey' }}>
       <div style={{ height: '200px', width: '250px', padding: '20px' }}>
         <KPI
+          thresholds={[
+            {
+              value: 435,
+              id: 'abc',
+              color: '#be1c1f',
+              comparisonOperator: 'GT',
+            },
+          ]}
           viewport={{ duration: '5m' }}
           query={MOCK_TIME_SERIES_DATA_QUERY}
         />
       </div>
       <div style={{ height: '200px', width: '250px', padding: '20px' }}>
         <KPI
+          thresholds={[
+            {
+              value: 35,
+              id: '123',
+              color: '#dfe7f5',
+              comparisonOperator: 'GT',
+            },
+          ]}
           viewport={{ duration: '5m' }}
           query={MOCK_TIME_SERIES_DATA_AGGREGATED_QUERY}
         />


### PR DESCRIPTION
## Overview
Config panel changes to add: 
- display options: hide/show unit, name, and timestamp
- show aggregation/resolution picker for gated status and KPI
- get thresholds working with gated KPI implementation
- hide color picker for property on new KPI/Status implementation

video confirming all property panel changes with gate enabled:
https://github.com/awslabs/iot-app-kit/assets/28601414/26e99a95-b475-4b89-9417-62cd9e84e3a6

video confirming that gate blocks all changes in dashboard:
https://github.com/awslabs/iot-app-kit/assets/28601414/f7af5d39-cdc6-4fb4-bb18-76221e7bd232



Other bonus changes:
- remove unused functions
- combine the 2 different aggregation/resolution pickers into One 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
