### PR TITLE
fix: remove fetchMostRecentBeforeStart from status and kpi

### DIFF
--- a/packages/react-components/src/components/kpi/kpi.tsx
+++ b/packages/react-components/src/components/kpi/kpi.tsx
@@ -35,7 +35,6 @@ export const KPI = ({
     queries: [query],
     settings: {
       fetchMostRecentBeforeEnd: true,
-      fetchMostRecentBeforeStart: true,
     },
     styles,
   });

--- a/packages/react-components/src/components/status/status.tsx
+++ b/packages/react-components/src/components/status/status.tsx
@@ -37,7 +37,6 @@ export const Status = ({
     queries: [query],
     settings: {
       fetchMostRecentBeforeEnd: true,
-      fetchMostRecentBeforeStart: true,
     },
     styles,
   });


### PR DESCRIPTION
## Overview
remove fetchMostRecentBeforeStart setting from status and kpi components
which was making extra API calls

before "last 5 min" made two API calls:
<img width="1257" alt="Screenshot 2024-02-27 at 13 59 05" src="https://github.com/awslabs/iot-app-kit/assets/28601414/c389a3a6-3a6f-46f8-8f25-068270696191">

after "last 5 minutes" makes one API call:
<img width="1275" alt="image" src="https://github.com/awslabs/iot-app-kit/assets/28601414/5acea06c-bc1d-4a5c-b7b9-98458baf707a">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
