### PR TITLE
fix: add missing loading indication for widget values

### DIFF
--- a/packages/react-components/src/components/chart/legend/table/columnDefinitions/latestValue/latestValueCell.tsx
+++ b/packages/react-components/src/components/chart/legend/table/columnDefinitions/latestValue/latestValueCell.tsx
@@ -11,5 +11,9 @@ export const LatestValueCell = ({ id, latestValue }: DataStreamInformation) => {
     [isDataStreamHidden, id]
   );
 
-  return <div className={!isVisible ? 'hidden-legend' : ''}>{latestValue}</div>;
+  return (
+    <div className={!isVisible ? 'hidden-legend' : ''}>
+      {latestValue ?? '-'}
+    </div>
+  );
 };


### PR DESCRIPTION
## Overview
- Only missing loading indication was LatestValue column in line chart legend. Added dash to match loading states of other columns when value is undefined.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/a5f27e94-54de-42bd-be51-08e39a6add77


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
