### PR TITLE
fix: migrated widget tooltip css to styled-components for theming #2668

### DIFF
--- a/packages/dashboard/src/components/palette/icons/index.css
+++ b/packages/dashboard/src/components/palette/icons/index.css
@@ -1,42 +1,4 @@
-@import "../../../styles/variables.css";
-
 .palette-component-icon {
   position: relative;
   cursor: grab;
-}
-
-.palette-component-icon .tooltiptext {
-  position: absolute;
-  left: 50%;
-  top: 105%;
-  border-style: solid;
-  z-index: 9;
-  transform: translateX(-50%);
-}
-
-/* Can't style pseudo selectors with inline styling */
-.palette-component-icon .tooltiptext::before,
-.palette-component-icon .tooltiptext::after {
-  content: "";
-  position: absolute;
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  left: 50%;
-  right: 50%;
-  margin: auto;
-  margin-left: -10px;
-  transform: rotate(180deg);
-}
-
-.palette-component-icon .tooltiptext::before {
-  bottom: 93%;
-  border-top: 11px solid #9ba7b6;
-  margin-bottom: 5px;
-}
-
-.palette-component-icon .tooltiptext::after {
-  bottom: 100%;
-  border-top: 10px solid var(--colors-white);
-  margin-top: -2px;
-  z-index: 1;
 }

--- a/packages/dashboard/src/components/palette/icons/index.tsx
+++ b/packages/dashboard/src/components/palette/icons/index.tsx
@@ -1,15 +1,16 @@
 import React, { useState, type DragEventHandler, useEffect } from 'react';
 import Box from '@cloudscape-design/components/box';
 import {
-  colorBackgroundLayoutMain,
   colorBorderButtonNormalDisabled,
-  colorTextButtonNormalActive,
-  spaceScaledS,
-  spaceScaledM,
-  spaceStaticXs,
-  spaceScaledXxxs,
+  colorBackgroundSegmentHover,
+  borderRadiusPopover,
+  fontSizeHeadingS,
+  spaceStaticM,
+  spaceStaticS,
+  colorTextBodyDefault,
 } from '@cloudscape-design/design-tokens';
 import './index.css';
+import styled from 'styled-components';
 
 type PaletteComponentIconProps = {
   Icon: React.FC;
@@ -21,16 +22,46 @@ const PaletteComponentIcon: React.FC<PaletteComponentIconProps> = ({
 }) => {
   const [hover, setHover] = useState<boolean>(false);
 
-  const tooltipStyle = {
-    fontSize: spaceScaledM,
-    color: colorTextButtonNormalActive,
-    backgroundColor: colorBackgroundLayoutMain,
-    padding: `${spaceScaledS} ${spaceScaledM}`,
-    borderRadius: spaceStaticXs,
-    borderWidth: spaceScaledXxxs,
-    borderColor: colorBorderButtonNormalDisabled,
-    boxShadow: `${spaceScaledXxxs} ${spaceScaledXxxs} ${spaceScaledXxxs} ${colorBorderButtonNormalDisabled}`,
-  };
+  const Tooltip = styled.div<{ hover: boolean }>`
+    ${({ hover }) => `visibility: ${hover ? 'visible' : 'hidden'};`}
+    font-size: ${fontSizeHeadingS};
+    color: ${colorTextBodyDefault};
+    background-color: ${colorBackgroundSegmentHover};
+    padding: ${spaceStaticS} ${spaceStaticM};
+    border-radius: ${borderRadiusPopover};
+    border-width: 2px;
+    border-color: ${colorBorderButtonNormalDisabled};
+    box-shadow: 2px 2px 2px ${colorBorderButtonNormalDisabled};
+    position: absolute;
+    left: 50%;
+    top: 105%;
+    border-style: solid;
+    z-index: 9;
+    transform: translateX(-50%);
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      border-left: 10px solid transparent;
+      border-right: 10px solid transparent;
+      left: 50%;
+      right: 50%;
+      margin: auto;
+      margin-left: -10px;
+      transform: rotate(180deg);
+    }
+    &::before {
+      bottom: 92%;
+      border-top: 11px solid ${colorBorderButtonNormalDisabled};
+      margin-bottom: 5px;
+    }
+    &::after {
+      bottom: 100%;
+      border-top: 10px solid ${colorBackgroundSegmentHover};
+      margin-top: -2px;
+      z-index: 1;
+    }
+  `;
 
   // Without this, Firefox widget drag and drop does not work correctly.
   const ignoreDragStart: DragEventHandler = (event) => event.preventDefault();
@@ -61,15 +92,7 @@ const PaletteComponentIcon: React.FC<PaletteComponentIconProps> = ({
     >
       <Box padding='xxs' className='palette-component-icon ripple'>
         <Icon />
-        <span
-          className='tooltiptext'
-          style={{
-            ...tooltipStyle,
-            visibility: `${hover ? 'visible' : 'hidden'}`,
-          }}
-        >
-          {widgetName}
-        </span>
+        <Tooltip {...{ hover }}>{widgetName}</Tooltip>
       </Box>
     </span>
   );


### PR DESCRIPTION
As part of theming issue #2668 , fixed the UI of widget panel tooltip to support dark mode and theming options

### Verifying changes:

**BEFORE** (RC)
Light mode 
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/733d7874-5ddd-4567-8699-4cebe678b3af)

Dark mode
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/54338989-48c9-49ae-8773-34e49951bfab)
---

### AFTER
Light mode
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/1678812b-f007-4479-8840-ec4a0d9d2db1)

Dark mode
![image](https://github.com/awslabs/iot-app-kit/assets/154328164/bf5400af-b777-4f8e-be65-9e187a83b7f6)

