### PR TITLE
fix: l4e code clean up

### DIFF
--- a/packages/react-components/src/components/l4eWidget/constants.ts
+++ b/packages/react-components/src/components/l4eWidget/constants.ts
@@ -149,14 +149,14 @@ const L4E_SERIES = {
       xAxisIndex: 0,
       yAxisIndex: 0,
       tooltip: {
-        formatter: ({ data }: { data: [number, number, AnomalyValue] }) =>
+        formatter: ({ data }: { data: [Date, number, AnomalyValue] }) =>
           formatTooltip(data),
       },
       encode: {
         x: 'time',
         y: 'value',
       },
-      selectedMode: 'multiple',
+      selectedMode: 'single',
       select: {
         itemStyle: {
           color: '#015b9d',

--- a/packages/react-components/src/components/l4eWidget/contributingPropertiesTable/columnDefinitions.tsx
+++ b/packages/react-components/src/components/l4eWidget/contributingPropertiesTable/columnDefinitions.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { AnomalyDiagnosticWithTimestamp } from '../types';
 import { Value } from '../../shared-components';
 import { colorChartsPaletteCategorical6 } from '@cloudscape-design/design-tokens';
+import { AnomalyDiagnostic } from '../types';
 
-export const getColumnDefinitions = (significantDigits?: number) => [
+type AnomalyDiagnosticWithTimestamp = AnomalyDiagnostic & { timestamp: Date };
+
+export const getColumnDefinitions = (decimalPlaces?: number) => [
   {
     id: 'property',
     header: 'Property',
@@ -20,7 +22,7 @@ export const getColumnDefinitions = (significantDigits?: number) => [
       return (
         <div style={{ display: 'grid', gridTemplateColumns: `75px 1fr` }}>
           <div>
-            <Value precision={significantDigits} value={percentage} unit='%' />
+            <Value precision={decimalPlaces} value={percentage} unit='%' />
           </div>
           <div
             style={{
@@ -38,6 +40,6 @@ export const getColumnDefinitions = (significantDigits?: number) => [
     sortingField: 'timestamp',
     header: 'Time',
     cell: (item: AnomalyDiagnosticWithTimestamp) =>
-      new Date(item.timestamp).toLocaleString(),
+      item.timestamp.toLocaleString(),
   },
 ];

--- a/packages/react-components/src/components/l4eWidget/contributingPropertiesTable/contributingPropertiesTable.tsx
+++ b/packages/react-components/src/components/l4eWidget/contributingPropertiesTable/contributingPropertiesTable.tsx
@@ -13,12 +13,12 @@ import { getColumnDefinitions } from './columnDefinitions';
 
 interface ContributingPropertiesTableProps {
   data?: AnomalyResult[];
-  significantDigits?: number;
+  decimalPlaces?: number;
 }
 
 export const ContributingPropertiesTable = ({
   data,
-  significantDigits,
+  decimalPlaces,
 }: ContributingPropertiesTableProps) => {
   // give a timestamp to each diagnostic so table can be sorted by time
   const mappedItems =
@@ -26,7 +26,7 @@ export const ContributingPropertiesTable = ({
       ?.map((d) =>
         d.value.diagnostics.map((diag) => ({
           ...diag,
-          timestamp: d.value.timestamp,
+          timestamp: d.timestamp,
         }))
       )
       .flat() ?? [];
@@ -65,7 +65,7 @@ export const ContributingPropertiesTable = ({
       <Table
         {...collectionProps}
         pagination={<Pagination {...paginationProps} />}
-        columnDefinitions={getColumnDefinitions(significantDigits)}
+        columnDefinitions={getColumnDefinitions(decimalPlaces)}
         columnDisplay={[
           { id: 'property', visible: true },
           { id: 'contributingPercentage', visible: true },

--- a/packages/react-components/src/components/l4eWidget/hooks/useSetDataSet.tsx
+++ b/packages/react-components/src/components/l4eWidget/hooks/useSetDataSet.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { ChartRef } from '../../../hooks/useECharts';
+import { AnomalyResult } from '../types';
+
+export const useSetDataSet = ({
+  chartRef,
+  data,
+}: {
+  chartRef: ChartRef;
+  data: AnomalyResult[];
+}) => {
+  useEffect(() => {
+    const mappedEvents = data.map((ev) => [ev.timestamp, 100, ev.value]);
+    chartRef.current?.setOption({
+      dataset: {
+        dimensions: ['time', 'value', 'extraData'],
+        source: mappedEvents,
+      },
+    });
+  }, [chartRef, data]);
+};

--- a/packages/react-components/src/components/l4eWidget/hooks/useSetTitle.tsx
+++ b/packages/react-components/src/components/l4eWidget/hooks/useSetTitle.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { ChartRef } from '../../../hooks/useECharts';
+
+export const useSetTitle = ({
+  chartRef,
+  title,
+}: {
+  chartRef: ChartRef;
+  title?: string;
+}) => {
+  useEffect(() => {
+    const l4e = chartRef.current;
+    l4e?.setOption({ title: { text: title } });
+  }, [chartRef, title]);
+};

--- a/packages/react-components/src/components/l4eWidget/hooks/useSetXAxis.tsx
+++ b/packages/react-components/src/components/l4eWidget/hooks/useSetXAxis.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { ChartRef } from '../../../hooks/useECharts';
+
+export const useSetXAxis = ({
+  chartRef,
+  viewportStart,
+  viewportEnd,
+}: {
+  chartRef: ChartRef;
+  viewportStart?: Date;
+  viewportEnd?: Date;
+}) => {
+  useEffect(() => {
+    const l4e = chartRef.current;
+    const customXAxis =
+      viewportStart && viewportEnd
+        ? [
+            {
+              name: 'l4e-timeline-axis',
+              min: viewportStart.getTime(),
+              max: viewportEnd.getTime(),
+            },
+            {
+              name: 'l4e-selection-axis',
+              min: viewportStart.getTime(),
+              max: viewportEnd.getTime(),
+            },
+          ]
+        : undefined;
+    l4e?.setOption({ xAxis: customXAxis });
+  }, [chartRef, viewportStart, viewportEnd]);
+};

--- a/packages/react-components/src/components/l4eWidget/types.ts
+++ b/packages/react-components/src/components/l4eWidget/types.ts
@@ -3,18 +3,14 @@ export type AnomalyDiagnostic = {
   value: number;
 };
 
-export type AnomalyDiagnosticWithTimestamp = AnomalyDiagnostic & {
-  timestamp: number;
-};
-
 export type AnomalyValue = {
   anomalyScore: number;
   predictionReason: string;
   diagnostics: AnomalyDiagnostic[];
-  timestamp: number;
 };
 
 export type AnomalyResult = {
   quality: string;
   value: AnomalyValue;
+  timestamp: Date;
 };

--- a/packages/react-components/src/components/l4eWidget/utils/formatTooltip.ts
+++ b/packages/react-components/src/components/l4eWidget/utils/formatTooltip.ts
@@ -1,11 +1,9 @@
 import { AnomalyValue } from '../types';
 
-export const formatTooltip = (data: [number, number, AnomalyValue]) => {
-  const { anomalyScore, diagnostics, predictionReason, timestamp } = data[2];
+export const formatTooltip = (data: [Date, number, AnomalyValue]) => {
+  const { anomalyScore, diagnostics, predictionReason } = data[2];
   const div = document.createElement('div');
-  const timestampString = `<div><b>${new Date(
-    timestamp
-  ).toLocaleString()}</b></div>`;
+  const timestampString = `<div><b>${data[0].toLocaleString()}</b></div>`;
   const anomalyScoreString = `<div><b>Anomaly Score</b> ${anomalyScore}</div>`;
   const predictionReasonString = `<div><b>Prediction reason</b> ${predictionReason}</div>`;
   const diagnosticString = diagnostics

--- a/packages/react-components/stories/l4e/l4e.stories.tsx
+++ b/packages/react-components/stories/l4e/l4e.stories.tsx
@@ -15,7 +15,13 @@ export const MockDataKPI: ComponentStory<typeof L4EWidget> = () => {
   return (
     <div style={{ background: 'grey' }}>
       <div style={{ height: '100%', width: '100%', padding: '20px' }}>
-        <L4EWidget data={mockData} widgetSettings={{ significantDigits: 2 }} />
+        <L4EWidget
+          data={mockData}
+          decimalPlaces={2}
+          viewportStart={new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)}
+          viewportEnd={new Date()}
+          title='Widget Title 123 @!'
+        />
       </div>
     </div>
   );

--- a/packages/react-components/stories/l4e/mockData.ts
+++ b/packages/react-components/stories/l4e/mockData.ts
@@ -31,9 +31,9 @@ const times = new Array(10)
 
 export const mockData: AnomalyResult[] = times.map((time) => ({
   ...BaseAnomalyResult,
+  timestamp: new Date(time),
   value: {
     ...BaseAnomalyResult.value,
-    timestamp: time,
     diagnostics: BaseAnomalyResult.value.diagnostics.map((d) => ({
       name: d.name,
       value: Math.random(),


### PR DESCRIPTION
## Overview
clean up l4e code:
- update types to be a flat widget API 
- handle custom viewports if passed in
- move setOption useEffects into their own hooks

example custom 7 day viewport
<img width="1027" alt="image" src="https://github.com/awslabs/iot-app-kit/assets/28601414/3b2d8e57-6530-43fb-ac03-b71c944aa2e1">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
