### PR TITLE
feat: updated background color tokens to support theming

### DIFF
--- a/packages/dashboard/src/components/internalDashboard/collapsiblePanel.tsx
+++ b/packages/dashboard/src/components/internalDashboard/collapsiblePanel.tsx
@@ -2,7 +2,8 @@ import React, { ReactNode } from 'react';
 
 import './index.css';
 import {
-  colorBackgroundButtonPrimaryDefault,
+  colorBackgroundLayoutMain,
+  colorBackgroundSegmentActive,
   colorBorderDividerDefault,
   spaceContainerHorizontal,
   spaceStaticL,
@@ -84,7 +85,7 @@ export function CollapsiblePanel(props: CollapsiblePanelProps) {
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
         style={{
-          backgroundColor: colorBackgroundButtonPrimaryDefault,
+          backgroundColor: colorBackgroundSegmentActive,
           margin: spaceContainerHorizontal,
         }}
         className='side_panels_collapsed_style'
@@ -109,6 +110,7 @@ export function CollapsiblePanel(props: CollapsiblePanelProps) {
         ...(props.isPanelCollapsed && {
           [`border${borderSide}`]: `${spaceStaticXxxs} solid ${colorBorderDividerDefault}`,
         }),
+        backgroundColor: colorBackgroundLayoutMain,
       }}
     >
       {props.isPanelCollapsed ? collapsedPanel : expandedPanel}

--- a/packages/dashboard/src/components/internalDashboard/index.css
+++ b/packages/dashboard/src/components/internalDashboard/index.css
@@ -28,11 +28,6 @@
   position: relative;
 }
 
-.dashboard .dashboard-toolbar,
-.dashboard .dashboard-toolbar-read-only {
-  background-color: var(--colors-white);
-}
-
 .dashboard .dashboard-toolbar .dashboard-toolbar-read-only {
   display: grid;
   grid-template-columns: auto max-content;
@@ -93,7 +88,6 @@
   height: 100%;
   max-height: calc(100vh - var(--toolbar-overlay-height));
   z-index: var(--stack-order-grid-inputs);
-  background-color: var(--colors-white);
 }
 
 .collapsible-panel-right {

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -5,6 +5,7 @@ import { WebglContext, TimeSync } from '@iot-app-kit/react-components';
 import Box from '@cloudscape-design/components/box';
 import {
   colorBackgroundCellShaded,
+  colorBackgroundLayoutMain,
   colorBorderDividerDefault,
   spaceScaledXxxs,
 } from '@cloudscape-design/design-tokens';
@@ -267,6 +268,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
 
   const dashboardToolbarBottomBorder = {
     borderBottom: `solid ${spaceScaledXxxs} ${colorBorderDividerDefault}`,
+    backgroundColor: colorBackgroundLayoutMain,
   };
 
   if (iotSiteWiseClient == null || iotTwinMakerClient == null) {

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/footer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/footer.tsx
@@ -5,7 +5,7 @@ import Box from '@cloudscape-design/components/box';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import Button from '@cloudscape-design/components/button';
 import {
-  colorBackgroundButtonNormalDefault,
+  colorBackgroundContainerContent,
   colorBorderDividerDefault,
   spaceStaticXxxs,
 } from '@cloudscape-design/design-tokens';
@@ -27,7 +27,7 @@ export const ResourceExplorerFooter = ({
 }: ResourceExplorerFooterOptions) => {
   const [componentRef, { width }] = useMeasure<HTMLDivElement>();
   const stickyFooter = {
-    backgroundColor: colorBackgroundButtonNormalDefault,
+    backgroundColor: colorBackgroundContainerContent,
     bottom: spaceStaticXxxs,
     width: width + STICKY_BUTTON_WIDTH_FACTOR,
     borderTop: `${spaceStaticXxxs} solid ${colorBorderDividerDefault}`,

--- a/packages/dashboard/src/components/widgets/selectionBoxAnchor.css
+++ b/packages/dashboard/src/components/widgets/selectionBoxAnchor.css
@@ -11,7 +11,6 @@
   height: var(--selection-box-size);
   border: var(--selection-border-width) solid;
   border-color: inherit;
-  background: var(--selection-bg-color);
   border-radius: var(--selection-radius-small);
   pointer-events: all;
 }

--- a/packages/dashboard/src/components/widgets/selectionBoxAnchor.tsx
+++ b/packages/dashboard/src/components/widgets/selectionBoxAnchor.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { colorBackgroundContainerContent } from '@cloudscape-design/design-tokens';
 import {
   anchorable,
   gestureable,
@@ -29,6 +30,9 @@ const SelectionBoxAnchor: React.FC<SelectionBoxAnchorProps> = ({ anchor }) => {
   const cornerClass = isCorner
     ? `selection-box-corner selection-box-corner-${anchor}`
     : '';
+  const cornerStyle = isCorner
+    ? { backgroundColor: colorBackgroundContainerContent }
+    : {};
   const sideClass = isSide
     ? `selection-box-side selection-box-side-${anchor}`
     : '';
@@ -45,6 +49,7 @@ const SelectionBoxAnchor: React.FC<SelectionBoxAnchorProps> = ({ anchor }) => {
         {...gestureable('resize')}
         {...anchorable(anchor)}
         className={anchorClass}
+        style={cornerStyle}
       />
     </>
   );

--- a/packages/dashboard/src/customization/widgets/components/no-chart-data.tsx
+++ b/packages/dashboard/src/customization/widgets/components/no-chart-data.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, SpaceBetween } from '@cloudscape-design/components';
-import { colorTextLayoutToggle } from '@cloudscape-design/design-tokens';
+import { colorBackgroundContainerContent } from '@cloudscape-design/design-tokens';
 
 import './no-chart-data.css';
 
@@ -16,7 +16,7 @@ const NoChartData = ({ icon, emptyStateText }: NoChartDataProps) => {
       aria-description='empty widget tile'
       className='no-chart-data-empty-state'
       style={{
-        backgroundColor: colorTextLayoutToggle,
+        backgroundColor: colorBackgroundContainerContent,
       }}
     >
       <Box textAlign='center'>


### PR DESCRIPTION
This PR is for ticket https://github.com/awslabs/iot-app-kit/issues/2668  and updated background color tokens to support theming.
This includes background color tokens for the empty widgets, resource explorer footer, widget header.

**Note:** The follow-up PRs will fix the remaining issues (as mentioned in the ticket, updating the changes incrementally, instead of doing all of the changes in the single PR).

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/142866907/42c3b7d6-cd41-41d7-9ac1-76d7d7005c75



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
