### PR TITLE
chore: set dependabot to target rc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
+    target-branch: rc
     # Disable auto version updates for npm dependencies temporarily
     open-pull-requests-limit: 0
     ignore:
@@ -20,7 +21,9 @@ updates:
       - dependency-name: 'three-mesh-bvh'
       - dependency-name: 'three-stdlib'
       - dependency-name: '@awsui'
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    target-branch: rc


### PR DESCRIPTION
## Overview
This change sets Dependabot to target `rc` instead of `main` to reduce the risk of merge conflicts during release process.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
