### PR TITLE
fix(react-components): KPI better handling of light/dark mode + thresholds

### DIFF
--- a/packages/react-components/src/components/kpi/kpi.tsx
+++ b/packages/react-components/src/components/kpi/kpi.tsx
@@ -55,10 +55,7 @@ export const KPI = ({
 
   const name = propertyStream?.name || alarmStream?.name;
   const unit = propertyStream?.unit || alarmStream?.unit;
-  const backgroundColor =
-    propertyThreshold?.color || settings?.color || settings?.backgroundColor;
-  const isThresholdVisible = !!propertyThreshold?.color;
-  const isFilledThreshold = !!propertyThreshold?.fill;
+  const backgroundColor = settings?.color || settings?.backgroundColor;
   const isLoading =
     alarmStream?.isLoading || propertyStream?.isLoading || false;
   const error = alarmStream?.error || propertyStream?.error;
@@ -68,8 +65,7 @@ export const KPI = ({
       propertyPoint={propertyPoint}
       alarmPoint={alarmPoint}
       settings={{ ...settings, backgroundColor }}
-      isThresholdVisible={isThresholdVisible}
-      isFilledThreshold={isFilledThreshold}
+      propertyThreshold={propertyThreshold}
       aggregationType={dataStreams[0]?.aggregationType}
       resolution={propertyResolution}
       name={name}

--- a/packages/react-components/src/components/kpi/kpiBase.tsx
+++ b/packages/react-components/src/components/kpi/kpiBase.tsx
@@ -11,8 +11,7 @@ import './kpi.css';
 import { highContrastColor } from './highContrastColor';
 import { getAggregationFrequency } from '../../utils/aggregationFrequency';
 import {
-  colorBackgroundButtonPrimaryDisabled,
-  colorTextBodyDefault,
+  colorTextHeadingDefault,
   fontSizeBodyS,
 } from '@cloudscape-design/design-tokens';
 import { DataQualityText } from '../data-quality/data-quality-text';
@@ -27,8 +26,7 @@ export const KpiBase: React.FC<KPIBaseProperties> = ({
   isLoading,
   settings = {},
   significantDigits,
-  isFilledThreshold,
-  isThresholdVisible,
+  propertyThreshold,
 }) => {
   const {
     showUnit,
@@ -36,7 +34,6 @@ export const KpiBase: React.FC<KPIBaseProperties> = ({
     showTimestamp,
     showDataQuality,
     showAggregationAndResolution,
-    backgroundColor,
     fontSize,
     secondaryFontSize,
   }: KPISettings = {
@@ -44,13 +41,21 @@ export const KpiBase: React.FC<KPIBaseProperties> = ({
     ...omitBy(settings, (x) => x == null),
   };
 
-  const background =
-    !isFilledThreshold && isThresholdVisible ? '#ffffff' : backgroundColor;
-  const highContrastFontColor =
-    background === '#ffffff' ? '' : highContrastColor(background);
-  const fontColor = isFilledThreshold
-    ? highContrastFontColor
-    : colorTextBodyDefault;
+  const showFilledThreshold =
+    propertyThreshold?.fill && propertyThreshold?.color;
+  const nonThresholdBackground = settings.backgroundColor
+    ? settings.backgroundColor
+    : DEFAULT_KPI_SETTINGS.backgroundColor;
+  const nonThresholdFontColor = settings.backgroundColor
+    ? highContrastColor(nonThresholdBackground)
+    : colorTextHeadingDefault;
+
+  const backgroundColor = showFilledThreshold
+    ? propertyThreshold.color
+    : nonThresholdBackground;
+  const fontColor = showFilledThreshold
+    ? highContrastColor(propertyThreshold.color)
+    : nonThresholdFontColor;
 
   const point = propertyPoint;
   const aggregationResolutionString = getAggregationFrequency(
@@ -63,10 +68,14 @@ export const KpiBase: React.FC<KPIBaseProperties> = ({
       <div
         className='kpi'
         data-testid='kpi-error-component'
-        style={{ fontSize: `${secondaryFontSize}px` }}
+        style={{
+          fontSize: `${secondaryFontSize}px`,
+          backgroundColor: nonThresholdBackground,
+          color: nonThresholdFontColor,
+        }}
       >
         {error && (
-          <Box margin={{ vertical: 's' }}>
+          <Box margin={{ vertical: 's', horizontal: 's' }}>
             <Alert statusIconAriaLabel='Error' type='error'>
               {error}
             </Alert>
@@ -80,7 +89,7 @@ export const KpiBase: React.FC<KPIBaseProperties> = ({
     <div
       className='kpi-container'
       data-testid='kpi-base-component'
-      style={{ backgroundColor: background }}
+      style={{ backgroundColor }}
     >
       <div className='kpi'>
         <div>
@@ -125,7 +134,7 @@ export const KpiBase: React.FC<KPIBaseProperties> = ({
                 <div
                   className='timestamp-border'
                   style={{
-                    backgroundColor: colorBackgroundButtonPrimaryDisabled,
+                    backgroundColor: fontColor,
                   }}
                 />
                 <div className='timestamp' data-testid='kpi-timestamp'>
@@ -136,10 +145,10 @@ export const KpiBase: React.FC<KPIBaseProperties> = ({
           </div>
         )}
       </div>
-      {!isFilledThreshold && isThresholdVisible && (
+      {!propertyThreshold?.fill && propertyThreshold?.color && (
         <div
           data-testid='kpi-side-threshold'
-          style={{ backgroundColor }}
+          style={{ backgroundColor: propertyThreshold?.color }}
           className='kpi-line-threshold'
         />
       )}

--- a/packages/react-components/src/components/kpi/types.ts
+++ b/packages/react-components/src/components/kpi/types.ts
@@ -1,9 +1,9 @@
+import { StyledThreshold } from '@iot-app-kit/core';
 import type { WidgetSettings } from '../../common/dataTypes';
 
 export type KPIBaseProperties = WidgetSettings & {
   settings?: Partial<KPISettings>;
-  isFilledThreshold?: boolean;
-  isThresholdVisible?: boolean;
+  propertyThreshold?: StyledThreshold;
 };
 
 export type KPISettings = {

--- a/packages/react-components/stories/kpi/kpi.stories.tsx
+++ b/packages/react-components/stories/kpi/kpi.stories.tsx
@@ -30,31 +30,78 @@ export default {
 
 export const MockDataKPI: ComponentStory<typeof KPI> = () => {
   return (
-    <div style={{ background: 'grey' }}>
+    <div
+      style={{
+        background: 'grey',
+        display: 'grid',
+        gridTemplateColumns: '250px 250px',
+        gridRow: 'auto auto',
+        gridColumnGap: '20px',
+        gridRowGap: '20px',
+      }}
+    >
+      {/* KPI with threshold line + active threshold */}
       <div style={{ height: '200px', width: '250px', padding: '20px' }}>
         <KPI
           thresholds={[
             {
-              value: 435,
+              value: 20,
               id: 'abc',
               color: '#be1c1f',
               comparisonOperator: 'GT',
             },
           ]}
+          // settings={{backgroundColor: '#00ff00'}}
           viewport={{ duration: '5m' }}
           query={MOCK_TIME_SERIES_DATA_QUERY}
         />
       </div>
+      {/* KPI with threshold line + inactive threshold */}
       <div style={{ height: '200px', width: '250px', padding: '20px' }}>
         <KPI
           thresholds={[
             {
-              value: 35,
-              id: '123',
-              color: '#dfe7f5',
+              value: 500,
+              id: 'abc',
+              color: '#be1c1f',
               comparisonOperator: 'GT',
             },
           ]}
+          // settings={{backgroundColor: '#00ff00'}}
+          viewport={{ duration: '5m' }}
+          query={MOCK_TIME_SERIES_DATA_QUERY}
+        />
+      </div>
+      {/* KPI with threshold line + active threshold */}
+      <div style={{ height: '200px', width: '250px', padding: '20px' }}>
+        <KPI
+          thresholds={[
+            {
+              value: 10,
+              id: '123',
+              color: '#be1c1f',
+              comparisonOperator: 'GT',
+              fill: '#be1c1f',
+            },
+          ]}
+          // settings={{backgroundColor: '#00ff00'}}
+          viewport={{ duration: '5m' }}
+          query={MOCK_TIME_SERIES_DATA_AGGREGATED_QUERY}
+        />
+      </div>
+      {/* KPI with threshold fill + inactive threshold */}
+      <div style={{ height: '200px', width: '250px', padding: '20px' }}>
+        <KPI
+          thresholds={[
+            {
+              value: 200,
+              id: '123',
+              color: '#be1c1f',
+              comparisonOperator: 'GT',
+              fill: '#be1c1f',
+            },
+          ]}
+          // settings={{backgroundColor: '#00ff00'}}
           viewport={{ duration: '5m' }}
           query={MOCK_TIME_SERIES_DATA_AGGREGATED_QUERY}
         />


### PR DESCRIPTION
## Overview

before the font was not accounting for custom background colors, threshold colors, and dark/light mode
leading to illegible widgets

### here are default background colors w thresholds in light/dark mode:
<img width="300" alt="Screenshot 2024-04-29 at 15 54 21" src="https://github.com/awslabs/iot-app-kit/assets/28601414/87f7e98f-4c8c-4917-8e52-ceb65b2c36bd">
<img width="300" alt="Screenshot 2024-04-29 at 15 54 27" src="https://github.com/awslabs/iot-app-kit/assets/28601414/b3ee0b0d-a782-484b-b9ad-65cc04771eee">

### and here are custom background colors w thresholds in light/dark mode
<img width="300" alt="Screenshot 2024-04-29 at 16 00 13" src="https://github.com/awslabs/iot-app-kit/assets/28601414/1a7d23ac-8ba2-42b7-95bc-75c241d60d42">
<img width="300" alt="Screenshot 2024-04-29 at 16 00 09" src="https://github.com/awslabs/iot-app-kit/assets/28601414/add0d1fd-596a-4a8e-9d5d-e82203563436">

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
