### PR TITLE
chore(app kit): removing dead turbo command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "start": "cd packages/components && npm start",
     "build": "turbo run build",
     "clean": "git clean -dxf -e /.idea -e /.vscode -e creds.json",
-    "dev": "turbo run dev",
     "lint": "turbo run lint",
     "fix": "turbo run fix && npm run fix:stylelint",
     "fix:stylelint": "stylelint '**/*.css' --fix",


### PR DESCRIPTION
## Overview
Removing dead script. `turbo dev` was originally created in PR #562 & was later removed in PR #680. This PR removes the script referencing it. 

Resolves Issue #1749

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
