### PR TITLE
feat: add threshold settings to KPI

### DIFF
--- a/packages/core/src/common/types.ts
+++ b/packages/core/src/common/types.ts
@@ -102,6 +102,13 @@ export interface Threshold<T extends ThresholdValue = ThresholdValue>
   dataStreamIds?: DataStreamId[];
 }
 
+export type ThresholdStyleType = {
+  visible?: boolean;
+  fill?: string;
+};
+
+export type StyledThreshold = Threshold & ThresholdStyleType;
+
 export type ThresholdSettings = {
   // Specify whether data that is breached by the thresholds will be colored based on the threshold configuration
   colorBreachedData?: boolean;

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/defaultThresholds.ts
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/defaultThresholds.ts
@@ -1,0 +1,55 @@
+import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
+import { ThresholdStyleType } from '@iot-app-kit/core';
+
+enum ThresholdStyleOptions {
+  asLines = 'As lines',
+  asFilledRegion = 'As filled region',
+  asLinesAndFilledRegion = 'As lines and filled region',
+}
+
+export const styledOptions = [
+  { label: ThresholdStyleOptions.asLines, value: '1' },
+  { label: ThresholdStyleOptions.asFilledRegion, value: '2' },
+  { label: ThresholdStyleOptions.asLinesAndFilledRegion, value: '3' },
+];
+
+export const convertOptionToThresholdStyle = (
+  selectedOption: OptionDefinition
+): ThresholdStyleType => {
+  switch (selectedOption.label) {
+    case ThresholdStyleOptions.asLines: {
+      return {
+        visible: true,
+      };
+    }
+    case ThresholdStyleOptions.asFilledRegion: {
+      return {
+        visible: false,
+        fill: 'color',
+      };
+    }
+    case ThresholdStyleOptions.asLinesAndFilledRegion: {
+      return {
+        visible: true,
+        fill: 'color',
+      };
+    }
+    default: {
+      return {};
+    }
+  }
+};
+
+export const convertThresholdStyleToOption = (
+  thresholdStyle: ThresholdStyleType
+): OptionDefinition => {
+  if (!!thresholdStyle.visible && !thresholdStyle.fill) {
+    return styledOptions[0];
+  } else if (!thresholdStyle.visible && !!thresholdStyle.fill) {
+    return styledOptions[1];
+  } else if (!!thresholdStyle.visible && !!thresholdStyle.fill) {
+    return styledOptions[2];
+  } else {
+    return styledOptions[0];
+  }
+};

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/index.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { ThresholdSettings } from '@iot-app-kit/core';
+import { StyledThreshold, ThresholdSettings } from '@iot-app-kit/core';
 
 import { PropertiesSection } from '~/customization/propertiesSectionComponent';
 import { PropertyLens } from '~/customization/propertiesSection';
-import { StyledThreshold, ThresholdWithId } from '~/customization/settings';
+import { ThresholdWithId } from '~/customization/settings';
 import { DashboardWidget } from '~/types';
 import ThresholdsSection from './thresholdsSection';
 import { getComparisonOperators } from './comparisonOperators';
@@ -49,6 +49,7 @@ const RenderThresholdsSettings = ({
   useProperty: PropertyLens<ThresholdsWidget>;
 }) => {
   const widgetType = maybeWithDefault('', type);
+  const hasNewKPI = !!localStorage?.getItem('USE_UPDATED_KPI');
 
   let doesSupportAnnotations;
   let doesSupportContainsOp;
@@ -62,8 +63,10 @@ const RenderThresholdsSettings = ({
     doesSupportContainsOp = types.every((v) =>
       thresholdsWithContainsOperator.includes(v)
     );
-    doesSupportStyledThreshold = types.every((v) =>
-      thresholdsWithStyle.includes(v)
+    doesSupportStyledThreshold = types.every(
+      (v) =>
+        thresholdsWithStyle.includes(v) ||
+        ((v === 'kpi' || v === 'status') && hasNewKPI)
     );
   } else {
     doesSupportAnnotations = thresholdsWithAnnotations.some(
@@ -72,9 +75,9 @@ const RenderThresholdsSettings = ({
     doesSupportContainsOp = thresholdsWithContainsOperator.some(
       (t) => t === widgetType
     );
-    doesSupportStyledThreshold = thresholdsWithStyle.some(
-      (t) => t === widgetType
-    );
+    doesSupportStyledThreshold =
+      thresholdsWithStyle.some((t) => t === widgetType) ||
+      ((widgetType === 'kpi' || widgetType === 'status') && hasNewKPI);
   }
 
   const [thresholds, updateThresholds] = useProperty(
@@ -115,6 +118,7 @@ const RenderThresholdsSettings = ({
 
   return (
     <ThresholdsSection
+      widgetType={widgetType}
       comparisonOperators={getComparisonOperators({
         supportsContains: doesSupportContainsOp,
       })}

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/kpiThresholds.ts
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/kpiThresholds.ts
@@ -1,0 +1,43 @@
+import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
+import { ThresholdStyleType } from '@iot-app-kit/core';
+
+enum ThresholdStyleOptions {
+  asFilledWidget = 'As filled widget',
+  asLine = 'As line',
+}
+
+export const styledOptionsKPI = [
+  { label: ThresholdStyleOptions.asLine, value: '1' },
+  { label: ThresholdStyleOptions.asFilledWidget, value: '2' },
+];
+
+export const convertOptionToThresholdStyleKPI = (
+  selectedOption: OptionDefinition
+): ThresholdStyleType => {
+  switch (selectedOption.label) {
+    case ThresholdStyleOptions.asLine: {
+      return {
+        visible: true,
+      };
+    }
+    case ThresholdStyleOptions.asFilledWidget: {
+      return {
+        visible: true,
+        fill: 'color',
+      };
+    }
+    default: {
+      return {};
+    }
+  }
+};
+
+export const convertThresholdStyleToOptionKPI = (
+  thresholdStyle: ThresholdStyleType
+): OptionDefinition => {
+  if (!!thresholdStyle.visible && !!thresholdStyle.fill) {
+    return styledOptionsKPI[1];
+  } else {
+    return styledOptionsKPI[0];
+  }
+};

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.spec.tsx
@@ -2,8 +2,13 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 import { ThresholdStyleSettings } from './thresholdStyle';
-import { ThresholdStyleType } from '~/customization/widgets/types';
 import wrapper from '@cloudscape-design/components/test-utils/dom';
+import { ThresholdStyleType } from '@iot-app-kit/core';
+import {
+  convertOptionToThresholdStyle,
+  convertThresholdStyleToOption,
+  styledOptions,
+} from './defaultThresholds';
 
 const thresholdStyle: ThresholdStyleType = {
   visible: true,
@@ -14,6 +19,9 @@ const component = (
   <ThresholdStyleSettings
     thresholdStyle={thresholdStyle}
     updateAllThresholdStyles={mockUpdateAllThresholdStyles}
+    convertOptionToThresholdStyle={convertOptionToThresholdStyle}
+    convertThresholdStyleToOption={convertThresholdStyleToOption}
+    styledOptions={styledOptions}
   />
 );
 

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdStyle.tsx
@@ -1,67 +1,19 @@
 import React, { useState } from 'react';
 import { FormField, Select, SelectProps } from '@cloudscape-design/components';
-import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
-// FIXME: Export ThresholdStyleType from @iot-app-kit/react-components
-// eslint-disable-next-line no-restricted-imports
-import { ThresholdStyleType } from '@iot-app-kit/react-components/src/components/chart/types';
 import { spaceScaledXs } from '@cloudscape-design/design-tokens';
+import { ThresholdStyleType } from '@iot-app-kit/core';
+import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
 
 export type ThresholdStyleSettingsProps = {
   thresholdStyle: ThresholdStyleType;
   updateAllThresholdStyles: (thresholdStyle: ThresholdStyleType) => void;
-};
-
-enum ThresholdStyleOptions {
-  asLines = 'As lines',
-  asFilledRegion = 'As filled region',
-  asLinesAndFilledRegion = 'As lines and filled region',
-}
-
-export const styledOptions = [
-  { label: ThresholdStyleOptions.asLines, value: '1' },
-  { label: ThresholdStyleOptions.asFilledRegion, value: '2' },
-  { label: ThresholdStyleOptions.asLinesAndFilledRegion, value: '3' },
-];
-
-export const convertOptionToThresholdStyle = (
-  selectedOption: OptionDefinition
-): ThresholdStyleType => {
-  switch (selectedOption.label) {
-    case ThresholdStyleOptions.asLines: {
-      return {
-        visible: true,
-      };
-    }
-    case ThresholdStyleOptions.asFilledRegion: {
-      return {
-        visible: false,
-        fill: 'color',
-      };
-    }
-    case ThresholdStyleOptions.asLinesAndFilledRegion: {
-      return {
-        visible: true,
-        fill: 'color',
-      };
-    }
-    default: {
-      return {};
-    }
-  }
-};
-
-const convertThresholdStyleToOption = (
-  thresholdStyle: ThresholdStyleType
-): OptionDefinition => {
-  if (!!thresholdStyle.visible && !thresholdStyle.fill) {
-    return styledOptions[0];
-  } else if (!thresholdStyle.visible && !!thresholdStyle.fill) {
-    return styledOptions[1];
-  } else if (!!thresholdStyle.visible && !!thresholdStyle.fill) {
-    return styledOptions[2];
-  } else {
-    return styledOptions[0];
-  }
+  convertThresholdStyleToOption: (
+    thresholdStyle: ThresholdStyleType
+  ) => OptionDefinition;
+  convertOptionToThresholdStyle: (
+    selectedOption: OptionDefinition
+  ) => ThresholdStyleType;
+  styledOptions: { label: string; value: string }[];
 };
 
 const style = {
@@ -71,6 +23,9 @@ const style = {
 export const ThresholdStyleSettings: React.FC<ThresholdStyleSettingsProps> = ({
   thresholdStyle,
   updateAllThresholdStyles,
+  convertThresholdStyleToOption,
+  convertOptionToThresholdStyle,
+  styledOptions,
 }) => {
   const [selectedOption, setSelectedOption] = useState<SelectProps.Option>(
     convertThresholdStyleToOption(thresholdStyle)

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsList.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsList.spec.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import { render } from '@testing-library/react';
-import { COMPARISON_OPERATOR } from '@iot-app-kit/core';
+import { COMPARISON_OPERATOR, StyledThreshold } from '@iot-app-kit/core';
 import { ThresholdsList } from './thresholdsList';
-import { StyledThreshold, ThresholdWithId } from '~/customization/settings';
+import { ThresholdWithId } from '~/customization/settings';
 
 const comparisonOperator1 = COMPARISON_OPERATOR.EQ;
 const mockComparisonOperator1 = { label: '=', value: comparisonOperator1 };

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsList.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsList.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 import { SpaceBetween, Box } from '@cloudscape-design/components';
 
-import { StyledThreshold, ThresholdWithId } from '~/customization/settings';
+import { ThresholdWithId } from '~/customization/settings';
 import { ThresholdComponent } from './thresholdComponent';
 import { ComparisonOperators } from './comparisonOperators';
+import { StyledThreshold } from '@iot-app-kit/core';
 
 const NoThresholds = () => <Box />;
 

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
@@ -1,6 +1,11 @@
 import React, { FC, useState } from 'react';
 
-import { ComparisonOperator, ThresholdSettings } from '@iot-app-kit/core';
+import {
+  ComparisonOperator,
+  ThresholdSettings,
+  StyledThreshold,
+  ThresholdStyleType,
+} from '@iot-app-kit/core';
 import { nanoid } from '@reduxjs/toolkit';
 
 import {
@@ -11,10 +16,7 @@ import {
 } from '@cloudscape-design/components';
 
 import { DEFAULT_THRESHOLD_COLOR } from './defaultValues';
-import type {
-  StyledThreshold,
-  ThresholdWithId,
-} from '~/customization/settings';
+import type { ThresholdWithId } from '~/customization/settings';
 import { Maybe, maybeWithDefault } from '~/util/maybe';
 import { SelectOneWidget } from '../shared/selectOneWidget';
 import { useExpandable } from '../shared/useExpandable';
@@ -25,16 +27,19 @@ import {
   CancelableEventHandler,
   ClickDetail,
 } from '@cloudscape-design/components/internal/events';
-import {
-  ThresholdStyleSettings,
-  convertOptionToThresholdStyle,
-  styledOptions,
-} from './thresholdStyle';
-// FIXME: Export ThresholdStyleType from @iot-app-kit/react-components
-// eslint-disable-next-line no-restricted-imports
-import { ThresholdStyleType } from '@iot-app-kit/react-components/src/components/chart/types';
+import { ThresholdStyleSettings } from './thresholdStyle';
 import '../propertiesSectionsStyle.css';
 import { spaceScaledXs } from '@cloudscape-design/design-tokens';
+import {
+  convertThresholdStyleToOptionKPI,
+  convertOptionToThresholdStyleKPI,
+  styledOptionsKPI,
+} from './kpiThresholds';
+import {
+  convertOptionToThresholdStyle,
+  convertThresholdStyleToOption,
+  styledOptions,
+} from './defaultThresholds';
 
 const ThresholdsExpandableSection: React.FC<
   React.PropsWithChildren<{ title: string }>
@@ -51,6 +56,7 @@ const ThresholdsExpandableSection: React.FC<
 );
 
 type ThresholdsSectionProps = {
+  widgetType: string;
   thresholds?: Maybe<ThresholdWithId[] | undefined>;
   updateThresholds?: (newValue: ThresholdWithId[] | undefined) => void;
   comparisonOperators: ComparisonOperators;
@@ -63,6 +69,7 @@ type ThresholdsSectionProps = {
 };
 
 const ThresholdsSection: FC<ThresholdsSectionProps> = ({
+  widgetType,
   thresholds,
   updateThresholds,
   comparisonOperators,
@@ -335,10 +342,23 @@ const ThresholdsSection: FC<ThresholdsSectionProps> = ({
         }
       };
 
+      const isStatusOrKPI = widgetType === 'kpi' || widgetType === 'status';
+
       return (
         <ThresholdStyleSettings
           thresholdStyle={thresholdStyle}
           updateAllThresholdStyles={updateAllThresholdStyles}
+          convertThresholdStyleToOption={
+            isStatusOrKPI
+              ? convertThresholdStyleToOptionKPI
+              : convertThresholdStyleToOption
+          }
+          convertOptionToThresholdStyle={
+            isStatusOrKPI
+              ? convertOptionToThresholdStyleKPI
+              : convertOptionToThresholdStyle
+          }
+          styledOptions={isStatusOrKPI ? styledOptionsKPI : styledOptions}
         />
       );
     }

--- a/packages/dashboard/src/customization/settings.ts
+++ b/packages/dashboard/src/customization/settings.ts
@@ -1,7 +1,4 @@
 import type { Threshold } from '@iot-app-kit/core';
-// FIXME: Export ThresholdStyleType from @iot-app-kit/react-components
-// eslint-disable-next-line no-restricted-imports
-import { ThresholdStyleType } from '@iot-app-kit/react-components/src/components/chart/types';
 
 export type SimpleFontSettings = {
   fontSize?: number;
@@ -16,7 +13,6 @@ export type ComplexFontSettings = {
   isUnderlined?: boolean;
 };
 export type ThresholdWithId = Threshold & { id: string };
-export type StyledThreshold = Threshold & ThresholdStyleType;
 
 export type AxisSettings = {
   showX?: boolean;

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -1,6 +1,6 @@
 import type {
   StyleSettingsMap,
-  Threshold,
+  StyledThreshold,
   ThresholdSettings,
 } from '@iot-app-kit/core';
 import type {
@@ -50,7 +50,7 @@ export type KPIProperties = QueryProperties & {
   showIcon?: boolean;
   showName?: boolean;
   showTimestamp?: boolean;
-  thresholds?: ThresholdWithId[];
+  thresholds?: StyledThreshold[];
   backgroundColor?: string;
   significantDigits?: number;
 };
@@ -66,7 +66,7 @@ export type StatusProperties = QueryProperties & {
   showUnit?: boolean;
   showIcon?: boolean;
   showName?: boolean;
-  thresholds?: ThresholdWithId[];
+  thresholds?: StyledThreshold[];
   showTimestamp?: boolean;
   backgroundColor?: string;
   significantDigits?: number;
@@ -140,13 +140,6 @@ export type StyledAssetQuery = {
     properties: StyledAssetPropertyQuery[];
   }[];
 };
-
-export type ThresholdStyleType = {
-  visible?: boolean;
-  fill?: string;
-};
-
-export type StyledThreshold = Threshold & ThresholdStyleType;
 
 type YAxisRange = {
   yMin?: number;

--- a/packages/react-components/src/common/widgetPropertiesFromInputs.ts
+++ b/packages/react-components/src/common/widgetPropertiesFromInputs.ts
@@ -7,6 +7,7 @@ import type {
   DataPoint,
   Viewport,
   Threshold,
+  StyledThreshold,
 } from '@iot-app-kit/core';
 
 const propertyInfo = ({
@@ -15,7 +16,7 @@ const propertyInfo = ({
   viewport,
 }: {
   dataStreams: DataStream[];
-  thresholds: Threshold[];
+  thresholds: StyledThreshold[];
   viewport: Viewport;
 }) => {
   const dataStream = dataStreams.find(({ streamType }) => streamType == null);

--- a/packages/react-components/src/components/chart/chartOptions/convertThresholds.ts
+++ b/packages/react-components/src/components/chart/chartOptions/convertThresholds.ts
@@ -2,9 +2,9 @@ import {
   AnnotationValue,
   COMPARISON_OPERATOR,
   ComparisonOperator,
+  StyledThreshold,
 } from '@iot-app-kit/core';
 import { COMPARATOR_MAP } from '../../../common/constants';
-import { StyledThreshold } from '../types';
 
 const comparisonOperatorToLowerYAxis = (
   comparisonOperator: ComparisonOperator,

--- a/packages/react-components/src/components/chart/hooks/useVisualizedDataStreams.ts
+++ b/packages/react-components/src/components/chart/hooks/useVisualizedDataStreams.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
   DataStream,
+  StyledThreshold,
   Threshold,
   TimeSeriesDataQuery,
   Viewport,
@@ -10,7 +11,6 @@ import isEqual from 'lodash.isequal';
 import { useTimeSeriesData } from '../../../hooks/useTimeSeriesData';
 import { useViewport } from '../../../hooks/useViewport';
 import { DEFAULT_VIEWPORT, StreamType } from '../../../common/constants';
-import { StyledThreshold } from '../types';
 
 const isNotAlarmStream = ({ streamType }: DataStream) =>
   streamType !== StreamType.ALARM;

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -1,7 +1,7 @@
 import {
   DataStream,
   Primitive,
-  Threshold,
+  StyledThreshold,
   ThresholdSettings,
   TimeSeriesDataQuery,
   Viewport,
@@ -87,13 +87,6 @@ export type ChartStyleSettings = {
 };
 
 export type ChartEventType = { target: { id?: OptionId }; offsetX?: number };
-
-export type ThresholdStyleType = {
-  visible?: boolean;
-  fill?: string;
-};
-
-export type StyledThreshold = Threshold & ThresholdStyleType;
 
 export type ChartOptions = {
   queries: TimeSeriesDataQuery[];

--- a/packages/react-components/src/components/kpi/kpi.css
+++ b/packages/react-components/src/components/kpi/kpi.css
@@ -1,26 +1,33 @@
+.updated-kpi-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  height: 100%;
+  overflow: hidden;
+}
+
 .updated-kpi {
-  padding: 8px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: calc(100% - 16px);
-  overflow: hidden;
+  height: 100%;
+  width: 100%;
 }
 
 .updated-kpi .property-name {
   font-weight: bold;
   color: #000716;
-  padding: 2px 0;
+  padding: 8px 8px 2px;
 }
 
 .updated-kpi .asset-name {
   color: #414d5c;
-  padding: 2px 0;
+  padding: 8px 8px 2px;
 }
 
 .updated-kpi .value {
   font-weight: bold;
-  padding: 4px 0;
+  padding: 8px 8px 2px;
 }
 
 .updated-kpi .timestamp-container {
@@ -28,10 +35,20 @@
 }
 
 .updated-kpi .timestamp-border {
-  position: relative;
-  width: calc(100% + 16px);
   height: 2px;
-  left: -8px;
   background-color: #e9ebed;
-  margin: 8px 0;
+}
+
+.updated-kpi .timestamp {
+  padding: 6px;
+  height: 18px;
+}
+
+.kpi-line-threshold {
+  height: 100%;
+  width: 16px;
+}
+
+.aggregation {
+  padding: 6px;
 }

--- a/packages/react-components/src/components/kpi/kpi.tsx
+++ b/packages/react-components/src/components/kpi/kpi.tsx
@@ -7,11 +7,11 @@ import type {
   StyleSettingsMap,
   Viewport,
   TimeSeriesDataQuery,
+  StyledThreshold,
 } from '@iot-app-kit/core';
 import type { KPISettings } from './types';
 import { UpdatedKpiBase } from './updatedKpiBase';
 import { KpiBase } from './kpiBase';
-import { StyledThreshold } from '../chart/types';
 
 export const KPI = ({
   query,
@@ -46,7 +46,6 @@ export const KPI = ({
   const {
     propertyPoint,
     alarmPoint,
-    alarmThreshold,
     propertyThreshold,
     alarmStream,
     propertyStream,
@@ -59,11 +58,10 @@ export const KPI = ({
 
   const name = propertyStream?.name || alarmStream?.name;
   const unit = propertyStream?.unit || alarmStream?.unit;
-  const color =
-    alarmThreshold?.color ||
-    propertyThreshold?.color ||
-    settings?.color ||
-    settings?.backgroundColor;
+  const backgroundColor =
+    propertyThreshold?.color || settings?.color || settings?.backgroundColor;
+  const isThresholdVisible = !!propertyThreshold?.color;
+  const isFilledThreshold = !!propertyThreshold?.fill;
   const isLoading =
     alarmStream?.isLoading || propertyStream?.isLoading || false;
   const error = alarmStream?.error || propertyStream?.error;
@@ -75,7 +73,9 @@ export const KPI = ({
       <UpdatedKpiBase
         propertyPoint={propertyPoint}
         alarmPoint={alarmPoint}
-        settings={{ ...settings, backgroundColor: color }}
+        settings={{ ...settings, backgroundColor }}
+        isThresholdVisible={isThresholdVisible}
+        isFilledThreshold={isFilledThreshold}
         aggregationType={dataStreams[0]?.aggregationType}
         resolution={propertyResolution}
         name={name}
@@ -95,7 +95,7 @@ export const KPI = ({
       resolution={propertyResolution}
       name={name}
       unit={unit}
-      color={color}
+      color={backgroundColor}
       isLoading={isLoading}
       error={error?.msg}
       significantDigits={significantDigits}

--- a/packages/react-components/src/components/kpi/types.ts
+++ b/packages/react-components/src/components/kpi/types.ts
@@ -2,6 +2,8 @@ import type { WidgetSettings } from '../../common/dataTypes';
 
 export type KPIProperties = WidgetSettings & {
   settings?: Partial<KPISettings>;
+  isFilledThreshold?: boolean;
+  isThresholdVisible?: boolean;
 };
 
 export type KPISettings = {

--- a/packages/react-components/src/components/kpi/updatedKpiBase.tsx
+++ b/packages/react-components/src/components/kpi/updatedKpiBase.tsx
@@ -22,6 +22,8 @@ export const UpdatedKpiBase: React.FC<KPIProperties> = ({
   isLoading,
   settings = {},
   significantDigits,
+  isFilledThreshold,
+  isThresholdVisible,
 }) => {
   const {
     showUnit,
@@ -36,9 +38,13 @@ export const UpdatedKpiBase: React.FC<KPIProperties> = ({
     ...omitBy(settings, (x) => x == null),
   };
 
+  const background =
+    !isFilledThreshold && isThresholdVisible ? '#ffffff' : backgroundColor;
+  const highContrastFontColor =
+    background === '#ffffff' ? '' : highContrastColor(background);
+  const fontColor = isFilledThreshold ? highContrastFontColor : '';
+
   const point = propertyPoint;
-  const fontColor =
-    backgroundColor === '#ffffff' ? '' : highContrastColor(backgroundColor);
   const aggregationResolutionString = getAggregationFrequency(
     resolution,
     aggregationType
@@ -64,57 +70,60 @@ export const UpdatedKpiBase: React.FC<KPIProperties> = ({
 
   return (
     <div
-      className='updated-kpi'
+      className='updated-kpi-container'
       data-testid='kpi-base-component'
-      style={{ backgroundColor }}
+      style={{ backgroundColor: background }}
     >
-      <div>
-        <div
-          className='property-name'
-          style={{ fontSize: `${secondaryFontSize}px`, color: fontColor }}
-        >
-          {isLoading ? '-' : showName && name}{' '}
-          {showUnit && !isLoading && unit && `(${unit})`}
+      <div className='updated-kpi'>
+        <div>
+          <div
+            className='property-name'
+            style={{ fontSize: `${secondaryFontSize}px`, color: fontColor }}
+          >
+            {isLoading ? '-' : showName && name}{' '}
+            {showUnit && !isLoading && unit && `(${unit})`}
+          </div>
+          <div
+            className='value'
+            data-testid='kpi-value'
+            style={{ fontSize: `${fontSize}px`, color: fontColor }}
+          >
+            {isLoading ? (
+              <Spinner data-testid='loading' />
+            ) : (
+              <Value value={point?.y} precision={significantDigits} />
+            )}
+          </div>
         </div>
-        <div
-          className='value'
-          data-testid='kpi-value'
-          style={{ fontSize: `${fontSize}px`, color: fontColor }}
-        >
-          {isLoading ? (
-            <Spinner data-testid='loading' />
-          ) : (
-            <Value value={point?.y} precision={significantDigits} />
-          )}
-        </div>
-      </div>
-      {point && (
-        <div
-          className='timestamp-container'
-          style={{ fontSize: `${secondaryFontSize}px`, color: fontColor }}
-        >
-          {showAggregationAndResolution && aggregationResolutionString && (
-            <div>{isLoading ? '-' : aggregationResolutionString}</div>
-          )}
-          {showTimestamp && (
-            <>
-              <div
-                className='timestamp-border'
-                style={{ backgroundColor: fontColor }}
-              />
-              {isLoading ? (
-                '-'
-              ) : (
+        {point && (
+          <div
+            className='timestamp-container'
+            style={{
+              fontSize: fontSizeBodyS,
+              color: fontColor,
+            }}
+          >
+            {showAggregationAndResolution && aggregationResolutionString && (
+              <div className='aggregation'>
+                {isLoading ? '-' : aggregationResolutionString}
+              </div>
+            )}
+            {showTimestamp && (
+              <>
                 <div
-                  className='timestamp'
-                  style={{ fontSize: `${fontSizeBodyS}` }}
-                >
-                  {new Date(point.x).toLocaleString()}
+                  className='timestamp-border'
+                  style={{ backgroundColor: fontColor }}
+                />
+                <div className='timestamp'>
+                  {isLoading ? '-' : new Date(point.x).toLocaleString()}
                 </div>
-              )}
-            </>
-          )}
-        </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+      {!isFilledThreshold && isThresholdVisible && (
+        <div style={{ backgroundColor }} className='kpi-line-threshold' />
       )}
     </div>
   );

--- a/packages/react-components/src/utils/breachedThreshold.ts
+++ b/packages/react-components/src/utils/breachedThreshold.ts
@@ -7,6 +7,7 @@ import type {
   DataStream,
   DataStreamId,
   Primitive,
+  StyledThreshold,
 } from '@iot-app-kit/core';
 
 const isHigherPriority = (
@@ -123,12 +124,12 @@ export const breachedThreshold = ({
   value: Primitive | undefined;
   // The point in time to evaluate the alarm streams at against the thresholds
   date: Date;
-  thresholds: Threshold[];
+  thresholds: StyledThreshold[];
   // All data streams, utilized to find the alarm streams associated with the info
   dataStreams: DataStream[];
   // stream associated with the point who's value is being evaluated. Used to find associated alarms
   dataStream: DataStream;
-}): Threshold | undefined => {
+}): StyledThreshold | undefined => {
   const applicableThresholds = thresholds.filter((threshold) =>
     thresholdAppliesToDataStream(threshold, dataStream.id)
   );

--- a/packages/react-components/src/utils/thresholdUtils.spec.ts
+++ b/packages/react-components/src/utils/thresholdUtils.spec.ts
@@ -60,6 +60,13 @@ describe('annotation logic', () => {
     ${'STOP'}    | ${'STOP'}      | ${COMPARISON_OPERATOR.CONTAINS}           | ${true}
     ${'STOPPED'} | ${'STOP'}      | ${COMPARISON_OPERATOR.CONTAINS}           | ${true}
     ${'3 STOP'}  | ${'STOP'}      | ${COMPARISON_OPERATOR.CONTAINS}           | ${true}
+    ${true}      | ${false}       | ${COMPARISON_OPERATOR.GREATER_THAN_EQUAL} | ${false}
+    ${true}      | ${false}       | ${COMPARISON_OPERATOR.GREATER_THAN}       | ${false}
+    ${true}      | ${false}       | ${COMPARISON_OPERATOR.LESS_THAN_EQUAL}    | ${false}
+    ${true}      | ${false}       | ${COMPARISON_OPERATOR.LESS_THAN}          | ${false}
+    ${true}      | ${false}       | ${COMPARISON_OPERATOR.CONTAINS}           | ${false}
+    ${true}      | ${false}       | ${COMPARISON_OPERATOR.EQUAL}              | ${false}
+    ${true}      | ${true}        | ${COMPARISON_OPERATOR.EQUAL}              | ${true}
   `(
     'Check if data point is within the threshold',
     ({ key, thresholdValue, operator, expected }) => {


### PR DESCRIPTION
## Overview
Add threshold style settings to KPI and Status (gated only!) 

this is what the different settings look like
with/without timestamp + with line or filled widget
<img width="481" alt="Screenshot 2024-02-23 at 12 11 27" src="https://github.com/awslabs/iot-app-kit/assets/28601414/f3dc0a84-6d6e-4b20-8d31-2df85573ce78">


video of threshold being added to new KPI widget 


https://github.com/awslabs/iot-app-kit/assets/28601414/c2a06a01-2563-45b2-ad2b-503831bc37c9


Also cleaned up some types 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
