### PR TITLE
feat: user selected dashboard refresh-rate

### DIFF
--- a/packages/core/src/data-module/TimeSeriesDataModule.ts
+++ b/packages/core/src/data-module/TimeSeriesDataModule.ts
@@ -26,7 +26,7 @@ import type {
 
 export const DEFAULT_CACHE_SETTINGS = {
   ttlDurationMapping: {
-    [1.2 * MINUTE_IN_MS]: SECOND_IN_MS * 1.5,
+    [1.2 * MINUTE_IN_MS]: SECOND_IN_MS,
     [3 * MINUTE_IN_MS]: 30 * SECOND_IN_MS,
     [20 * MINUTE_IN_MS]: 5 * MINUTE_IN_MS,
   },

--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -20,6 +20,7 @@ it('renders', function () {
         },
         widgets: [],
         viewport: { duration: '5m' },
+        querySettings: {},
       }}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
@@ -48,6 +49,7 @@ it('renders in readonly initially', function () {
         },
         widgets: [],
         viewport: { duration: '5m' },
+        querySettings: {},
       }}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
@@ -84,6 +86,7 @@ it('renders in edit initially', function () {
         },
         widgets: [],
         viewport: { duration: '5m' },
+        querySettings: {},
       }}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
@@ -117,6 +120,9 @@ it('passes the correct viewMode to onSave', function () {
     },
     widgets: [],
     viewport: { duration: '5m' },
+    querySettings: {
+      refreshRate: 5000,
+    },
   };
 
   render(
@@ -157,6 +163,7 @@ it('renders dashboard name', function () {
         },
         widgets: [],
         viewport: { duration: '5m' },
+        querySettings: {},
       }}
       name='Test dashboard'
       clientConfiguration={{
@@ -183,6 +190,7 @@ it('renders without dashboard name', function () {
         },
         widgets: [],
         viewport: { duration: '5m' },
+        querySettings: {},
       }}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),

--- a/packages/dashboard/src/components/dashboard/view.test.tsx
+++ b/packages/dashboard/src/components/dashboard/view.test.tsx
@@ -19,6 +19,7 @@ it('renders', function () {
         },
         widgets: [],
         viewport: { duration: '5m' },
+        querySettings: {},
       }}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),

--- a/packages/dashboard/src/components/internalDashboard/dashboardHeader.spec.tsx
+++ b/packages/dashboard/src/components/internalDashboard/dashboardHeader.spec.tsx
@@ -1,8 +1,13 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { render } from '@testing-library/react';
 import DashboardHeader from './dashboardHeader';
+import { configureDashboardStore } from '~/store';
+import { Provider } from 'react-redux';
 
 describe('DashboardHeader', () => {
+  const ProviderWrapper = ({ children }: PropsWithChildren) => (
+    <Provider store={configureDashboardStore()}>{children}</Provider>
+  );
   it('should render the dashboard title', () => {
     const props = {
       name: 'My Dashboard',
@@ -11,6 +16,7 @@ describe('DashboardHeader', () => {
       onSave: jest.fn(),
       dashboardConfiguration: {
         widgets: [],
+        querySettings: {},
       },
       grid: {
         enabled: true,
@@ -20,7 +26,9 @@ describe('DashboardHeader', () => {
       },
       significantDigits: 2,
     };
-    const { getByText } = render(<DashboardHeader {...props} />);
+    const { getByText } = render(<DashboardHeader {...props} />, {
+      wrapper: ProviderWrapper,
+    });
     const titleElement = getByText('My Dashboard');
     expect(titleElement).toBeInTheDocument();
   });
@@ -33,6 +41,7 @@ describe('DashboardHeader', () => {
       onSave: jest.fn(),
       dashboardConfiguration: {
         widgets: [],
+        querySettings: {},
       },
       grid: {
         enabled: true,
@@ -42,7 +51,9 @@ describe('DashboardHeader', () => {
       },
       significantDigits: 2,
     };
-    const { getByTestId } = render(<DashboardHeader {...props} />);
+    const { getByTestId } = render(<DashboardHeader {...props} />, {
+      wrapper: ProviderWrapper,
+    });
     const timeSelectionElement = getByTestId('time-selection');
     expect(timeSelectionElement).toBeInTheDocument();
   });

--- a/packages/dashboard/src/components/internalDashboard/dashboardHeader.tsx
+++ b/packages/dashboard/src/components/internalDashboard/dashboardHeader.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react';
 
 import { Box, Header, SpaceBetween } from '@cloudscape-design/components';
 import { TimeSelection } from '@iot-app-kit/react-components';
+import { RefreshRateDropDown } from '../querySettingsSync/refreshRateDropDown';
 
 import {
   colorChartsLineGrid,
@@ -11,7 +12,11 @@ import {
 } from '@cloudscape-design/design-tokens';
 
 import Actions from '../actions';
-import type { DashboardSave, DashboardWidget } from '~/types';
+import type {
+  DashboardSave,
+  DashboardTimeSeriesSettings,
+  DashboardWidget,
+} from '~/types';
 
 type DashboardHeaderProps = {
   name?: string;
@@ -19,6 +24,7 @@ type DashboardHeaderProps = {
   readOnly: boolean;
   dashboardConfiguration: {
     widgets: DashboardWidget<Record<string, unknown>>[];
+    querySettings?: DashboardTimeSeriesSettings;
   };
   grid: {
     enabled: boolean;
@@ -57,6 +63,7 @@ const DashboardHeader = ({
     <Box float='right'>
       <SpaceBetween size='s' direction='horizontal' alignItems='end'>
         <TimeSelection isPaginationEnabled />
+        <RefreshRateDropDown />
         {editable && (
           <>
             <Divider key='2' />

--- a/packages/dashboard/src/components/querySettingsSync/refreshRateDropDown.spec.tsx
+++ b/packages/dashboard/src/components/querySettingsSync/refreshRateDropDown.spec.tsx
@@ -1,0 +1,56 @@
+import React, { PropsWithChildren } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RefreshRateDropDown } from './refreshRateDropDown';
+import { Provider } from 'react-redux';
+import { configureDashboardStore } from '~/store';
+
+describe('Refresh rate drop down', () => {
+  const ProviderWrapper = ({ children }: PropsWithChildren) => (
+    <Provider store={configureDashboardStore()}>{children}</Provider>
+  );
+
+  it('selecting option changes on screen', async () => {
+    const dropDownElement = <RefreshRateDropDown />;
+    const user = userEvent.setup();
+    render(dropDownElement, { wrapper: ProviderWrapper });
+    const dropDown = screen.getByLabelText('Refresh rate');
+    expect(screen.queryByText('1s')).not.toBeInTheDocument();
+    expect(screen.getByText('5s')).toBeVisible();
+    await user.click(dropDown);
+    const oneSecondOption = screen.getByText('1s');
+    await user.click(oneSecondOption);
+    expect(screen.queryByText('5s')).not.toBeInTheDocument();
+    expect(screen.getByText('1s')).toBeVisible();
+  });
+
+  it('all options are visible on dropdown click', async () => {
+    const dropDownElement = <RefreshRateDropDown />;
+    const user = userEvent.setup();
+    render(dropDownElement, { wrapper: ProviderWrapper });
+    const dropDown = screen.getByLabelText('Refresh rate');
+    await user.click(dropDown);
+    expect(screen.getByText('1s')).toBeVisible();
+    const fiveSecondOptions = screen.getAllByText('5s');
+    fiveSecondOptions.forEach((option) => expect(option).toBeVisible()); //default option + dropdown option
+    expect(screen.getByText('10s')).toBeVisible();
+    expect(screen.getByText('1m')).toBeVisible();
+    expect(screen.getByText('5m')).toBeVisible();
+  });
+
+  it('triggers modal when 1s option is selected', async () => {
+    const dropDownElement = <RefreshRateDropDown />;
+    const user = userEvent.setup();
+    render(dropDownElement, { wrapper: ProviderWrapper });
+    expect(screen.getByText('5s')).toBeVisible();
+    const dropDown = screen.getByLabelText('Refresh rate');
+    await user.click(dropDown);
+    const oneSecondOption = screen.getByText('1s');
+    await user.click(oneSecondOption);
+    expect(
+      screen.getByText(
+        'You may experience some lag by selecting the 1 second refresh rate.'
+      )
+    ).toBeVisible();
+  });
+});

--- a/packages/dashboard/src/components/querySettingsSync/refreshRateDropDown.tsx
+++ b/packages/dashboard/src/components/querySettingsSync/refreshRateDropDown.tsx
@@ -1,0 +1,46 @@
+import { Alert, FormField, Modal, Select } from '@cloudscape-design/components';
+import React, { useState } from 'react';
+import {
+  DEFAULT_REFRESH_RATE,
+  DEFAULT_OPTION,
+  refreshRateOptionMap,
+  refreshRateOptions,
+} from './utils';
+import { useRefreshRate } from '~/customization/hooks/useRefreshRate';
+import { SECOND_IN_MS } from '@iot-app-kit/core';
+
+export const RefreshRateDropDown = () => {
+  const [refreshRate, updateRefreshRate] = useRefreshRate();
+  const [visible, setVisible] = useState(refreshRate === SECOND_IN_MS);
+
+  const currentOption =
+    refreshRateOptionMap[refreshRate ?? DEFAULT_REFRESH_RATE];
+
+  return (
+    <>
+      <FormField label='Refresh rate'>
+        <Select
+          selectedOption={currentOption ?? DEFAULT_OPTION}
+          onChange={({ detail }) => {
+            updateRefreshRate(
+              parseInt(
+                detail.selectedOption.value ?? DEFAULT_REFRESH_RATE.toString()
+              )
+            );
+            setVisible(detail.selectedOption.value === SECOND_IN_MS.toString());
+          }}
+          options={refreshRateOptions}
+        />
+      </FormField>
+      <Modal
+        onDismiss={() => setVisible(false)}
+        visible={visible}
+        header='Potential Performance Impact'
+      >
+        <Alert statusIconAriaLabel='Warning' type='warning'>
+          You may experience some lag by selecting the 1 second refresh rate.
+        </Alert>
+      </Modal>
+    </>
+  );
+};

--- a/packages/dashboard/src/components/querySettingsSync/types.ts
+++ b/packages/dashboard/src/components/querySettingsSync/types.ts
@@ -1,0 +1,5 @@
+export const SECOND_IN_MS = 1000;
+export const FIVE_SECONDS_IN_MS = 5 * SECOND_IN_MS;
+export const TEN_SECONDS_IN_MS = 10 * SECOND_IN_MS;
+export const MINUTE_IN_MS = 60 * SECOND_IN_MS;
+export const FIVE_MINUTES_IN_MS = 5 * MINUTE_IN_MS;

--- a/packages/dashboard/src/components/querySettingsSync/utils.ts
+++ b/packages/dashboard/src/components/querySettingsSync/utils.ts
@@ -1,0 +1,31 @@
+import {
+  SECOND_IN_MS,
+  FIVE_SECONDS_IN_MS,
+  TEN_SECONDS_IN_MS,
+  MINUTE_IN_MS,
+  FIVE_MINUTES_IN_MS,
+} from './types';
+import { type SelectProps } from '@cloudscape-design/components';
+
+export const DEFAULT_REFRESH_RATE = 5000; // 5 seconds
+export const DEFAULT_OPTION = { label: '5s', value: '5000' };
+
+export const refreshRateOptions = [
+  { label: '1s', value: SECOND_IN_MS.toString() },
+  { label: '5s', value: FIVE_SECONDS_IN_MS.toString() },
+  { label: '10s', value: TEN_SECONDS_IN_MS.toString() },
+  { label: '1m', value: MINUTE_IN_MS.toString() },
+  { label: '5m', value: FIVE_MINUTES_IN_MS.toString() },
+] satisfies SelectProps['selectedOption'][];
+
+export const DEFAULT_REFRESH_RATE_OPTION = refreshRateOptions[1];
+
+export const refreshRateOptionMap: {
+  [key: string]: SelectProps['selectedOption'];
+} = refreshRateOptions.reduce(
+  (optionMap, { label, value }) => ({
+    ...optionMap,
+    [parseInt(value, 10)]: { label, value },
+  }),
+  {}
+);

--- a/packages/dashboard/src/customization/hooks/useRefreshRate.ts
+++ b/packages/dashboard/src/customization/hooks/useRefreshRate.ts
@@ -1,0 +1,22 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { onUpdateRefreshRateAction } from '~/store/actions';
+import { DashboardState } from '~/store/state';
+
+export const useRefreshRate = () => {
+  const dispatch = useDispatch();
+
+  const updateRefreshRate = (refreshRate: number) => {
+    dispatch(
+      onUpdateRefreshRateAction({
+        refreshRate,
+      })
+    );
+  };
+
+  const refreshRate = useSelector(
+    (state: DashboardState) =>
+      state.dashboardConfiguration.querySettings?.refreshRate
+  );
+
+  return [refreshRate, updateRefreshRate] as const;
+};

--- a/packages/dashboard/src/customization/propertiesSections/axisSettings/section.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/axisSettings/section.spec.tsx
@@ -10,6 +10,7 @@ import { AxisSettingsConfiguration } from './index';
 const state: Partial<DashboardState> = {
   dashboardConfiguration: {
     widgets: [MOCK_LINE_CHART_WIDGET],
+    querySettings: {},
   },
   selectedWidgets: [MOCK_LINE_CHART_WIDGET],
 };

--- a/packages/dashboard/src/customization/propertiesSections/settings/section.test.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/settings/section.test.tsx
@@ -9,6 +9,7 @@ import { SettingsConfiguration } from './index';
 const state: Partial<DashboardState> = {
   dashboardConfiguration: {
     widgets: [MOCK_LINE_CHART_WIDGET],
+    querySettings: {},
   },
   selectedWidgets: [MOCK_LINE_CHART_WIDGET],
 };

--- a/packages/dashboard/src/customization/propertiesSections/textSettings/link.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/textSettings/link.spec.tsx
@@ -11,6 +11,7 @@ import { TextSettingsConfiguration } from './index';
 const state: Partial<DashboardState> = {
   dashboardConfiguration: {
     widgets: [MOCK_TEXT_LINK_WIDGET],
+    querySettings: {},
   },
   selectedWidgets: [MOCK_TEXT_LINK_WIDGET],
 };

--- a/packages/dashboard/src/customization/propertiesSections/textSettings/text.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/textSettings/text.spec.tsx
@@ -22,6 +22,7 @@ const widget: TextWidget = {
 const state: Partial<DashboardState> = {
   dashboardConfiguration: {
     widgets: [widget],
+    querySettings: {},
   },
   selectedWidgets: [widget],
 };

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/index.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/index.spec.tsx
@@ -36,6 +36,7 @@ const widget: ThresholdsWidget = {
 const state: Partial<DashboardState> = {
   dashboardConfiguration: {
     widgets: [widget],
+    querySettings: {},
   },
   selectedWidgets: [widget],
 };

--- a/packages/dashboard/src/customization/widgets/barChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/component.tsx
@@ -11,6 +11,7 @@ import { getAggregation } from '../utils/widgetAggregationUtils';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
 import { useChartSize } from '~/hooks/useChartSize';
 import WidgetTile from '~/components/widgets/tile';
+import { useRefreshRate } from '~/customization/hooks/useRefreshRate';
 
 const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
   const { viewport } = useViewport();
@@ -18,6 +19,7 @@ const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
   const dashboardSignificantDigits = useSelector(
     (state: DashboardState) => state.significantDigits
   );
+  const [refreshRate] = useRefreshRate();
   const chartSize = useChartSize(widget);
 
   const {
@@ -57,6 +59,7 @@ const BarChartWidgetComponent: React.FC<BarChartWidget> = (widget) => {
         thresholds={thresholds}
         thresholdSettings={thresholdSettings}
         significantDigits={significantDigits}
+        refreshRate={refreshRate}
       />
     </WidgetTile>
   );

--- a/packages/dashboard/src/customization/widgets/kpi/component.tsx
+++ b/packages/dashboard/src/customization/widgets/kpi/component.tsx
@@ -13,12 +13,15 @@ import { getAggregation } from '../utils/widgetAggregationUtils';
 import './component.css';
 import { aggregateToString } from '~/customization/propertiesSections/aggregationSettings/helpers';
 import WidgetTile from '~/components/widgets/tile';
+import { useRefreshRate } from '~/customization/hooks/useRefreshRate';
 
 const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
   const { viewport } = useViewport();
   const dashboardSignificantDigits = useSelector(
     (state: DashboardState) => state.significantDigits
   );
+
+  const [refreshRate] = useRefreshRate();
 
   const {
     styleSettings,
@@ -79,6 +82,7 @@ const KPIWidgetComponent: React.FC<KPIWidget> = (widget) => {
         thresholds={thresholds}
         aggregationType={aggregateToString(aggregation)}
         significantDigits={significantDigits}
+        refreshRate={refreshRate}
       />
     </WidgetTile>
   );

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -29,6 +29,7 @@ import { default as lineSvgDark } from './line-dark.svg';
 import { IoTSiteWiseDataStreamQuery } from '~/types';
 import { assetModelQueryToSiteWiseAssetQuery } from '../utils/assetModelQueryToAssetQuery';
 import { onUpdateWidgetsAction } from '~/store/actions';
+import { useRefreshRate } from '~/customization/hooks/useRefreshRate';
 
 const mapConnectionStyleToVisualizationType = (
   connectionStyle: LineStyles['connectionStyle']
@@ -150,6 +151,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (
   const dashboardSignificantDigits = useSelector(
     (state: DashboardState) => state.significantDigits
   );
+  const [refreshRate] = useRefreshRate();
 
   const {
     title,
@@ -225,6 +227,7 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (
         defaultVisualizationType={mapConnectionStyleToVisualizationType(
           line?.connectionStyle
         )}
+        refreshRate={refreshRate}
       />
     </WidgetTile>
   );

--- a/packages/dashboard/src/customization/widgets/lineSymbol/component.test.tsx
+++ b/packages/dashboard/src/customization/widgets/lineSymbol/component.test.tsx
@@ -24,6 +24,9 @@ const TestComponent = (object: { widget: LineWidget; isSelected: boolean }) => {
   const initialState: Partial<DashboardState> = {
     dashboardConfiguration: {
       widgets: [widget],
+      querySettings: {
+        refreshRate: 5000,
+      },
     },
     selectedWidgets: isSelected ? [widget] : [],
   };

--- a/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
+++ b/packages/dashboard/src/customization/widgets/status-timeline/statusTimeline.tsx
@@ -10,6 +10,7 @@ import { getAggregation } from '../utils/widgetAggregationUtils';
 import WidgetTile from '~/components/widgets/tile';
 import NoChartData from '../components/no-chart-data';
 import { default as timelineSvgDark } from './timeline-dark.svg';
+import { useRefreshRate } from '~/customization/hooks/useRefreshRate';
 
 const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (
   widget
@@ -19,6 +20,7 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (
   const dashboardSignificantDigits = useSelector(
     (state: DashboardState) => state.significantDigits
   );
+  const [refreshRate] = useRefreshRate();
 
   const {
     title,
@@ -59,6 +61,7 @@ const StatusTimelineWidgetComponent: React.FC<StatusTimelineWidget> = (
         thresholds={thresholds}
         aggregationType={aggregateToString(aggregation)}
         significantDigits={significantDigits}
+        refreshRate={refreshRate}
       />
     </WidgetTile>
   );

--- a/packages/dashboard/src/customization/widgets/status/component.tsx
+++ b/packages/dashboard/src/customization/widgets/status/component.tsx
@@ -12,12 +12,14 @@ import { aggregateToString } from '~/customization/propertiesSections/aggregatio
 import { getAggregation } from '../utils/widgetAggregationUtils';
 import './component.css';
 import WidgetTile from '~/components/widgets/tile/tile';
+import { useRefreshRate } from '~/customization/hooks/useRefreshRate';
 
 const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
   const { viewport } = useViewport();
   const dashboardSignificantDigits = useSelector(
     (state: DashboardState) => state.significantDigits
   );
+  const [refreshRate] = useRefreshRate();
 
   const {
     styleSettings,
@@ -77,6 +79,7 @@ const StatusWidgetComponent: React.FC<StatusWidget> = (widget) => {
       thresholds={thresholds}
       aggregationType={aggregateToString(aggregation)}
       significantDigits={significantDigits}
+      refreshRate={refreshRate}
     />
   );
 };

--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -29,6 +29,7 @@ import { onUpdateWidgetsAction } from '~/store/actions';
 import { useTableItems } from './useTableItems';
 import WidgetTile from '~/components/widgets/tile/tile';
 import { assetModelQueryToSiteWiseAssetQuery } from '../utils/assetModelQueryToAssetQuery';
+import { useRefreshRate } from '~/customization/hooks/useRefreshRate';
 
 export const DEFAULT_TABLE_COLUMN_DEFINITIONS: TableColumnDefinition[] = [
   {
@@ -53,6 +54,7 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
   const dashboardSignificantDigits = useSelector(
     (state: DashboardState) => state.significantDigits
   );
+  const [refreshRate] = useRefreshRate();
 
   const {
     queryConfig,
@@ -137,6 +139,7 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
             )
           }
           propertyFiltering={PROPERTY_FILTERING}
+          refreshRate={refreshRate}
         />
       </div>
     </WidgetTile>

--- a/packages/dashboard/src/store/actions/changeRefreshRate/index.spec.ts
+++ b/packages/dashboard/src/store/actions/changeRefreshRate/index.spec.ts
@@ -1,0 +1,27 @@
+import { initialState } from '../../state';
+import { onUpdateRefreshRateAction, updateRefreshRate } from './index';
+
+it('it intiializes to 5 seconds', () => {
+  expect(
+    initialState.dashboardConfiguration.querySettings?.refreshRate
+  ).toEqual(5000);
+});
+it('can change refresh rate', () => {
+  expect(
+    updateRefreshRate(
+      initialState,
+      onUpdateRefreshRateAction({
+        refreshRate: 1000,
+      })
+    ).dashboardConfiguration.querySettings?.refreshRate
+  ).toEqual(1000);
+
+  expect(
+    updateRefreshRate(
+      initialState,
+      onUpdateRefreshRateAction({
+        refreshRate: 10000,
+      })
+    ).dashboardConfiguration.querySettings?.refreshRate
+  ).toEqual(10000);
+});

--- a/packages/dashboard/src/store/actions/changeRefreshRate/index.ts
+++ b/packages/dashboard/src/store/actions/changeRefreshRate/index.ts
@@ -1,0 +1,34 @@
+import type { Action } from 'redux';
+import type { DashboardState } from '../../state';
+
+type UpdateRefreshRateActionPayload = {
+  refreshRate: number;
+};
+
+export interface UpdateRefreshRateAction extends Action {
+  type: 'UPDATE_REFRESH_RATE';
+  payload: UpdateRefreshRateActionPayload;
+}
+
+export const onUpdateRefreshRateAction = (
+  payload: UpdateRefreshRateActionPayload
+): UpdateRefreshRateAction => ({
+  type: 'UPDATE_REFRESH_RATE',
+  payload,
+});
+
+export const updateRefreshRate = (
+  state: DashboardState,
+  action: UpdateRefreshRateAction
+): DashboardState => {
+  return {
+    ...state,
+    dashboardConfiguration: {
+      ...state.dashboardConfiguration,
+      querySettings: {
+        ...state.dashboardConfiguration.querySettings,
+        refreshRate: action.payload.refreshRate,
+      },
+    },
+  };
+};

--- a/packages/dashboard/src/store/actions/index.ts
+++ b/packages/dashboard/src/store/actions/index.ts
@@ -16,6 +16,7 @@ import type { BringWidgetsToFrontAction } from './bringToFront';
 import type { SendWidgetsToBackAction } from './sendToBack';
 import type { UpdateWidgetsAction } from './updateWidget';
 import type { UpdateSignificantDigitsAction } from './updateSignificantDigits';
+import { UpdateRefreshRateAction } from './changeRefreshRate';
 
 export * from './createWidget';
 export * from './deleteWidgets';
@@ -30,6 +31,7 @@ export * from './updateWidget';
 export * from './changeDashboardGrid';
 export * from './toggleReadOnly';
 export * from './updateSignificantDigits';
+export * from './changeRefreshRate';
 
 export type DashboardAction =
   | CreateWidgetsAction
@@ -47,4 +49,5 @@ export type DashboardAction =
   | ChangeDashboardHeightAction
   | ChangeDashboardCellSizeAction
   | ChangeDashboardGridEnabledAction
-  | UpdateSignificantDigitsAction;
+  | UpdateSignificantDigitsAction
+  | UpdateRefreshRateAction;

--- a/packages/dashboard/src/store/index.ts
+++ b/packages/dashboard/src/store/index.ts
@@ -36,7 +36,7 @@ export const configureDashboardStore = (
 export const toDashboardState = (
   dashboardConfiguration: DashboardConfiguration
 ): RecursivePartial<DashboardState> => {
-  const { widgets, displaySettings } = dashboardConfiguration;
+  const { widgets, displaySettings, querySettings } = dashboardConfiguration;
   const { numRows, numColumns, cellSize } = displaySettings;
 
   return {
@@ -47,6 +47,7 @@ export const toDashboardState = (
     },
     dashboardConfiguration: {
       widgets,
+      querySettings,
     },
   };
 };

--- a/packages/dashboard/src/store/reducer.ts
+++ b/packages/dashboard/src/store/reducer.ts
@@ -15,6 +15,7 @@ import {
   toggleReadOnly,
   updateSignificantDigits,
   updateWidgets,
+  updateRefreshRate,
 } from './actions';
 
 import { createWidgets } from './actions/createWidget';
@@ -89,6 +90,10 @@ export const dashboardReducer: Reducer<DashboardState, DashboardAction> = (
 
     case 'UPDATE_SIGNIFICANT_DIGITS': {
       return updateSignificantDigits(state, action);
+    }
+
+    case 'UPDATE_REFRESH_RATE': {
+      return updateRefreshRate(state, action);
     }
 
     default:

--- a/packages/dashboard/src/store/state.ts
+++ b/packages/dashboard/src/store/state.ts
@@ -1,4 +1,4 @@
-import type { DashboardWidget } from '~/types';
+import type { DashboardTimeSeriesSettings, DashboardWidget } from '~/types';
 import { deepFreeze } from '~/util/deepFreeze';
 
 export type DashboardState<
@@ -15,7 +15,10 @@ export type DashboardState<
   selectedWidgets: DashboardWidget<Properties>[];
   copiedWidgets: DashboardWidget<Properties>[];
   pasteCounter: number;
-  dashboardConfiguration: { widgets: DashboardWidget<Properties>[] };
+  dashboardConfiguration: {
+    widgets: DashboardWidget<Properties>[];
+    querySettings?: DashboardTimeSeriesSettings;
+  };
   significantDigits: number;
 };
 
@@ -42,6 +45,9 @@ export const initialState: DashboardState = deepFreeze({
   pasteCounter: 0,
   dashboardConfiguration: {
     widgets: [],
+    querySettings: {
+      refreshRate: 5000,
+    },
   },
   significantDigits: 4,
 });

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -59,10 +59,15 @@ export type DashboardDisplaySettings = {
   significantDigits?: number;
 };
 
+export type DashboardTimeSeriesSettings = {
+  refreshRate?: number;
+};
+
 export type DashboardConfiguration<
   Properties extends Record<string, unknown> = Record<string, unknown>
 > = {
   displaySettings: DashboardDisplaySettings;
+  querySettings?: DashboardTimeSeriesSettings;
   widgets: DashboardWidget<Properties>[];
   viewport: Viewport;
 };

--- a/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
@@ -25,6 +25,7 @@ const displaySettings = {
 };
 
 const viewport = { duration: '5m' };
+const querySettings = { refreshRate: 5000 };
 
 const emptyDashboardConfiguration: DashboardProperties = {
   clientConfiguration,
@@ -32,6 +33,7 @@ const emptyDashboardConfiguration: DashboardProperties = {
     displaySettings,
     viewport,
     widgets: [],
+    querySettings,
   },
   onSave: () => Promise.resolve(),
 };
@@ -41,6 +43,7 @@ const widgetDashboardConfiguration = {
   dashboardConfiguration: {
     displaySettings,
     viewport,
+    querySettings,
     widgets: [
       {
         type: 'iot-line-chart',

--- a/packages/react-components/src/components/bar-chart/barChart.tsx
+++ b/packages/react-components/src/components/bar-chart/barChart.tsx
@@ -36,6 +36,7 @@ export interface BarChartProps {
   aggregationType?: string;
   gestures?: boolean;
   significantDigits?: number;
+  refreshRate?: number;
 }
 
 export const BarChart = (props: BarChartProps) => {
@@ -49,6 +50,7 @@ export const BarChart = (props: BarChartProps) => {
     thresholdSettings,
     aggregationType,
     styles,
+    refreshRate,
     ...rest
   } = props;
 
@@ -65,6 +67,7 @@ export const BarChart = (props: BarChartProps) => {
         [HOUR_IN_MS]: '1h',
         [DAY_IN_MS * 5]: '1d',
       },
+      refreshRate,
     },
     styles,
   });

--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -55,6 +55,7 @@ const BaseChart = ({
   queries,
   onChartOptionsChange,
   size = { width: 500, height: 500 },
+  refreshRate,
   ...options
 }: ChartOptions) => {
   const isLegendVisible = options.legend?.visible;
@@ -81,7 +82,7 @@ const BaseChart = ({
 
   // convert TimeSeriesDataQuery to TimeSeriesData
   const { isLoading, dataStreams, thresholds, utilizedViewport, visibleData } =
-    useVisualizedDataStreams(queries, viewport);
+    useVisualizedDataStreams(queries, viewport, refreshRate);
 
   //handle dataZoom updates, which are dependent on user events and viewportInMS changes
   useDataZoom(chartRef, utilizedViewport);

--- a/packages/react-components/src/components/chart/hooks/useVisualizedDataStreams.ts
+++ b/packages/react-components/src/components/chart/hooks/useVisualizedDataStreams.ts
@@ -20,6 +20,7 @@ const dataStreamHasError = ({ error }: DataStream) => error != null;
 export const useVisualizedDataStreams = (
   queries: TimeSeriesDataQuery[],
   passedInViewport?: Viewport,
+  refreshRate = 5000,
   thresholdOptions: StyledThreshold[] = []
 ) => {
   const { viewport, lastUpdatedBy } = useViewport();
@@ -35,6 +36,7 @@ export const useVisualizedDataStreams = (
     queries,
     settings: {
       fetchFromStartToEnd: true,
+      refreshRate,
     },
   });
 

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -107,6 +107,7 @@ export type ChartOptions = {
   id?: string;
   titleText?: string;
   onChartOptionsChange?: (options: Pick<ChartOptions, 'legend'>) => void;
+  refreshRate?: number;
 };
 
 export interface ViewportInMs {

--- a/packages/react-components/src/components/kpi/kpi.tsx
+++ b/packages/react-components/src/components/kpi/kpi.tsx
@@ -21,6 +21,7 @@ export const KPI = ({
   settings,
   aggregationType,
   significantDigits,
+  refreshRate,
 }: {
   query: TimeSeriesDataQuery;
   viewport?: Viewport;
@@ -29,12 +30,14 @@ export const KPI = ({
   aggregationType?: string;
   settings?: Partial<KPISettings>;
   significantDigits?: number;
+  refreshRate?: number;
 }) => {
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
     queries: [query],
     settings: {
       fetchMostRecentBeforeEnd: true,
+      refreshRate,
     },
     styles,
   });

--- a/packages/react-components/src/components/status-timeline/statusTimeline.tsx
+++ b/packages/react-components/src/components/status-timeline/statusTimeline.tsx
@@ -33,6 +33,7 @@ export const StatusTimeline = ({
   viewport: passedInViewport,
   aggregationType,
   styles,
+  refreshRate,
   ...rest
 }: {
   queries: TimeSeriesDataQuery[];
@@ -43,6 +44,7 @@ export const StatusTimeline = ({
   aggregationType?: string;
   gestures?: boolean;
   significantDigits?: number;
+  refreshRate?: number;
 }) => {
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
@@ -51,6 +53,7 @@ export const StatusTimeline = ({
       fetchFromStartToEnd: true,
       fetchMostRecentBeforeStart: true,
       resolution: '0',
+      refreshRate,
     },
     styles,
   });

--- a/packages/react-components/src/components/status/status.tsx
+++ b/packages/react-components/src/components/status/status.tsx
@@ -23,6 +23,7 @@ export const Status = ({
   aggregationType,
   settings,
   significantDigits,
+  refreshRate,
 }: {
   query: TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>;
   viewport?: Viewport;
@@ -31,12 +32,14 @@ export const Status = ({
   styles?: StyleSettingsMap;
   settings?: Partial<StatusSettings>;
   significantDigits?: number;
+  refreshRate?: number;
 }) => {
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
     queries: [query],
     settings: {
       fetchMostRecentBeforeEnd: true,
+      refreshRate,
     },
     styles,
   });
@@ -81,6 +84,7 @@ export const Status = ({
         aggregationType={aggregationType}
         settings={settings}
         significantDigits={significantDigits}
+        refreshRate={refreshRate}
       />
     );
 

--- a/packages/react-components/src/components/table/table.tsx
+++ b/packages/react-components/src/components/table/table.tsx
@@ -28,6 +28,7 @@ export const Table = ({
   significantDigits,
   paginationEnabled,
   pageSize,
+  refreshRate,
   ...props
 }: {
   columnDefinitions: TableColumnDefinition[];
@@ -41,6 +42,7 @@ export const Table = ({
   significantDigits?: number;
   paginationEnabled?: boolean;
   pageSize?: number;
+  refreshRate?: number;
 } & Pick<
   TableBaseProps,
   | 'resizableColumns'
@@ -54,7 +56,7 @@ export const Table = ({
     queries,
     // Currently set to only fetch raw data.
     // TODO: Support all resolutions and aggregation types
-    settings: { fetchMostRecentBeforeEnd: true, resolution: '0' },
+    settings: { fetchMostRecentBeforeEnd: true, resolution: '0', refreshRate },
     styles,
   });
   const { viewport } = useViewport();

--- a/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.ts
+++ b/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.ts
@@ -138,7 +138,7 @@ export const useTimeSeriesData = ({
       unsubscribeProvider(id);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [queriesString]);
+  }, [queriesString, settings.refreshRate]);
 
   useEffect(() => {
     if (prevViewportRef.current != null) {


### PR DESCRIPTION
## Overview
Allow the user to select a refresh rate is used by the dashboard to get latest data. 

## Verifying Changes

Persistance + Warning
https://github.com/awslabs/iot-app-kit/assets/145582655/ccde2300-efde-4fd3-9b1b-e5de2934f8ac

KPI/Status

https://github.com/awslabs/iot-app-kit/assets/145582655/80aa2982-bfc9-4af4-9ca9-7ea910e5e234

All widgets except Line

https://github.com/awslabs/iot-app-kit/assets/145582655/b6399201-1dbe-4cc7-8322-210e259d34a5






## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
