### PR TITLE
fix: fix for css style issue in doc-site

### DIFF
--- a/packages/doc-site/.storybook/preview.js
+++ b/packages/doc-site/.storybook/preview.js
@@ -1,4 +1,6 @@
 /** @type { import('@storybook/react').Preview } */
+import '@iot-app-kit/components/dist/iot-app-kit-components/iot-app-kit-components.css';
+
 const preview = {
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },


### PR DESCRIPTION
This PR is for ticket https://github.com/awslabs/iot-app-kit/issues/2718 and added the CSS import in the preview file for the storybook to load the CSS style sheet in the doc site.

## Verifying Changes
font-family is applied from the CSS style sheet for the widget after this fix.

![image](https://github.com/awslabs/iot-app-kit/assets/142866907/8af3bffc-d6a0-43fa-940a-4ecd8f61b6f9)



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
