### PR TITLE
fix: updated the viewport settings for dynamic input

### DIFF
--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -19,7 +19,7 @@ it('renders', function () {
           numRows: 100,
         },
         widgets: [],
-        viewport: { duration: '5m' },
+        viewport: { duration: '55m' },
       }}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
@@ -35,6 +35,7 @@ it('renders', function () {
   expect(queryByText(/component library/i)).not.toBeInTheDocument();
   expect(queryByTestId(/dashboard-actions/i)).toBeInTheDocument();
   expect(queryByTestId(/time-selection/i)).toBeInTheDocument();
+  expect(queryByText('Last 55 minutes')).toBeInTheDocument();
 });
 
 it('renders in readonly initially', function () {
@@ -116,7 +117,7 @@ it('passes the correct viewMode to onSave', function () {
       significantDigits: 4,
     },
     widgets: [],
-    viewport: { duration: '5m' },
+    viewport: { duration: '55m' },
   };
 
   render(

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -76,6 +76,7 @@ const Dashboard: React.FC<DashboardProperties> = ({
                   onSave={onSave}
                   editable={true}
                   name={name}
+                  viewport={dashboardConfiguration.viewport}
                   propertiesPanel={<PropertiesPanel />}
                 />
               </DndProvider>

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactNode, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { getPlugin } from '@iot-app-kit/core';
+import { Viewport, getPlugin } from '@iot-app-kit/core';
 import { WebglContext, TimeSync } from '@iot-app-kit/react-components';
 import Box from '@cloudscape-design/components/box';
 import {
@@ -66,6 +66,7 @@ type InternalDashboardProperties = {
   editable?: boolean;
   name?: string;
   propertiesPanel?: ReactNode;
+  viewport?: Viewport;
 };
 
 const defaultUserSelect: CSSProperties = { userSelect: 'initial' };
@@ -76,6 +77,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
   editable,
   name,
   propertiesPanel,
+  viewport,
 }) => {
   const { iotSiteWiseClient, iotTwinMakerClient } = useClients();
 
@@ -393,7 +395,10 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
   );
 
   return (
-    <TimeSync initialViewport={{ duration: '5m' }} group='dashboard-timesync'>
+    <TimeSync
+      initialViewport={viewport ?? { duration: '5m' }}
+      group='dashboard-timesync'
+    >
       {readOnly ? ReadOnlyComponent : EditComponent}
       <ConfirmDeleteModal
         visible={visible}


### PR DESCRIPTION
## Overview
This PR is for ticket #2565 and updated viewport settings for the dynamic input timestamp

## Verifying Changes
https://github.com/awslabs/iot-app-kit/assets/142866907/c55e94c2-6846-442d-8c77-2c72d7675216

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
