### PR TITLE
chore(doc site): adding node version to doc site workflow

### DIFF
--- a/.github/workflows/doc-site-deploy.yml
+++ b/.github/workflows/doc-site-deploy.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           lfs: 'true'
 
+      - name: Set node version 
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
+
       - name: Install and Build 🔧
         run: npm run bootstrap
 


### PR DESCRIPTION
## Overview
Release is blocked due to [failing builds](https://github.com/awslabs/iot-app-kit/actions/workflows/doc-site-deploy.yml) on Node version. Adding flag to correct the issue. 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
