### PR TITLE
fix(scene): round ground plane opacity to whole percent

### DIFF
--- a/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.tsx
+++ b/packages/scene-composer/src/components/panels/scene-settings/GroundPlaneSettingsEditor.tsx
@@ -130,7 +130,7 @@ export const GroundPlaneSettingsEditor: React.FC = () => {
           <FormField label={intl.formatMessage({ defaultMessage: 'Opacity %', description: 'Form Field label' })}>
             <Input
               data-testid='ground-plane-opacity-input'
-              value={String(internalOpacity * 100)}
+              value={(internalOpacity * 100).toFixed(0)}
               type='number'
               onBlur={onInputBlur}
               onChange={onOpacityChange}


### PR DESCRIPTION
## Overview
Ground plane opacity show decimal values at certain intervals of +/- 1 percent due to floating point percision as it's stored as 1 to 0 in the system.  The input widget will do a rounding to whole percentage points to make the widgets performance consistent.

## Verifying Changes
run storybook and open a scene in composer
go to the settings tab and open the scene settings
click up and down with the spinner to move the opacity from 0 to 100.  It should not show decimal values only whole percent. 
Same for manually typing in values.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
