### PR TITLE
fix: chart gesture icons overlap on mouse hover

### DIFF
--- a/packages/dashboard/src/components/widgets/widgetActions.css
+++ b/packages/dashboard/src/components/widgets/widgetActions.css
@@ -2,6 +2,6 @@
   display: flex;
   align-items: center;
   position: absolute;
-  top: -20px;
+  top: -18px;
   z-index: 999; /* Widget actions toolbox should be above the widget container */
 }

--- a/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
+++ b/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
@@ -34,7 +34,7 @@ const useTitle = ({
   return useMemo(
     () => ({
       text: hasSeries ? titleText ?? '' : 'No data present',
-      padding: [0, 12],
+      padding: [4, 12],
       textStyle: {
         width: chartWidth - 90, // Decreased 90px width from chart width for title to avoid overlapping with the title and zoom in and out buttons
         overflow: 'truncate',

--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -11,6 +11,7 @@ import type {
 export const DEFAULT_TOOLBOX_CONFIG: ToolboxComponentOption = {
   show: true,
   right: 30,
+  top: 6, // top 6 is to avoid the overalping of echart toolbox with widget toolbox
   feature: {
     dataZoom: { title: { back: 'Undo\nzoom' }, filterMode: 'none' },
   },


### PR DESCRIPTION
## Overview
Updated the UX as per comments in #2589  for ticket #2439 . Provided top 6 for the echart toolbox and padding 4 to echart title to avoid overlapping with the widget toolbox. 

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/139960352/38def2f0-462e-4e27-9d50-a2ab9039d935


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
