### PR TITLE
fix: update docsite with requestSettings type on query

### DIFF
--- a/packages/doc-site/stories/data-sources/AWSIoTSiteWiseSource.mdx
+++ b/packages/doc-site/stories/data-sources/AWSIoTSiteWiseSource.mdx
@@ -160,6 +160,14 @@ Each asset contains the following fields:
 
   Type: String
 
+`requestSettings`
+
+(Optional) Specifies how the query requests time series data.
+
+- `refreshRate`
+
+  (Optional) Specifies how often to request data again, in milliseconds. This applies to data whose time to live (TTL) has expired or to live streaming data when a viewport is specified, The default value is 5 seconds.
+
 #### Alarms
 
 AWS IoT SiteWise has a concept of [alarms](https://docs.aws.amazon.com/iot-sitewise/latest/userguide/industrial-alarms.html).


### PR DESCRIPTION
## Overview
- update docsite with querySettings object in query that contains refreshRate property

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
