### PR TITLE
fix(dashboard): style fixes to make the dashboard accessible at small screensizes

### DIFF
--- a/packages/dashboard/src/components/assetModelSelection/assetModelSelection.css
+++ b/packages/dashboard/src/components/assetModelSelection/assetModelSelection.css
@@ -1,4 +1,5 @@
 .asset-model-selection {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 }

--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -65,6 +65,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 200px;
 }
 
 .collapsible-panel-header-container {
@@ -73,6 +74,16 @@
 
 .collapsible-panel {
   position: relative;
+}
+
+/* subtract the collapsed right panel width plus the drag handle */
+.collapsible-panel-left {
+  max-width: calc(100vw - 94px);
+}
+
+/* subtract the collapsed left panel width */
+.collapsible-panel-right {
+  max-width: calc(100vw - 84px);
 }
 
 .collapsible-panel-left,


### PR DESCRIPTION
## Overview
In order to make the dashboard accessible, the content needs to reflow correctly at small or zoomed in screen sizes. It should be accessible at a minimum viewport width of 320px without requiring horizontal scrolling.

These fixes are so that the toolbar and resource / config panels do not cause overflow when the viewport is small.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
