### PR TITLE
fix(react-components): fix get value history request

### DIFF
--- a/packages/react-components/src/components/anomaly-widget/constants.ts
+++ b/packages/react-components/src/components/anomaly-widget/constants.ts
@@ -34,7 +34,7 @@ export const ANOMALY_Y_AXIS = {
 };
 
 export const ANOMALY_GRID = {
-  top: 35,
+  top: 40,
   left: 45,
   right: 15,
   bottom: 80,
@@ -71,7 +71,7 @@ export const ANOMALY_TITLE = {
 };
 
 export const ANOMALY_BAR_SERIES_CONFIGURATION = {
-  barMinWidth: 5,
+  barMinWidth: 2,
   barMaxWidth: 10,
   stack: 'Total',
   type: 'bar',

--- a/packages/react-components/src/data/dataSourceLoader/dataSourceLoader.spec.ts
+++ b/packages/react-components/src/data/dataSourceLoader/dataSourceLoader.spec.ts
@@ -13,7 +13,7 @@ const validAnomalyObjectDataSource: AnomalyObjectDataSource = {
     },
     data: [
       {
-        timestamp: '2024-03-21T21:37:02.000000',
+        timestamp: 1711078622000,
         diagnostics: [
           {
             name: 'Diagnostic Name 1',
@@ -30,7 +30,7 @@ const validAnomalyObjectDataSource: AnomalyObjectDataSource = {
         ],
       },
       {
-        timestamp: '2024-03-22T21:37:02.000000',
+        timestamp: 1711165022000,
         diagnostics: [
           {
             name: 'Diagnostic Name 1',

--- a/packages/react-components/src/data/transformers/anomaly/object/input.ts
+++ b/packages/react-components/src/data/transformers/anomaly/object/input.ts
@@ -13,7 +13,7 @@ export type Diagnostic = {
 export type Diagnostics = Diagnostic[];
 
 export type AnomalyObjectDataInput = {
-  timestamp: string;
+  timestamp: number;
   diagnostics: Diagnostics;
 }[];
 

--- a/packages/react-components/src/data/transformers/anomaly/object/transformer.spec.ts
+++ b/packages/react-components/src/data/transformers/anomaly/object/transformer.spec.ts
@@ -10,7 +10,7 @@ const validDataSource: AnomalyObjectDataSource = {
     },
     data: [
       {
-        timestamp: '2024-03-21T21:37:02.000000',
+        timestamp: 1711078622000,
         diagnostics: [
           {
             name: 'Diagnostic Name 1',
@@ -27,7 +27,7 @@ const validDataSource: AnomalyObjectDataSource = {
         ],
       },
       {
-        timestamp: '2024-03-22T21:37:02.000000',
+        timestamp: 1711165022000,
         diagnostics: [
           {
             name: 'Diagnostic Name 1',
@@ -53,7 +53,7 @@ const invalidDataSourcePropertyNames: DataSource = {
     styles: {},
     data: [
       {
-        time: '2024-03-22T21:37:02.000000',
+        time: 1711165022000,
         properties: [
           {
             name: 'Diagnostic Name 1',
@@ -79,7 +79,7 @@ const invalidDataSourceDataTypes: DataSource = {
     styles: {},
     data: [
       {
-        timestamp: 1000,
+        timestamp: new Date(1000),
         diagnostics: [
           {
             name: 'Diagnostic Name 1',

--- a/packages/react-components/src/queries/useGetAssetPropertyValueHistory/getAssetPropertyValueHistoryQueryKeyFactory.ts
+++ b/packages/react-components/src/queries/useGetAssetPropertyValueHistory/getAssetPropertyValueHistoryQueryKeyFactory.ts
@@ -3,22 +3,26 @@ export class AssetPropertyValueHistoryCacheKeyFactory {
   #propertyId?: string;
   #startDate?: Date;
   #endDate?: Date;
+  #fetchAll?: boolean;
 
   constructor({
     assetId,
     propertyId,
     startDate,
     endDate,
+    fetchAll,
   }: {
     assetId?: string;
     propertyId?: string;
     startDate?: Date;
     endDate?: Date;
+    fetchAll?: boolean;
   }) {
     this.#assetId = assetId;
     this.#propertyId = propertyId;
     this.#startDate = startDate;
     this.#endDate = endDate;
+    this.#fetchAll = fetchAll;
   }
 
   create() {
@@ -29,6 +33,7 @@ export class AssetPropertyValueHistoryCacheKeyFactory {
         propertyId: this.#propertyId,
         startDate: this.#startDate?.getTime(),
         endDate: this.#endDate?.getTime(),
+        fetchAll: this.#fetchAll,
       },
     ] as const;
 

--- a/packages/react-components/src/queries/useGetAssetPropertyValueHistory/useGetAssetPropertyValueHistory.ts
+++ b/packages/react-components/src/queries/useGetAssetPropertyValueHistory/useGetAssetPropertyValueHistory.ts
@@ -28,6 +28,7 @@ export function useGetAssetPropertyValueHistory({
     propertyId,
     startDate,
     endDate,
+    fetchAll,
   });
 
   const {
@@ -50,8 +51,6 @@ export function useGetAssetPropertyValueHistory({
 
   const { pages } = data ?? { pages: [] };
 
-  if (fetchAll && hasNextPage) fetchNextPage();
-
   const assetPropertyValueHistory = createNonNullableList(
     pages.flatMap((res) => res.assetPropertyValueHistory)
   );
@@ -67,13 +66,7 @@ export function useGetAssetPropertyValueHistory({
     status,
     isError,
     error,
-    /**
-     * isLoading will flip true / false for a second
-     * after 1 page loads and fetchNextPage is called
-     * This makes using the boolean on the UI difficult becase
-     * components will flicker
-     */
-    isLoading: fetchAll ? hasNextPage : isLoading,
+    isLoading,
   };
 }
 
@@ -101,7 +94,7 @@ const isEnabled = ({
 
 const createQueryFn = (client: IoTSiteWiseClient) => {
   return async ({
-    queryKey: [{ assetId, propertyId, startDate, endDate }],
+    queryKey: [{ assetId, propertyId, startDate, endDate, fetchAll }],
     pageParam: nextToken,
     signal,
   }: QueryFunctionContext<
@@ -134,7 +127,7 @@ const createQueryFn = (client: IoTSiteWiseClient) => {
       signal,
     });
 
-    const response = await request.send();
+    const response = await request.send(fetchAll);
 
     return response;
   };

--- a/packages/react-components/src/queries/useSiteWiseAnomalyDataSource/parseAnomaly/parseAnomalyEvent.ts
+++ b/packages/react-components/src/queries/useSiteWiseAnomalyDataSource/parseAnomaly/parseAnomalyEvent.ts
@@ -13,6 +13,7 @@ export const parseAnomalyEvent = (
   if (!stringValueIsAnomalyEvent) return;
   return {
     ...parsedStringValue,
+    timestamp: (assetPropertyValue.timestamp?.timeInSeconds ?? 0) * 1000,
     diagnostics: parseDiagnostics(parsedStringValue.diagnostics),
   };
 };

--- a/packages/react-components/src/queries/useSiteWiseAnomalyDataSource/parseAnomaly/types.ts
+++ b/packages/react-components/src/queries/useSiteWiseAnomalyDataSource/parseAnomaly/types.ts
@@ -4,7 +4,7 @@ export type AnomalyEventDiagnostic = {
 };
 
 export type AnomalyEvent = {
-  timestamp: string;
+  timestamp: number; // time in ms
   prediction: number;
   prediction_reason: string;
   anomaly_score: number;

--- a/packages/react-components/src/queries/useSiteWiseAnomalyDataSource/useAnomalyEventsViewport.ts
+++ b/packages/react-components/src/queries/useSiteWiseAnomalyDataSource/useAnomalyEventsViewport.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import {
   HistoricalViewport,
   Viewport,
@@ -9,7 +10,6 @@ import {
   DurationViewport,
 } from '@iot-app-kit/core';
 import { DEFAULT_ANOMALY_DATA_SOURCE_VIEWPORT } from './constants';
-import { useEffect, useState } from 'react';
 
 const getDurationViewportRefreshRate = (
   viewport: DurationViewport,
@@ -76,32 +76,11 @@ export const useAnomalyEventsViewport = ({
     };
   }, [liveModeRefreshRate, viewport]);
 
-  /**
-   * Update the start and end to be the largest observed window.
-   * Start and end are used to get the property value history
-   * for anomaly result properties. Because these are the raw values,
-   * and there are no aggregation based on the selected viewport
-   * we don't need to re-request data if we zoom in. The data
-   * will be the same at any fidelity.
-   *
-   * The data will be re-requested after the stale time is complete.
-   */
   useEffect(() => {
     if (!isHistoricalViewport(viewport)) return;
-
-    const updatedStartDate = Math.min(
-      viewport.start.getTime(),
-      startDate.getTime()
-    );
-    if (startDate.getTime() !== updatedStartDate) {
-      setStartDate(new Date(updatedStartDate));
-    }
-
-    const updatedEndDate = Math.max(viewport.end.getTime(), endDate.getTime());
-    if (endDate.getTime() !== updatedEndDate) {
-      setEndDate(new Date(updatedEndDate));
-    }
-  }, [viewport, startDate, endDate]);
+    setStartDate(new Date(viewport.start.getTime()));
+    setEndDate(new Date(viewport.end.getTime()));
+  }, [viewport]);
 
   return {
     start: startDate,

--- a/packages/react-components/stories/anomaly/mockData.ts
+++ b/packages/react-components/stories/anomaly/mockData.ts
@@ -57,7 +57,7 @@ export const mockDatasource: AnomalyObjectDataSource = {
   state: 'success',
   value: {
     data: times.map((t) => ({
-      timestamp: new Date(t).toISOString(),
+      timestamp: t,
       diagnostics: BaseAnomalyResult.value.diagnostics.map((d) => ({
         id: d.name,
         name: d.name,


### PR DESCRIPTION
## Overview
Fix pagination for get property value history. The hook no longer fetches all programmatically using Tanstack, but instead fetches all in the command handler. Tanstack advises this as the best practice.

Update the datasource to use the timestamp from the TQV data point instead of the anomaly event timestamp which is a string. The string is not correctly formatted to represent a unix timestamp.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
