### PR TITLE
fix: grouped the style buttons and associated with style label

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/textSettings/text.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/textSettings/text.tsx
@@ -131,30 +131,36 @@ const TextSettings: FC<TextSettingsProps> = ({
             updateColor={updateFontColor}
           />
 
-          <label>{defaultMessages.style}</label>
-          <SpaceBetween size='xxs' direction='horizontal'>
-            <ButtonWithState
-              aria-label='toggle bold text'
-              checked={isBold}
-              onToggle={() => toggleBold(!isBold)}
-            >
-              <b>B</b>
-            </ButtonWithState>
-            <ButtonWithState
-              aria-label='toggle italicize text'
-              checked={isItalic}
-              onToggle={() => toggleItalic(!isItalic)}
-            >
-              <i>I</i>
-            </ButtonWithState>
-            <ButtonWithState
-              aria-label='toggle underline text'
-              checked={isUnderlined}
-              onToggle={() => toggleUnderlined(!isUnderlined)}
-            >
-              <u>U</u>
-            </ButtonWithState>
-          </SpaceBetween>
+          <label id='text-style'>{defaultMessages.style}</label>
+          <div
+            aria-labelledby='text-style'
+            //eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+            tabIndex={0}
+          >
+            <SpaceBetween size='xxs' direction='horizontal'>
+              <ButtonWithState
+                aria-label='toggle bold text'
+                checked={isBold}
+                onToggle={() => toggleBold(!isBold)}
+              >
+                <b>B</b>
+              </ButtonWithState>
+              <ButtonWithState
+                aria-label='toggle italicize text'
+                checked={isItalic}
+                onToggle={() => toggleItalic(!isItalic)}
+              >
+                <i>I</i>
+              </ButtonWithState>
+              <ButtonWithState
+                aria-label='toggle underline text'
+                checked={isUnderlined}
+                onToggle={() => toggleUnderlined(!isUnderlined)}
+              >
+                <u>U</u>
+              </ButtonWithState>
+            </SpaceBetween>
+          </div>
 
           <label>{defaultMessages.size}</label>
           <Select


### PR DESCRIPTION
With this PR, the style group for text config is made accessible for the screen reader as per issue #2360 

### Verifying changes:

Before:

https://github.com/awslabs/iot-app-kit/assets/154328164/b4794167-fe2a-4b38-8cbe-2ff4036b4b36

After:

https://github.com/awslabs/iot-app-kit/assets/154328164/a7ed02c2-aeba-49c6-b80f-1b4709ec6a50

The style buttons are now first announced as group "Style" then user can tab over individual controls

Please download the videos and play on your machine to watch video with audio.