### PR TITLE
feat: added support for border theming options #2668

### DIFF
--- a/packages/react-components/src/hooks/useTheming/applyTokens.ts
+++ b/packages/react-components/src/hooks/useTheming/applyTokens.ts
@@ -3,5 +3,14 @@ import { Tokens } from './types';
 export const applyTokens = (tokens?: Tokens) => {
   return {
     fontFamilyBase: tokens?.fontFamilyBase,
+    borderRadiusButton: tokens?.borderRadiusButton,
+    borderRadiusContainer: tokens?.borderRadiusContainer,
+    borderRadiusDropdown: tokens?.borderRadiusDropdown,
+    borderRadiusInput: tokens?.borderRadiusInput,
+    colorBorderButtonNormalActive: tokens?.colorBorderButtonNormalActive,
+    colorBorderButtonNormalDefault: tokens?.colorBorderButtonNormalDefault,
+    colorBorderButtonNormalDisabled: tokens?.colorBorderButtonNormalDisabled,
+    colorBorderButtonNormalHover: tokens?.colorBorderButtonNormalHover,
+    colorBorderButtonPrimaryDisabled: tokens?.colorBorderButtonPrimaryDisabled,
   };
 };


### PR DESCRIPTION
Added support for border theming options in useTheme hook as per #2668 
Note: this PR only supports some of the properties from the #2668 , we will be raising more PRs for other properties and dark mode fixes.
- [] Support `borderRadiusButton`.
- [] Support `borderRadiusContainer`.
- [] Support `borderRadiusDropdown`.
- [] Support `borderRadiusInput`.
- [] Support `colorBorderButtonNormalActive`.
- [] Support `colorBorderButtonNormalDefault`.
- [] Support `colorBorderButtonNormalDisabled`.
- [] Support `colorBorderButtonNormalHover`.
- [] Support `colorBorderButtonPrimaryDisabled`.


### Verifying changes:
**Tested by importing useTheme in below component:**
```/home/kausarshaikh/Amazon/iot-app-kit/packages/dashboard/src/components/widgets/widget.tsx```
```
import { useTheme } from '../../../../react-components/src/hooks/useTheming';
useTheme({
    tokens: {
      borderRadiusButton: '2px',
      borderRadiusContainer: '2px',
      borderRadiusDropdown: '2px',
      borderRadiusInput: '2px',
      colorBorderButtonNormalActive: '#0be625',
      colorBorderButtonNormalDefault: '#920ea9',
      colorBorderButtonNormalDisabled: '#ecf006',
      colorBorderButtonNormalHover: '#3e57e2',
      colorBorderButtonPrimaryDisabled: '#8a1323',
    },
  });
```
[border-theming-testing-part1.webm](https://github.com/awslabs/iot-app-kit/assets/154328164/d3c948be-d5c6-41c5-ba86-94f3a8b0794c)
[border-theming-testing-part2.webm](https://github.com/awslabs/iot-app-kit/assets/154328164/0f67ad25-a855-4d2d-80a9-b35699c073ec)
