### PR TITLE
feat: ds ga

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ npm-debug.log
 .idea/
 .vscode/
 .sass-cache/
+.turbo/
 .versions/
 node_modules/
 $RECYCLE.BIN/

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "npm-run-all": "^4.1.5",
     "stylelint": "14.16.1",
     "stylelint-config-standard": "25.0.0",
-    "turbo": "^1.10.3"
+    "turbo": "^1.13.3"
   },
   "npm-pretty-much": {
     "useWorkspaces": true,

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -46,7 +46,7 @@
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --index-template tools/index-template.js -- src/assets/icons/",
     "release": "run-s compile copy-assets",
     "copy-assets": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" dist/",
-    "lint": "eslint . --max-warnings=478",
+    "lint": "eslint . --max-warnings=481",
     "fix": "eslint --fix .",
     "test": "jest --config jest.config.ts --coverage --silent",
     "test:reliability": "npm run test:ui:reliability",

--- a/packages/scene-composer/src/SceneViewer.tsx
+++ b/packages/scene-composer/src/SceneViewer.tsx
@@ -73,6 +73,7 @@ export const SceneViewer: React.FC<SceneViewerProps> = ({ sceneComposerId, confi
             ...((config as any)?.featureConfig || {}),
             [COMPOSER_FEATURES.Matterport]: true,
             [COMPOSER_FEATURES.SceneAppearance]: true,
+            [COMPOSER_FEATURES.DynamicScene]: true,
           },
         }}
         onSceneLoaded={onSceneLoaded}

--- a/packages/scene-composer/src/__snapshots__/SceneViewer.spec.tsx.snap
+++ b/packages/scene-composer/src/__snapshots__/SceneViewer.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`SceneViewer should render correctly 1`] = `
   data-testid="webgl-root"
 >
   <div
-    config="{\\"mode\\":\\"Viewing\\",\\"featureConfig\\":{\\"Matterport\\":true,\\"SceneAppearance\\":true}}"
+    config="{\\"mode\\":\\"Viewing\\",\\"featureConfig\\":{\\"Matterport\\":true,\\"SceneAppearance\\":true,\\"DynamicScene\\":true}}"
     data-mocked="SceneComposerInternal"
     onSceneLoaded={[Function]}
     sceneComposerId="123"

--- a/packages/scene-composer/src/common/entityModelConstants.ts
+++ b/packages/scene-composer/src/common/entityModelConstants.ts
@@ -37,6 +37,7 @@ export const MATTERPORT_TAG_LAYER_PREFIX = 'Matterport_Tag_';
 export const DEFAULT_LAYER_RELATIONSHIP_NAME = 'inLayerOf';
 export const DEFAULT_LAYER_COMPONENT_NAME = 'Layer';
 export const LAYER_ROOT_ENTITY_ID = 'LAYERS_EntityId';
+export const RESERVED_LAYER_ID = 'reserved_layer_id';
 export const LAYER_ROOT_ENTITY_NAME = '$LAYERS';
 export enum LayerType {
   Relationship = 'Relationship',

--- a/packages/scene-composer/src/components/SceneLayers.spec.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { useQuery } from '@tanstack/react-query';
@@ -6,7 +7,7 @@ import { useStore } from '../store';
 import { processQueries } from '../utils/entityModelUtils/processQueries';
 import { KnownSceneProperty } from '../interfaces';
 import { LAYER_DEFAULT_REFRESH_INTERVAL } from '../utils/entityModelUtils/sceneLayerUtils';
-
+import { RESERVED_LAYER_ID } from '../common/entityModelConstants';
 import { SceneLayers } from './SceneLayers';
 
 jest.mock('../utils/entityModelUtils/processQueries', () => ({
@@ -40,20 +41,7 @@ describe('SceneLayers', () => {
     });
   });
 
-  it('should enable query when have layerId', async () => {
-    useStore('default').setState(baseState);
-    let enabledValue = false;
-    (useQuery as jest.Mock).mockImplementation(({ enabled, ..._ }) => {
-      enabledValue = enabled;
-      return {};
-    });
-
-    render(<SceneLayers />);
-
-    expect(enabledValue).toBe(true);
-  });
-
-  it('should not enable query when no layerId', async () => {
+  it('should enable query even no layerId specified', async () => {
     useStore('default').setState(baseState);
     getScenePropertyMock.mockReturnValue([]);
 
@@ -65,7 +53,7 @@ describe('SceneLayers', () => {
 
     render(<SceneLayers />);
 
-    expect(enabledValue).toBe(false);
+    expect(enabledValue).toBe(true);
   });
 
   it('should not refetch when not in viewing mode', async () => {
@@ -141,13 +129,6 @@ describe('SceneLayers', () => {
     await queryFunction();
 
     expect(processQueries as jest.Mock).toBeCalledTimes(1);
-    expect(processQueries as jest.Mock).toBeCalledWith(
-      [
-        expect.stringContaining("AND e.entityId = 'layer1'"),
-        expect.stringContaining(`MATCH (binding)<-[r2]-(entity)-[r]->(e)`),
-      ],
-      expect.anything(),
-    );
     expect(renderSceneNodesFromLayersMock).not.toBeCalled();
   });
 
@@ -164,6 +145,6 @@ describe('SceneLayers', () => {
 
     expect(processQueries as jest.Mock).toBeCalledTimes(1);
     expect(renderSceneNodesFromLayersMock).toBeCalledTimes(1);
-    expect(renderSceneNodesFromLayersMock).toBeCalledWith(['random'], 'layer1');
+    expect(renderSceneNodesFromLayersMock).toBeCalledWith(['random'], RESERVED_LAYER_ID);
   });
 });

--- a/packages/scene-composer/src/components/SceneLayers.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.tsx
@@ -6,11 +6,7 @@ import { sceneComposerIdContext } from '../common/sceneComposerIdContext';
 import { useStore } from '../store';
 import { processQueries } from '../utils/entityModelUtils/processQueries';
 import { KnownSceneProperty } from '../interfaces';
-import {
-  DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME,
-  DEFAULT_LAYER_RELATIONSHIP_NAME,
-  SUB_MODEL_REF_PARENT_RELATIONSHIP_NAME,
-} from '../common/entityModelConstants';
+import { DEFAULT_PARENT_RELATIONSHIP_NAME, RESERVED_LAYER_ID } from '../common/entityModelConstants';
 
 export const SceneLayers: React.FC = () => {
   const sceneComposerId = useContext(sceneComposerIdContext);
@@ -20,32 +16,48 @@ export const SceneLayers: React.FC = () => {
   );
 
   const renderSceneNodesFromLayers = useStore(sceneComposerId)((state) => state.renderSceneNodesFromLayers);
-  const layerIds = useStore(sceneComposerId)((state) => state.getSceneProperty<string[]>(KnownSceneProperty.LayerIds));
-  const layerId = layerIds?.[0];
+  const layerId = RESERVED_LAYER_ID;
+
+  const sceneRootEntityId = useStore(sceneComposerId)((state) =>
+    state.getSceneProperty(KnownSceneProperty.SceneRootEntityId),
+  );
 
   const nodes = useQuery({
-    enabled: !isEmpty(layerIds),
-    queryKey: ['scene-layers', layerIds, sceneComposerId],
+    enabled: !!sceneRootEntityId,
+    queryKey: ['scene-layers', sceneRootEntityId, sceneComposerId],
     queryFn: async () => {
-      const nodes = await processQueries(
-        [
-          // Get node entities in the layer
-          `SELECT entity, r, e
-        FROM EntityGraph 
-        MATCH (entity)-[r]->(e)
-        WHERE r.relationshipName = '${DEFAULT_LAYER_RELATIONSHIP_NAME}'
-        AND e.entityId = '${layerId}'`,
-          // Get entityBinding and subModel parentRef for the nodes in the layer
-          `SELECT entity, r2, binding
-        FROM EntityGraph 
-        MATCH (binding)<-[r2]-(entity)-[r]->(e)
-        WHERE r.relationshipName = '${DEFAULT_LAYER_RELATIONSHIP_NAME}'
-        AND e.entityId = '${layerId}'
-        AND (r2.relationshipName = '${DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME}'
-        OR r2.relationshipName = '${SUB_MODEL_REF_PARENT_RELATIONSHIP_NAME}')`,
-        ],
-        (node) => (node.properties.layerIds = [...(node.properties.layerIds ?? []), layerId!]),
-      );
+      const nodes = await processQueries([
+        // Get node entities under the sceneRootEntityId
+        `select entity, r, e
+          from EntityGraph
+          match (entity)-[r]->(e)
+          where r.relationshipName = '${DEFAULT_PARENT_RELATIONSHIP_NAME}'
+          and e.entityId = '${sceneRootEntityId}'`,
+
+        `select c, r1, entity
+          from EntityGraph
+          match (c)-[r1]->(entity)-[r]->(e)
+          where r.relationshipName = '${DEFAULT_PARENT_RELATIONSHIP_NAME}'
+          and e.entityId = '${sceneRootEntityId}'`,
+
+        `select c2, r2, c
+          from EntityGraph
+          match (c2)-[r2]->(c)-[r1]->(entity)-[r]->(e)
+          where r.relationshipName = '${DEFAULT_PARENT_RELATIONSHIP_NAME}'
+          and e.entityId = '${sceneRootEntityId}'`,
+
+        `select c3, r3, c2
+          from EntityGraph
+          match (c3)-[r3]->(c2)-[r2]->(c)-[r1]->(entity)-[r]->(e)
+          where r.relationshipName = '${DEFAULT_PARENT_RELATIONSHIP_NAME}'
+          and e.entityId = '${sceneRootEntityId}'`,
+
+        `select c4, r4, c3
+          from EntityGraph
+          match (c4)-[r4]->(c3)-[r3]->(c2)-[r2]->(c)-[r1]->(entity)-[r]->(e)
+          where r.relationshipName = '${DEFAULT_PARENT_RELATIONSHIP_NAME}'
+          and e.entityId = '${sceneRootEntityId}'`,
+      ]);
       return nodes;
     },
     refetchInterval: (_, query) => {

--- a/packages/scene-composer/src/components/StateManager.spec.tsx
+++ b/packages/scene-composer/src/components/StateManager.spec.tsx
@@ -265,8 +265,6 @@ describe('StateManager', () => {
       capabilities: [SceneCapabilities.DYNAMIC_SCENE],
       sceneMetadata: { [SceneMetadataMapKeys.SCENE_ROOT_ENTITY_ID]: 'root-id' },
     });
-    const mockSceneContent = 'mock scene content';
-    (parseSceneCompFromEntity as jest.Mock).mockReturnValue(mockSceneContent);
 
     let container;
     await act(async () => {
@@ -286,9 +284,8 @@ describe('StateManager', () => {
     });
 
     expect(container).toMatchSnapshot();
-    expect(mockSceneLoader.getSceneUri).not.toBeCalled();
-    expect(mockSceneMetadataModule.getSceneEntity).toBeCalledTimes(1);
-    expect(mockSceneMetadataModule.getSceneEntity).toBeCalledWith({ entityId: 'root-id' });
+    expect(mockSceneLoader.getSceneUri).toBeCalled();
+    expect(mockSceneMetadataModule.getSceneEntity).not.toBeCalled();
     expect(baseState.loadScene).toBeCalledTimes(1);
     expect(baseState.loadScene).toBeCalledWith(mockSceneContent, { disableMotionIndicator: false });
   });
@@ -319,10 +316,9 @@ describe('StateManager', () => {
     });
 
     expect(container).toMatchSnapshot();
-    expect(mockSceneLoader.getSceneUri).not.toBeCalled();
-    expect(mockSceneMetadataModule.getSceneEntity).toBeCalledTimes(1);
-    expect(mockSceneMetadataModule.getSceneEntity).toBeCalledWith({ entityId: 'root-id' });
-    expect(baseState.loadScene).not.toBeCalled();
+    expect(mockSceneLoader.getSceneUri).toBeCalled();
+    expect(mockSceneMetadataModule.getSceneEntity).not.toBeCalled();
+    expect(baseState.loadScene).toBeCalled();
   });
 
   it('should load dynamic scene with error for getting scene entity failure', async () => {
@@ -353,10 +349,9 @@ describe('StateManager', () => {
     });
 
     expect(container).toMatchSnapshot();
-    expect(mockSceneLoader.getSceneUri).not.toBeCalled();
-    expect(mockSceneMetadataModule.getSceneEntity).toBeCalledTimes(1);
-    expect(mockSceneMetadataModule.getSceneEntity).toBeCalledWith({ entityId: 'root-id' });
-    expect(baseState.loadScene).not.toBeCalled();
+    expect(mockSceneLoader.getSceneUri).toBeCalled();
+    expect(mockSceneMetadataModule.getSceneEntity).not.toBeCalled();
+    expect(baseState.loadScene).toBeCalled();
   });
 
   it('should load dynamic scene with error for getting scene info failure', async () => {

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -108,6 +108,7 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
     () => createStandardUriModifier(sceneContentUri || '', undefined),
     [sceneContentUri],
   );
+  const [sceneRootEntityId, setSceneRootEntityId] = useState(null);
 
   const isViewing = config.mode === 'Viewing';
 
@@ -245,22 +246,21 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       return;
     }
 
-    if (sceneInfo && sceneMetadataModule && sceneInfo.capabilities?.includes(SceneCapabilities.DYNAMIC_SCENE)) {
-      // Fetch scene level metadata for dynamic scene
-      const rootId = sceneInfo.sceneMetadata?.[SceneMetadataMapKeys.SCENE_ROOT_ENTITY_ID];
-      if (!rootId) {
-        setLoadSceneError(new Error('Failed to get scene root entity id'));
-        return;
+    if (sceneRootEntityId && sceneInfo && sceneMetadataModule) {
+      if (sceneInfo.contentLocation && sceneInfo.contentLocation.length > 0) {
+        setSceneContentUri(sceneInfo.contentLocation!);
       }
 
       sceneMetadataModule
-        .getSceneEntity({ entityId: rootId })
+        .getSceneEntity({ entityId: sceneRootEntityId })
         .then((res) => {
-          const document = parseSceneCompFromEntity(res);
-          if (!document) {
-            throw new Error('Failed to parse scene metadata');
+          if (res?.components?.length) {
+            const document = parseSceneCompFromEntity(res);
+            if (!document) {
+              throw new Error('Failed to parse scene metadata');
+            }
+            setSceneContent(document);
           }
-          setSceneContent(document);
         })
         .catch((e) => {
           setLoadSceneError(e || new Error('Failed to get scene root entity'));
@@ -282,7 +282,7 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       .catch((error) => {
         setLoadSceneError(error || new Error('Failed to get scene uri'));
       });
-  }, [sceneLoader, sceneMetadataModule, sceneInfo]);
+  }, [sceneLoader, sceneMetadataModule, sceneInfo, sceneRootEntityId]);
 
   useEffect(() => {
     if (sceneContentUri && sceneContentUri.length > 0) {
@@ -368,6 +368,10 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
         // Transient document update will also trigger onSceneUpdated, the app side will debounce the actual saving to S3 call.
         if (!state.sceneLoaded || !old.sceneLoaded || state.document === old.document) {
           return;
+        }
+        const rootId = state.document.properties?.sceneRootEntityId ?? null;
+        if (rootId) {
+          setSceneRootEntityId(rootId);
         }
         onSceneUpdated(sceneDocumentSnapshotCreator.create({ document: state.document }));
       });

--- a/packages/scene-composer/src/components/__snapshots__/StateManager.spec.tsx.snap
+++ b/packages/scene-composer/src/components/__snapshots__/StateManager.spec.tsx.snap
@@ -14,271 +14,29 @@ exports[`StateManager should load dynamic scene correctly 1`] = `
 `;
 
 exports[`StateManager should load dynamic scene with error for empty document 1`] = `
-.c0 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  background-color: colorBackgroundLayoutMain;
-}
-
-.c3 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  position: relative;
-  overflow: hidden;
-}
-
-.c4 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  position: relative;
-  overflow: hidden;
-}
-
-.c5 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  overflow: hidden;
-  padding: 4px;
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c1 {
-  position: absolute;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1000;
-  background-color: rgba(0,0,0,0.7);
-}
-
-.c2 {
-  width: 600px;
-  margin: auto;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-  z-index: 1000;
-}
-
-<div
-  className="c0"
-  data-mocked="Box"
->
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-      data-mocked="Container"
-    >
-      <div>
-        <div
-          data-mocked="Header"
-          variant="h2"
-        >
-          Error
-        </div>
-      </div>
-      <div
-        data-mocked="TextContent"
-      >
-        <p>
-          Failed to parse scene metadata
-        </p>
-      </div>
-    </div>
-  </div>
-  <div
-    className="c3"
-    data-mocked="Box"
-  >
-    <div
-      className="c4"
-      data-mocked="Box"
-    >
-      <div
-        className="c5"
-        data-mocked="Box"
-      />
-    </div>
-  </div>
-</div>
+<SceneLayout
+  LoadingView={
+    <Provider>
+      <LoadingProgress />
+    </Provider>
+  }
+  externalLibraryConfig={Object {}}
+  isViewing={false}
+  onPointerMissed={[Function]}
+/>
 `;
 
 exports[`StateManager should load dynamic scene with error for getting scene entity failure 1`] = `
-.c0 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  background-color: colorBackgroundLayoutMain;
-}
-
-.c3 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  position: relative;
-  overflow: hidden;
-}
-
-.c4 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  position: relative;
-  overflow: hidden;
-}
-
-.c5 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  overflow: hidden;
-  padding: 4px;
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c1 {
-  position: absolute;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1000;
-  background-color: rgba(0,0,0,0.7);
-}
-
-.c2 {
-  width: 600px;
-  margin: auto;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-  z-index: 1000;
-}
-
-<div
-  className="c0"
-  data-mocked="Box"
->
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-      data-mocked="Container"
-    >
-      <div>
-        <div
-          data-mocked="Header"
-          variant="h2"
-        >
-          Error
-        </div>
-      </div>
-      <div
-        data-mocked="TextContent"
-      >
-        <p>
-          get scene entity failure
-        </p>
-      </div>
-    </div>
-  </div>
-  <div
-    className="c3"
-    data-mocked="Box"
-  >
-    <div
-      className="c4"
-      data-mocked="Box"
-    >
-      <div
-        className="c5"
-        data-mocked="Box"
-      />
-    </div>
-  </div>
-</div>
+<SceneLayout
+  LoadingView={
+    <Provider>
+      <LoadingProgress />
+    </Provider>
+  }
+  externalLibraryConfig={Object {}}
+  isViewing={false}
+  onPointerMissed={[Function]}
+/>
 `;
 
 exports[`StateManager should load dynamic scene with error for getting scene info failure 1`] = `

--- a/packages/scene-composer/src/components/modals/ConvertSceneModal.spec.tsx
+++ b/packages/scene-composer/src/components/modals/ConvertSceneModal.spec.tsx
@@ -15,7 +15,7 @@ import {
 import { createLayer } from '../../utils/entityModelUtils/sceneLayerUtils';
 import { COMPOSER_FEATURES, KnownSceneProperty } from '../../interfaces';
 import { setFeatureConfig, setTwinMakerSceneMetadataModule } from '../../common/GlobalSettings';
-import { LayerType } from '../../common/entityModelConstants';
+import { LayerType, RESERVED_LAYER_ID } from '../../common/entityModelConstants';
 import { defaultNode } from '../../../__mocks__/sceneNode';
 import { SceneCapabilities, SceneMetadataMapKeys } from '../../common/sceneModelConstants';
 
@@ -134,7 +134,7 @@ describe('ConvertSceneModal', () => {
     expect(createLayer as jest.Mock).toBeCalledWith('test-scene_Default', LayerType.Relationship);
     expect(createSceneRootEntity as jest.Mock).toBeCalledTimes(1);
     expect(setSceneProperty).toBeCalledTimes(2);
-    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.LayerIds, ['test-scene_Default']);
+    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.LayerIds, [RESERVED_LAYER_ID]);
     expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.SceneRootEntityId, 'scene-root-id');
   });
 
@@ -160,7 +160,7 @@ describe('ConvertSceneModal', () => {
     expect(createSceneRootEntity as jest.Mock).not.toBeCalled();
     expect(updateSceneRootEntity as jest.Mock).not.toBeCalled();
     expect(setSceneProperty).toBeCalledTimes(1);
-    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.LayerIds, ['test-scene_Default']);
+    expect(setSceneProperty).toBeCalledWith(KnownSceneProperty.LayerIds, [RESERVED_LAYER_ID]);
   });
 
   it('should call updateSceneRootEntity when root entity exists and DynamicSceneAlpha is enabled', async () => {

--- a/packages/scene-composer/src/components/modals/ConvertSceneModal.tsx
+++ b/packages/scene-composer/src/components/modals/ConvertSceneModal.tsx
@@ -15,7 +15,7 @@ import {
   updateSceneRootEntity,
 } from '../../utils/entityModelUtils/sceneUtils';
 import { createLayer } from '../../utils/entityModelUtils/sceneLayerUtils';
-import { LayerType } from '../../common/entityModelConstants';
+import { LayerType, RESERVED_LAYER_ID } from '../../common/entityModelConstants';
 import { getGlobalSettings } from '../../common/GlobalSettings';
 import CenteredContainer from '../CenteredContainer';
 import { ConvertingProgress } from '../ConvertingProgress';
@@ -105,7 +105,7 @@ const ConvertSceneModal: React.FC = () => {
         // Create default layer and default scene root node
         if (!layerId || isEmpty(layerId) || !(await checkIfEntityExists(layerId, sceneMetadataModule))) {
           const layer = await createLayer(layerName, LayerType.Relationship);
-          layerId = layer?.entityId;
+          layerId = RESERVED_LAYER_ID;
           setSceneProperty(KnownSceneProperty.LayerIds, [layerId]);
         }
         const rootEntityExist = rootId && (await checkIfEntityExists(rootId, sceneMetadataModule));

--- a/packages/scene-composer/src/components/three-fiber/hooks/useProgress.tsx
+++ b/packages/scene-composer/src/components/three-fiber/hooks/useProgress.tsx
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { DefaultLoadingManager } from 'three';
 
 import { tmLoadingManagers } from '../../../common/loadingManagers';

--- a/packages/scene-composer/src/store/Store.ts
+++ b/packages/scene-composer/src/store/Store.ts
@@ -1,4 +1,4 @@
-import create, { StateCreator, StoreApi } from 'zustand';
+import { create, StateCreator, StoreApi } from 'zustand';
 import { shallow } from 'zustand/shallow';
 import { immer } from 'zustand/middleware/immer';
 

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.spec.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_LAYER_COMPONENT_NAME,
   DEFAULT_LAYER_RELATIONSHIP_NAME,
   NODE_COMPONENT_TYPE_ID,
+  RESERVED_LAYER_ID,
   componentTypeToId,
 } from '../../common/entityModelConstants';
 import { ISceneComponent, ISceneNode, KnownComponentType } from '../../interfaces';
@@ -81,7 +82,7 @@ describe('createNodeEntityComponent', () => {
       [DEFAULT_LAYER_RELATIONSHIP_NAME]: {
         value: {
           relationshipValue: {
-            targetEntityId: 'layer-1',
+            targetEntityId: RESERVED_LAYER_ID,
             targetComponentName: DEFAULT_LAYER_COMPONENT_NAME,
           },
         },

--- a/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/nodeComponent.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_ENTITY_BINDING_RELATIONSHIP_NAME,
   NODE_COMPONENT_TYPE_ID,
   componentTypeToId,
+  RESERVED_LAYER_ID,
 } from '../../common/entityModelConstants';
 import { ISceneComponentInternal, ISceneNodeInternal } from '../../store';
 import { SceneNodeRuntimeProperty } from '../../store/internalInterfaces';
@@ -71,7 +72,7 @@ export const createNodeEntityComponent = (node: ISceneNode, layerId?: string): C
     };
   }
   if (layerId) {
-    comp.properties = Object.assign(comp.properties!, attachToLayerRequest(layerId));
+    comp.properties = Object.assign(comp.properties!, attachToLayerRequest(RESERVED_LAYER_ID));
   }
 
   const params = {};

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneComponent.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneComponent.spec.ts
@@ -1,6 +1,6 @@
 import { GetEntityCommandOutput } from '@aws-sdk/client-iottwinmaker';
 
-import { SCENE_COMPONENT_TYPE_ID } from '../../common/entityModelConstants';
+import { RESERVED_LAYER_ID, SCENE_COMPONENT_TYPE_ID } from '../../common/entityModelConstants';
 import {
   IDataBindingConfig,
   IOverlaySettings,
@@ -322,6 +322,11 @@ describe('parseSceneCompFromEntity', () => {
         [KnownSceneProperty.SceneRootEntityId]: emptyEntity.entityId,
         [KnownSceneProperty.DataBindingConfig]: { fieldMapping: {}, template: {} },
         [KnownSceneProperty.ComponentSettings]: {},
+        [KnownSceneProperty.EnvironmentPreset]: undefined,
+        [KnownSceneProperty.LayerDefaultRefreshInterval]: undefined,
+        [KnownSceneProperty.LayerIds]: [RESERVED_LAYER_ID],
+        [KnownSceneProperty.TagCustomColors]: undefined,
+        [KnownSceneProperty.MatterportModelId]: undefined,
       },
     };
 
@@ -613,7 +618,7 @@ describe('parseSceneCompFromEntity', () => {
       },
       [KnownSceneProperty.ComponentSettings]: {},
       [KnownSceneProperty.MatterportModelId]: 'matterport-id',
-      [KnownSceneProperty.LayerIds]: ['layer-1', 'layer-2'],
+      [KnownSceneProperty.LayerIds]: [RESERVED_LAYER_ID],
       [KnownSceneProperty.TagCustomColors]: ['red', 'blue'],
       [KnownSceneProperty.LayerDefaultRefreshInterval]: 1223,
     };

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneComponent.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneComponent.ts
@@ -17,7 +17,7 @@ import {
   KnownComponentType,
   KnownSceneProperty,
 } from '../../interfaces';
-import { SCENE_COMPONENT_TYPE_ID } from '../../common/entityModelConstants';
+import { SCENE_COMPONENT_TYPE_ID, RESERVED_LAYER_ID } from '../../common/entityModelConstants';
 import { CURRENT_VERSION, DEFAULT_DISTANCE_UNIT, DEFAULT_TAG_GLOBAL_SETTINGS } from '../../common/constants';
 import { ISceneDocumentInternal } from '../../store';
 
@@ -266,9 +266,7 @@ export const parseSceneCompFromEntity = (entity: GetEntityCommandOutput): IScene
       [KnownSceneProperty.ComponentSettings]: componentSettings,
       [KnownSceneProperty.MatterportModelId]:
         comp.properties[SceneComponentProperty.PropertiesMatterportModelId]?.value?.stringValue,
-      [KnownSceneProperty.LayerIds]: comp.properties[SceneComponentProperty.ConnectedToLayers]?.value?.listValue?.map(
-        (layer) => layer.relationshipValue?.targetEntityId,
-      ),
+      [KnownSceneProperty.LayerIds]: [RESERVED_LAYER_ID],
       [KnownSceneProperty.TagCustomColors]: comp.properties[
         SceneComponentProperty.PropertiesTagCustomColors
       ]?.value?.listValue?.map((color) => color.stringValue),


### PR DESCRIPTION
1. enable loading query results with child nodes.
2. remove dependent layer concept.

## Overview
Provide an explanation of what the change is

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
