### PR TITLE
feat(tmdt): support endpoint-url parameter and respect S3 bucket name character limit

### DIFF
--- a/packages/tools-iottwinmaker/README.md
+++ b/packages/tools-iottwinmaker/README.md
@@ -57,6 +57,9 @@ ___
 - *--workspace-id*: Specify the ID of the Workspace to bootstrap the project from
 - *--out*: Specify the directory to initialize a project in
 
+### Init Parameters (optional flags)
+- *--endpoint-url*: Specify the TM service endpoint url
+
 Use this command to bootstrap a TMDT project from an existing workspace.
 
 The following will initialize a tmdt project at the specified directory with a `tmdt.json` file
@@ -77,6 +80,10 @@ ___
 - *--region*: Specify the AWS region to deploy to
 - *--workspace-id*: Specify the ID of the Workspace to deploy to
 - *--dir*: Specify the project location, directory for tmdt.json file
+
+### Deploy Parameters (optional flags)
+- *--endpoint-url*: Specify the TM service endpoint url
+- *--execution-role*: Specify the name of the execution role to associate with a new workspace
 
 The following will deploy a tmdt project at the specified directory (the directory must contain a `tmdt.json` file) into the specified workspace.
 
@@ -104,6 +111,7 @@ TMDT destroy is a destructive command hence it is a "Dry Run" by default command
 - *--delete-workspace*: Specify if TM workspace should also be deleted
 - *--delete-s3-bucket*: Specify if workspace s3 Bucket, its contents, and any associated logging bucket should be deleted
 - *--nonDryRun*: Use this flag for real deletion of resources
+- *--endpoint-url*: Specify the TM service endpoint url
 
 **Example 1:**
 

--- a/packages/tools-iottwinmaker/functional-tests/basic-functional/basic-functional.test.ts
+++ b/packages/tools-iottwinmaker/functional-tests/basic-functional/basic-functional.test.ts
@@ -432,6 +432,7 @@ test('basic functional test', async () => {
     $0: 'tmdt_local',
     region: 'us-east-1',
     'workspace-id': constants.workspaceId,
+    'non-dry-run': true,
   } as Arguments<destroy.Options>;
   expect(await destroy.handler(argv2)).toBe(0);
 

--- a/packages/tools-iottwinmaker/src/commands/destroy.ts
+++ b/packages/tools-iottwinmaker/src/commands/destroy.ts
@@ -19,6 +19,7 @@ export type Options = {
   'delete-workspace': boolean;
   'delete-s3-bucket': boolean;
   'non-dry-run': boolean;
+  'endpoint-url': string;
 };
 
 export const command = 'destroy';
@@ -56,6 +57,12 @@ export const builder: CommandBuilder<Options> = (yargs) =>
       description: 'Specify non-dry-run for real run execution of destroy.',
       default: false,
     },
+    'endpoint-url': {
+      type: 'string',
+      require: false,
+      description: 'Specify the AWS IoT TwinMaker endpoint.',
+      default: '',
+    },
   });
 
 export const handler = async (argv: Arguments<Options>) => {
@@ -64,8 +71,9 @@ export const handler = async (argv: Arguments<Options>) => {
   let deleteWorkspaceFlag: boolean = argv['delete-workspace'];
   let deleteS3Flag: boolean = argv['delete-s3-bucket'];
   const nonDryRun: boolean = argv['non-dry-run'];
+  const tmEndpoint: string = argv['endpoint-url'];
 
-  initDefaultAwsClients({ region: region });
+  initDefaultAwsClients({ region, tmEndpoint });
 
   await verifyWorkspaceExists(workspaceId);
 

--- a/packages/tools-iottwinmaker/src/commands/init.ts
+++ b/packages/tools-iottwinmaker/src/commands/init.ts
@@ -21,6 +21,7 @@ export type Options = {
   region: string;
   'workspace-id': string;
   out: string;
+  'endpoint-url': string;
 };
 
 export type tmdt_config_file = {
@@ -62,6 +63,12 @@ export const builder: CommandBuilder<Options> = (yargs) =>
       type: 'string',
       require: true,
       description: 'Specify the directory to initialize a project in.',
+    },
+    'endpoint-url': {
+      type: 'string',
+      require: false,
+      description: 'Specify the AWS IoT TwinMaker endpoint.',
+      default: '',
     },
   });
 
@@ -417,11 +424,12 @@ export const handler = async (argv: Arguments<Options>) => {
   const workspaceId: string = argv['workspace-id'];
   const region: string = argv.region;
   const outDir: string = argv.out;
+  const tmEndpoint: string = argv['endpoint-url'];
   console.log(
     `Bootstrapping project from workspace ${workspaceId} in ${region} at project directory ${outDir}`
   );
 
-  initDefaultAwsClients({ region: region });
+  initDefaultAwsClients({ region, tmEndpoint });
 
   await verifyWorkspaceExists(workspaceId);
 

--- a/packages/tools-iottwinmaker/src/lib/aws-clients.ts
+++ b/packages/tools-iottwinmaker/src/lib/aws-clients.ts
@@ -15,11 +15,14 @@ class AwsClients {
   cf: CloudFormation;
   kvs: KinesisVideo;
 
-  constructor(region: string) {
+  constructor(region: string, tmEndpoint?: string) {
     this.region = region;
     const options = { customUserAgent: 'tmdt/0.0.2', region: region };
     this.sts = new STS(options);
-    this.tm = new IoTTwinMaker(options);
+    // Only pass an endpoint if there is a string with content
+    const endpoint =
+      tmEndpoint === undefined || tmEndpoint === '' ? undefined : tmEndpoint;
+    this.tm = new IoTTwinMaker({ ...options, endpoint });
     this.iam = new IAM(options);
     this.s3 = new S3(options);
     this.cf = new CloudFormation(options);
@@ -45,8 +48,11 @@ let defaultAwsClients: AwsClients | null = null;
  * Helper function that create new aws client with a given region
  * @param options object containing the aws region
  */
-function initDefaultAwsClients(options: { region: string }) {
-  defaultAwsClients = new AwsClients(options.region);
+function initDefaultAwsClients(options: {
+  region: string;
+  tmEndpoint?: string;
+}) {
+  defaultAwsClients = new AwsClients(options.region, options.tmEndpoint);
 }
 
 /**


### PR DESCRIPTION
## Overview

Adding support for specifying a different endpoint URL for interacting with IoT TwinMaker. This is an optional parameter for the init, deploy, and destroy commands.

When deploying a TMDT workspace from scratch, if the endpoint url points to TwinMaker gamma then the IAM role must have a trust policy with the gamma service principal.

Was running into a bug where my workspace name caused S3 to throw an error when creating a bucket with too long a name. Added a method `generateS3BucketName` to ensure the S3 bucket name character limit is met.

## Verifying Changes

Tested each command with a gamma workspace successfully.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
