### PR TITLE
fix(scene): validation scene json on deserialize

### DIFF
--- a/packages/scene-composer/public/invalidInputTest.scene.json
+++ b/packages/scene-composer/public/invalidInputTest.scene.json
@@ -1,0 +1,489 @@
+{
+  "specVersion": "1.0",
+  "version": "1",
+  "unit": "meters",
+  "properties": {
+    "environmentPreset": "neutral",
+    "dataBindingConfig": {
+      "template": {
+        "sel_entity": "room1",
+        "sel_comp": "temperatureSensor2"
+      },
+      "fieldMapping": {
+        "entityId": [
+          "sel_entity"
+        ],
+        "componentName": [
+          "sel_comp"
+        ]
+      }
+    },
+    "fogSettings": {
+      "color": "NOTHEX",
+      "near": -10,
+      "far": "undefined"
+    },
+    "sceneBackgroundSettings": {
+      "color": "NOTHEX",
+      "textureUri": "TE\n\nST"
+    },
+    "groundPlaneSettings": {
+      "color": "#NOTHEX",
+      "opacity": -1,
+      "textureUri": "TE\n\nST"
+    },
+    "groundCustomColors": ["#ff0000", "NOTHEX"],
+    "fogCustomColors": ["#ff0000", "NOTHEX"],
+    "backgroundCustomColors": ["#ff0000", "NOTHEX"]
+  },
+  "nodes": [
+    {
+      "name": "Pallet Jack",
+      "transform": {
+        "position": [
+          1,
+          0,
+          0
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {
+
+      },
+      "children": [
+        1,
+        4,
+        5,
+        7
+      ],
+      "components": [
+        {
+          "type": "ModelRef",
+          "uri": "PALLET_\n\nJACK.glb",
+          "modelType": "GLB",
+          "unitOfMeasure": "meters"
+        }
+      ],
+      "properties": {
+
+      }
+    },
+    {
+      "name": "Obstruction Alarm",
+      "transform": {
+        "position": [
+          0,
+          2.2462426122230426,
+          0
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {
+
+      },
+      "children": [
+        8
+      ],
+      "components": [
+        {
+          "type": "Tag",
+          "ruleBasedMapId": "sampleTimeSeriesIconRule",
+          "valueDataBinding": {
+            "dataBindingContext": {
+              "entityId": "${sel_entity}",
+              "componentName": "${sel_comp}",
+              "propertyName": "temperature"
+            }
+          },
+          "navLink": {
+            "destination": "http://localhost:4300/d/KKIARDInk/new-dashboard-copy",
+            "params": {
+              "foo": "bar"
+            }
+          }
+        }
+      ],
+      "properties": {
+
+      }
+    },
+    {
+      "name": "directional light",
+      "transform": {
+        "position": [
+          -5,
+          10,
+          10
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {
+
+      },
+      "components": [
+        {
+          "type": "Light",
+          "lightType": "Directional",
+          "lightSettings": {
+            "color": 16777215,
+            "intensity": 1,
+            "castShadow":true
+          }
+        }
+      ],
+      "properties": {
+
+      }
+    },
+    {
+      "name": "ambient light",
+      "transform": {
+        "position": [
+          10,
+          10,
+          10
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {
+
+      },
+      "components": [
+        {
+          "type": "Light",
+          "lightType": "Ambient",
+          "lightSettings": {
+            "color": 16777215,
+            "intensity": 0.2
+          }
+        }
+      ],
+      "properties": {
+
+      }
+    },
+    {
+      "name": "Lift Direction",
+      "transform": {
+        "position": [
+          0.026177569273909795,
+          0.12487268539819854,
+          -0.6475704349193628
+        ],
+        "rotation": [
+          3.0891109067350975,
+          1.5423817718730837,
+          -3.089601298590836
+        ],
+        "scale": [
+          1.3444898056140844,
+          1,
+          1.008107454341504
+        ]
+      },
+      "transformConstraint": {
+
+      },
+      "components": [
+        {
+          "type": "MotionIndicator",
+          "shape": "LinearPlane",
+          "valueDataBindings": {
+            "foregroundColor": {
+
+            }
+          },
+          "config": {
+            "numOfRepeatInY": 2,
+            "backgroundColorOpacity": 1,
+            "defaultSpeed": "0.5",
+            "defaultForegroundColor": "#29f502"
+          }
+        }
+      ],
+      "properties": {
+
+      }
+    },
+    {
+      "name": "Fork Lift",
+      "transform": {
+        "position": [
+          0,
+          0,
+          0
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {
+
+      },
+      "components": [
+        {
+          "parentRef": "1BB44716-4325-436C-A098-CD2A53A8336C",
+          "selector": "Scene491",
+          "type": "SubModelRef"
+        }
+      ],
+      "properties": {
+        "subModelId": "Scene491"
+      }
+    },
+    {
+      "name": "Camera1",
+      "transform": {
+        "position": [
+          3.8592914668132337,
+          1.660816595658845,
+          -0.29774633590225036
+        ],
+        "rotation": [
+          -1.6451249704899187,
+          1.4253822264470961,
+          1.6459148400213455
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {
+
+      },
+      "components": [
+        {
+          "type": "Camera",
+          "cameraIndex": 0
+        }
+      ],
+      "properties": {
+
+      }
+    },
+    {
+      "name": "Text Annotation",
+      "transform": {
+        "position": [
+          0,
+          0.9,
+          0.25
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {
+
+      },
+      "components": [
+        {
+          "type": "DataOverlay",
+          "subType": "TextAnnotation",
+          "valueDataBindings": [],
+          "dataRows": [
+            {
+              "rowType": "Markdown",
+              "content": "# || Annotation || \n Second line"
+            }
+          ]
+        }
+      ],
+      "properties": {
+
+      }
+    },
+    {
+      "name": "Overlay Panel",
+      "transform": {
+        "position": [
+          0,
+          0.25,
+          0
+        ],
+        "rotation": [
+          0,
+          0,
+          0
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "transformConstraint": {
+
+      },
+      "components": [
+        {
+          "type": "Tag"
+        },
+        {
+          "type": "DataOverlay",
+          "subType": "OverlayPanel",
+          "valueDataBindings": [
+            {
+              "bindingName": "binding a",
+              "valueDataBinding" : {
+                "dataBindingContext": {
+                  "entityId": "room1",
+                  "componentName": "temperatureSensor1",
+                  "propertyName": "temperature"    
+                }
+              }
+            },
+            {
+              "bindingName": "binding b",
+              "valueDataBinding" : {
+                "dataBindingContext": {
+                  "entityId": "room2",
+                  "componentName": "temperatureSensor1",
+                  "propertyName": "temperature"    
+                }
+              }
+            }
+          ],
+          "dataRows": [
+            {
+              "rowType": "Markdown",
+              "content": "## || Panel || \n ## [Click me](https://github.com/awslabs/iot-app-kit) \n ${binding a} ${binding b}xxxx"
+            }
+          ]
+        }
+      ],
+      "properties": {
+
+      }
+    }
+  ],
+  "rootNodeIndexes": [
+    0,
+    2,
+    3,
+    6
+  ],
+  "cameras": [
+    {
+      "cameraType": "Perspective",
+      "fov": 53.13,
+      "far": 1000,
+      "near": 0.1,
+      "zoom": 1
+    }
+  ],
+  "rules": {
+    "sampleAlarmIconRule": {
+      "statements": [
+        {
+          "expression": "alarm_status == 'ACTIVE'",
+          "target": "iottwinmaker.common.icon:Error"
+        },
+        {
+          "expression": "alarm_status == 'ACKNOWLEDGED'",
+          "target": "iottwinmaker.common.icon:Warning"
+        },
+        {
+          "expression": "alarm_status == 'SNOOZE_DISABLED'",
+          "target": "iottwinmaker.common.icon:Warning"
+        },
+        {
+          "expression": "alarm_status == 'NORMAL'",
+          "target": "iottwinmaker.common.icon:Info"
+        }
+      ]
+    },
+    "sampleTimeSeriesIconRule": {
+      "statements": [
+        {
+          "expression": "temperature >= 20",
+          "target": "iottwinmaker.common.icon:Error"
+        },
+        {
+          "expression": "temperature >= 30",
+          "target": "iottwinmaker.common.icon:Warning"
+        },
+        {
+          "expression": "temperature < 30",
+          "target": "iottwinmaker.common.icon:Info"
+        }
+      ]
+    },
+    "sampleTimeSeriesColorRule": {
+      "statements": [
+        {
+          "expression": "temperature >= 37",
+          "target": "iottwinmaker.common.color:#ff0000"
+        },
+        {
+          "expression": "temperature >= 20",
+          "target": "iottwinmaker.common.color:#ffff00"
+        },
+        {
+          "expression": "temperature < 20",
+          "target": "iottwinmaker.common.color:#00ff00"
+        }
+      ]
+    },
+    "AlwaysOn": {
+      "statements": [
+        {
+          "expression": "1==1",
+          "target": "iottwinmaker.common.color:#d13212"
+        }
+      ]
+    }
+  }
+}

--- a/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo.tsx
+++ b/packages/scene-composer/src/components/panels/scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo.tsx
@@ -7,6 +7,7 @@ import '../IconPicker/IconPickerUtils/IconPicker-aws-overrides.scss';
 import { ColorRepresentation } from 'three';
 
 import { colors } from '../../../../../utils/styleUtils';
+import { isValidHexCode } from '../../../../../utils/colorUtils';
 import { IColorPickerProps } from '../interface';
 import { ColorPicker } from '../../../ColorPicker/ColorPicker';
 import { hexString } from '../../../ColorPicker/ColorPickerHelpers';
@@ -39,19 +40,6 @@ export const ColorSelectorCombo = ({
   const generateRandomString = Math.random().toString(16).slice(2);
   const [randomDomId] = useState<string>(generateRandomString);
   const intl = useIntl();
-
-  /**
-   * This method uses a regular expression (`hexRegex`) to validate a hex color code.
-   * The regex checks if the hex code starts with a "#" symbol, followed by either a
-   * 6-digit or 3-digit combination of characters from A-F, a-f, and 0-9.
-   * The `test` method is then used to validate the `hexCode` against the regex pattern.
-   * @param hexCode
-   * @returns
-   */
-  const isValidHexCode = (hexCode: string) => {
-    const hexRegex = /^#([A-Fa-f0-9]{6})$/;
-    return hexRegex.test(hexCode);
-  };
 
   const handleOutsideClick = useCallback((event: MouseEvent) => {
     const target = event.target as HTMLElement;

--- a/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.spec.tsx
@@ -24,7 +24,14 @@ describe('FogSettingsEditor', () => {
   });
 
   it('should save fogsettings when enabled', async () => {
-    getScenePropertyMock.mockReturnValue(undefined);
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.FogSettings) {
+        return undefined;
+      } else if (property === KnownSceneProperty.FogCustomColors) {
+        const customColors: string[] = [];
+        return customColors;
+      }
+    });
     useStore('default').setState(baseState);
     const { container } = render(<FogSettingsEditor />);
     const polarisWrapper = wrapper(container);
@@ -45,10 +52,17 @@ describe('FogSettingsEditor', () => {
   });
 
   it('should clear fogsettings when untoggled', async () => {
-    getScenePropertyMock.mockReturnValue({
-      color: '#cccccc',
-      near: 1,
-      far: 1000,
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.FogSettings) {
+        return {
+          color: '#cccccc',
+          near: 1,
+          far: 1000,
+        };
+      } else if (property === KnownSceneProperty.FogCustomColors) {
+        const customColors: string[] = [];
+        return customColors;
+      }
     });
     useStore('default').setState(baseState);
     const { container } = render(<FogSettingsEditor />);
@@ -66,10 +80,17 @@ describe('FogSettingsEditor', () => {
   });
 
   it('should update fog when near changes', async () => {
-    getScenePropertyMock.mockReturnValue({
-      color: '#cccccc',
-      near: 1,
-      far: 1000,
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.FogSettings) {
+        return {
+          color: '#cccccc',
+          near: 1,
+          far: 1000,
+        };
+      } else if (property === KnownSceneProperty.FogCustomColors) {
+        const customColors: string[] = [];
+        return customColors;
+      }
     });
     useStore('default').setState(baseState);
     const { container } = render(<FogSettingsEditor />);
@@ -91,10 +112,17 @@ describe('FogSettingsEditor', () => {
   });
 
   it('should update fog when far changes', async () => {
-    getScenePropertyMock.mockReturnValue({
-      color: '#cccccc',
-      near: 1,
-      far: 1000,
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.FogSettings) {
+        return {
+          color: '#cccccc',
+          near: 1,
+          far: 1000,
+        };
+      } else if (property === KnownSceneProperty.FogCustomColors) {
+        const customColors: string[] = [];
+        return customColors;
+      }
     });
     useStore('default').setState(baseState);
     const { container } = render(<FogSettingsEditor />);

--- a/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/FogSettingsEditor.tsx
@@ -3,7 +3,13 @@ import { useIntl } from 'react-intl';
 import { FormField, Input, SpaceBetween, Toggle } from '@cloudscape-design/components';
 
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
-import { IFogSettings, KnownSceneProperty } from '../../../interfaces';
+import {
+  DEFAULT_FOG_COLOR,
+  DEFAULT_FOG_FAR,
+  DEFAULT_FOG_NEAR,
+  IFogSettings,
+  KnownSceneProperty,
+} from '../../../interfaces';
 import useLifecycleLogging from '../../../logger/react-logger/hooks/useLifecycleLogging';
 import { useStore } from '../../../store';
 import { ColorSelectorCombo } from '../scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo';
@@ -19,9 +25,9 @@ export const FogSettingsEditor: React.FC = () => {
   );
 
   const [fogEnabled, setFogEnabled] = useState(!!fogSettings);
-  const [internalColor, setInternalColor] = useState(fogSettings?.color || '#cccccc');
-  const [internalNearDistance, setInternalNearDistance] = useState(fogSettings?.near || 1);
-  const [internalFarDistance, setInternalFarDistance] = useState(fogSettings?.far || 1000);
+  const [internalColor, setInternalColor] = useState(fogSettings?.color || DEFAULT_FOG_COLOR);
+  const [internalNearDistance, setInternalNearDistance] = useState(fogSettings?.near || DEFAULT_FOG_NEAR);
+  const [internalFarDistance, setInternalFarDistance] = useState(fogSettings?.far || DEFAULT_FOG_FAR);
 
   const fogColors = useStore(sceneComposerId)((state) =>
     state.getSceneProperty<string[]>(KnownSceneProperty.FogCustomColors, []),

--- a/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.spec.tsx
@@ -66,9 +66,16 @@ describe('GroundPlaneSettingsEditor', () => {
   });
 
   it('should open asset browser when select texture clicked and set texture uri', () => {
-    getScenePropertyMock.mockReturnValue({
-      color: '#cccccc',
-      opacity: 0,
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.GroundPlaneSettings) {
+        return {
+          color: '#cccccc',
+          opacity: 0,
+        };
+      } else if (property === KnownSceneProperty.GroundCustomColors) {
+        const customColors: string[] = [];
+        return customColors;
+      }
     });
     const globalSettingsMock = getGlobalSettings as jest.Mock;
     globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
@@ -94,9 +101,16 @@ describe('GroundPlaneSettingsEditor', () => {
   });
 
   it('should remove texture uri', () => {
-    getScenePropertyMock.mockReturnValue({
-      textureUri: 'filepath',
-      opacity: 1,
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.GroundPlaneSettings) {
+        return {
+          textureUri: 'filepath',
+          opacity: 1,
+        };
+      } else if (property === KnownSceneProperty.GroundCustomColors) {
+        const customColors: string[] = [];
+        return customColors;
+      }
     });
     const globalSettingsMock = getGlobalSettings as jest.Mock;
     globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
@@ -118,9 +132,16 @@ describe('GroundPlaneSettingsEditor', () => {
   });
 
   it('should update opacity', () => {
-    getScenePropertyMock.mockReturnValue({
-      textureUri: 'filepath',
-      opacity: 0,
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.GroundPlaneSettings) {
+        return {
+          textureUri: 'filepath',
+          opacity: 0,
+        };
+      } else if (property === KnownSceneProperty.GroundCustomColors) {
+        const customColors: string[] = [];
+        return customColors;
+      }
     });
     const globalSettingsMock = getGlobalSettings as jest.Mock;
     globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });

--- a/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.tsx
@@ -4,7 +4,13 @@ import { Button, FormField, Input, SpaceBetween } from '@cloudscape-design/compo
 
 import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
-import { IGroundPlaneSettings, KnownSceneProperty, COMPOSER_FEATURES, TextureFileTypeList } from '../../../interfaces';
+import {
+  DEFAULT_GROUND_PLANE_COLOR,
+  IGroundPlaneSettings,
+  KnownSceneProperty,
+  COMPOSER_FEATURES,
+  TextureFileTypeList,
+} from '../../../interfaces';
 import useLifecycleLogging from '../../../logger/react-logger/hooks/useLifecycleLogging';
 import { useStore } from '../../../store';
 import { ColorSelectorCombo } from '../scene-components/tag-style/ColorSelectorCombo/ColorSelectorCombo';
@@ -23,7 +29,7 @@ export const GroundPlaneSettingsEditor: React.FC = () => {
     state.getSceneProperty<IGroundPlaneSettings>(KnownSceneProperty.GroundPlaneSettings),
   );
 
-  const [internalColor, setInternalColor] = useState(groundSettings?.color || '#00FF00');
+  const [internalColor, setInternalColor] = useState(groundSettings?.color || DEFAULT_GROUND_PLANE_COLOR);
   const [internalUri, setInternalUri] = useState(groundSettings?.textureUri || '');
   const [internalOpacity, setInternalOpacity] = useState(groundSettings?.opacity || 0);
 

--- a/packages/scene-composer/src/components/panels/scene-settings/SceneBackgroundSettingsEditor.spec.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/SceneBackgroundSettingsEditor.spec.tsx
@@ -34,7 +34,14 @@ describe('SceneBackgroundSettingsEditor', () => {
   });
 
   it('should save background on clean scene', () => {
-    getScenePropertyMock.mockReturnValue(undefined);
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.SceneBackgroundSettings) {
+        return undefined;
+      } else if (property === KnownSceneProperty.BackgroundCustomColors) {
+        const customColors: string[] = [];
+        return customColors;
+      }
+    });
     const globalSettingsMock = getGlobalSettings as jest.Mock;
     globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
     useStore('default').setState(baseState);
@@ -78,8 +85,15 @@ describe('SceneBackgroundSettingsEditor', () => {
   });
 
   it('should open asset browser when select texture clicked and set texture uri', () => {
-    getScenePropertyMock.mockReturnValue({
-      color: '#cccccc',
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.SceneBackgroundSettings) {
+        return {
+          color: '#cccccc',
+        };
+      } else if (property === KnownSceneProperty.BackgroundCustomColors) {
+        const customColors: string[] = [];
+        return customColors;
+      }
     });
     const globalSettingsMock = getGlobalSettings as jest.Mock;
     globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });
@@ -104,8 +118,15 @@ describe('SceneBackgroundSettingsEditor', () => {
   });
 
   it('should remove texture uri', () => {
-    getScenePropertyMock.mockReturnValue({
-      textureUri: 'filepath',
+    getScenePropertyMock.mockImplementation((property: string) => {
+      if (property === KnownSceneProperty.SceneBackgroundSettings) {
+        return {
+          textureUri: 'filepath',
+        };
+      } else if (property === KnownSceneProperty.BackgroundCustomColors) {
+        const customColors: string[] = [];
+        return customColors;
+      }
     });
     const globalSettingsMock = getGlobalSettings as jest.Mock;
     globalSettingsMock.mockReturnValue({ featureConfig: mockFeatureConfigOn });

--- a/packages/scene-composer/src/components/panels/scene-settings/SceneBackgroundSettingsEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/SceneBackgroundSettingsEditor.tsx
@@ -6,6 +6,7 @@ import { getGlobalSettings } from '../../../common/GlobalSettings';
 import { sceneComposerIdContext } from '../../../common/sceneComposerIdContext';
 import {
   COMPOSER_FEATURES,
+  DEFAULT_SCENE_BACKGROUND_COLOR,
   ISceneBackgroundSetting,
   KnownSceneProperty,
   TextureFileTypeList,
@@ -31,19 +32,26 @@ export const SceneBackgroundSettingsEditor: React.FC = () => {
     (state) => state.getEditorConfig().showAssetBrowserCallback,
   );
 
-  const [internalColor, setInternalColor] = useState(backgroundSettings?.color || '#2a2e33');
+  const [internalColor, setInternalColor] = useState(backgroundSettings?.color || DEFAULT_SCENE_BACKGROUND_COLOR);
   const [internalUri, setInternalUri] = useState(backgroundSettings?.textureUri || '');
   const backgroundColors = useStore(sceneComposerId)((state) =>
     state.getSceneProperty<string[]>(KnownSceneProperty.BackgroundCustomColors, []),
   );
   const setBackgroundColorsSceneProperty = useStore(sceneComposerId)((state) => state.setSceneProperty<string[]>);
 
-  //set default
+  //set default and restore editor when background failed validiation elsewhere
   useEffect(() => {
     if (!backgroundSettings?.color && !backgroundSettings?.textureUri) {
       setSceneProperty(KnownSceneProperty.SceneBackgroundSettings, {
         color: internalColor,
       });
+    } else {
+      if (backgroundSettings.color && backgroundSettings.color !== internalColor) {
+        setInternalColor(backgroundSettings?.color);
+      }
+      if (backgroundSettings.textureUri && backgroundSettings.textureUri !== internalUri) {
+        setInternalUri(backgroundSettings.textureUri);
+      }
     }
   }, [backgroundSettings]);
 

--- a/packages/scene-composer/src/interfaces/interfaces.tsx
+++ b/packages/scene-composer/src/interfaces/interfaces.tsx
@@ -79,7 +79,7 @@ export enum KnownSceneProperty {
   BackgroundCustomColors = 'backgroundCustomColors',
   LayerDefaultRefreshInterval = 'layerDefaultRefreshInterval',
   GeometryCustomColors = 'geometryCustomColors',
-  GroundCustomColors = 'groundCustomColors,',
+  GroundCustomColors = 'groundCustomColors',
 }
 
 /************************************************
@@ -155,13 +155,19 @@ export interface IFogSettings {
   far: number;
 }
 
+export const DEFAULT_FOG_COLOR = '#cccccc';
+export const DEFAULT_FOG_NEAR = 1;
+export const DEFAULT_FOG_FAR = 1000;
+
 export interface ISceneBackgroundSetting {
   color?: string;
   textureUri?: string;
 }
+export const DEFAULT_SCENE_BACKGROUND_COLOR = '#2a2e33';
 
 export interface IGroundPlaneSettings {
   color?: string;
   textureUri?: string;
   opacity: number;
 }
+export const DEFAULT_GROUND_PLANE_COLOR = '#00FF00';

--- a/packages/scene-composer/src/utils/colorUtils.spec.ts
+++ b/packages/scene-composer/src/utils/colorUtils.spec.ts
@@ -1,0 +1,16 @@
+import { isValidHexCode } from './colorUtils';
+
+describe('colorUtils', () => {
+  it('should confirm a valid color hexcode', () => {
+    expect(isValidHexCode('#00FF00')).toBeTruthy();
+    expect(isValidHexCode('#00ff00')).toBeTruthy();
+  });
+
+  it('should detect invalid color hexcode', () => {
+    expect(isValidHexCode('00FF00')).toBeFalsy();
+    expect(isValidHexCode('0F0')).toBeFalsy();
+    expect(isValidHexCode('undefined')).toBeFalsy();
+    expect(isValidHexCode('null')).toBeFalsy();
+    expect(isValidHexCode('blue')).toBeFalsy();
+  });
+});

--- a/packages/scene-composer/src/utils/colorUtils.ts
+++ b/packages/scene-composer/src/utils/colorUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * This method uses a regular expression (`hexRegex`) to validate a hex color code.
+ * The regex checks if the hex code starts with a "#" symbol, followed by either a
+ * 6-digit combination of characters from A-F, a-f, and 0-9.
+ * The `test` method is then used to validate the `hexCode` against the regex pattern.
+ * @param hexCode
+ * @returns
+ */
+export const isValidHexCode = (hexCode: string): boolean => {
+  const hexRegex = /^#([A-Fa-f0-9]{6})$/;
+  return hexRegex.test(hexCode);
+};


### PR DESCRIPTION
## Overview
Scene json load invalid values for
color hexcodes
opacity ranges
fog near and far distances.

If an invalid value is detected on load then the value will be replaced with the default value.

## Verifying Changes
Run storybook and load the invalidInputTest.scene.json file to verify that invalid values are converted to defaults

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
