### PR TITLE
fix: add default settings to charts

### DIFF
--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -59,7 +59,7 @@ const BaseChart = ({
   viewport,
   queries,
   onChartOptionsChange,
-  size = { width: 500, height: 500 },
+  size = { width: 650, height: 400 },
   ...options
 }: ChartOptions) => {
   const {

--- a/packages/react-components/src/components/chart/chart.tsx
+++ b/packages/react-components/src/components/chart/chart.tsx
@@ -3,12 +3,15 @@ import { ChartOptions } from './types';
 import { ChartStoreProvider } from './store';
 import BaseChart from './baseChart';
 import { useChartId } from './hooks/useChartId';
+import { DEFAULT_CHART_SETTINGS } from './eChartsConstants';
 
 export const Chart: React.FC<ChartOptions> = (options) => {
   const chartId = useChartId(options.id);
+  const chartOptions = { ...DEFAULT_CHART_SETTINGS, ...options };
+
   return (
     <ChartStoreProvider id={chartId}>
-      <BaseChart {...options} id={chartId} />
+      <BaseChart {...chartOptions} id={chartId} />
     </ChartStoreProvider>
   );
 };

--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -7,6 +7,7 @@ import type {
   YAXisComponentOption,
   EChartsOption,
 } from 'echarts';
+import { ChartAxisOptions, ChartLegend } from './types';
 
 export const DEFAULT_TOOLBOX_CONFIG: ToolboxComponentOption = {
   show: true,
@@ -150,4 +151,31 @@ export const DEFAULT_CHART_OPTION: EChartsOption = {
   yAxis: [DEFAULT_Y_AXIS],
   grid: DEFAULT_GRID,
   tooltip: DEFAULT_TOOLTIP,
+};
+
+export const DEFAULT_CHART_SETTINGS = {
+  line: {
+    connectionStyle: 'linear',
+    style: 'solid',
+  },
+  symbol: {
+    style: 'filled-circle',
+  },
+  axis: {
+    yVisible: true,
+    xVisible: true,
+  } as ChartAxisOptions,
+  legend: {
+    visible: true,
+    position: 'right',
+    width: '30%',
+    height: '30%',
+    visibleContent: {
+      unit: true,
+      asset: true,
+      latestValue: true,
+      maxValue: false,
+      minValue: false,
+    },
+  } as ChartLegend,
 };

--- a/packages/react-components/src/components/gauge/constants.ts
+++ b/packages/react-components/src/components/gauge/constants.ts
@@ -177,3 +177,14 @@ export const DEFAULT_GAUGE_PROGRESS_SETTINGS_WITH_THRESHOLDS = {
     },
   ],
 };
+
+export const DEFAULT_GAUGE_STYLES = {
+  gaugeThickness: 30,
+  showName: false,
+  showUnit: true,
+  fontSize: 40,
+  labelFontSize: 12,
+  unitFontSize: 16,
+  yMin: 0,
+  yMax: 100,
+};

--- a/packages/react-components/src/components/gauge/gauge.tsx
+++ b/packages/react-components/src/components/gauge/gauge.tsx
@@ -8,6 +8,7 @@ import { useViewport } from '../../hooks/useViewport';
 import { widgetPropertiesFromInputs } from '../../common/widgetPropertiesFromInputs';
 import { DEFAULT_VIEWPORT, ECHARTS_GESTURE } from '../../common/constants';
 import { DataStream } from '@iot-app-kit/core';
+import { DEFAULT_GAUGE_STYLES } from './constants';
 
 export const Gauge = ({
   query,
@@ -51,7 +52,7 @@ export const Gauge = ({
       unit={unit}
       isLoading={isLoading}
       error={error?.msg}
-      settings={settings}
+      settings={{ ...DEFAULT_GAUGE_STYLES, ...settings }}
       thresholds={thresholds}
       significantDigits={significantDigits}
       theme={theme}

--- a/packages/react-components/stories/allChartsWithDefaultSettings/defaultCharts.stories.tsx
+++ b/packages/react-components/stories/allChartsWithDefaultSettings/defaultCharts.stories.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { TimeSelection, TimeSync, useViewport, Chart, KPI } from '../../src';
+import {
+  getSingleValueTimeSeriesDataQuery,
+  getTimeSeriesDataQuery,
+  queryConfigured,
+} from '../utils/query';
+import { ComponentMeta } from '@storybook/react';
+import { Gauge } from '../../src/components/gauge/gauge';
+
+export default {
+  title: 'Widgets/Default Charts',
+  component: Chart,
+  argTypes: {
+    name: { control: { type: 'text' }, defaultValue: 'Windmill' },
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Chart>;
+
+export const DefaultCharts = () => {
+  const { viewport } = useViewport();
+
+  if (!queryConfigured()) {
+    return (
+      <div>
+        <h1>All required Env variables not set</h1>
+        <p>Required:</p>
+        <ul>
+          <li>AWS_ACCESS_KEY_ID</li>
+          <li>AWS_SECRET_ACCESS_KEY</li>
+          <li>AWS_SESSION_TOKEN</li>
+          <li>AWS_REGION</li>
+          <li>ASSET_ID_1</li>
+          <li>PROPERTY_ID_1</li>
+          <li>PROPERTY_ID_2</li>
+          <li>PROPERTY_ID_3</li>
+        </ul>
+      </div>
+    );
+  }
+
+  const Divider = (
+    <div
+      style={{
+        width: '100%',
+        height: '5px',
+        background: 'grey',
+        margin: '20px 0',
+      }}
+    />
+  );
+
+  return (
+    <div style={{ padding: '16px' }}>
+      <TimeSync>
+        <h3>
+          This page shows all charts with their default settings (including
+          styles, legend settings, sizes, colors)
+        </h3>
+        <div
+          id='story-container'
+          style={{ width: '100%', height: 'fit-content' }}
+        >
+          <TimeSelection />
+          <br />
+          {Divider}
+          <Chart viewport={viewport} queries={[getTimeSeriesDataQuery()]} />
+          {Divider}
+          <div style={{ width: '350px', height: '200px' }}>
+            <KPI
+              viewport={viewport}
+              query={getSingleValueTimeSeriesDataQuery()}
+            />
+          </div>
+          {Divider}
+          <div style={{ width: '350px', height: '350px' }}>
+            <Gauge
+              viewport={viewport}
+              query={getSingleValueTimeSeriesDataQuery()}
+            />
+          </div>
+          {Divider}
+        </div>
+      </TimeSync>
+    </div>
+  );
+};


### PR DESCRIPTION
## Overview
#### Add default style/display settings to all charts used directly from react-components
#### Create new storybook page in react-components which showcases the default charts

<img width="704" alt="Screenshot 2024-04-12 at 11 38 15" src="https://github.com/awslabs/iot-app-kit/assets/28601414/59673e1f-6374-4cbd-bed1-a2689245a885">
<img width="383" alt="Screenshot 2024-04-12 at 11 38 17" src="https://github.com/awslabs/iot-app-kit/assets/28601414/d37b630f-38c4-4977-b0ed-af9759608bbe">
<img width="389" alt="Screenshot 2024-04-12 at 11 38 20" src="https://github.com/awslabs/iot-app-kit/assets/28601414/22e51bd3-5b7f-49f3-888f-7a87f0cdd386">

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
