### PR TITLE
feat(composer): createDynamicScene util

### DIFF
--- a/packages/scene-composer/src/common/sceneModelConstants.ts
+++ b/packages/scene-composer/src/common/sceneModelConstants.ts
@@ -1,0 +1,9 @@
+export enum SceneCapabilities {
+  MATTERPORT = 'MATTERPORT',
+  DYNAMIC_SCENE = 'DYNAMIC_SCENE',
+}
+
+export enum SceneMetadataMapKeys {
+  MATTERPORT_SECRET_ARN = 'MATTERPORT_SECRET_ARN',
+  SCENE_ROOT_ENTITY_ID = 'SCENE_ROOT_ENTITY_ID',
+}

--- a/packages/scene-composer/src/utils/emptyScene.ts
+++ b/packages/scene-composer/src/utils/emptyScene.ts
@@ -1,0 +1,66 @@
+import { ISceneDocument } from '../interfaces';
+
+export const emptyScene: ISceneDocument = {
+  specVersion: '1.0',
+  version: '1',
+  unit: 'meters',
+  nodeMap: {},
+  rootNodeRefs: [],
+  ruleMap: {
+    sampleAlarmIconRule: {
+      statements: [
+        {
+          expression: "alarm_status == 'ACTIVE'",
+          target: 'iottwinmaker.common.icon:Error',
+        },
+        {
+          expression: "alarm_status == 'ACKNOWLEDGED'",
+          target: 'iottwinmaker.common.icon:Warning',
+        },
+        {
+          expression: "alarm_status == 'SNOOZE_DISABLED'",
+          target: 'iottwinmaker.common.icon:Warning',
+        },
+        {
+          expression: "alarm_status == 'NORMAL'",
+          target: 'iottwinmaker.common.icon:Info',
+        },
+      ],
+    },
+    sampleTimeSeriesIconRule: {
+      statements: [
+        {
+          expression: 'temperature >= 40',
+          target: 'iottwinmaker.common.icon:Error',
+        },
+        {
+          expression: 'temperature >= 20',
+          target: 'iottwinmaker.common.icon:Warning',
+        },
+        {
+          expression: 'temperature < 20',
+          target: 'iottwinmaker.common.icon:Info',
+        },
+      ],
+    },
+    sampleTimeSeriesColorRule: {
+      statements: [
+        {
+          expression: 'temperature >= 40',
+          target: 'iottwinmaker.common.color:#FF0000',
+        },
+        {
+          expression: 'temperature >= 20',
+          target: 'iottwinmaker.common.color:#FFFF00',
+        },
+        {
+          expression: 'temperature < 20',
+          target: 'iottwinmaker.common.color:#00FF00',
+        },
+      ],
+    },
+  },
+  properties: {
+    environmentPreset: 'neutral',
+  },
+};

--- a/packages/scene-composer/src/utils/entityModelUtils/SceneLifecycleModule.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/SceneLifecycleModule.spec.ts
@@ -1,0 +1,73 @@
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
+
+import { setTwinMakerSceneMetadataModule } from '../../common/GlobalSettings';
+import { SCENE_ROOT_ENTITY_COMPONENT_NAME } from '../../common/entityModelConstants';
+import { SceneCapabilities } from '../../common/sceneModelConstants';
+import { emptyScene } from '../emptyScene';
+import { KnownSceneProperty } from '../../interfaces';
+
+import { SceneLifecycleModule } from './SceneLifecycleModule';
+import { updateSceneEntityComponent } from './sceneComponent';
+
+describe('createDynamicScene', () => {
+  const createScene = jest.fn();
+  const getSceneInfo = jest.fn().mockResolvedValue({
+    workspaceId: 'workspace-id',
+    sceneId: 'dynamic-scene',
+    contentLocation: undefined,
+    arn: 'dynamic-scene-arn',
+    creationDateTime: new Date(2022, 2, 1),
+    updateDateTime: new Date(2022, 2, 1),
+    capabilities: ['DYNAMIC_SCENE'],
+    sceneMetadata: { sceneRootEntityId: 'example-dynamic-scene-entity-id' },
+  });
+  const updateSceneEntity = jest.fn().mockResolvedValue({
+    updateDateTime: new Date(2022, 2, 1),
+    state: 'ACTIVE',
+  });
+  const createSceneEntity = jest.fn().mockResolvedValue({
+    entityId: 'dynamic-scene-entity-id',
+    arn: 'dynamic-scene-entity-arn',
+    creationDateTime: new Date(2022, 2, 1),
+    state: 'ACTIVE',
+  });
+  const getSceneId = jest.fn().mockReturnValue('dynamic-scene-entity-id');
+  const mockMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
+    createScene,
+    getSceneInfo,
+    updateSceneEntity,
+    createSceneEntity,
+    getSceneId,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const sceneLifecycleModule = new SceneLifecycleModule();
+
+  it('should call correct APIs with expected input', async () => {
+    setTwinMakerSceneMetadataModule(mockMetadataModule as unknown as TwinMakerSceneMetadataModule);
+
+    await sceneLifecycleModule.createDynamicScene(mockMetadataModule);
+
+    expect(createScene).toBeCalledWith({ capabilities: [SceneCapabilities.DYNAMIC_SCENE] });
+    expect(getSceneInfo).toBeCalledWith();
+    const emptySceneSettings = {
+      ...emptyScene,
+      properties: {
+        ...emptyScene.properties,
+        [KnownSceneProperty.LayerIds]: ['dynamic-scene-entity-id'],
+      },
+    };
+    expect(updateSceneEntity).toBeCalledWith({
+      entityId: 'example-dynamic-scene-entity-id',
+      componentUpdates: {
+        [SCENE_ROOT_ENTITY_COMPONENT_NAME]: updateSceneEntityComponent(emptySceneSettings),
+      },
+    });
+    expect(createScene).toBeCalledTimes(1);
+    expect(getSceneInfo).toBeCalledTimes(1);
+    expect(updateSceneEntity).toBeCalledTimes(1);
+  });
+});

--- a/packages/scene-composer/src/utils/entityModelUtils/SceneLifecycleModule.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/SceneLifecycleModule.ts
@@ -1,0 +1,38 @@
+import { GetSceneCommandOutput } from '@aws-sdk/client-iottwinmaker';
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
+
+import { SCENE_ROOT_ENTITY_COMPONENT_NAME, LayerType } from '../../common/entityModelConstants';
+import { SceneCapabilities } from '../../common/sceneModelConstants';
+import { KnownSceneProperty } from '../../interfaces';
+import { emptyScene } from '../emptyScene';
+import { createLayer } from '../../utils/entityModelUtils/sceneLayerUtils';
+
+import { updateSceneEntityComponent } from './sceneComponent';
+
+export class SceneLifecycleModule {
+  createDynamicScene = async (sceneMetadataModule: TwinMakerSceneMetadataModule): Promise<GetSceneCommandOutput> => {
+    await sceneMetadataModule.createScene({
+      capabilities: [SceneCapabilities.DYNAMIC_SCENE],
+    });
+    const sceneInfo = await sceneMetadataModule.getSceneInfo();
+    const layerName = `${sceneMetadataModule?.getSceneId()}_Default`;
+    const layer = await createLayer(layerName, LayerType.Relationship);
+    const layerId = layer?.entityId;
+    const emptySceneSettings = {
+      ...emptyScene,
+      properties: {
+        ...emptyScene.properties,
+        [KnownSceneProperty.LayerIds]: [layerId],
+      },
+    };
+    const entityComponentModelDefault = updateSceneEntityComponent(emptySceneSettings);
+    const sceneRootEntityId = sceneInfo?.sceneMetadata?.[KnownSceneProperty.SceneRootEntityId];
+    await sceneMetadataModule.updateSceneEntity({
+      entityId: sceneRootEntityId,
+      componentUpdates: {
+        [SCENE_ROOT_ENTITY_COMPONENT_NAME]: entityComponentModelDefault,
+      },
+    });
+    return sceneInfo;
+  };
+}

--- a/packages/source-iottwinmaker/src/__mocks__/iottwinmakerSDK.ts
+++ b/packages/source-iottwinmaker/src/__mocks__/iottwinmakerSDK.ts
@@ -21,6 +21,7 @@ import {
   UpdateSceneCommandInput,
   UpdateSceneCommandOutput,
 } from '@aws-sdk/client-iottwinmaker';
+import { SceneInfo } from '../types';
 
 const nonOverriddenMock = () => Promise.reject(new Error('Mock method not override.'));
 
@@ -35,6 +36,7 @@ export const createMockTwinMakerSDK = ({
   listEntities = nonOverriddenMock,
   updateScene = nonOverriddenMock,
   executeQuery = nonOverriddenMock,
+  createScene = nonOverriddenMock,
 }: {
   getEntity?: (input: GetEntityCommandInput) => Promise<GetEntityCommandOutput>;
   createEntity?: (input: CreateEntityCommandInput) => Promise<CreateEntityCommandOutput>;
@@ -50,6 +52,7 @@ export const createMockTwinMakerSDK = ({
   listEntities?: (input: ListEntitiesCommandInput) => Promise<ListEntitiesCommandOutput>;
   updateScene?: (input: UpdateSceneCommandInput) => Promise<UpdateSceneCommandOutput>;
   executeQuery?: (input: ExecuteQueryCommandInput) => Promise<ExecuteQueryCommandOutput>;
+  createScene?: (input: SceneInfo) => Promise<void>;
 } = {}) =>
   ({
     send: (command: { input: any }) => {
@@ -78,6 +81,8 @@ export const createMockTwinMakerSDK = ({
           return updateScene(command.input);
         case 'ExecuteQueryCommand':
           return executeQuery(command.input);
+        case 'CreateSceneCommand':
+          return createScene(command.input);
         default:
           throw new Error(
             `missing mock implementation for command name ${commandName}. Add a new command within the mock IotTwinMaker SDK.`

--- a/packages/source-iottwinmaker/src/scene-module/SceneMetadataModule.spec.ts
+++ b/packages/source-iottwinmaker/src/scene-module/SceneMetadataModule.spec.ts
@@ -9,6 +9,7 @@ const getEntity = jest.fn();
 const createEntity = jest.fn();
 const updateEntity = jest.fn();
 const deleteEntity = jest.fn();
+const createScene = jest.fn();
 const twinMakerClientMock = createMockTwinMakerSDK({
   getScene,
   updateScene,
@@ -16,6 +17,7 @@ const twinMakerClientMock = createMockTwinMakerSDK({
   createEntity,
   updateEntity,
   deleteEntity,
+  createScene,
 });
 
 const listSecrets = jest.fn();
@@ -262,6 +264,37 @@ describe('deleteSceneEntity', () => {
     } catch (err) {
       expect(err).toEqual('TwinMaker API failed');
       expect(deleteEntity).toBeCalledTimes(1);
+    }
+  });
+});
+
+describe('createScene', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call API to create scene successfully', async () => {
+    await sceneMetadataModule.createScene({ capabilities: ['DYNAMIC_SCENE'] });
+    expect(createScene).toBeCalledTimes(1);
+    expect(createScene).toBeCalledWith({
+      workspaceId: 'ws-id',
+      sceneId: 'scene-id',
+      capabilities: ['DYNAMIC_SCENE'],
+      contentLocation: undefined,
+      sceneMetadata: undefined,
+    });
+  });
+
+  it('should get error when API failed', async () => {
+    createScene.mockRejectedValue('TwinMaker API failed');
+
+    try {
+      await sceneMetadataModule.createScene({
+        capabilities: ['DYNAMIC_SCENE'],
+      });
+    } catch (err) {
+      expect(err).toEqual('TwinMaker API failed');
+      expect(createScene).toBeCalledTimes(1);
     }
   });
 });

--- a/packages/source-iottwinmaker/src/scene-module/SceneMetadataModule.ts
+++ b/packages/source-iottwinmaker/src/scene-module/SceneMetadataModule.ts
@@ -11,6 +11,7 @@ import {
   UpdateEntityCommand,
   UpdateEntityCommandInput,
   UpdateSceneCommand,
+  CreateSceneCommand,
 } from '@aws-sdk/client-iottwinmaker';
 import {
   ListSecretsCommand,
@@ -122,6 +123,18 @@ export class SceneMetadataModule implements TwinMakerSceneMetadataModule {
   ) => {
     return this.twinMakerClient.send(
       new DeleteEntityCommand({ ...input, workspaceId: this.workspaceId })
+    );
+  };
+
+  createScene = async (sceneInfo: SceneInfo): Promise<void> => {
+    await this.twinMakerClient.send(
+      new CreateSceneCommand({
+        workspaceId: this.workspaceId,
+        sceneId: this.sceneId,
+        contentLocation: undefined,
+        capabilities: sceneInfo.capabilities,
+        sceneMetadata: sceneInfo.sceneMetadata,
+      })
     );
   };
 }

--- a/packages/source-iottwinmaker/src/types.ts
+++ b/packages/source-iottwinmaker/src/types.ts
@@ -48,6 +48,7 @@ export interface TwinMakerSceneMetadataModule {
   deleteSceneEntity: (
     input: Omit<DeleteEntityCommandInput, 'workspaceId'>
   ) => Promise<DeleteEntityCommandOutput>;
+  createScene: (input: SceneInfo) => Promise<void>;
 }
 
 export interface VideoData {


### PR DESCRIPTION
## Overview
Implement createDynamicScene util and SceneLifecycleModule

## Verifying Changes

npm run test passes.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
