### PR TITLE
feat(composer): update convert to attached scene component and load data from it

### DIFF
--- a/packages/scene-composer/src/common/constants.ts
+++ b/packages/scene-composer/src/common/constants.ts
@@ -165,9 +165,7 @@ export const FONT_AWESOME_PREFIX = 'fas';
 /******************************************************************************
  * Matterport Constants
  ******************************************************************************/
-export const SCENE_CAPABILITY_MATTERPORT = 'MATTERPORT';
 export const SECRET_MANAGER_MATTERPORT_TAG = 'AWSIoTTwinMaker_Matterport';
-export const MATTERPORT_SECRET_ARN = 'MATTERPORT_SECRET_ARN';
 export const MATTERPORT_ACCESS_TOKEN = 'MATTERPORT_ACCESS_TOKEN';
 export const MATTERPORT_APPLICATION_KEY = 'MATTERPORT_APPLICATION_KEY';
 export const MATTERPORT_ERROR = 'MATTERPORT_ERROR';

--- a/packages/scene-composer/src/components/SceneComposerInternal.spec.tsx
+++ b/packages/scene-composer/src/components/SceneComposerInternal.spec.tsx
@@ -4,6 +4,7 @@ import { cleanup, renderHook } from '@testing-library/react-hooks';
 import str2ab from 'string-to-arraybuffer';
 import flushPromises from 'flush-promises';
 import { Object3D, Event, Mesh, MeshBasicMaterial, Color } from 'three';
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 
 import { useSceneComposerApi, SceneComposerApi } from '..';
 import { testScenes } from '../../tests/testData';
@@ -44,8 +45,17 @@ function createSceneLoaderMock(sceneContent: string) {
 }
 
 describe('SceneComposerInternal', () => {
+  const getSceneInfo = jest.fn();
+  const mockSceneMetadataModule = {
+    getSceneInfo,
+  } as unknown as TwinMakerSceneMetadataModule;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    getSceneInfo.mockResolvedValue({
+      capabilities: [],
+      sceneMetadata: {},
+    });
   });
 
   describe('useSceneComposerApi', () => {
@@ -62,6 +72,7 @@ describe('SceneComposerInternal', () => {
               sceneComposerId={sceneComposerId}
               config={{ mode: 'Editing' }}
               sceneLoader={createSceneLoaderMock(testScenes.scene1)}
+              sceneMetadataModule={mockSceneMetadataModule}
             />
           );
         };
@@ -81,6 +92,7 @@ describe('SceneComposerInternal', () => {
             sceneComposerId={sceneComposerId}
             config={{ mode: 'Editing' }}
             sceneLoader={createSceneLoaderMock(testScenes.waterTank)}
+            sceneMetadataModule={mockSceneMetadataModule}
           />
         );
       };

--- a/packages/scene-composer/src/components/SceneComposerInternalSnap.spec.tsx
+++ b/packages/scene-composer/src/components/SceneComposerInternalSnap.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { create, act } from 'react-test-renderer';
 import str2ab from 'string-to-arraybuffer';
 import flushPromises from 'flush-promises';
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 
 import * as SceneLayoutComponents from '../layouts/SceneLayout';
 import { invalidTestScenes, testScenes } from '../../tests/testData';
@@ -33,15 +34,28 @@ function createSceneLoaderMock(sceneContent: string) {
 }
 
 describe('SceneComposerInternal', () => {
+  const getSceneInfo = jest.fn();
+  const mockSceneMetadataModule = {
+    getSceneInfo,
+  } as unknown as TwinMakerSceneMetadataModule;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    getSceneInfo.mockResolvedValue({
+      capabilities: [],
+      sceneMetadata: {},
+    });
   });
 
   it('should render correctly with an empty scene in editing mode', async () => {
     let container;
     await act(async () => {
       container = create(
-        <SceneComposerInternal config={{ mode: 'Editing' }} sceneLoader={createSceneLoaderMock('')} />,
+        <SceneComposerInternal
+          config={{ mode: 'Editing' }}
+          sceneLoader={createSceneLoaderMock('')}
+          sceneMetadataModule={mockSceneMetadataModule}
+        />,
       );
 
       await flushPromises();
@@ -55,7 +69,11 @@ describe('SceneComposerInternal', () => {
     let container;
     await act(async () => {
       container = create(
-        <SceneComposerInternal config={{ mode: 'Viewing' }} sceneLoader={createSceneLoaderMock('')} />,
+        <SceneComposerInternal
+          config={{ mode: 'Viewing' }}
+          sceneLoader={createSceneLoaderMock('')}
+          sceneMetadataModule={mockSceneMetadataModule}
+        />,
       );
 
       await flushPromises();
@@ -69,7 +87,11 @@ describe('SceneComposerInternal', () => {
     let container;
     await act(async () => {
       container = create(
-        <SceneComposerInternal config={{ mode: 'Editing' }} sceneLoader={createSceneLoaderMock(testScenes.scene1)} />,
+        <SceneComposerInternal
+          config={{ mode: 'Editing' }}
+          sceneLoader={createSceneLoaderMock(testScenes.scene1)}
+          sceneMetadataModule={mockSceneMetadataModule}
+        />,
       );
 
       await flushPromises();
@@ -86,6 +108,7 @@ describe('SceneComposerInternal', () => {
         <SceneComposerInternal
           config={{ mode: 'Editing' }}
           sceneLoader={createSceneLoaderMock(invalidTestScenes.unsupportedMinorVersionScene)}
+          sceneMetadataModule={mockSceneMetadataModule}
         />,
       );
 
@@ -102,6 +125,7 @@ describe('SceneComposerInternal', () => {
         <SceneComposerInternal
           config={{ mode: 'Editing' }}
           sceneLoader={createSceneLoaderMock(invalidTestScenes.unsupportedMajorVersion)}
+          sceneMetadataModule={mockSceneMetadataModule}
         />,
       );
 
@@ -118,6 +142,7 @@ describe('SceneComposerInternal', () => {
         <SceneComposerInternal
           config={{ mode: 'Editing' }}
           sceneLoader={createSceneLoaderMock(invalidTestScenes.invalidSpecVersionScene)}
+          sceneMetadataModule={mockSceneMetadataModule}
         />,
       );
 
@@ -132,8 +157,16 @@ describe('SceneComposerInternal', () => {
     await act(async () => {
       container = create(
         <div>
-          <SceneComposerInternal config={{ mode: 'Editing' }} sceneLoader={createSceneLoaderMock(testScenes.scene1)} />
-          <SceneComposerInternal config={{ mode: 'Editing' }} sceneLoader={createSceneLoaderMock(testScenes.scene2)} />
+          <SceneComposerInternal
+            config={{ mode: 'Editing' }}
+            sceneLoader={createSceneLoaderMock(testScenes.scene1)}
+            sceneMetadataModule={mockSceneMetadataModule}
+          />
+          <SceneComposerInternal
+            config={{ mode: 'Editing' }}
+            sceneLoader={createSceneLoaderMock(testScenes.scene2)}
+            sceneMetadataModule={mockSceneMetadataModule}
+          />
         </div>,
       );
 
@@ -152,8 +185,13 @@ describe('SceneComposerInternal', () => {
           <SceneComposerInternal
             config={{ mode: 'Editing' }}
             sceneLoader={createSceneLoaderMock(invalidTestScenes.invalidJson)}
+            sceneMetadataModule={mockSceneMetadataModule}
           />
-          <SceneComposerInternal config={{ mode: 'Editing' }} sceneLoader={createSceneLoaderMock(testScenes.scene1)} />
+          <SceneComposerInternal
+            config={{ mode: 'Editing' }}
+            sceneLoader={createSceneLoaderMock(testScenes.scene1)}
+            sceneMetadataModule={mockSceneMetadataModule}
+          />
         </div>,
       );
 
@@ -170,6 +208,7 @@ describe('SceneComposerInternal', () => {
         <SceneComposerInternal
           config={{ mode: 'Editing' }}
           sceneLoader={createSceneLoaderMock(invalidTestScenes.invalidJson)}
+          sceneMetadataModule={mockSceneMetadataModule}
         />,
       );
 
@@ -185,7 +224,11 @@ describe('SceneComposerInternal', () => {
     });
 
     const container = create(
-      <SceneComposerInternal config={{ mode: 'Editing' }} sceneLoader={createSceneLoaderMock('')} />,
+      <SceneComposerInternal
+        config={{ mode: 'Editing' }}
+        sceneLoader={createSceneLoaderMock('')}
+        sceneMetadataModule={mockSceneMetadataModule}
+      />,
     );
 
     await flushPromises();

--- a/packages/scene-composer/src/components/__snapshots__/StateManager.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/StateManager.spec.tsx.snap
@@ -1,5 +1,420 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`StateManager should load dynamic scene correctly 1`] = `
+<SceneLayout
+  LoadingView={
+    <Provider>
+      <LoadingProgress />
+    </Provider>
+  }
+  externalLibraryConfig={Object {}}
+  isViewing={false}
+  onPointerMissed={[Function]}
+/>
+`;
+
+exports[`StateManager should load dynamic scene with error for empty document 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background-color: colorBackgroundLayoutMain;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  position: relative;
+  overflow: hidden;
+}
+
+.c4 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+.c5 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  overflow: hidden;
+  padding: 4px;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background-color: rgba(0,0,0,0.7);
+}
+
+.c2 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div
+  className="c0"
+  data-mocked="Box"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+      data-mocked="Container"
+    >
+      <div>
+        <div
+          data-mocked="Header"
+          variant="h2"
+        >
+          Error
+        </div>
+      </div>
+      <div
+        data-mocked="TextContent"
+      >
+        <p>
+          Failed to parse scene metadata
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    className="c3"
+    data-mocked="Box"
+  >
+    <div
+      className="c4"
+      data-mocked="Box"
+    >
+      <div
+        className="c5"
+        data-mocked="Box"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StateManager should load dynamic scene with error for getting scene entity failure 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background-color: colorBackgroundLayoutMain;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  position: relative;
+  overflow: hidden;
+}
+
+.c4 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+.c5 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  overflow: hidden;
+  padding: 4px;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background-color: rgba(0,0,0,0.7);
+}
+
+.c2 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div
+  className="c0"
+  data-mocked="Box"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+      data-mocked="Container"
+    >
+      <div>
+        <div
+          data-mocked="Header"
+          variant="h2"
+        >
+          Error
+        </div>
+      </div>
+      <div
+        data-mocked="TextContent"
+      >
+        <p>
+          get scene entity failure
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    className="c3"
+    data-mocked="Box"
+  >
+    <div
+      className="c4"
+      data-mocked="Box"
+    >
+      <div
+        className="c5"
+        data-mocked="Box"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StateManager should load dynamic scene with error for getting scene info failure 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background-color: colorBackgroundLayoutMain;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  position: relative;
+  overflow: hidden;
+}
+
+.c4 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+.c5 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  overflow: hidden;
+  padding: 4px;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background-color: rgba(0,0,0,0.7);
+}
+
+.c2 {
+  width: 600px;
+  margin: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  z-index: 1000;
+}
+
+<div
+  className="c0"
+  data-mocked="Box"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+      data-mocked="Container"
+    >
+      <div>
+        <div
+          data-mocked="Header"
+          variant="h2"
+        >
+          Error
+        </div>
+      </div>
+      <div
+        data-mocked="TextContent"
+      >
+        <p>
+          Failed to get scene info
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    className="c3"
+    data-mocked="Box"
+  >
+    <div
+      className="c4"
+      data-mocked="Box"
+    >
+      <div
+        className="c5"
+        data-mocked="Box"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`StateManager should render correctly 1`] = `
 <SceneLayout
   LoadingView={

--- a/packages/scene-composer/src/components/panels/scene-settings/MatterportIntegration.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/MatterportIntegration.tsx
@@ -7,13 +7,14 @@ import { useStore, useViewOptionState } from '../../../store';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import { KnownSceneProperty } from '../../../interfaces';
 import { getGlobalSettings, subscribe, unsubscribe } from '../../../common/GlobalSettings';
-import { MATTERPORT_ERROR, MATTERPORT_SECRET_ARN } from '../../../common/constants';
+import { MATTERPORT_ERROR } from '../../../common/constants';
 import {
   getMatterportConnectionList,
   getUpdatedSceneInfoForConnection,
 } from '../../../utils/matterportIntegrationUtils';
 import { OPTIONS_PLACEHOLDER_VALUE } from '../../../common/internalConstants';
 import { DisplayMessageCategory } from '../../../store/internalInterfaces';
+import { SceneMetadataMapKeys } from '../../../common/sceneModelConstants';
 
 import { MatterportTagSync } from './MatterportTagSync';
 
@@ -44,10 +45,14 @@ export const MatterportIntegration: React.FC = () => {
   const updateSelectedConnectionName = useCallback(async () => {
     if (twinMakerSceneMetadataModule) {
       const getSceneResponse = await twinMakerSceneMetadataModule.getSceneInfo();
-      if (getSceneResponse && getSceneResponse.sceneMetadata && getSceneResponse.sceneMetadata[MATTERPORT_SECRET_ARN]) {
+      if (
+        getSceneResponse &&
+        getSceneResponse.sceneMetadata &&
+        getSceneResponse.sceneMetadata[SceneMetadataMapKeys.MATTERPORT_SECRET_ARN]
+      ) {
         const isValidConnection = !(getSceneResponse.error && getSceneResponse.error.code === MATTERPORT_ERROR);
         setIsValidConnection(isValidConnection);
-        setSelectedConnectionName(getSceneResponse.sceneMetadata[MATTERPORT_SECRET_ARN]);
+        setSelectedConnectionName(getSceneResponse.sceneMetadata[SceneMetadataMapKeys.MATTERPORT_SECRET_ARN]);
       } else {
         setIsValidConnection(false);
         setSelectedConnectionName(OPTIONS_PLACEHOLDER_VALUE);

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneComponent.spec.ts
@@ -1,7 +1,18 @@
-import { SCENE_COMPONENT_TYPE_ID } from '../../common/entityModelConstants';
-import { KnownComponentType, KnownSceneProperty } from '../../interfaces';
+import { GetEntityCommandOutput } from '@aws-sdk/client-iottwinmaker';
 
-import { createSceneEntityComponent, updateSceneEntityComponent } from './sceneComponent';
+import { SCENE_COMPONENT_TYPE_ID } from '../../common/entityModelConstants';
+import {
+  IDataBindingConfig,
+  IOverlaySettings,
+  IRuleBasedMap,
+  ITagSettings,
+  KnownComponentType,
+  KnownSceneProperty,
+} from '../../interfaces';
+import { ISceneDocumentInternal } from '../../store';
+import { DEFAULT_DISTANCE_UNIT, DEFAULT_TAG_GLOBAL_SETTINGS } from '../../common/constants';
+
+import { createSceneEntityComponent, parseSceneCompFromEntity, updateSceneEntityComponent } from './sceneComponent';
 
 describe('createSceneEntityComponent', () => {
   it('should return expected scene component with basic fields', () => {
@@ -220,5 +231,393 @@ describe('updateSceneEntityComponent', () => {
         },
       },
     });
+  });
+});
+
+describe('parseSceneCompFromEntity', () => {
+  const emptyEntity: GetEntityCommandOutput = {
+    entityId: 'random-eid',
+    entityName: 'random-ename',
+    arn: 'random-arn',
+    status: { state: 'ACTIVE' },
+    workspaceId: 'random-wid',
+    parentEntityId: undefined,
+    hasChildEntities: undefined,
+    creationDateTime: undefined,
+    updateDateTime: undefined,
+    $metadata: {},
+  };
+  const requiredProperties = {
+    version: {
+      value: {
+        stringValue: '1',
+      },
+    },
+    specVersion: {
+      value: {
+        stringValue: '1',
+      },
+    },
+  };
+
+  it('should return undefined when expected component does not exist', () => {
+    const sceneEntity: GetEntityCommandOutput = {
+      ...emptyEntity,
+      components: {
+        random: { componentTypeId: 'random' },
+      },
+    };
+
+    expect(parseSceneCompFromEntity(sceneEntity)).toBeUndefined();
+  });
+
+  it('should return undefined when specVersion does not exist', () => {
+    const sceneEntity: GetEntityCommandOutput = {
+      ...emptyEntity,
+      components: {
+        Scene: {
+          componentTypeId: SCENE_COMPONENT_TYPE_ID,
+          properties: {
+            version: requiredProperties.version,
+          },
+        },
+      },
+    };
+
+    expect(parseSceneCompFromEntity(sceneEntity)).toBeUndefined();
+  });
+
+  it('should return undefined when version does not exist', () => {
+    const sceneEntity: GetEntityCommandOutput = {
+      ...emptyEntity,
+      components: {
+        Scene: {
+          componentTypeId: SCENE_COMPONENT_TYPE_ID,
+          properties: {
+            specVersion: requiredProperties.specVersion,
+          },
+        },
+      },
+    };
+
+    expect(parseSceneCompFromEntity(sceneEntity)).toBeUndefined();
+  });
+
+  it('should return empty scene with default values', () => {
+    const sceneEntity: GetEntityCommandOutput = {
+      ...emptyEntity,
+      components: {
+        Scene: { componentTypeId: SCENE_COMPONENT_TYPE_ID, properties: requiredProperties },
+      },
+    };
+    const expected: ISceneDocumentInternal = {
+      unit: DEFAULT_DISTANCE_UNIT,
+      ruleMap: {},
+      nodeMap: {},
+      componentNodeMap: {},
+      rootNodeRefs: [],
+      version: '1',
+      specVersion: '1',
+      properties: {
+        [KnownSceneProperty.SceneRootEntityId]: emptyEntity.entityId,
+        [KnownSceneProperty.DataBindingConfig]: { fieldMapping: {}, template: {} },
+        [KnownSceneProperty.ComponentSettings]: {},
+      },
+    };
+
+    expect(parseSceneCompFromEntity(sceneEntity)).toEqual(expected);
+  });
+
+  it('should return error with when rule statement is missing expression', () => {
+    const sceneEntity: GetEntityCommandOutput = {
+      ...emptyEntity,
+      components: {
+        Scene: {
+          componentTypeId: SCENE_COMPONENT_TYPE_ID,
+          properties: {
+            ...requiredProperties,
+            rule_statements: {
+              value: {
+                mapValue: {
+                  alarm: {
+                    listValue: [{ stringValue: JSON.stringify({ target: 'alarm on target' }) }],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    try {
+      parseSceneCompFromEntity(sceneEntity);
+    } catch (e) {
+      expect(e.message).toEqual('Invalid rule statement');
+    }
+  });
+
+  it('should return error with when rule statement is missing target', () => {
+    const sceneEntity: GetEntityCommandOutput = {
+      ...emptyEntity,
+      components: {
+        Scene: {
+          componentTypeId: SCENE_COMPONENT_TYPE_ID,
+          properties: {
+            ...requiredProperties,
+            rule_statements: {
+              value: {
+                mapValue: {
+                  alarm: {
+                    listValue: [{ stringValue: JSON.stringify({ expression: 'alarm on' }) }],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    try {
+      parseSceneCompFromEntity(sceneEntity);
+    } catch (e) {
+      expect(e.message).toEqual('Invalid rule statement');
+    }
+  });
+
+  it('should return scene with expected rules map', () => {
+    const ruleStatement1 = { expression: 'alarm on', target: 'alarm on target' };
+    const ruleStatement2 = { expression: 'alarm off', target: 'alarm off target' };
+
+    const sceneEntity: GetEntityCommandOutput = {
+      ...emptyEntity,
+      components: {
+        Scene: {
+          componentTypeId: SCENE_COMPONENT_TYPE_ID,
+          properties: {
+            ...requiredProperties,
+            rule_statements: {
+              value: {
+                mapValue: {
+                  alarm: {
+                    listValue: [
+                      { stringValue: JSON.stringify(ruleStatement1) },
+                      { stringValue: JSON.stringify(ruleStatement2) },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: Record<string, IRuleBasedMap> = {
+      alarm: {
+        statements: [ruleStatement1, ruleStatement2],
+      },
+    };
+
+    expect(parseSceneCompFromEntity(sceneEntity)?.ruleMap).toEqual(expected);
+  });
+
+  it('should return scene with expected data binding config', () => {
+    const config: IDataBindingConfig = {
+      fieldMapping: {
+        entityId: ['sel_entity'],
+        componentName: ['sel_comp'],
+      },
+      template: {
+        sel_entity: 'room1',
+        sel_comp: 'temperatureSensor2',
+      },
+    };
+
+    const sceneEntity: GetEntityCommandOutput = {
+      ...emptyEntity,
+      components: {
+        Scene: {
+          componentTypeId: SCENE_COMPONENT_TYPE_ID,
+          properties: {
+            ...requiredProperties,
+            properties_dataBindingConfig: {
+              value: {
+                mapValue: {
+                  fieldMapping: {
+                    mapValue: {
+                      entityId: {
+                        stringValue: JSON.stringify(config.fieldMapping.entityId),
+                      },
+                      componentName: {
+                        stringValue: JSON.stringify(config.fieldMapping.componentName),
+                      },
+                    },
+                  },
+                  template: {
+                    mapValue: {
+                      sel_entity: {
+                        stringValue: config.template!.sel_entity,
+                      },
+                      sel_comp: {
+                        stringValue: config.template!.sel_comp,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(parseSceneCompFromEntity(sceneEntity)?.properties?.[KnownSceneProperty.DataBindingConfig]).toEqual(config);
+  });
+
+  it('should return scene with expected component settings with default values', () => {
+    const sceneEntity: GetEntityCommandOutput = {
+      ...emptyEntity,
+      components: {
+        Scene: {
+          componentTypeId: SCENE_COMPONENT_TYPE_ID,
+          properties: {
+            ...requiredProperties,
+            properties_componentSettings: {
+              value: {
+                mapValue: {
+                  [KnownComponentType.Tag]: {
+                    mapValue: {},
+                  },
+                  [KnownComponentType.DataOverlay]: {
+                    mapValue: {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected = {
+      [KnownComponentType.Tag]: DEFAULT_TAG_GLOBAL_SETTINGS,
+      [KnownComponentType.DataOverlay]: {
+        overlayPanelVisible: false,
+      },
+    };
+
+    expect(parseSceneCompFromEntity(sceneEntity)?.properties?.[KnownSceneProperty.ComponentSettings]).toEqual(expected);
+  });
+
+  it('should return scene with expected component settings with custom values', () => {
+    const tagSettings: ITagSettings = {
+      scale: 4.4,
+      autoRescale: true,
+      enableOcclusion: false,
+    };
+    const overlaySettings: IOverlaySettings = {
+      overlayPanelVisible: false,
+    };
+
+    const sceneEntity: GetEntityCommandOutput = {
+      ...emptyEntity,
+      components: {
+        Scene: {
+          componentTypeId: SCENE_COMPONENT_TYPE_ID,
+          properties: {
+            ...requiredProperties,
+            properties_componentSettings: {
+              value: {
+                mapValue: {
+                  [KnownComponentType.Tag]: {
+                    mapValue: {
+                      scale: {
+                        stringValue: '4.4',
+                      },
+                      autoRescale: {
+                        stringValue: 'true',
+                      },
+                      enableOcclusion: {
+                        stringValue: 'false',
+                      },
+                    },
+                  },
+                  [KnownComponentType.DataOverlay]: {
+                    mapValue: {
+                      overlayPanelVisible: {
+                        stringValue: 'false',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected = {
+      [KnownComponentType.Tag]: tagSettings,
+      [KnownComponentType.DataOverlay]: overlaySettings,
+    };
+
+    expect(parseSceneCompFromEntity(sceneEntity)?.properties?.[KnownSceneProperty.ComponentSettings]).toEqual(expected);
+  });
+
+  it('should return scene with other known scene properties', () => {
+    const sceneEntity: GetEntityCommandOutput = {
+      ...emptyEntity,
+      components: {
+        Scene: {
+          componentTypeId: SCENE_COMPONENT_TYPE_ID,
+          properties: {
+            ...requiredProperties,
+            properties_environmentPreset: {
+              value: {
+                stringValue: 'neutral',
+              },
+            },
+            properties_matterportModelId: {
+              value: {
+                stringValue: 'matterport-id',
+              },
+            },
+            connectedToLayers: {
+              value: {
+                listValue: [
+                  { relationshipValue: { targetEntityId: 'layer-1' } },
+                  { relationshipValue: { targetEntityId: 'layer-2' } },
+                ],
+              },
+            },
+            properties_tagCustomColors: {
+              value: {
+                listValue: [{ stringValue: 'red' }, { stringValue: 'blue' }],
+              },
+            },
+            properties_layerDefaultRefreshInterval: {
+              value: {
+                integerValue: 1223,
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected = {
+      [KnownSceneProperty.SceneRootEntityId]: emptyEntity.entityId,
+      [KnownSceneProperty.EnvironmentPreset]: 'neutral',
+      [KnownSceneProperty.DataBindingConfig]: {
+        fieldMapping: {},
+        template: {},
+      },
+      [KnownSceneProperty.ComponentSettings]: {},
+      [KnownSceneProperty.MatterportModelId]: 'matterport-id',
+      [KnownSceneProperty.LayerIds]: ['layer-1', 'layer-2'],
+      [KnownSceneProperty.TagCustomColors]: ['red', 'blue'],
+      [KnownSceneProperty.LayerDefaultRefreshInterval]: 1223,
+    };
+
+    expect(parseSceneCompFromEntity(sceneEntity)?.properties).toEqual(expected);
   });
 });

--- a/packages/scene-composer/src/utils/matterportIntegrationUtils.spec.ts
+++ b/packages/scene-composer/src/utils/matterportIntegrationUtils.spec.ts
@@ -1,7 +1,8 @@
 import { useIntl } from 'react-intl';
+import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 
 import { OPTIONS_PLACEHOLDER_VALUE } from '../common/internalConstants';
-import { SCENE_CAPABILITY_MATTERPORT } from '../common/constants';
+import { SceneCapabilities, SceneMetadataMapKeys } from '../common/sceneModelConstants';
 
 import { getMatterportConnectionList, getUpdatedSceneInfoForConnection } from './matterportIntegrationUtils';
 
@@ -13,7 +14,7 @@ describe('matterportIntegrationUtils', () => {
   const getSceneInfo = jest.fn();
   const updateSceneInfo = jest.fn();
   const get3pConnectionList = jest.fn();
-  const mockSceneMetadataModule = {
+  const mockSceneMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
     getSceneInfo,
     updateSceneInfo,
     get3pConnectionList,
@@ -34,7 +35,10 @@ describe('matterportIntegrationUtils', () => {
 
   it('should return valid list when SceneMetadataModule is defined', async () => {
     get3pConnectionList.mockResolvedValue([{ Name: MOCK_CONNECTION_NAME, ARN: MOCK_ARN }]);
-    const connectionList = await getMatterportConnectionList(intl, mockSceneMetadataModule);
+    const connectionList = await getMatterportConnectionList(
+      intl,
+      mockSceneMetadataModule as TwinMakerSceneMetadataModule,
+    );
     expect(connectionList).toEqual([
       {
         label: 'Select a connection',
@@ -49,19 +53,25 @@ describe('matterportIntegrationUtils', () => {
 
   it('should remove Matterport config when connection is cleared', async () => {
     getSceneInfo.mockResolvedValue({
-      capabilities: [SCENE_CAPABILITY_MATTERPORT],
-      sceneMetadata: { MATTERPORT_SECRET_ARN: MOCK_ARN },
+      capabilities: [SceneCapabilities.MATTERPORT],
+      sceneMetadata: { [SceneMetadataMapKeys.MATTERPORT_SECRET_ARN]: MOCK_ARN },
     });
-    const updatedSceneInfo = await getUpdatedSceneInfoForConnection(OPTIONS_PLACEHOLDER_VALUE, mockSceneMetadataModule);
+    const updatedSceneInfo = await getUpdatedSceneInfoForConnection(
+      OPTIONS_PLACEHOLDER_VALUE,
+      mockSceneMetadataModule as TwinMakerSceneMetadataModule,
+    );
     expect(updatedSceneInfo).toEqual({ capabilities: [], sceneMetadata: {} });
   });
 
   it('should remove Matterport config when connection is cleared leaving other settings', async () => {
     getSceneInfo.mockResolvedValue({
-      capabilities: [SCENE_CAPABILITY_MATTERPORT, MOCK_CAPABILITY],
-      sceneMetadata: { MATTERPORT_SECRET_ARN: MOCK_ARN },
+      capabilities: [SceneCapabilities.MATTERPORT, MOCK_CAPABILITY],
+      sceneMetadata: { [SceneMetadataMapKeys.MATTERPORT_SECRET_ARN]: MOCK_ARN },
     });
-    const updatedSceneInfo = await getUpdatedSceneInfoForConnection(OPTIONS_PLACEHOLDER_VALUE, mockSceneMetadataModule);
+    const updatedSceneInfo = await getUpdatedSceneInfoForConnection(
+      OPTIONS_PLACEHOLDER_VALUE,
+      mockSceneMetadataModule as TwinMakerSceneMetadataModule,
+    );
     expect(updatedSceneInfo).toEqual({ capabilities: [MOCK_CAPABILITY], sceneMetadata: {} });
   });
 
@@ -70,22 +80,28 @@ describe('matterportIntegrationUtils', () => {
       capabilities: [],
       sceneMetadata: {},
     });
-    const updatedSceneInfo = await getUpdatedSceneInfoForConnection(MOCK_ARN, mockSceneMetadataModule);
+    const updatedSceneInfo = await getUpdatedSceneInfoForConnection(
+      MOCK_ARN,
+      mockSceneMetadataModule as TwinMakerSceneMetadataModule,
+    );
     expect(updatedSceneInfo).toEqual({
-      capabilities: [SCENE_CAPABILITY_MATTERPORT],
-      sceneMetadata: { MATTERPORT_SECRET_ARN: MOCK_ARN },
+      capabilities: [SceneCapabilities.MATTERPORT],
+      sceneMetadata: { [SceneMetadataMapKeys.MATTERPORT_SECRET_ARN]: MOCK_ARN },
     });
   });
 
   it('should update connection ARN when connection changed for Matterport scene', async () => {
     getSceneInfo.mockResolvedValue({
-      capabilities: [SCENE_CAPABILITY_MATTERPORT],
-      sceneMetadata: { MATTERPORT_SECRET_ARN: MOCK_ARN },
+      capabilities: [SceneCapabilities.MATTERPORT],
+      sceneMetadata: { [SceneMetadataMapKeys.MATTERPORT_SECRET_ARN]: MOCK_ARN },
     });
-    const updatedSceneInfo = await getUpdatedSceneInfoForConnection('new-ARN', mockSceneMetadataModule);
+    const updatedSceneInfo = await getUpdatedSceneInfoForConnection(
+      'new-ARN',
+      mockSceneMetadataModule as TwinMakerSceneMetadataModule,
+    );
     expect(updatedSceneInfo).toEqual({
-      capabilities: [SCENE_CAPABILITY_MATTERPORT],
-      sceneMetadata: { MATTERPORT_SECRET_ARN: 'new-ARN' },
+      capabilities: [SceneCapabilities.MATTERPORT],
+      sceneMetadata: { [SceneMetadataMapKeys.MATTERPORT_SECRET_ARN]: 'new-ARN' },
     });
   });
 });

--- a/packages/scene-composer/src/utils/matterportIntegrationUtils.ts
+++ b/packages/scene-composer/src/utils/matterportIntegrationUtils.ts
@@ -1,8 +1,9 @@
 import { TwinMakerSceneMetadataModule } from '@iot-app-kit/source-iottwinmaker';
 import { IntlShape } from 'react-intl';
 
-import { MATTERPORT_SECRET_ARN, SCENE_CAPABILITY_MATTERPORT, SECRET_MANAGER_MATTERPORT_TAG } from '../common/constants';
+import { SECRET_MANAGER_MATTERPORT_TAG } from '../common/constants';
 import { OPTIONS_PLACEHOLDER_VALUE } from '../common/internalConstants';
+import { SceneCapabilities, SceneMetadataMapKeys } from '../common/sceneModelConstants';
 
 export const getMatterportConnectionList = async (
   intl: IntlShape,
@@ -46,25 +47,25 @@ export const getUpdatedSceneInfoForConnection = async (
   }
 
   if (connection === OPTIONS_PLACEHOLDER_VALUE) {
-    if (sceneCapabilities && sceneCapabilities.includes(SCENE_CAPABILITY_MATTERPORT)) {
-      sceneCapabilities = sceneCapabilities.filter((capability) => capability !== SCENE_CAPABILITY_MATTERPORT);
+    if (sceneCapabilities && sceneCapabilities.includes(SceneCapabilities.MATTERPORT)) {
+      sceneCapabilities = sceneCapabilities.filter((capability) => capability !== SceneCapabilities.MATTERPORT);
     }
 
-    if (sceneMetadata && sceneMetadata[MATTERPORT_SECRET_ARN]) {
-      delete sceneMetadata[MATTERPORT_SECRET_ARN];
+    if (sceneMetadata && sceneMetadata[SceneMetadataMapKeys.MATTERPORT_SECRET_ARN]) {
+      delete sceneMetadata[SceneMetadataMapKeys.MATTERPORT_SECRET_ARN];
     }
   } else {
     if (!sceneCapabilities) {
       sceneCapabilities = [];
     }
-    if (!sceneCapabilities.includes(SCENE_CAPABILITY_MATTERPORT)) {
-      sceneCapabilities.push(SCENE_CAPABILITY_MATTERPORT);
+    if (!sceneCapabilities.includes(SceneCapabilities.MATTERPORT)) {
+      sceneCapabilities.push(SceneCapabilities.MATTERPORT);
     }
 
     if (!sceneMetadata) {
       sceneMetadata = {};
     }
-    sceneMetadata[MATTERPORT_SECRET_ARN] = connection;
+    sceneMetadata[SceneMetadataMapKeys.MATTERPORT_SECRET_ARN] = connection;
   }
 
   return { capabilities: sceneCapabilities, sceneMetadata: sceneMetadata };

--- a/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
+++ b/packages/scene-composer/stories/Developer/SceneComposer.stories.mdx
@@ -16,7 +16,6 @@ export const defaultArgs = {
     COMPOSER_FEATURES.Matterport,
     COMPOSER_FEATURES.SceneAppearance,
     COMPOSER_FEATURES.DynamicScene,
-    COMPOSER_FEATURES.DynamicSceneAlpha,
     COMPOSER_FEATURES.Textures,
   ],
 };

--- a/packages/source-iottwinmaker/src/scene-module/SceneMetadataModule.ts
+++ b/packages/source-iottwinmaker/src/scene-module/SceneMetadataModule.ts
@@ -67,10 +67,9 @@ export class SceneMetadataModule implements TwinMakerSceneMetadataModule {
   updateSceneInfo = async (sceneInfo: SceneInfo): Promise<void> => {
     await this.twinMakerClient.send(
       new UpdateSceneCommand({
+        ...sceneInfo,
         workspaceId: this.workspaceId,
         sceneId: this.sceneId,
-        capabilities: sceneInfo.capabilities,
-        sceneMetadata: sceneInfo.sceneMetadata,
       })
     );
   };

--- a/packages/source-iottwinmaker/src/types.ts
+++ b/packages/source-iottwinmaker/src/types.ts
@@ -9,6 +9,7 @@ import {
   DeleteEntityCommandOutput,
   GetEntityCommandInput,
   GetEntityCommandOutput,
+  UpdateSceneCommandInput,
 } from '@aws-sdk/client-iottwinmaker';
 import { SecretListEntry } from '@aws-sdk/client-secrets-manager';
 
@@ -21,10 +22,9 @@ export interface SceneLoader {
   getSceneObject: (uri: string) => Promise<ArrayBuffer> | null;
 }
 
-export type SceneInfo = {
-  capabilities?: string[];
-  sceneMetadata?: Record<string, string>;
-};
+export type SceneInfo = Partial<
+  Omit<UpdateSceneCommandInput, 'workspaceId' | 'sceneId'>
+>;
 
 export interface TwinMakerSceneMetadataModule {
   kgModule: TwinMakerKGQueryDataModule;


### PR DESCRIPTION
## Overview
- update convert scene to attached scene component 
- load scene level data from scene component for dynamic scene

## Verifying Changes
- with DynamicSceneAlpha flag off, convert scene correctly creates scene root entity without component
- static scene can be rendered
- matterport scene can be rendered
- dynamic scene can be rendered

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
