### PR TITLE
fix(scene): update dependency for selection change use effect

### DIFF
--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -182,7 +182,7 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
         additionalComponentData,
       });
     }
-  }, [selectedSceneNodeRef]);
+  }, [selectedSceneNodeRef, onSelectionChanged]);
 
   useEffect(() => {
     const node = getSceneNodeByRef(selectedSceneNodeRef);


### PR DESCRIPTION
## Overview
Customers report OnSelectionChange not firing in certain instances.  It's possible that if OnSelectionChange changes over the life time of the application that the useEffect firing it isn't being updated properly because it's not in the dependency list

## Verifying Changes
use storybook and click on hierarchy objects and ensure that Action still logs selection changes.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
