### PR TITLE
fix: clear the selection list after clicking add in unmodeled section

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
@@ -131,6 +131,7 @@ export function UnmodeledDataStreamTable({
             onClickAdd(
               collectionProps.selectedItems as unknown as UnmodeledDataStream[]
             );
+            actions.setSelectedItems([]);
             metricsRecorder?.record({
               metricName: 'UnmodeledDataStreamAdd',
               metricValue: 1,


### PR DESCRIPTION
This PR is for ticket https://github.com/awslabs/iot-app-kit/issues/2659 and added the reset selection list logic after the user clicks the Add button in the unmodeled section.

## Verifying Changes
https://github.com/awslabs/iot-app-kit/assets/142866907/d0e5fecd-7412-47b8-83ed-b414d19cd029


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
