### PR TITLE
fix: add range for table significant digits test

### DIFF
--- a/packages/dashboard/e2e/tests/widgets/table.spec.ts
+++ b/packages/dashboard/e2e/tests/widgets/table.spec.ts
@@ -55,7 +55,10 @@ test.describe('Test Table Widget', () => {
       .getByTestId('table-value')
       .textContent();
 
-    expect(getDecimalPlaces(widgetValue)).toBe(3);
+    // because of rounding, sometimes 0 gets cut off
+    // hence we want to check a range of [sig digits - 1, sig digits]
+    expect(getDecimalPlaces(widgetValue)).toBeGreaterThanOrEqual(2);
+    expect(getDecimalPlaces(widgetValue)).toBeLessThanOrEqual(3);
 
     //change sig digits to 1
     await configPanel.collapsedButton.click();
@@ -66,7 +69,10 @@ test.describe('Test Table Widget', () => {
       .getByTestId('table-value')
       .textContent();
 
-    expect(getDecimalPlaces(updatedWidgetValue)).toBe(1);
+    // because of rounding, sometimes 0 gets cut off
+    // hence we want to check a range of [sig digits - 1, sig digits]
+    expect(getDecimalPlaces(updatedWidgetValue)).toBeGreaterThanOrEqual(0);
+    expect(getDecimalPlaces(updatedWidgetValue)).toBeLessThanOrEqual(1);
   });
 
   test('Table Widget supports thresholds', async ({


### PR DESCRIPTION
## Overview
  Because of rounding, sometimes the last digit rounds to 0 and is not displayed. Hence we want to check a range of [sig digits - 1, sig digits] in our tests.

This is to fix a flaky test for table widgets.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
