### PR TITLE
fix: clearing the properties table when navigated using breadcrumbs

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/assetTable/assetTable.tsx
@@ -84,6 +84,11 @@ export function AssetTable({
     onClickNextPage();
   }
 
+  function handleClickBreadCrumb(parentAssetId?: string) {
+    onSelectAsset(undefined);
+    onClickAsset(parentAssetId);
+  }
+
   const columnDefinitionFactory = new AssetTableColumnDefinitionsFactory({
     NameLink: AssetTableNameLink,
     onClickNameLink: handleClickAsset,
@@ -130,7 +135,7 @@ export function AssetTable({
           <AssetTableHierarchyPath
             client={client}
             parentAssetId={parentAssetId}
-            onClickAssetName={onClickAsset}
+            onClickAssetName={handleClickBreadCrumb}
           />
         </>
       }


### PR DESCRIPTION
This PR fixes the issue mentioned in #2751

Verifying changes:
if navigating out of an asset using the breadcrumbs link at the top, the properties table will clear now.

[clear-properties-table-using-breadcrumbs.webm](https://github.com/awslabs/iot-app-kit/assets/154328164/be4a8059-beea-42aa-ad88-eb79832f75be)
