### PR TITLE
chore: configuring manual test account and adding example stories

### DIFF
--- a/packages/scene-composer/stories/Tests/Adding Tests.stories.mdx
+++ b/packages/scene-composer/stories/Tests/Adding Tests.stories.mdx
@@ -1,0 +1,40 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+
+<Meta title="Tests/How To Add Tests" />
+
+## How To: Add Tests
+
+Create a scene that demonstrates your use case in AWS Account `540844875673`.
+
+Create a new story in this folder, and set the scene appropriately.
+
+Example:
+
+```md
+export const defaultArgs = {
+  source: 'aws',
+  sceneId: 'MatterportIntegration',
+  workspaceId: 'CookieFactory',
+  ...
+}
+
+export const Template = (args) => {
+  return <SceneComposer {...defaultArgs} {...args} />
+}
+
+## Test Case
+
+### Steps
+
+### Verification
+
+<Canvas>
+  <Story name='Viewer'
+    height='500px'
+    parameters={{ controls: { include: ['matterportModelId', 'matterportApplicationKey', 'onSelectionChanged', 'onWidgetClick'], hideNoControlsWarning: true }}}
+    args={{ ...defaultArgs }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+```
+

--- a/packages/scene-composer/stories/Tests/Matterport.stories.mdx
+++ b/packages/scene-composer/stories/Tests/Matterport.stories.mdx
@@ -1,46 +1,44 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
 
-import SceneComposer, { argTypes, args } from './components/scene-composer';
-import { testScenes } from '../tests/testData';
-import { COMPOSER_FEATURES } from '../src/interfaces/feature';
+import SceneComposer, { argTypes, args } from '../components/scene-composer';
 
 <Meta title="Tests/Matterport" component={SceneComposer} argTypes={argTypes} />
 
 export const defaultArgs = {
-  source: 'local',
-  scene: 'scene1',
-  assetType: 'GLB',
+  source: 'aws',
+  sceneId: 'MatterportIntegration',
+  workspaceId: 'CookieFactory',
   theme: 'dark',
   mode: 'Viewing',
   density: 'comfortable',
-  matterportModelId: 'cZowU1FxWEQ',
-  matterportApplicationKey: '',
-  features: [
-    COMPOSER_FEATURES.Matterport,
-  ]
 }
 
 export const Template = (args) => {
   return <SceneComposer {...defaultArgs} {...args} />
 }
 
-# Viewing
+## Matterport Integration
+
+For these tests, you should authenticate against our demo aws account `540844875673`
+
+# Viewer
 
 <Canvas>
   <Story name='Viewer'
     height='500px'
     parameters={{ controls: { include: ['matterportModelId', 'matterportApplicationKey', 'onSelectionChanged', 'onWidgetClick'], hideNoControlsWarning: true }}}
-    args={{ ...defaultArgs, scene: 'CookieFactoryWaterTank' }}>
+    args={{ ...defaultArgs }}>
     {Template.bind({})}
   </Story>
 </Canvas>
 
-# Editing
+# Editer
 <Canvas>
   <Story name='Editor'
     height='500px'
+    width='100vw'
     parameters={{ controls: { include: ['matterportModelId', 'matterportApplicationKey', 'onSelectionChanged', 'onWidgetClick'], hideNoControlsWarning: true }}}
-    args={{ ...defaultArgs, scene: 'CookieFactoryWaterTankMatterportTag', mode: 'Editing' }}>
+    args={{ ...defaultArgs, mode: 'Editing' }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/packages/scene-composer/stories/Tests/MotionIndicator.stories.mdx
+++ b/packages/scene-composer/stories/Tests/MotionIndicator.stories.mdx
@@ -2,21 +2,17 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs';
 
 import { useState, useCallback } from 'react';
 
-import SceneViewer, { argTypes, args } from './components/scene-viewer';
-import { testScenes } from '../tests/testData';
-import { COMPOSER_FEATURES } from '../src/interfaces/feature';
+import SceneViewer, { argTypes, args } from './../components/scene-viewer';
 
-<Meta title="Tests/Scene Viewer" component={SceneViewer} argTypes={argTypes} />
+<Meta title="Tests/Scene Viewer/Motion Indicator" component={SceneViewer} argTypes={argTypes} />
 
 export const defaultArgs = {
-  source: 'local',
-  scene: 'scene1',
+  source: 'aws',
+  sceneId: 'MotionIndicators',
+  workspaceId: 'CookieFactory',
   theme: 'dark',
   mode: 'Viewing',
   density: 'comfortable',
-  features: [
-    COMPOSER_FEATURES.Matterport,
-  ]
 }
 
 export const Template = (args) => {
@@ -41,9 +37,9 @@ export const MountToggle = (args) => {
   )
 }
 
-# Scene Viewer
-
 ## Motion Indicator
+
+For these tests, you should authenticate against our demo aws account `540844875673`
 
 ### Verification
 
@@ -58,9 +54,8 @@ Motion Indicators should disappear when turned off.
 
 <Canvas>
   <Story name='Motion Indicator'
-    height='500px'
     parameters={{ controls: { include: ['onSelectionChanged', 'onWidgetClick'], hideNoControlsWarning: true }}}
-    args={{ ...defaultArgs, scene: 'CookieFactoryWaterTank', sceneComposerId: "motion-indicator-view-options" }}>
+    args={{ ...defaultArgs, sceneComposerId: "motion-indicator-view-options" }}>
     {Template.bind({})}
   </Story>
 </Canvas>
@@ -78,9 +73,21 @@ during development Hot-Module-Reloaders (HMR) typically do this all the time, so
 
 <Canvas>
   <Story name='Remounting'
-    height='500px'
     parameters={{ controls: { include: ['onSelectionChanged', 'onWidgetClick'], hideNoControlsWarning: true }}}
-    args={{ ...defaultArgs, scene: 'CookieFactoryWaterTank' }}>
+    args={{ ...defaultArgs, sceneComposerId: "remount-test"}}>
     {MountToggle.bind({})}
+  </Story>
+</Canvas>
+
+## Editing
+
+This test is around editing motion indicators, see if you can add a motion indicator to achieve your desired
+results.
+
+<Canvas>
+  <Story name='Editing'
+    parameters={{ controls: { include: ['onSelectionChanged', 'onWidgetClick'], hideNoControlsWarning: true }}}
+    args={{ ...defaultArgs, sceneComposerId: "editor-test", mode: 'editing' }}>
+    {Template.bind({})}
   </Story>
 </Canvas>

--- a/packages/scene-composer/stories/components/scene-composer.tsx
+++ b/packages/scene-composer/stories/components/scene-composer.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useCallback, useMemo, useRef } from 'react';
-import styled from 'styled-components';
 import { CredentialProvider, Credentials } from '@aws-sdk/types';
 import { Viewport } from '@iot-app-kit/core';
 import { TimeSync, TimeSelection } from '@iot-app-kit/react-components';
@@ -28,19 +27,6 @@ import useSceneMetadataModule from './hooks/useSceneMetadataModule';
 import { mapFeatures } from './utils';
 import { viewerArgTypes } from './argTypes';
 import useDataSource from './hooks/useDataSource';
-
-const SceneComposerContainer = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-
-  canvas {
-    outline: none;
-    -webkit-tap-highlight-color: rgba(255, 255, 255, 0); /* mobile webkit */
-  }
-`;
 
 interface SceneComposerWrapperProps extends SceneViewerPropsShared {
   source: 'local' | 'aws';
@@ -167,7 +153,7 @@ const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
   if (loader) {
     return (
       <TimeSync group='scene-composer' initialViewport={viewport}>
-        <SceneComposerContainer data-testid='webgl-root' className='sceneViewer'>
+        <div data-testid='webgl-root' style={{ height: '100vh' }}>
           <TimeSelection />
           <SceneComposerInternal
             sceneLoader={loader}
@@ -181,7 +167,7 @@ const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
             showAssetBrowserCallback={mockAssetBrowserCallback}
             {...props}
           />
-        </SceneComposerContainer>
+        </div>
       </TimeSync>
     );
   }


### PR DESCRIPTION
## Overview
Sets up base logic for Manual Tests in AppKit to match Grafana

## Verifying Changes
- sign into aws cli for account `540844875673` (make sure this is your default profile)
- run storybook
- Verify the `Tests/Scene Viewer` section of the documents load motion indicators and matterport tests correctly.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
