### PR TITLE
fix(scene): handle bad texture files gracefully and toggle opacity on selection

### DIFF
--- a/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.spec.tsx
@@ -68,7 +68,7 @@ describe('GroundPlaneSettingsEditor', () => {
   it('should open asset browser when select texture clicked and set texture uri', () => {
     getScenePropertyMock.mockReturnValue({
       color: '#cccccc',
-      opacity: 1,
+      opacity: 0,
     });
     const globalSettingsMock = getGlobalSettings as jest.Mock;
     globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });

--- a/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.tsx
@@ -85,11 +85,15 @@ export const GroundPlaneSettingsEditor: React.FC = () => {
         } else {
           localTextureUri = `s3://${parseS3BucketFromArn(s3BucketArn)}/${contentLocation}`;
         }
-
+        let newOpacity = internalOpacity;
+        if (internalOpacity === 0) {
+          setInternalOpacity(1);
+          newOpacity = 1;
+        }
         setInternalUri(localTextureUri);
         setSceneProperty(KnownSceneProperty.GroundPlaneSettings, {
           textureUri: localTextureUri,
-          opacity: internalOpacity,
+          opacity: newOpacity,
         });
       }, TextureFileTypeList);
     } else {

--- a/packages/scene-composer/src/hooks/useTwinMakerTextureLoader.tsx
+++ b/packages/scene-composer/src/hooks/useTwinMakerTextureLoader.tsx
@@ -72,10 +72,14 @@ const useTwinMakerTextureLoader: (options?: TwinMakerTextureLoaderOptions) => {
         const oldTexture = material.map;
         material.color = new Color('#FFFFFF');
         loadTexture(uri, (result) => {
-          material.map = result as unknown as Texture;
-          material.needsUpdate = true;
+          if (result instanceof Texture) {
+            material.map = result as Texture;
+            material.needsUpdate = true;
+          } else {
+            console.error('Error parsing Texture file');
+          }
         });
-        if (oldTexture) {
+        if (oldTexture?.dispose) {
           oldTexture.dispose();
         }
       }
@@ -89,7 +93,7 @@ const useTwinMakerTextureLoader: (options?: TwinMakerTextureLoaderOptions) => {
       const oldTexture = material.map;
       material.map = null;
       material.needsUpdate = true;
-      if (oldTexture) {
+      if (oldTexture?.dispose) {
         oldTexture.dispose();
       }
     }


### PR DESCRIPTION
## Overview
1. Opacity doesn't change when a texture is selected for the ground plane which can make it seem like it did not load.  Now if it's zero the opacity will change 1 when a new texture is set. If the opacity is greater than zero it will not change.
2. Bad texture files could fail to load but get set as a material leading to error messages when the bad texture is removed from the ground plane.

## Verifying Changes
1. run story book scene composer
2. select the default composer scene
3. set the scene setting -> ground plane opacity to 0
4. select a texture for the ground plane.  verify the texture appears and the ground plane opacity is now 100%

5. edit the scene composer storybook to use an empty text file, or a non-texture fiile.
6. run storybook select texture for the scene composer ground plane in.  The file should URI should be set and the ground plane color will awy.  A blank white or black texture may be set.
7. remove the texture.  The ground plane color should return. there should be no error message in the scene composer.
8. select the texture again, and then remove it again.  There should still be no texture visible.  The second attempt is to verify that the caching in Three.js's file loader also didn't corrupt the texture.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
