### PR TITLE
fix(dashboard): revert the title change for line chart

### DIFF
--- a/packages/dashboard/src/components/widgets/tile/tile.css
+++ b/packages/dashboard/src/components/widgets/tile/tile.css
@@ -21,6 +21,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-height: 22px;
 }
 
 .tile-button-contianer {

--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -20,7 +20,7 @@ export type WidgetTileProps = PropsWithChildren<{
  * Component to add functionality to the widget container
  * Allows a user to title a widget for bar and status-timeline
  */
-const WidgetTile: React.FC<WidgetTileProps> = ({ widget, title, children }) => {
+const WidgetTile: React.FC<WidgetTileProps> = ({ title, children }) => {
   return (
     <div
       aria-description='widget tile'
@@ -31,16 +31,14 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ widget, title, children }) => {
         backgroundColor: colorBackgroundContainerContent,
       }}
     >
-      {(widget.type === 'bar-chart' || widget.type === 'status-timeline') && (
-        <Box
-          padding={{ horizontal: 's', top: 'xs' }}
-          color='text-body-secondary'
-          fontSize='heading-m'
-          fontWeight='bold'
-        >
-          <div className='widget-tile-header'>{title}</div>
-        </Box>
-      )}
+      <Box
+        padding={{ horizontal: 's', top: 'xs' }}
+        color='text-body-secondary'
+        fontSize='heading-m'
+        fontWeight='bold'
+      >
+        <div className='widget-tile-header'>{title}</div>
+      </Box>
       <div className='widget-tile-body'>{children}</div>
     </div>
   );

--- a/packages/dashboard/src/components/widgets/widgetActions.tsx
+++ b/packages/dashboard/src/components/widgets/widgetActions.tsx
@@ -62,6 +62,9 @@ const DeletableTileAction = ({
 
 const WidgetActions = ({ widget }: { widget: DashboardWidget }) => {
   const dispatch = useDispatch();
+  const isEdgeModeEnabled = useSelector(
+    (state: DashboardState) => state.isEdgeModeEnabled
+  );
   const { iotSiteWiseClient } = useClients();
   const { onDelete } = useDeleteWidgets();
   const metricsRecorder = getPlugin('metricsRecorder');
@@ -117,7 +120,7 @@ const WidgetActions = ({ widget }: { widget: DashboardWidget }) => {
         pointerEvents: 'auto',
       }}
     >
-      {widget.type !== 'text' && iotSiteWiseClient && (
+      {!isEdgeModeEnabled && widget.type !== 'text' && iotSiteWiseClient && (
         <CSVDownloadButton
           variant='inline-icon'
           fileName={`${widget.properties.title ?? widget.type}`}

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -177,7 +177,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (
 
   // the 4 is from the widget tile top, bottom boder lines height
   // the 8 is from the left and right border lines width
-  const size = { width: chartSize.width - 8, height: chartSize.height - 4 };
+  const size = { width: chartSize.width - 8, height: chartSize.height - 34 };
 
   const onChartOptionsChange = (options: Pick<ChartOptions, 'legend'>) => {
     dispatch(
@@ -208,7 +208,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (
   }
 
   return (
-    <WidgetTile widget={widget}>
+    <WidgetTile widget={widget} title={title}>
       <Chart
         id={widget.id}
         queries={queries}
@@ -220,7 +220,6 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (
         thresholds={thresholds}
         significantDigits={significantDigits}
         size={size}
-        titleText={title}
         legend={legend}
         onChartOptionsChange={onChartOptionsChange}
         defaultVisualizationType={mapConnectionStyleToVisualizationType(


### PR DESCRIPTION
## Overview
A recent change to the widget tile moved the title of the xy-plot widget from the tile component into the chart. The tile title acted as a drag area for the widget, meaning the widget drag UX degraded. As a temporary fix, this change adds the title back to the tile.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
