### PR TITLE
feat: simple paginated hooks used by resource explorers

### DIFF
--- a/packages/react-components/src/components/resource-explorers/queries/helpers/testing.tsx
+++ b/packages/react-components/src/components/resource-explorers/queries/helpers/testing.tsx
@@ -1,0 +1,406 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  type AssetSummary,
+  type AssetModelSummary,
+  type TimeSeriesSummary,
+  type AssetPropertySummary,
+  type AssetModelPropertySummary,
+} from '@aws-sdk/client-iotsitewise';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React, { useRef, type PropsWithChildren } from 'react';
+import { v4 as uuid } from 'uuid';
+
+import type { ListAssetModels, ListAssets } from '../../types/data-source';
+import type { UseListAPIBaseResult } from '../types';
+
+export function TestWrapper({ children }: PropsWithChildren) {
+  const queryClientRef = useRef<QueryClient | undefined>(undefined);
+
+  function getQueryClient(): QueryClient {
+    if (!queryClientRef.current) {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+          },
+        },
+        logger: {
+          log: console.log,
+          warn: console.warn,
+          error: () => {},
+        },
+      });
+
+      queryClientRef.current = queryClient;
+
+      return queryClient;
+    }
+
+    return queryClientRef.current;
+  }
+
+  return (
+    <QueryClientProvider client={getQueryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+}
+
+export function createFakeListAssetsResponse({
+  nextToken,
+}: { nextToken?: string } = {}) {
+  const response = {
+    assetSummaries: [
+      createFakeAssetSummary(),
+      createFakeAssetSummary(),
+      createFakeAssetSummary(),
+    ],
+    nextToken,
+  } satisfies Awaited<ReturnType<ListAssets>>;
+
+  return response;
+}
+
+export function createFakeAssetSummary(): AssetSummary {
+  const id = uuid();
+
+  return {
+    id,
+    arn: 'arn',
+    name: 'asset name',
+    assetModelId: 'assetModelId',
+    creationDate: new Date(0),
+    lastUpdateDate: new Date(1),
+    status: {
+      state: 'ACTIVE',
+    },
+    hierarchies: [],
+  };
+}
+
+export function createFakeListAssetModelsResponse({
+  nextToken,
+}: { nextToken?: string } = {}) {
+  const response = {
+    assetModelSummaries: [
+      createFakeAssetModelSummary(),
+      createFakeAssetModelSummary(),
+      createFakeAssetModelSummary(),
+    ],
+    nextToken,
+  } satisfies Awaited<ReturnType<ListAssetModels>>;
+
+  return response;
+}
+
+export function createFakeAssetModelSummary(): AssetModelSummary {
+  const id = uuid();
+
+  return {
+    id,
+    arn: 'arn',
+    name: 'asset model name',
+    description: 'asset model description',
+    creationDate: new Date(0),
+    lastUpdateDate: new Date(1),
+    status: {
+      state: 'ACTIVE',
+    },
+  };
+}
+
+export function createFakeAssetPropertySummary() {
+  const id = uuid();
+
+  return {
+    id,
+  } satisfies AssetPropertySummary;
+}
+
+export function createFakeAssetModelPropertySummary(id: string) {
+  return {
+    id,
+    name: 'asset model property name',
+    dataType: 'STRING',
+    type: {},
+  } satisfies AssetModelPropertySummary;
+}
+
+export function createFakeTimeSeriesSummary(): TimeSeriesSummary {
+  const timeSeriesId = uuid();
+
+  return {
+    timeSeriesId,
+    dataType: 'STRING',
+    timeSeriesArn: 'arn',
+    timeSeriesCreationDate: new Date(0),
+    timeSeriesLastUpdateDate: new Date(0),
+  };
+}
+
+type Hook<Options, Result> = (options: Options) => Result;
+
+interface TestUseListResourcesHook<Options, Result> {
+  resourceName: string;
+  hook: Hook<Options, Result>;
+  renderHookWithEmptyList?: () => {
+    resourceHookOptions: Options;
+  };
+  renderHookWithSinglePage?: () => {
+    expectedResources: unknown[];
+    resourceHookOptions: Options;
+  };
+  renderHookWithMultiplePages?: () => {
+    expectedResourcesPage1: unknown[];
+    expectedResourcesPage2: unknown[];
+    expectedResourcesPage3: unknown[];
+    resourceHookOptions: Options;
+  };
+  renderHookWithError?: () => {
+    resourceHookOptions: Options;
+  };
+  renderDisabledRequest?: () => {
+    resourceHookOptions: Options;
+  };
+}
+
+/** Test suite which should pass for all paginated resource hooks. */
+export function testUseListResourcesHook<
+  Options,
+  Result extends UseListAPIBaseResult
+>({
+  resourceName,
+  hook,
+  renderHookWithEmptyList,
+  renderHookWithSinglePage,
+  renderHookWithMultiplePages,
+  renderHookWithError,
+  renderDisabledRequest,
+}: TestUseListResourcesHook<Options, Result>) {
+  if (renderHookWithSinglePage) {
+    it('returns resources', async () => {
+      const { expectedResources, resourceHookOptions } =
+        renderHookWithSinglePage();
+
+      const { result } = renderHook(() => hook(resourceHookOptions), {
+        wrapper: TestWrapper,
+      });
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: [],
+          hasNextPage: false,
+          nextPage: expect.toBeFunction(),
+          isSuccess: false,
+          isFetching: true,
+          error: null,
+        })
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBeTrue());
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: expectedResources,
+          hasNextPage: false,
+          nextPage: expect.toBeFunction(),
+          isSuccess: true,
+          isFetching: false,
+          error: null,
+        })
+      );
+    });
+  }
+
+  if (renderHookWithEmptyList) {
+    it('returns an empty list when there are no resources', async () => {
+      const { resourceHookOptions } = renderHookWithEmptyList();
+
+      const { result } = renderHook(() => hook(resourceHookOptions), {
+        wrapper: TestWrapper,
+      });
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: [],
+          hasNextPage: false,
+          nextPage: expect.toBeFunction(),
+          isSuccess: false,
+          isFetching: true,
+          error: null,
+        })
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBeTrue());
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: [],
+          hasNextPage: false,
+          nextPage: expect.toBeFunction(),
+          isSuccess: true,
+          isFetching: false,
+          error: null,
+        })
+      );
+    });
+  }
+
+  if (renderHookWithMultiplePages) {
+    it('returns a paginated list of resources', async () => {
+      const {
+        expectedResourcesPage1,
+        expectedResourcesPage2,
+        expectedResourcesPage3,
+        resourceHookOptions,
+      } = renderHookWithMultiplePages();
+
+      const { result } = renderHook(() => hook(resourceHookOptions), {
+        wrapper: TestWrapper,
+      });
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: [],
+          // hasNextPage: false,
+          nextPage: expect.toBeFunction(),
+          isSuccess: false,
+          isFetching: true,
+          error: null,
+        })
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBeTrue());
+
+      // First page
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: expectedResourcesPage1,
+          hasNextPage: true,
+          nextPage: expect.toBeFunction(),
+          isSuccess: true,
+          isFetching: false,
+          error: null,
+        })
+      );
+
+      act(() => {
+        result.current.nextPage();
+      });
+      await waitFor(() => expect(result.current.isFetching).toBeFalse());
+
+      // First + second pages
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: [
+            ...expectedResourcesPage1,
+            ...expectedResourcesPage2,
+          ],
+          hasNextPage: true,
+          nextPage: expect.toBeFunction(),
+          isSuccess: true,
+          isFetching: false,
+          error: null,
+        })
+      );
+
+      act(() => {
+        result.current.nextPage();
+      });
+      await waitFor(() => expect(result.current.isFetching).toBeFalse());
+
+      // All three pages
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: [
+            ...expectedResourcesPage1,
+            ...expectedResourcesPage2,
+            ...expectedResourcesPage3,
+          ],
+          hasNextPage: false,
+          nextPage: expect.toBeFunction(),
+          isSuccess: true,
+          isFetching: false,
+          error: null,
+        })
+      );
+
+      // Attempt to paginate again
+      act(() => {
+        result.current.nextPage();
+      });
+      await waitFor(() => expect(result.current.isFetching).toBeFalse());
+
+      // Return same three pages
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: [
+            ...expectedResourcesPage1,
+            ...expectedResourcesPage2,
+            ...expectedResourcesPage3,
+          ],
+          hasNextPage: false,
+          nextPage: expect.toBeFunction(),
+          isSuccess: true,
+          isFetching: false,
+          error: null,
+        })
+      );
+    });
+  }
+
+  if (renderHookWithError) {
+    it('handles errors', async () => {
+      const { resourceHookOptions } = renderHookWithError();
+
+      const { result } = renderHook(() => hook(resourceHookOptions), {
+        wrapper: TestWrapper,
+      });
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: [],
+          hasNextPage: false,
+          nextPage: expect.toBeFunction(),
+          isSuccess: false,
+          isFetching: true,
+          error: null,
+        })
+      );
+
+      await waitFor(() => expect(result.current.error).not.toBeNull());
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: [],
+          hasNextPage: false,
+          nextPage: expect.toBeFunction(),
+          isSuccess: false,
+          isFetching: false,
+          error: expect.objectContaining({ message: expect.any(String) }),
+        })
+      );
+    });
+  }
+
+  if (renderDisabledRequest) {
+    it('does not send request when disabled', async () => {
+      const { resourceHookOptions } = renderDisabledRequest();
+
+      const { result } = renderHook(() => hook(resourceHookOptions), {
+        wrapper: TestWrapper,
+      });
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          [resourceName]: [],
+          hasNextPage: false,
+          nextPage: expect.toBeFunction(),
+          isSuccess: false,
+          isFetching: false,
+          error: null,
+        })
+      );
+    });
+  }
+}

--- a/packages/react-components/src/components/resource-explorers/queries/helpers/use-list-resources/index.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/helpers/use-list-resources/index.ts
@@ -1,0 +1,5 @@
+export {
+  useListResources,
+  type UseListResourcesOptions,
+  type UseListResourcesResult,
+} from './use-list-resources';

--- a/packages/react-components/src/components/resource-explorers/queries/helpers/use-list-resources/use-list-resources.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/helpers/use-list-resources/use-list-resources.ts
@@ -1,0 +1,80 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export interface UseListResourcesOptions<Request, Response, Resource> {
+  /** Request will be attempted when true. Default - true. */
+  isEnabled?: boolean;
+
+  /** Unique key used to cache the resources. */
+  resourceName: string;
+
+  /** Request parameters without `nextToken`. */
+  params?: Omit<Request, 'nextToken'>;
+
+  /** Async function called with params + nextToken. */
+  requestFn: (request: Request) => PromiseLike<Response>;
+
+  /** Used to get the resources from the pages. */
+  resourceSelector: (response: Response) => Resource[];
+}
+
+export interface UseListResourcesResult<Resource> {
+  resources: Resource[];
+  isSuccess: boolean;
+  isFetching: boolean;
+  hasNextPage: boolean;
+  nextPage: () => void;
+  error: Error | null;
+}
+
+/** Use to request paginated resources. */
+export function useListResources<
+  Request extends { nextToken?: string; maxResults?: number },
+  Response extends { nextToken?: string },
+  Resource
+>({
+  resourceName,
+  params,
+  requestFn,
+  resourceSelector,
+  isEnabled = true,
+}: UseListResourcesOptions<
+  Request,
+  Response,
+  Resource
+>): UseListResourcesResult<Resource> {
+  // Resources are scoped by `resourceName`.
+  const queryKey = [{ resource: resourceName, ...params }];
+
+  const {
+    data: { pages: responses = [] } = {},
+    isSuccess,
+    isFetching,
+    hasNextPage = false,
+    fetchNextPage: nextPage,
+    error,
+  } = useInfiniteQuery<Response, Error, Response, typeof queryKey>({
+    enabled: isEnabled,
+    queryKey,
+    queryFn: async ({ pageParam: nextToken }) => {
+      const request: Request = {
+        ...params,
+        nextToken,
+      } as Request;
+      const response = await requestFn(request);
+
+      return response;
+    },
+    getNextPageParam: ({ nextToken }) => nextToken,
+  });
+
+  const resources = responses.flatMap(resourceSelector);
+
+  return {
+    resources,
+    isSuccess,
+    isFetching,
+    hasNextPage,
+    nextPage,
+    error,
+  };
+}

--- a/packages/react-components/src/components/resource-explorers/queries/helpers/use-two-dimensional-list-resources/index.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/helpers/use-two-dimensional-list-resources/index.ts
@@ -1,0 +1,5 @@
+export {
+  useTwoDimensionalListResources,
+  type UseTwoDimensionalListResourcesOptions,
+  type UseTwoDimensionalListResourcesResult,
+} from './use-two-dimensional-list-resources';

--- a/packages/react-components/src/components/resource-explorers/queries/helpers/use-two-dimensional-list-resources/use-cached-resources.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/helpers/use-two-dimensional-list-resources/use-cached-resources.ts
@@ -1,0 +1,19 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+export interface UseCachedResourcesOptions {
+  resource: string;
+}
+
+export type UseCachedResourcesResult<Resource> = Resource[];
+
+/** Use resources loaded into the cache. */
+export function useCachedResources<Resource>({
+  resource,
+}: UseCachedResourcesOptions): UseCachedResourcesResult<Resource> {
+  const queryClient = useQueryClient();
+
+  const resourcePages = queryClient.getQueriesData<Resource[]>([{ resource }]);
+  const resources = resourcePages.flatMap(([_, resources = []]) => resources);
+
+  return resources;
+}

--- a/packages/react-components/src/components/resource-explorers/queries/helpers/use-two-dimensional-list-resources/use-two-dimensional-list-resources.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/helpers/use-two-dimensional-list-resources/use-two-dimensional-list-resources.ts
@@ -1,0 +1,97 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useQueryPagination } from './use-two-dimensional-pagination';
+import { useCachedResources } from './use-cached-resources';
+
+export interface UseTwoDimensionalListResourcesOptions<
+  Request,
+  Response,
+  Resource
+> {
+  maxResults: number;
+
+  resourceName: string;
+
+  requests: Omit<Request, 'nextToken' | 'maxResults'>[];
+
+  /** Async function called with params + nextToken. */
+  requestFn: (request: Request) => PromiseLike<Response>;
+
+  /** Used to get the resources from the pages. */
+  resourceSelector: (response: Response) => Resource[];
+
+  isEnabled?: boolean;
+}
+
+export interface UseTwoDimensionalListResourcesResult<Resource> {
+  resources: Resource[];
+  isSuccess: boolean;
+  isFetching: boolean;
+  hasNextPage: boolean;
+  nextPage: () => void;
+  error: Error | null;
+}
+
+function removeMaxResults<Query extends { maxResults: number }>(
+  query: Query
+): Omit<Query, 'maxResults'> {
+  const { maxResults: _maxResults, ...queryWithoutMaxResults } = query;
+
+  return queryWithoutMaxResults;
+}
+
+/** Use paginated resources across multiple queries. */
+export function useTwoDimensionalListResources<
+  Request extends { nextToken?: string; maxResults?: number },
+  Response extends { nextToken?: string },
+  Resource
+>({
+  maxResults,
+  resourceName,
+  requests: queries,
+  requestFn,
+  resourceSelector,
+  isEnabled = true,
+}: UseTwoDimensionalListResourcesOptions<
+  Request,
+  Response,
+  Resource
+>): UseTwoDimensionalListResourcesResult<Resource> {
+  const {
+    query,
+    hasNextPage,
+    fetchNextPage: nextPage,
+    loadNextToken,
+  } = useQueryPagination({ queries, defaultPageSize: maxResults });
+
+  const queryWithoutMaxResults = removeMaxResults(query);
+  const queryKey = [{ resource: resourceName, ...queryWithoutMaxResults }];
+
+  const { isSuccess, isFetching, error } = useQuery<unknown, Error>({
+    enabled: isEnabled,
+    refetchOnWindowFocus: false,
+    queryKey,
+    queryFn: async () => {
+      const response = await requestFn(query as Request);
+      const resources = resourceSelector(response);
+
+      loadNextToken({
+        nextToken: response.nextToken,
+        resources,
+      });
+
+      return resources;
+    },
+  });
+
+  const resources = useCachedResources<Resource>(queryKey[0]);
+
+  return {
+    resources,
+    isSuccess,
+    isFetching,
+    hasNextPage,
+    nextPage,
+    error,
+  };
+}

--- a/packages/react-components/src/components/resource-explorers/queries/helpers/use-two-dimensional-list-resources/use-two-dimensional-pagination.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/helpers/use-two-dimensional-list-resources/use-two-dimensional-pagination.ts
@@ -1,0 +1,153 @@
+import { useCallback, useReducer } from 'react';
+
+interface NextPageAction {
+  type: 'next_page';
+  payload: {
+    pageSize: number;
+  };
+}
+
+interface NextQueryAction {
+  type: 'next_query';
+  payload: {
+    pageSize: number;
+  };
+}
+
+interface PrepareNextTokenAction {
+  type: 'prepare_next_token';
+  payload: {
+    nextToken?: string;
+  };
+}
+
+type Actions = NextPageAction | NextQueryAction | PrepareNextTokenAction;
+
+interface ReducerState {
+  nextNextToken: string | undefined;
+  currentNextToken: string | undefined;
+  currentMaxResults: number;
+  currentQueryIndex: number;
+}
+
+function reducer(state: ReducerState, action: Actions): ReducerState {
+  if (action.type === 'next_page') {
+    return {
+      ...state,
+      currentNextToken: state.nextNextToken,
+      currentMaxResults: action.payload.pageSize,
+      nextNextToken: undefined,
+    };
+  }
+
+  if (action.type === 'next_query') {
+    return {
+      ...state,
+      nextNextToken: undefined,
+      currentNextToken: undefined,
+      currentMaxResults: action.payload.pageSize,
+      currentQueryIndex: state.currentQueryIndex + 1,
+    };
+  }
+
+  if (action.type === 'prepare_next_token') {
+    return {
+      ...state,
+      nextNextToken: action.payload.nextToken,
+    };
+  }
+
+  throw new Error('Unknown action');
+}
+
+export interface UseQueryPaginationOptions<Query> {
+  queries: Query[];
+  defaultPageSize: number;
+}
+
+export function useQueryPagination<Query>({
+  queries,
+  defaultPageSize,
+}: UseQueryPaginationOptions<Query>) {
+  const [
+    { nextNextToken, currentMaxResults, currentNextToken, currentQueryIndex },
+    dispatch,
+  ] = useReducer(reducer, {
+    nextNextToken: undefined,
+    currentMaxResults: defaultPageSize,
+    currentNextToken: undefined,
+    currentQueryIndex: 0,
+  });
+
+  function prepareNextToken(nextToken?: string) {
+    dispatch({
+      type: 'prepare_next_token',
+      payload: { nextToken },
+    });
+  }
+
+  function nextPage() {
+    dispatch({
+      type: 'next_page',
+      payload: { pageSize: defaultPageSize },
+    });
+  }
+
+  function nextQuery(initialPageSize?: number) {
+    dispatch({
+      type: 'next_query',
+      payload: {
+        pageSize: initialPageSize ?? defaultPageSize,
+      },
+    });
+  }
+
+  const hasNextToken: boolean = nextNextToken != null;
+  const hasNextQuery: boolean = currentQueryIndex < queries.length - 1;
+  const hasNextPage: boolean = hasNextToken || hasNextQuery;
+
+  const currentQuery = queries[currentQueryIndex];
+  const query = {
+    ...currentQuery,
+    nextToken: currentNextToken,
+    maxResults: currentMaxResults,
+  };
+
+  const fetchNextPage = useCallback(() => {
+    if (hasNextToken) {
+      nextPage();
+    } else if (hasNextQuery) {
+      nextQuery();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasNextToken, hasNextQuery]);
+
+  const loadNextToken = useCallback(
+    ({
+      nextToken,
+      resources,
+    }: {
+      nextToken: string | undefined;
+      resources: unknown[];
+    }) => {
+      if (
+        nextToken == null &&
+        resources.length < defaultPageSize &&
+        hasNextQuery
+      ) {
+        nextQuery(defaultPageSize - resources.length);
+      }
+
+      prepareNextToken(nextToken);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [hasNextQuery, defaultPageSize]
+  );
+
+  return {
+    query,
+    hasNextPage,
+    fetchNextPage,
+    loadNextToken,
+  };
+}

--- a/packages/react-components/src/components/resource-explorers/queries/index.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/index.ts
@@ -1,0 +1,23 @@
+export {
+  useAssetModels,
+  type UseAssetModelsOptions,
+  type UseAssetModelsResult,
+} from './use-asset-models';
+
+export {
+  useAssets,
+  type UseAssetsOptions,
+  type UseAssetsResult,
+} from './use-assets';
+
+export {
+  useAssetProperties,
+  type UseAssetPropertiesOptions,
+  type UseAssetPropertiesResult,
+} from './use-asset-properties';
+
+export {
+  useTimeSeries,
+  type UseTimeSeriesOptions,
+  type UseTimeSeriesResult,
+} from './use-time-series';

--- a/packages/react-components/src/components/resource-explorers/queries/types.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Generalized hook options expected to be implemented by all paginated list hooks.
+ *
+ * @privateRemarks
+ * This type is used to limit implicit dependence on Tanstack Query.
+ */
+export interface UseListAPIBaseOptions {
+  maxResults: number;
+}
+
+/**
+ * Generalized hook result expected to be implemented by all paginated list hooks.
+ *
+ * @privateRemarks
+ * This type is used to limit implicit dependence on Tanstack Query.
+ */
+export interface UseListAPIBaseResult {
+  /** True when there is a next page to request. */
+  hasNextPage: boolean;
+
+  /** True when the first page has been successfully requested. */
+  isSuccess: boolean;
+
+  /** True when the next page is being requested. */
+  isFetching: boolean;
+
+  /** Defined when there is an error. */
+  error: Error | null;
+
+  /** Call to request the next page of resources. */
+  nextPage: () => void;
+}

--- a/packages/react-components/src/components/resource-explorers/queries/use-asset-models/index.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-asset-models/index.ts
@@ -1,0 +1,5 @@
+export {
+  useAssetModels,
+  type UseAssetModelsOptions,
+  type UseAssetModelsResult,
+} from './use-asset-models';

--- a/packages/react-components/src/components/resource-explorers/queries/use-asset-models/use-asset-models.spec.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-asset-models/use-asset-models.spec.ts
@@ -1,0 +1,75 @@
+import {
+  createFakeListAssetModelsResponse,
+  testUseListResourcesHook,
+} from '../helpers/testing';
+import { useAssetModels } from './use-asset-models';
+
+testUseListResourcesHook({
+  resourceName: 'assetModels',
+  hook: useAssetModels,
+  renderHookWithEmptyList() {
+    const fakeListAssetModels = jest
+      .fn()
+      .mockResolvedValue({ assetModelSummaries: [] });
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssetModels: fakeListAssetModels,
+      },
+    };
+  },
+  renderHookWithSinglePage() {
+    const fakeListAssetModelsResponse = createFakeListAssetModelsResponse();
+    const fakeListAssetModels = jest
+      .fn()
+      .mockResolvedValue(fakeListAssetModelsResponse);
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssetModels: fakeListAssetModels,
+      },
+      expectedResources: fakeListAssetModelsResponse.assetModelSummaries,
+    };
+  },
+  renderHookWithMultiplePages() {
+    const fakeListAssetModelsResponseWithNextToken1 =
+      createFakeListAssetModelsResponse({
+        nextToken: 'token-1',
+      });
+    const fakeListAssetModelsResponseWithNextToken2 =
+      createFakeListAssetModelsResponse({
+        nextToken: 'token-2',
+      });
+    const fakeListAssetModelsResponse = createFakeListAssetModelsResponse();
+    const fakeListAssetModels = jest
+      .fn()
+      .mockResolvedValue(fakeListAssetModelsResponse)
+      .mockResolvedValueOnce(fakeListAssetModelsResponseWithNextToken1)
+      .mockResolvedValueOnce(fakeListAssetModelsResponseWithNextToken2);
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssetModels: fakeListAssetModels,
+      },
+      expectedResourcesPage1:
+        fakeListAssetModelsResponseWithNextToken1.assetModelSummaries,
+      expectedResourcesPage2:
+        fakeListAssetModelsResponseWithNextToken2.assetModelSummaries,
+      expectedResourcesPage3: fakeListAssetModelsResponse.assetModelSummaries,
+    };
+  },
+
+  renderHookWithError() {
+    const fakeListAssetModels = jest.fn().mockRejectedValue(new Error());
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssetModels: fakeListAssetModels,
+      },
+    };
+  },
+});

--- a/packages/react-components/src/components/resource-explorers/queries/use-asset-models/use-asset-models.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-asset-models/use-asset-models.ts
@@ -1,0 +1,44 @@
+import { type AssetModelSummary } from '@aws-sdk/client-iotsitewise';
+
+import { useListResources } from '../helpers/use-list-resources/use-list-resources';
+import type { UseListAPIBaseOptions, UseListAPIBaseResult } from '../types';
+import type { ListAssetModels } from '../../types/data-source';
+
+export type UseAssetModelsQuery = Pick<
+  Parameters<ListAssetModels>[0],
+  'assetModelTypes'
+>;
+
+export interface UseAssetModelsOptions extends UseListAPIBaseOptions {
+  query?: UseAssetModelsQuery;
+  listAssetModels: ListAssetModels;
+}
+
+export interface UseAssetModelsResult extends UseListAPIBaseResult {
+  assetModels: AssetModelSummary[];
+}
+
+/**
+ * Use a list of IoT SiteWise AssetModelSummary resources.
+ *
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_AssetModelSummary.html}
+ *
+ * @experimental Do not use in production.
+ */
+export function useAssetModels({
+  query,
+  maxResults,
+  listAssetModels,
+}: UseAssetModelsOptions): UseAssetModelsResult {
+  const { resources: assetModels, ...responseResult } = useListResources({
+    resourceName: 'AssetModelSummary',
+    params: { ...query, maxResults },
+    requestFn: listAssetModels,
+    resourceSelector: ({ assetModelSummaries = [] }) => assetModelSummaries,
+  });
+
+  return {
+    assetModels,
+    ...responseResult,
+  };
+}

--- a/packages/react-components/src/components/resource-explorers/queries/use-asset-properties/index.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-asset-properties/index.ts
@@ -1,0 +1,5 @@
+export {
+  useAssetProperties,
+  type UseAssetPropertiesOptions,
+  type UseAssetPropertiesResult,
+} from './use-asset-properties';

--- a/packages/react-components/src/components/resource-explorers/queries/use-asset-properties/use-asset-model-properties.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-asset-properties/use-asset-model-properties.ts
@@ -1,0 +1,69 @@
+import { type AssetModelPropertySummary } from '@aws-sdk/client-iotsitewise';
+import { useQueries } from '@tanstack/react-query';
+
+import { ListAssetModelProperties } from '../../types/data-source';
+
+export interface UseAssetModelPropertiesOptions {
+  assetModelIds: string[];
+  listAssetModelProperties: ListAssetModelProperties;
+}
+
+export interface UseAssetModelPropertiesResult {
+  assetModelPropertiesById: {
+    [assetModelId: string]: AssetModelPropertySummary[];
+  };
+  isSuccess: boolean;
+  error: Error | null;
+}
+
+export function useAssetModelProperties({
+  assetModelIds,
+  listAssetModelProperties,
+}: UseAssetModelPropertiesOptions): UseAssetModelPropertiesResult {
+  const queries = useQueries({
+    queries: assetModelIds.map((assetModelId) => ({
+      queryKey: [{ resource: 'AssetModelPropertySummary', assetModelId }],
+      queryFn: async () => {
+        let currentNextToken: string | undefined = undefined;
+        const assetModelPropertySummaries: AssetModelPropertySummary[] = [];
+
+        do {
+          const response: Awaited<ReturnType<ListAssetModelProperties>> =
+            await listAssetModelProperties({
+              assetModelId,
+              nextToken: currentNextToken,
+              maxResults: 250,
+            });
+
+          currentNextToken = response.nextToken;
+          assetModelPropertySummaries.push(
+            ...(response.assetModelPropertySummaries ?? [])
+          );
+        } while (currentNextToken);
+
+        return assetModelPropertySummaries;
+      },
+    })),
+  });
+
+  const assetModelPropertiesById = assetModelIds.reduce<{
+    [assetModelId: string]: AssetModelPropertySummary[];
+  }>((acc, prev, index) => {
+    const total = {
+      ...acc,
+      [prev]: queries[index].data ?? [],
+    };
+
+    return total;
+  }, {});
+
+  const isSuccess = queries.every((query) => query.isSuccess);
+  const error: Error | null = (queries.find((query) => query.error)?.error ??
+    null) as Error | null;
+
+  return {
+    assetModelPropertiesById,
+    isSuccess,
+    error,
+  };
+}

--- a/packages/react-components/src/components/resource-explorers/queries/use-asset-properties/use-asset-properties.spec.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-asset-properties/use-asset-properties.spec.ts
@@ -1,0 +1,203 @@
+import {
+  AssetProperty,
+  AssetPropertySummary,
+  AssetModelPropertySummary,
+} from '@aws-sdk/client-iotsitewise';
+import {
+  testUseListResourcesHook,
+  createFakeAssetPropertySummary,
+  createFakeAssetModelPropertySummary,
+} from '../helpers/testing';
+import { useAssetProperties } from './use-asset-properties';
+
+function createExpectedResources(
+  assetPropertySummaries: AssetPropertySummary[],
+  assetModelPropertySummaries: AssetModelPropertySummary[]
+): AssetProperty[] {
+  const matchingAssetModelPropertySummaries = assetPropertySummaries.map(
+    ({ id: assetPropertyId }) => {
+      return assetModelPropertySummaries.find(
+        ({ id: assetModelPropertyId }) =>
+          assetModelPropertyId === assetPropertyId
+      );
+    }
+  ) as AssetModelPropertySummary[];
+
+  return assetPropertySummaries.map((assetPropertySummary, index) => ({
+    ...assetPropertySummary,
+    ...matchingAssetModelPropertySummaries.map(
+      ({ type: _type, ...rest }) => rest
+    )[index],
+  }));
+}
+
+testUseListResourcesHook({
+  resourceName: 'assetProperties',
+  hook: useAssetProperties,
+  renderHookWithEmptyList() {
+    const fakeListAssetProperties = jest
+      .fn()
+      .mockResolvedValueOnce({ assetPropertySummaries: [] });
+    const fakeListAssetModelProperties = jest
+      .fn()
+      .mockResolvedValueOnce({ assetModelPropertySummaries: [] });
+
+    return {
+      resourceHookOptions: {
+        queries: [{ assetId: '123', assetModelId: '456' }],
+        maxResults: 5,
+        listAssetProperties: fakeListAssetProperties,
+        listAssetModelProperties: fakeListAssetModelProperties,
+      },
+    };
+  },
+  renderHookWithSinglePage() {
+    const assetPropertySummaries = [
+      createFakeAssetPropertySummary(),
+      createFakeAssetPropertySummary(),
+      createFakeAssetPropertySummary(),
+    ];
+    const fakeListAssetPropertiesResponse = {
+      assetPropertySummaries,
+    };
+    const fakeListAssetProperties = jest
+      .fn()
+      .mockResolvedValue(fakeListAssetPropertiesResponse);
+
+    const assetModelPropertySummaries = assetPropertySummaries.map(({ id }) =>
+      createFakeAssetModelPropertySummary(id)
+    );
+    const fakeListAssetModelPropertiesResponse = {
+      assetModelPropertySummaries,
+    };
+    const fakeListAssetModelProperties = jest
+      .fn()
+      .mockResolvedValue(fakeListAssetModelPropertiesResponse);
+
+    return {
+      resourceHookOptions: {
+        queries: [{ assetId: '123', assetModelId: '456' }],
+        maxResults: 5,
+        listAssetProperties: fakeListAssetProperties,
+        listAssetModelProperties: fakeListAssetModelProperties,
+      },
+      expectedResources: createExpectedResources(
+        assetPropertySummaries,
+        assetModelPropertySummaries
+      ),
+    };
+  },
+  renderHookWithMultiplePages() {
+    const page1AssetPropertySummaries = [
+      createFakeAssetPropertySummary(),
+      createFakeAssetPropertySummary(),
+      createFakeAssetPropertySummary(),
+    ];
+    const page2AssetPropertySummaries = [
+      createFakeAssetPropertySummary(),
+      createFakeAssetPropertySummary(),
+    ];
+    const page3AssetPropertySummaries = [
+      createFakeAssetPropertySummary(),
+      createFakeAssetPropertySummary(),
+      createFakeAssetPropertySummary(),
+      createFakeAssetPropertySummary(),
+      createFakeAssetPropertySummary(),
+    ];
+    const page4AssetPropertySummaries = [
+      createFakeAssetPropertySummary(),
+      createFakeAssetPropertySummary(),
+      createFakeAssetPropertySummary(),
+    ];
+    const assetModelPropertySummariesResponse1 =
+      page1AssetPropertySummaries.map(({ id }) =>
+        createFakeAssetModelPropertySummary(id)
+      );
+    const assetModelPropertySummariesResponse2 = [
+      ...page2AssetPropertySummaries,
+      ...page3AssetPropertySummaries,
+      ...page4AssetPropertySummaries,
+    ].map(({ id }) => createFakeAssetModelPropertySummary(id));
+
+    const page1 = {
+      assetPropertySummaries: page1AssetPropertySummaries,
+    };
+    const page2 = {
+      assetPropertySummaries: page2AssetPropertySummaries,
+      nextToken: 'token-1',
+    };
+    const page3 = {
+      assetPropertySummaries: page3AssetPropertySummaries,
+      nextToken: 'token-2',
+    };
+    const page4 = {
+      assetPropertySummaries: page4AssetPropertySummaries,
+    };
+    const fakeListAssetProperties = jest
+      .fn()
+      .mockResolvedValueOnce(page1)
+      .mockResolvedValueOnce(page2)
+      .mockResolvedValueOnce(page3)
+      .mockResolvedValue(page4);
+    const fakeListAssetModelProperties = jest
+      .fn()
+      .mockResolvedValueOnce({
+        assetModelPropertySummaries: assetModelPropertySummariesResponse1,
+      })
+      .mockResolvedValueOnce({
+        assetModelPropertySummaries: assetModelPropertySummariesResponse2,
+      });
+
+    const expectedResourcesPage1 = [
+      ...createExpectedResources(
+        page1AssetPropertySummaries,
+        assetModelPropertySummariesResponse1
+      ),
+      ...createExpectedResources(
+        page2AssetPropertySummaries,
+        assetModelPropertySummariesResponse2
+      ),
+    ];
+    const expectedResourcesPage2 = createExpectedResources(
+      page3AssetPropertySummaries,
+      assetModelPropertySummariesResponse2
+    );
+    const expectedResourcesPage3 = createExpectedResources(
+      page4AssetPropertySummaries,
+      assetModelPropertySummariesResponse2
+    );
+
+    return {
+      resourceHookOptions: {
+        queries: [
+          { assetId: '123', assetModelId: '456' },
+          { assetId: 'abc', assetModelId: 'xyz' },
+        ],
+        maxResults: 5,
+        listAssetProperties: fakeListAssetProperties,
+        listAssetModelProperties: fakeListAssetModelProperties,
+      },
+      expectedResourcesPage1: expectedResourcesPage1,
+      expectedResourcesPage2: expectedResourcesPage2,
+      expectedResourcesPage3: expectedResourcesPage3,
+    };
+  },
+
+  renderHookWithError() {
+    const fakeListAssetProperties = jest
+      .fn()
+      .mockRejectedValue(new Error('Error'));
+    const fakeListAssetModelProperties = jest
+      .fn()
+      .mockRejectedValue(new Error('Error'));
+
+    return {
+      resourceHookOptions: {
+        queries: [{ assetId: '123', assetModelId: '456' }],
+        maxResults: 5,
+        listAssetProperties: fakeListAssetProperties,
+        listAssetModelProperties: fakeListAssetModelProperties,
+      },
+    };
+  },
+});

--- a/packages/react-components/src/components/resource-explorers/queries/use-asset-properties/use-asset-properties.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-asset-properties/use-asset-properties.ts
@@ -1,0 +1,98 @@
+import { type AssetProperty } from '@aws-sdk/client-iotsitewise';
+
+import type { UseListAPIBaseOptions, UseListAPIBaseResult } from '../types';
+import {
+  ListAssetModelProperties,
+  ListAssetProperties,
+} from '../../types/data-source';
+import { useTwoDimensionalListResources } from '../helpers/use-two-dimensional-list-resources';
+import { useAssetModelProperties } from './use-asset-model-properties';
+
+export type UseAssetPropertiesQuery = Readonly<{
+  assetId: string;
+  assetModelId: string;
+}>;
+
+export interface UseAssetPropertiesOptions extends UseListAPIBaseOptions {
+  queries: UseAssetPropertiesQuery[];
+  listAssetProperties: ListAssetProperties;
+  listAssetModelProperties: ListAssetModelProperties;
+}
+
+export interface UseAssetPropertiesResult extends UseListAPIBaseResult {
+  assetProperties: AssetProperty[];
+}
+
+/**
+ * Use a list of IoT SiteWise AssetProperty resources.
+ *
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_AssetProperty.html}
+ *
+ * @experimental Do not use in production.
+ */
+export function useAssetProperties({
+  queries,
+  maxResults,
+  listAssetProperties,
+  listAssetModelProperties,
+}: UseAssetPropertiesOptions): UseAssetPropertiesResult {
+  const {
+    assetModelPropertiesById,
+    isSuccess: assetModelPropertiesIsSuccess,
+    error: assetModelPropertiesError,
+  } = useAssetModelProperties({
+    assetModelIds: queries.map(({ assetModelId }) => assetModelId),
+    listAssetModelProperties,
+  });
+
+  const { resources: assetProperties, ...responseResult } =
+    useTwoDimensionalListResources({
+      isEnabled: assetModelPropertiesIsSuccess,
+      maxResults,
+      resourceName: 'AssetProperty',
+      requests: queries,
+      requestFn: async (
+        request: UseAssetPropertiesQuery & {
+          nextToken?: string;
+          maxResults?: number;
+        }
+      ) => {
+        const { nextToken, assetPropertySummaries = [] } =
+          await listAssetProperties(request);
+
+        const assetModelProperties =
+          assetModelPropertiesById[request.assetModelId];
+
+        const assetProperties = assetPropertySummaries.map(
+          ({ id: assetPropertyId, path, notification, unit }) => {
+            const { dataType, dataTypeSpec, name } =
+              assetModelProperties.find(
+                ({ id: assetModelPropertyId }) =>
+                  assetModelPropertyId === assetPropertyId
+              ) ?? {};
+
+            const assetProperty: AssetProperty = {
+              id: assetPropertyId,
+              path,
+              notification,
+              unit,
+              dataType,
+              dataTypeSpec,
+              name,
+            };
+
+            return assetProperty;
+          }
+        );
+
+        return { assetProperties, nextToken };
+      },
+      resourceSelector: ({ assetProperties }) => assetProperties,
+    });
+
+  const error = assetModelPropertiesError ?? responseResult.error;
+  const isFetching =
+    !error && (!assetModelPropertiesIsSuccess || responseResult.isFetching);
+
+  return { assetProperties, ...responseResult, isFetching, error };
+}

--- a/packages/react-components/src/components/resource-explorers/queries/use-assets/index.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-assets/index.ts
@@ -1,0 +1,5 @@
+export {
+  useAssets,
+  type UseAssetsOptions,
+  type UseAssetsResult,
+} from './use-assets';

--- a/packages/react-components/src/components/resource-explorers/queries/use-assets/use-asset-model-assets.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-assets/use-asset-model-assets.ts
@@ -1,0 +1,37 @@
+import type { AssetSummary } from '@aws-sdk/client-iotsitewise';
+
+import { useTwoDimensionalListResources } from '../helpers/use-two-dimensional-list-resources';
+import type { ListAssets } from '../../types/data-source';
+import type { UseListAPIBaseOptions, UseListAPIBaseResult } from '../types';
+
+export type UseAssetModelAssetsQuery = Required<
+  Pick<Parameters<ListAssets>[0], 'assetModelId'>
+>;
+
+export interface UseAssetModelAssetsOptions extends UseListAPIBaseOptions {
+  queries: UseAssetModelAssetsQuery[];
+  listAssets: ListAssets;
+}
+
+export interface UseAssetModelAssetsResult extends UseListAPIBaseResult {
+  assets: AssetSummary[];
+}
+
+/** Use the list of assets created from the given asset models. */
+export function useAssetModelAssets({
+  queries,
+  maxResults,
+  listAssets,
+}: UseAssetModelAssetsOptions): UseAssetModelAssetsResult {
+  const { resources: assets, ...responseResult } =
+    useTwoDimensionalListResources({
+      isEnabled: queries.length > 0,
+      maxResults,
+      resourceName: 'AssetSummary(model)',
+      requests: queries,
+      requestFn: listAssets,
+      resourceSelector: ({ assetSummaries = [] }) => assetSummaries,
+    });
+
+  return { assets, ...responseResult };
+}

--- a/packages/react-components/src/components/resource-explorers/queries/use-assets/use-assets.spec.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-assets/use-assets.spec.ts
@@ -1,0 +1,85 @@
+import {
+  createFakeListAssetsResponse,
+  testUseListResourcesHook,
+} from '../helpers/testing';
+import { useAssets } from './use-assets';
+
+testUseListResourcesHook({
+  resourceName: 'assets',
+  hook: useAssets,
+  renderHookWithEmptyList() {
+    const fakeListAssets = jest.fn().mockResolvedValue({ assetSummaries: [] });
+    const fakeListAssociatedAssets = jest
+      .fn()
+      .mockResolvedValue({ assetSummaries: [] });
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssets: fakeListAssets,
+        listAssociatedAssets: fakeListAssociatedAssets,
+      },
+    };
+  },
+  renderHookWithSinglePage() {
+    const fakeListAssetsResponse = createFakeListAssetsResponse();
+    const fakeListAssets = jest.fn().mockResolvedValue(fakeListAssetsResponse);
+    const fakeListAssociatedAssets = jest
+      .fn()
+      .mockResolvedValue({ assetSummaries: [] });
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssets: fakeListAssets,
+        listAssociatedAssets: fakeListAssociatedAssets,
+      },
+      expectedResources: fakeListAssetsResponse.assetSummaries,
+    };
+  },
+  renderHookWithMultiplePages() {
+    const fakeListAssetsResponseWithNextToken1 = createFakeListAssetsResponse({
+      nextToken: 'token-1',
+    });
+    const fakeListAssetsResponseWithNextToken2 = createFakeListAssetsResponse({
+      nextToken: 'token-2',
+    });
+    const fakeListAssetsResponse = createFakeListAssetsResponse();
+    const fakeListAssets = jest
+      .fn()
+      .mockResolvedValue(fakeListAssetsResponse)
+      .mockResolvedValueOnce(fakeListAssetsResponseWithNextToken1)
+      .mockResolvedValueOnce(fakeListAssetsResponseWithNextToken2);
+    const fakeListAssociatedAssets = jest
+      .fn()
+      .mockResolvedValue({ assetSummaries: [] });
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssets: fakeListAssets,
+        listAssociatedAssets: fakeListAssociatedAssets,
+      },
+      expectedResourcesPage1:
+        fakeListAssetsResponseWithNextToken1.assetSummaries,
+      expectedResourcesPage2:
+        fakeListAssetsResponseWithNextToken2.assetSummaries,
+      expectedResourcesPage3: fakeListAssetsResponse.assetSummaries,
+    };
+  },
+
+  renderHookWithError() {
+    const fakeListAssets = jest.fn().mockRejectedValue(new Error('Error'));
+    const fakeListAssociatedAssets = jest
+      .fn()
+      .mockRejectedValue(new Error('Error'));
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssets: fakeListAssets,
+        listAssociatedAssets: fakeListAssociatedAssets,
+      },
+    };
+  },
+});

--- a/packages/react-components/src/components/resource-explorers/queries/use-assets/use-assets.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-assets/use-assets.ts
@@ -1,0 +1,62 @@
+import type { AssetSummary } from '@aws-sdk/client-iotsitewise';
+
+import { useChildAssets } from './use-child-assets';
+import { useRootAssets } from './use-root-assets';
+import { useAssetModelAssets } from './use-asset-model-assets';
+import type { ListAssets, ListAssociatedAssets } from '../../types/data-source';
+import type { UseListAPIBaseOptions, UseListAPIBaseResult } from '../types';
+
+export interface UseAssetsOptions extends UseListAPIBaseOptions {
+  /** Optional asset ID for listing child assets of the asset for the given ID. */
+  assetId?: string;
+  assetModelIds?: string[];
+  listAssets: ListAssets;
+  listAssociatedAssets: ListAssociatedAssets;
+}
+
+export interface UseAssetsResult extends UseListAPIBaseResult {
+  assets: AssetSummary[];
+}
+
+/**
+ * Use a list of IoT SiteWise AssetSummary resources.
+ *
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_AssetSummary.html}
+ *
+ * @experimental Do not use in production.
+ */
+export function useAssets({
+  assetId,
+  assetModelIds = [],
+  listAssets,
+  listAssociatedAssets,
+  maxResults,
+}: UseAssetsOptions): UseAssetsResult {
+  const assetModelAssetsQueryResult = useAssetModelAssets({
+    queries: assetModelIds.map((assetModelId) => ({ assetModelId })),
+    maxResults,
+    listAssets,
+  });
+
+  const rootAssetsQueryResult = useRootAssets({
+    maxResults,
+    listAssets,
+  });
+
+  const childAssetsQueryResult = useChildAssets({
+    query: { assetId },
+    maxResults,
+    listAssociatedAssets,
+  });
+
+  const shouldReturnAssetModelAssetsQueryResult = assetModelIds.length > 0;
+  const shouldReturnChildAssetsQueryResult = assetId != null;
+
+  const queryResult = shouldReturnAssetModelAssetsQueryResult
+    ? assetModelAssetsQueryResult
+    : shouldReturnChildAssetsQueryResult
+    ? childAssetsQueryResult
+    : rootAssetsQueryResult;
+
+  return queryResult;
+}

--- a/packages/react-components/src/components/resource-explorers/queries/use-assets/use-child-assets.spec.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-assets/use-child-assets.spec.ts
@@ -1,0 +1,94 @@
+import {
+  createFakeListAssetsResponse,
+  testUseListResourcesHook,
+} from '../helpers/testing';
+import { useChildAssets } from './use-child-assets';
+
+testUseListResourcesHook({
+  resourceName: 'assets',
+  hook: useChildAssets,
+  renderHookWithEmptyList() {
+    const fakeListAssociatedAssets = jest
+      .fn()
+      .mockResolvedValueOnce({ assetSummaries: [] });
+
+    return {
+      resourceHookOptions: {
+        query: { assetId: '123' },
+        maxResults: 5,
+        listAssociatedAssets: fakeListAssociatedAssets,
+      },
+    };
+  },
+  renderHookWithSinglePage() {
+    const fakeListAssociatedAssetsResponse = createFakeListAssetsResponse();
+    const fakeListAssociatedAssets = jest
+      .fn()
+      .mockResolvedValue(fakeListAssociatedAssetsResponse);
+
+    return {
+      resourceHookOptions: {
+        query: { assetId: '123' },
+        maxResults: 5,
+        listAssociatedAssets: fakeListAssociatedAssets,
+      },
+      expectedResources: fakeListAssociatedAssetsResponse.assetSummaries,
+    };
+  },
+  renderHookWithMultiplePages() {
+    const fakeListAssociatedAssetsResponseWithNextToken1 =
+      createFakeListAssetsResponse({
+        nextToken: 'token-1',
+      });
+    const fakeListAssociatedAssetsResponseWithNextToken2 =
+      createFakeListAssetsResponse({
+        nextToken: 'token-2',
+      });
+    const fakeListAssociatedAssetsResponse = createFakeListAssetsResponse();
+    const fakeListAssociatedAssets = jest
+      .fn()
+      .mockResolvedValue(fakeListAssociatedAssetsResponse)
+      .mockResolvedValueOnce(fakeListAssociatedAssetsResponseWithNextToken1)
+      .mockResolvedValueOnce(fakeListAssociatedAssetsResponseWithNextToken2);
+
+    return {
+      resourceHookOptions: {
+        query: { assetId: '123' },
+        maxResults: 5,
+        listAssociatedAssets: fakeListAssociatedAssets,
+      },
+      expectedResourcesPage1:
+        fakeListAssociatedAssetsResponseWithNextToken1.assetSummaries,
+      expectedResourcesPage2:
+        fakeListAssociatedAssetsResponseWithNextToken2.assetSummaries,
+      expectedResourcesPage3: fakeListAssociatedAssetsResponse.assetSummaries,
+    };
+  },
+
+  renderHookWithError() {
+    const fakeListAssociatedAssets = jest
+      .fn()
+      .mockRejectedValue(new Error('Error'));
+
+    return {
+      resourceHookOptions: {
+        query: { assetId: '123' },
+        maxResults: 5,
+        listAssociatedAssets: fakeListAssociatedAssets,
+      },
+    };
+  },
+
+  renderDisabledRequest() {
+    const fakeListAssociatedAssets = jest
+      .fn()
+      .mockRejectedValue(new Error('Error'));
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssociatedAssets: fakeListAssociatedAssets,
+      },
+    };
+  },
+});

--- a/packages/react-components/src/components/resource-explorers/queries/use-assets/use-child-assets.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-assets/use-child-assets.ts
@@ -1,0 +1,43 @@
+import { type AssetSummary } from '@aws-sdk/client-iotsitewise';
+
+import { useListResources } from '../helpers/use-list-resources/use-list-resources';
+import type { UseListAPIBaseOptions, UseListAPIBaseResult } from '../types';
+import type { ListAssociatedAssets } from '../../types/data-source';
+
+export type UseChildAssetsQuery = Pick<
+  Parameters<ListAssociatedAssets>[0],
+  'assetId'
+>;
+
+export interface UseChildAssetsOptions extends UseListAPIBaseOptions {
+  query?: UseChildAssetsQuery;
+  listAssociatedAssets: ListAssociatedAssets;
+}
+
+export interface UseChildAssetsResult extends UseListAPIBaseResult {
+  assets: AssetSummary[];
+}
+
+/**
+ * Use a list of child IoT SiteWise AssetSummary resources.
+ *
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_AssetSummary.html}
+ */
+export function useChildAssets({
+  query = { assetId: '' },
+  maxResults,
+  listAssociatedAssets,
+}: UseChildAssetsOptions): UseChildAssetsResult {
+  const { resources: assets, ...responseResult } = useListResources({
+    isEnabled: Boolean(query?.assetId),
+    resourceName: 'AssetSummary(child)',
+    params: { ...query, maxResults },
+    requestFn: listAssociatedAssets,
+    resourceSelector: ({ assetSummaries = [] }) => assetSummaries,
+  });
+
+  return {
+    assets,
+    ...responseResult,
+  };
+}

--- a/packages/react-components/src/components/resource-explorers/queries/use-assets/use-root-assets.spec.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-assets/use-root-assets.spec.ts
@@ -1,0 +1,73 @@
+import {
+  createFakeListAssetsResponse,
+  testUseListResourcesHook,
+} from '../helpers/testing';
+import { useRootAssets } from './use-root-assets';
+
+testUseListResourcesHook({
+  resourceName: 'assets',
+  hook: useRootAssets,
+  renderHookWithEmptyList() {
+    const fakeListAssets = jest
+      .fn()
+      .mockResolvedValueOnce({ assetSummaries: [] });
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssets: fakeListAssets,
+      },
+    };
+  },
+  renderHookWithSinglePage() {
+    const fakeListAssetsResponse = createFakeListAssetsResponse();
+    const fakeListAssets = jest.fn().mockResolvedValue(fakeListAssetsResponse);
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssets: fakeListAssets,
+      },
+      expectedResources: fakeListAssetsResponse.assetSummaries,
+    };
+  },
+  renderHookWithMultiplePages() {
+    const fakeListAssetsResponseWithNextToken1 = createFakeListAssetsResponse({
+      nextToken: 'token-1',
+    });
+    const fakeListAssetsResponseWithNextToken2 = createFakeListAssetsResponse({
+      nextToken: 'token-2',
+    });
+    const fakeListAssetsResponse = createFakeListAssetsResponse();
+    const fakeListAssets = jest
+      .fn()
+      .mockResolvedValue(fakeListAssetsResponse)
+      .mockResolvedValueOnce(fakeListAssetsResponseWithNextToken1)
+      .mockResolvedValueOnce(fakeListAssetsResponseWithNextToken2);
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssets: fakeListAssets,
+      },
+      expectedResourcesPage1:
+        fakeListAssetsResponseWithNextToken1.assetSummaries,
+      expectedResourcesPage2:
+        fakeListAssetsResponseWithNextToken2.assetSummaries,
+      expectedResourcesPage3: fakeListAssetsResponse.assetSummaries,
+    };
+  },
+
+  renderHookWithError() {
+    const fakeListAssets = jest
+      .fn()
+      .mockRejectedValue(new Error('errrrrorrrr'));
+
+    return {
+      resourceHookOptions: {
+        maxResults: 5,
+        listAssets: fakeListAssets,
+      },
+    };
+  },
+});

--- a/packages/react-components/src/components/resource-explorers/queries/use-assets/use-root-assets.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-assets/use-root-assets.ts
@@ -1,0 +1,35 @@
+import { type AssetSummary } from '@aws-sdk/client-iotsitewise';
+
+import { useListResources } from '../helpers/use-list-resources';
+import type { UseListAPIBaseOptions, UseListAPIBaseResult } from '../types';
+import type { ListAssets } from '../../types/data-source';
+
+export interface UseRootAssetsOptions extends UseListAPIBaseOptions {
+  listAssets: ListAssets;
+}
+
+export interface UseRootAssetsResult extends UseListAPIBaseResult {
+  assets: AssetSummary[];
+}
+
+/**
+ * Use a list of root IoT SiteWise AssetSummary resources.
+ *
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_AssetSummary.html}
+ */
+export function useRootAssets({
+  maxResults,
+  listAssets,
+}: UseRootAssetsOptions): UseRootAssetsResult {
+  const { resources: assets, ...responseResult } = useListResources({
+    resourceName: 'AssetSummary(root)',
+    params: { filter: 'TOP_LEVEL', maxResults },
+    requestFn: listAssets,
+    resourceSelector: ({ assetSummaries = [] }) => assetSummaries,
+  });
+
+  return {
+    assets,
+    ...responseResult,
+  };
+}

--- a/packages/react-components/src/components/resource-explorers/queries/use-time-series/index.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-time-series/index.ts
@@ -1,0 +1,5 @@
+export {
+  useTimeSeries,
+  type UseTimeSeriesOptions,
+  type UseTimeSeriesResult,
+} from './use-time-series';

--- a/packages/react-components/src/components/resource-explorers/queries/use-time-series/use-time-series.spec.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-time-series/use-time-series.spec.ts
@@ -1,0 +1,109 @@
+import {
+  testUseListResourcesHook,
+  createFakeTimeSeriesSummary,
+} from '../helpers/testing';
+import { useTimeSeries } from './use-time-series';
+
+testUseListResourcesHook({
+  resourceName: 'timeSeries',
+  hook: useTimeSeries,
+  renderHookWithEmptyList() {
+    const fakeListTimeSeries = jest
+      .fn()
+      .mockResolvedValueOnce({ TimeSeriesSummaries: [] });
+
+    return {
+      resourceHookOptions: {
+        queries: [{ assetId: '123' }],
+        maxResults: 5,
+        listTimeSeries: fakeListTimeSeries,
+      },
+    };
+  },
+  renderHookWithSinglePage() {
+    const fakeListTimeSeriesResponse = {
+      TimeSeriesSummaries: [
+        createFakeTimeSeriesSummary(),
+        createFakeTimeSeriesSummary(),
+        createFakeTimeSeriesSummary(),
+      ],
+    };
+    const fakeListTimeSeries = jest
+      .fn()
+      .mockResolvedValue(fakeListTimeSeriesResponse);
+
+    return {
+      resourceHookOptions: {
+        queries: [{ assetId: '123' }],
+        maxResults: 5,
+        listTimeSeries: fakeListTimeSeries,
+      },
+      expectedResources: fakeListTimeSeriesResponse.TimeSeriesSummaries,
+    };
+  },
+  renderHookWithMultiplePages() {
+    const page1 = {
+      TimeSeriesSummaries: [
+        createFakeTimeSeriesSummary(),
+        createFakeTimeSeriesSummary(),
+        createFakeTimeSeriesSummary(),
+      ],
+    };
+    const page2 = {
+      TimeSeriesSummaries: [
+        createFakeTimeSeriesSummary(),
+        createFakeTimeSeriesSummary(),
+      ],
+      nextToken: 'token-1',
+    };
+    const page3 = {
+      TimeSeriesSummaries: [
+        createFakeTimeSeriesSummary(),
+        createFakeTimeSeriesSummary(),
+        createFakeTimeSeriesSummary(),
+        createFakeTimeSeriesSummary(),
+        createFakeTimeSeriesSummary(),
+      ],
+      nextToken: 'token-2',
+    };
+    const page4 = {
+      TimeSeriesSummaries: [
+        createFakeTimeSeriesSummary(),
+        createFakeTimeSeriesSummary(),
+        createFakeTimeSeriesSummary(),
+      ],
+    };
+    const fakeListTimeSeries = jest
+      .fn()
+      .mockResolvedValueOnce(page1)
+      .mockResolvedValueOnce(page2)
+      .mockResolvedValueOnce(page3)
+      .mockResolvedValue(page4);
+
+    return {
+      resourceHookOptions: {
+        queries: [{ assetId: '123' }, { assetId: '456' }],
+        maxResults: 5,
+        listTimeSeries: fakeListTimeSeries,
+      },
+      expectedResourcesPage1: [
+        ...page1.TimeSeriesSummaries,
+        ...page2.TimeSeriesSummaries,
+      ],
+      expectedResourcesPage2: page3.TimeSeriesSummaries,
+      expectedResourcesPage3: page4.TimeSeriesSummaries,
+    };
+  },
+
+  renderHookWithError() {
+    const fakeListTimeSeries = jest.fn().mockRejectedValue(new Error('Error'));
+
+    return {
+      resourceHookOptions: {
+        queries: [{ assetId: '123' }],
+        maxResults: 5,
+        listTimeSeries: fakeListTimeSeries,
+      },
+    };
+  },
+});

--- a/packages/react-components/src/components/resource-explorers/queries/use-time-series/use-time-series.ts
+++ b/packages/react-components/src/components/resource-explorers/queries/use-time-series/use-time-series.ts
@@ -1,0 +1,43 @@
+import type { TimeSeriesSummary } from '@aws-sdk/client-iotsitewise';
+
+import { useTwoDimensionalListResources } from '../helpers/use-two-dimensional-list-resources';
+import type { ListTimeSeries } from '../../types/data-source';
+import type { UseListAPIBaseOptions, UseListAPIBaseResult } from '../types';
+
+export type UseTimeSeriesQuery = Pick<
+  Parameters<ListTimeSeries>[0],
+  'aliasPrefix' | 'assetId' | 'timeSeriesType'
+>;
+
+export interface UseTimeSeriesOptions extends UseListAPIBaseOptions {
+  queries: UseTimeSeriesQuery[];
+  listTimeSeries: ListTimeSeries;
+}
+
+export interface UseTimeSeriesResult extends UseListAPIBaseResult {
+  timeSeries: TimeSeriesSummary[];
+}
+
+/**
+ * Use a list of IoT SiteWise TimeSeriesSummary resources.
+ *
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_TimeSeriesSummary.html}
+ *
+ * @experimental Do not use in production.
+ */
+export function useTimeSeries({
+  queries,
+  maxResults,
+  listTimeSeries,
+}: UseTimeSeriesOptions): UseTimeSeriesResult {
+  const { resources: timeSeries, ...responseResult } =
+    useTwoDimensionalListResources({
+      maxResults,
+      resourceName: 'TimeSeriesSummary',
+      requests: queries,
+      requestFn: listTimeSeries,
+      resourceSelector: ({ TimeSeriesSummaries = [] }) => TimeSeriesSummaries,
+    });
+
+  return { timeSeries, ...responseResult };
+}

--- a/packages/react-components/src/components/resource-explorers/types/data-source.ts
+++ b/packages/react-components/src/components/resource-explorers/types/data-source.ts
@@ -1,0 +1,56 @@
+import type {
+  ListAssetModelsRequest,
+  ListAssetModelsResponse,
+  ListAssetModelPropertiesRequest,
+  ListAssetModelPropertiesResponse,
+  ListAssetsRequest,
+  ListAssetsResponse,
+  ListAssociatedAssetsRequest,
+  ListAssociatedAssetsResponse,
+  ListAssetPropertiesRequest,
+  ListAssetPropertiesResponse,
+  ListTimeSeriesRequest,
+  ListTimeSeriesResponse,
+} from '@aws-sdk/client-iotsitewise';
+
+/**
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssetModels.html}
+ */
+export type ListAssetModels = (
+  request: ListAssetModelsRequest
+) => PromiseLike<ListAssetModelsResponse>;
+
+/**
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssetModelProperties.html}
+ */
+export type ListAssetModelProperties = (
+  request: ListAssetModelPropertiesRequest
+) => PromiseLike<ListAssetModelPropertiesResponse>;
+
+/**
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssets.html}
+ */
+export type ListAssets = (
+  request: ListAssetsRequest
+) => PromiseLike<ListAssetsResponse>;
+
+/**
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssociatedAssets.html}
+ */
+export type ListAssociatedAssets = (
+  request: ListAssociatedAssetsRequest
+) => PromiseLike<ListAssociatedAssetsResponse>;
+
+/**
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListTimeSeries.html}
+ */
+export type ListTimeSeries = (
+  request: ListTimeSeriesRequest
+) => PromiseLike<ListTimeSeriesResponse>;
+
+/**
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssetProperties.html}
+ */
+export type ListAssetProperties = (
+  request: ListAssetPropertiesRequest
+) => PromiseLike<ListAssetPropertiesResponse>;


### PR DESCRIPTION
## Overview
This change introduces a series of React hooks for various IoT SiteWise resources. The hooks enable UI-driven pagination of resources and are intended to be used with the majority of user experiences involving listing resources. The hooks will be combined used with the Cloudscape table in a follow-up PR to replicate the existing resource explorer experience.


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
