### PR TITLE
fix: updated the ux for widget actions

### DIFF
--- a/packages/dashboard/src/components/widgets/widgetActions.tsx
+++ b/packages/dashboard/src/components/widgets/widgetActions.tsx
@@ -7,9 +7,8 @@ import {
   colorBackgroundButtonNormalDefault,
   spaceStaticXl,
   spaceStaticL,
-  spaceStaticXxs,
   spaceStaticXs,
-  borderRadiusBadge,
+  spaceStaticXxxs,
 } from '@cloudscape-design/design-tokens';
 import {
   CancelableEventHandler,
@@ -109,10 +108,10 @@ const WidgetActions = ({ widget }: { widget: DashboardWidget }) => {
       className='widget-actions-container'
       aria-label='widget-actions-container'
       style={{
-        padding: `${spaceStaticXxs} ${spaceStaticXs}`,
+        padding: `${spaceStaticXxxs} ${spaceStaticXs}`,
         height: `${spaceStaticXl}`,
         right: `${spaceStaticL}`,
-        borderRadius: `${borderRadiusBadge}`,
+        borderRadius: `${spaceStaticXs}`,
         border: `2px solid ${colorBackgroundButtonPrimaryDefault}`,
         backgroundColor: `${colorBackgroundButtonNormalDefault}`,
         pointerEvents: 'auto',


### PR DESCRIPTION
## Overview
updated the UX as per comments in https://github.com/awslabs/iot-app-kit/pull/2589 for the ticket [#2439](https://github.com/awslabs/iot-app-kit/issues/2439). and updated the vertical padding and the border radius to 2px and 8px.

## Verifying Changes
old: 
![image](https://github.com/awslabs/iot-app-kit/assets/142866907/862f2562-89d2-4dd3-aca8-89cf80271536)
  
new update:
![image](https://github.com/awslabs/iot-app-kit/assets/142866907/565fc269-9556-4c1c-b50a-78d7910b057e)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
