### PR TITLE
fix: unit shows empty if it's undefined in the legend table datastreams

### DIFF
--- a/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
+++ b/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
@@ -35,7 +35,8 @@ const mapDataStreamInformation = ({
       return valueMap;
     }, {});
 
-    const dataStreamName = visibleContent?.unit ? `${name} (${unit})` : name;
+    const dataStreamName =
+      visibleContent?.unit && unit ? `${name} (${unit})` : name;
     const maxValue = dataStreamMaxes[id] ?? '-';
     const minValue = dataStreamMins[id] ?? '-';
 


### PR DESCRIPTION
This PR is for ticket https://github.com/awslabs/iot-app-kit/issues/2660 and updated the condition to check the unit in the legend datastream name. shows empty If the property has a unit undefined

## Verifying Changes
**Before:**
![image](https://github.com/awslabs/iot-app-kit/assets/142866907/c4f466ed-771c-4ccc-b653-71801f0cb2f9)

**After:**
![image](https://github.com/awslabs/iot-app-kit/assets/142866907/b8485ae2-adc8-4451-96e1-7bd88ab3abd0)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
