### PR TITLE
fix(react-components): lowered min/max throttle to match TC throttle

### DIFF
--- a/packages/react-components/src/echarts/extensions/minMaxDataStreamValues/updateDataStreamMinMax.ts
+++ b/packages/react-components/src/echarts/extensions/minMaxDataStreamValues/updateDataStreamMinMax.ts
@@ -5,7 +5,7 @@ import throttle from 'lodash.throttle';
 import Grid from 'echarts/types/src/coord/cartesian/Grid';
 import { LifecycleEvents } from 'echarts/types/src/core/lifecycle';
 
-const THROTTLE_RATE = 2000;
+const THROTTLE_RATE = 1000;
 
 // Echarts core use type does not map correctly to the echarts extension type so exporting as any
 // eslint-disable-next-line


### PR DESCRIPTION
## Overview
Lowered throttle of min/max sync to 1 second to match TC throttle

https://github.com/awslabs/iot-app-kit/assets/145582655/255f1142-bb67-4d12-a546-ae3e2292bffd

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
