### PR TITLE
fix: remove double aggregation picker

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/lineAndScatterStyleSettings/section.tsx
@@ -13,7 +13,6 @@ import { LegendSection } from './legendSection';
 import { maybeWithDefault } from '~/util/maybe';
 import { PropertyLens } from '~/customization/propertiesSection';
 import { getPlugin } from '@iot-app-kit/core';
-import { AggregationsSettingsConfiguration } from '../aggregationSettings';
 
 const isLineAndScatterWidget = (
   w: DashboardWidget
@@ -160,7 +159,6 @@ const RenderLineAndScatterStyleSettingsSection = ({
 
   return (
     <>
-      <AggregationsSettingsConfiguration />
       <YAxisSection
         visible={axis?.yVisible ?? true}
         min={axis?.yMin ?? null}


### PR DESCRIPTION
## Overview
Remove duplicate aggregation/resolution picker now that its one component

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
