### PR TITLE
fix(react-components): sort and legend pagination colors

### DIFF
--- a/packages/react-components/src/data/transformers/anomaly/object/transformer.ts
+++ b/packages/react-components/src/data/transformers/anomaly/object/transformer.ts
@@ -102,9 +102,10 @@ export class AnomalyObjectDataSourceTransformer extends ObjectDataSourceTransfor
    */
   #getUniqueDiagnostics(dataSource: AnomalyObjectDataSource) {
     return unique(
-      dataSource.value.data.flatMap(({ diagnostics }) =>
-        diagnostics.map(({ name }) => name)
-      )
+      dataSource.value.data
+        .flatMap(({ diagnostics }) => diagnostics.map(({ name }) => name))
+        .sort()
+        .reverse()
     );
   }
 

--- a/packages/react-components/src/echarts/themes/registerCloudscapeThemes.ts
+++ b/packages/react-components/src/echarts/themes/registerCloudscapeThemes.ts
@@ -385,6 +385,9 @@ export const registerCloudscapeThemes = () => {
       textStyle: {
         color: '#404d5c',
       },
+      pageTextStyle: {
+        color: '#404d5c',
+      },
     },
     tooltip: {
       axisPointer: {
@@ -833,6 +836,9 @@ export const registerCloudscapeThemes = () => {
     },
     legend: {
       textStyle: {
+        color: '#b6bec9',
+      },
+      pageTextStyle: {
         color: '#b6bec9',
       },
     },


### PR DESCRIPTION
## Overview
Add legend pagination dark/light mode colors
Sort streams in alphabetical order so they match an alphabetically ordered tooltip

<img width="450" alt="Screenshot 2024-05-01 at 09 18 06" src="https://github.com/awslabs/iot-app-kit/assets/28601414/8a3c4730-0f47-4415-a0d2-9d42aef6cd56">

<img width="450" alt="Screenshot 2024-05-01 at 09 18 23" src="https://github.com/awslabs/iot-app-kit/assets/28601414/18f1476d-b610-469f-856d-437868d15dde">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
