### PR TITLE
feat(widgets): add name style settings for line/table + edit label in config panel

### DIFF
--- a/packages/dashboard/e2e/tests/configPanel/ConfigPanel.ts
+++ b/packages/dashboard/e2e/tests/configPanel/ConfigPanel.ts
@@ -18,6 +18,8 @@ export class ConfigPanel {
   readonly showHideName: Locator;
   readonly showHideTimestamp: Locator;
   readonly showHideAggregationResolution: Locator;
+  readonly propertiesTab: Locator;
+  readonly labelInput: Locator;
 
   constructor({ page }: { page: Page }) {
     this.page = page;
@@ -54,5 +56,9 @@ export class ConfigPanel {
     this.showHideAggregationResolution = this.container
       .getByTestId('show-hide-aggregation-resolution')
       .locator(CHECKBOX_LOCATOR);
+    this.propertiesTab = this.container.getByTestId('properties');
+    this.labelInput = this.container
+      .getByTestId('label-input')
+      .locator('input');
   }
 }

--- a/packages/dashboard/e2e/tests/constants.ts
+++ b/packages/dashboard/e2e/tests/constants.ts
@@ -26,3 +26,4 @@ export const MAX_VALUE_TABLE_HEADER = 'base-chart-legend-max-header-container';
 export const MAX_TABLE_CELL = 'max-value';
 export const MIN_VALUE_TABLE_HEADER = 'base-chart-legend-min-header-container';
 export const MIN_TABLE_CELL = 'min-value';
+export const NEW_PROPERTY_NAME = 'New property name';

--- a/packages/dashboard/e2e/tests/widgets/kpi.spec.ts
+++ b/packages/dashboard/e2e/tests/widgets/kpi.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../test';
 import { getDecimalPlaces } from '../utils/getDecimalPlaces';
+import { NEW_PROPERTY_NAME } from '../constants';
 
 test.describe('Test KPI Widget', () => {
   test('KPI widget can be added to the dashboard', async ({
@@ -157,5 +158,38 @@ test.describe('Test KPI Widget', () => {
     const widgetValue =
       dashboardWithKPIWidget.gridArea.getByTestId('kpi-value');
     await expect(widgetValue).toHaveCSS('color', 'rgb(255, 255, 255)');
+  });
+
+  test('KPI widget can change label', async ({
+    page,
+    resourceExplorer,
+    configPanel,
+    dashboardWithKPIWidget,
+  }) => {
+    //add property and open config panel
+    await resourceExplorer.addModeledProperties(['Max Temperature']);
+    await configPanel.collapsedButton.click();
+    await configPanel.propertiesTab.click();
+
+    // wait one second for config panel to load
+    await page.waitForTimeout(1000);
+
+    // open up dropdowns
+    await configPanel.page
+      .getByRole('button', { name: 'Max Temperature (Reactor 1)' })
+      .click();
+    await configPanel.page.getByRole('button', { name: 'Label' }).click();
+
+    // uncheck default value
+    await configPanel.page.getByText('Use default datastream name').click();
+    await page.waitForTimeout(1000);
+
+    // click and change input value
+    await configPanel.labelInput.fill(NEW_PROPERTY_NAME);
+
+    // check if widget is updated
+    const widget =
+      dashboardWithKPIWidget.gridArea.getByTestId('kpi-base-component');
+    expect(await widget.textContent()).toContain(NEW_PROPERTY_NAME);
   });
 });

--- a/packages/dashboard/e2e/tests/widgets/line.spec.ts
+++ b/packages/dashboard/e2e/tests/widgets/line.spec.ts
@@ -1,3 +1,4 @@
+import { NEW_PROPERTY_NAME } from '../constants';
 import { expect, test } from '../test';
 import { getTrendCursorText } from './LineWidget';
 import { Locator } from '@playwright/test';
@@ -306,6 +307,7 @@ test.describe('Testing Line Widget property changes', () => {
     dashboardWithLineWidget,
     configPanel,
     resourceExplorer,
+    page,
   }) => {
     const widget = dashboardWithLineWidget.gridArea.locator(
       '[data-gesture=widget]'
@@ -315,6 +317,8 @@ test.describe('Testing Line Widget property changes', () => {
     await configPanel.container.getByText('Properties').click();
 
     await configPanel.container.getByLabel('delete property').first().click();
+
+    await page.waitForTimeout(1000);
 
     const legendText = await widget.textContent();
 
@@ -471,6 +475,40 @@ test.describe('Testing Line Widget property changes', () => {
     const max = multiYAxis.getByText('99');
     await expect(min).toBeVisible();
     await expect(max).toBeVisible();
+  });
+
+  test('Line widget can change label', async ({
+    page,
+    resourceExplorer,
+    configPanel,
+    dashboardWithLineWidget,
+  }) => {
+    //add property and open config panel
+    await resourceExplorer.addModeledProperties(['Max Temperature']);
+    await configPanel.collapsedButton.click();
+    await configPanel.propertiesTab.click();
+
+    // wait one second for config panel to load
+    await page.waitForTimeout(1000);
+
+    // open up dropdowns
+    await configPanel.page
+      .getByRole('button', { name: 'Max Temperature (Reactor 1)' })
+      .click();
+    await configPanel.page.getByRole('button', { name: 'Label' }).click();
+
+    // uncheck default value
+    await configPanel.page.getByText('Use default datastream name').click();
+    await page.waitForTimeout(1000);
+
+    // click and change input value
+    await configPanel.labelInput.fill(NEW_PROPERTY_NAME);
+
+    // check if widget is updated
+    const widgetText = await dashboardWithLineWidget.gridArea
+      .locator('[data-gesture=widget]')
+      .textContent();
+    expect(widgetText).toContain(NEW_PROPERTY_NAME);
   });
 });
 

--- a/packages/dashboard/e2e/tests/widgets/table.spec.ts
+++ b/packages/dashboard/e2e/tests/widgets/table.spec.ts
@@ -1,3 +1,4 @@
+import { NEW_PROPERTY_NAME } from '../constants';
 import { expect, test } from '../test';
 import { getDecimalPlaces } from '../utils/getDecimalPlaces';
 
@@ -118,5 +119,39 @@ test.describe('Test Table Widget', () => {
     const widget = dashboardWithTableWidget.gridArea.getByTestId('table-value');
 
     await expect(widget).toHaveCSS('color', 'rgb(246, 56, 4)');
+  });
+
+  test('Table widget can change label', async ({
+    page,
+    resourceExplorer,
+    configPanel,
+    dashboardWithTableWidget,
+  }) => {
+    //add property and open config panel
+    await resourceExplorer.addModeledProperties(['Max Temperature']);
+    await configPanel.collapsedButton.click();
+    await configPanel.propertiesTab.click();
+
+    // wait one second for config panel to load
+    await page.waitForTimeout(1000);
+
+    // open up dropdowns
+    await configPanel.page
+      .getByRole('button', { name: 'Max Temperature (Reactor 1)' })
+      .click();
+    await configPanel.page.getByRole('button', { name: 'Label' }).click();
+
+    // uncheck default value
+    await configPanel.page.getByText('Use default datastream name').click();
+    await page.waitForTimeout(1000);
+
+    // click and change input value
+    await configPanel.labelInput.fill(NEW_PROPERTY_NAME);
+
+    // check if widget is updated
+    const widgetText = await dashboardWithTableWidget.gridArea
+      .getByTestId('table-widget-component')
+      .textContent();
+    expect(widgetText).toContain(NEW_PROPERTY_NAME);
   });
 });

--- a/packages/dashboard/src/customization/propertiesSections/components/dataStreamLabelComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/components/dataStreamLabelComponent.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import {
+  Checkbox,
+  SpaceBetween,
+  FormField,
+  Input,
+  ExpandableSection,
+} from '@cloudscape-design/components';
+
+type DataStreamTextBoxProps = {
+  name?: string;
+  label: string;
+  updateName: (newName: string) => void;
+};
+
+export const DataStreamLabelComponent = ({
+  label,
+  updateName,
+  name,
+}: DataStreamTextBoxProps) => {
+  const [value, setValue] = useState(name ?? label);
+  const [checked, setChecked] = useState(value === label);
+
+  return (
+    <ExpandableSection headerText='Label' disableContentPaddings={true}>
+      <FormField label='Label'>
+        <SpaceBetween size='xs'>
+          <Checkbox
+            onChange={({ detail }) => {
+              setChecked(detail.checked);
+              if (detail.checked) {
+                setValue(label);
+                updateName(label);
+              }
+            }}
+            checked={checked}
+          >
+            Use default datastream name
+          </Checkbox>
+          <Input
+            data-testid='label-input'
+            onChange={({ detail }) => {
+              setValue(detail.value);
+              updateName(detail.value);
+            }}
+            value={value}
+            disabled={checked}
+          />
+        </SpaceBetween>
+      </FormField>
+    </ExpandableSection>
+  );
+};

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { Button, SpaceBetween, Box } from '@cloudscape-design/components';
+import {
+  Button,
+  SpaceBetween,
+  Box,
+  ExpandableSection,
+} from '@cloudscape-design/components';
 import ColorPicker from '../shared/colorPicker';
 import type { FC } from 'react';
 import type { StyleSettingsMap } from '@iot-app-kit/core';
@@ -7,6 +12,8 @@ import type { StyleSettingsMap } from '@iot-app-kit/core';
 import './propertyComponent.css';
 import { getPropertyDisplay } from './getPropertyDisplay';
 import type { AssetSummary } from '~/hooks/useAssetDescriptionQueries';
+import { DataStreamLabelComponent } from '../components/dataStreamLabelComponent';
+import { spaceStaticXl } from '@cloudscape-design/design-tokens';
 
 export type PropertyComponentProps = {
   propertyId: string;
@@ -15,6 +22,7 @@ export type PropertyComponentProps = {
   styleSettings: StyleSettingsMap;
   onDeleteAssetQuery: () => void;
   onUpdatePropertyColor: (color: string) => void;
+  onUpdatePropertyName: (name: string) => void;
   colorable: boolean;
 };
 
@@ -25,16 +33,21 @@ export const PropertyComponent: FC<PropertyComponentProps> = ({
   styleSettings,
   onDeleteAssetQuery,
   onUpdatePropertyColor,
+  onUpdatePropertyName,
   colorable,
 }) => {
   const { display, label } = getPropertyDisplay(propertyId, assetSummary);
 
   const color = styleSettings[refId]?.color;
+  const name = styleSettings[refId]?.name;
 
-  return (
+  const header = (
     <div className='property-display'>
-      <div className='property-display-summary'>
-        <SpaceBetween size='xxxs'>
+      <div
+        className='property-display-summary'
+        style={{ display: 'flex', width: '100%' }}
+      >
+        <SpaceBetween size='xs'>
           <Box padding={{ top: 'xxs' }}>
             <SpaceBetween size='xs' direction='horizontal'>
               {colorable && display === 'property' && (
@@ -43,12 +56,28 @@ export const PropertyComponent: FC<PropertyComponentProps> = ({
                   updateColor={onUpdatePropertyColor}
                 />
               )}
-              {label}
+              {name ?? label}
             </SpaceBetween>
           </Box>
         </SpaceBetween>
       </div>
       <Button onClick={onDeleteAssetQuery} variant='icon' iconName='close' />
+    </div>
+  );
+
+  return (
+    <div>
+      <Box color='text-body-secondary'>
+        <ExpandableSection headerText={header} disableContentPaddings={true}>
+          <div style={{ padding: `0 ${spaceStaticXl}` }}>
+            <DataStreamLabelComponent
+              name={name}
+              label={label}
+              updateName={onUpdatePropertyName}
+            />
+          </div>
+        </ExpandableSection>
+      </Box>
     </div>
   );
 };

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/section.tsx
@@ -82,6 +82,16 @@ export const GeneralPropertiesAlarmsSection: FC<
       });
     };
 
+    const onUpdatePropertyName = (refId: string) => (name: string) => {
+      updateStyleSettings({
+        ...styleSettingsValue,
+        [refId]: {
+          ...styleSettingsValue[refId],
+          name,
+        },
+      });
+    };
+
     const modeled =
       siteWiseAssetQuery?.assets?.flatMap(({ assetId, properties }) =>
         properties.map(({ propertyId, refId = propertyId }) =>
@@ -99,6 +109,7 @@ export const GeneralPropertiesAlarmsSection: FC<
                 updateSiteWiseAssetQuery,
               })}
               onUpdatePropertyColor={onUpdatePropertyColor(refId)}
+              onUpdatePropertyName={onUpdatePropertyName(refId)}
               colorable={colorable}
             />
           ) : null
@@ -126,6 +137,7 @@ export const GeneralPropertiesAlarmsSection: FC<
               updateSiteWiseAssetQuery,
             })}
             onUpdatePropertyColor={onUpdatePropertyColor(refId)}
+            onUpdatePropertyName={onUpdatePropertyName(refId)}
             colorable={colorable}
           />
         )
@@ -168,6 +180,7 @@ export const GeneralPropertiesAlarmsSection: FC<
                 })
               }
               onUpdatePropertyColor={onUpdatePropertyColor(refId)}
+              onUpdatePropertyName={onUpdatePropertyName(refId)}
               colorable={colorable}
             />
           );

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
@@ -30,6 +30,7 @@ import { LineStyleDropdown } from '../components/lineStyleDropdown';
 import { LineThicknessDropdown } from '../components/lineThicknessDropdown';
 
 import './propertyComponent.css';
+import { DataStreamLabelComponent } from '../components/dataStreamLabelComponent';
 
 const propertiesPadding = {
   paddingLeft: spaceScaledXl,
@@ -296,6 +297,8 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
     property.propertyId,
     assetSummary
   );
+
+  const name = property.name;
   const labelRef = useRef<HTMLDivElement | null>(null);
   const [isNameTruncated, setIsNameTruncated] = useState(false);
   const resetStyles = (styleToReset: object) => {
@@ -328,7 +331,7 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
             style={{ marginBlock: spaceStaticXxs }}
             ref={labelRef}
           >
-            {label}
+            {name ?? label}
           </div>
         </Tooltip>
         <div style={{ float: 'right' }}>
@@ -352,6 +355,11 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
             disableContentPaddings={true}
           >
             <div style={{ padding: `0 ${spaceStaticXl}` }}>
+              <DataStreamLabelComponent
+                name={name}
+                label={label}
+                updateName={(newName) => updateStyle({ name: newName })}
+              />
               <LineStylePropertyConfig
                 resetStyles={resetStyles}
                 onUpdate={updateStyle}

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -81,7 +81,6 @@ const useAdaptedStyleSettings = (
   const depStyles = JSON.stringify(rootStyles);
   return useMemo(() => {
     if (!styledAssetQuery) return {};
-
     const styleSettings: ChartOptions['styleSettings'] = {};
 
     styledAssetQuery.assets?.forEach((asset) => {
@@ -120,6 +119,7 @@ const mapStyledAssetPropertyToChartStyleSettings = (
     lineThickness: styles.line?.thickness ?? line?.thickness,
     yAxis: styles.yAxis?.visible ? styles.yAxis : undefined,
     significantDigits: styles.significantDigits,
+    name: styles.name,
   };
 };
 

--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -58,13 +58,15 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
     queryConfig,
     thresholds,
     significantDigits: widgetSignificantDigits,
+    styleSettings,
   } = widget.properties;
 
   const queries = useQueries(queryConfig.query);
   const key = createWidgetRenderKey(widget.id);
 
   const mappedQuery = assetModelQueryToSiteWiseAssetQuery(queryConfig.query);
-  const items = useTableItems(mappedQuery);
+  // if styleSettings is undefined, pass empty object so useTableItems does not pick name property
+  const items = useTableItems(mappedQuery, styleSettings ?? {});
 
   const significantDigits =
     widgetSignificantDigits ?? dashboardSignificantDigits;
@@ -119,6 +121,7 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
           items={items}
           thresholds={thresholds}
           significantDigits={significantDigits}
+          styles={styleSettings}
           sortingDisabled
           stickyHeader
           pageSize={widget.properties.pageSize ?? DEFAULT_PREFERENCES.pageSize}

--- a/packages/dashboard/src/customization/widgets/table/useTableItems.ts
+++ b/packages/dashboard/src/customization/widgets/table/useTableItems.ts
@@ -4,8 +4,12 @@ import { useClients } from '~/components/dashboard/clientContext';
 import { AssetCacheKeyFactory } from '~/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/useAsset/assetCacheKeyFactory';
 import { createQueryFn } from '~/components/queryEditor/iotSiteWiseQueryEditor/modeledDataStreamQueryEditor/assetExplorer/useAsset/useAsset';
 import { SiteWiseQueryConfig } from '../types';
+import { StyleSettingsMap } from '@iot-app-kit/core';
 
-export const useTableItems = (query: SiteWiseQueryConfig['query']) => {
+export const useTableItems = (
+  query: SiteWiseQueryConfig['query'],
+  styles: StyleSettingsMap
+) => {
   const { iotSiteWiseClient } = useClients();
 
   const assets = query?.assets ?? [];
@@ -22,7 +26,7 @@ export const useTableItems = (query: SiteWiseQueryConfig['query']) => {
   });
 
   const assetItems = assets.flatMap(({ assetId, properties }) =>
-    properties.map(({ propertyId }) => {
+    properties.map(({ propertyId, refId }) => {
       const assetDescription = queries.find(
         ({ data }) => data?.assetId === assetId
       )?.data;
@@ -30,7 +34,10 @@ export const useTableItems = (query: SiteWiseQueryConfig['query']) => {
         ({ id }) => id === propertyId
       ) ?? { unit: '' };
       return {
-        property: `${name} (${assetDescription?.assetName ?? ''})`,
+        //if refId is undefined, use property name
+        property:
+          styles[refId ?? ''].name ??
+          `${name} (${assetDescription?.assetName ?? ''})`,
         unit,
         value: {
           $cellRef: {

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -125,6 +125,7 @@ export type SymbolStyles = {
 };
 
 export type AssetPropertyStyles = LineAndScatterStyles & {
+  name?: string;
   yAxis?: YAxisOptions;
 };
 export type StyledAssetPropertyQuery = AssetPropertyQuery & AssetPropertyStyles;

--- a/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
+++ b/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
@@ -9,7 +9,7 @@ import {
   useGroupableEChart,
   useLoadableEChart,
 } from '../../../hooks/useECharts';
-import { ChartDataQuality, ChartOptions } from '../types';
+import { ChartDataQuality, ChartOptions, ChartStyleSettings } from '../types';
 import { useXAxis } from './axes/xAxis';
 import { useTooltip } from './tooltip/convertTooltip';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -71,7 +71,8 @@ const toDataStreamIdentifiers = (dataStreams: DataStream[]) =>
 
 const toDataStreamMetaData = (
   datastreams: ReturnType<typeof toDataStreamIdentifiers>,
-  series: SeriesOption[]
+  series: SeriesOption[],
+  styleSettings?: ChartStyleSettings
 ) => {
   return datastreams.map(
     ({
@@ -89,9 +90,13 @@ const toDataStreamMetaData = (
         ({ id: seriesId }) => seriesId === id
       ) ?? { appKitColor: color };
       const colorUsed = (foundSeries as GenericSeries).appKitColor;
+
+      const styledName =
+        refId && styleSettings ? styleSettings[refId]?.name : undefined;
+
       return {
         id,
-        name,
+        name: styledName ?? name,
         refId,
         color: colorUsed,
         dataType,
@@ -162,7 +167,7 @@ export const useChartConfiguration = (
   );
 
   const [dataStreamMetaData, setDataStreamMetaData] = useState(
-    toDataStreamMetaData(dataSteamIdentifiers, [])
+    toDataStreamMetaData(dataSteamIdentifiers, [], styleSettings)
   );
 
   useEffect(() => {
@@ -243,7 +248,9 @@ export const useChartConfiguration = (
       : { replaceMerge: ['series'] };
     previousDataStreamIdentifiers.current = dataSteamIdentifiers;
 
-    setDataStreamMetaData(toDataStreamMetaData(dataSteamIdentifiers, series));
+    setDataStreamMetaData(
+      toDataStreamMetaData(dataSteamIdentifiers, series, styleSettings)
+    );
 
     chart.setOption(
       {
@@ -265,6 +272,7 @@ export const useChartConfiguration = (
     id,
     backgroundColor,
     significantDigits,
+    styleSettings,
     xAxis,
     tooltip,
     title,

--- a/packages/react-components/src/components/chart/hooks/useVisualizedDataStreams.ts
+++ b/packages/react-components/src/components/chart/hooks/useVisualizedDataStreams.ts
@@ -11,6 +11,7 @@ import isEqual from 'lodash.isequal';
 import { useTimeSeriesData } from '../../../hooks/useTimeSeriesData';
 import { useViewport } from '../../../hooks/useViewport';
 import { DEFAULT_VIEWPORT, StreamType } from '../../../common/constants';
+// import { ChartStyleSettings } from '../types';
 
 const isNotAlarmStream = ({ streamType }: DataStream) =>
   streamType !== StreamType.ALARM;
@@ -30,13 +31,13 @@ export const useVisualizedDataStreams = (
   const utilizedViewport =
     (lastUpdatedBy ? viewport : passedInViewport || viewport) ??
     DEFAULT_VIEWPORT;
-
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: utilizedViewport,
     queries,
     settings: {
       fetchFromStartToEnd: true,
     },
+    // styles: styleSettings,
   });
 
   useEffect(() => {

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -80,6 +80,7 @@ export type ChartStyleSettingsOptions = {
   yAxis?: YAxisOptions; // allows us to do multiple y axis
 
   significantDigits?: number; // allows us to customize decimals at a property level
+  name?: string; // Used to custom label the datastream name
 };
 
 export type ChartStyleSettings = {

--- a/packages/react-components/src/components/chart/utils/getStyles.ts
+++ b/packages/react-components/src/components/chart/utils/getStyles.ts
@@ -33,5 +33,6 @@ export const getDefaultStyles = (
     significantDigits: significantDigits ?? 4,
     emphasis: 'none',
     hidden: false,
+    name: '',
   };
 };


### PR DESCRIPTION
## Overview
- Add name property to style settings object for non-line widgets
- Add name property style chart options for line chart
- created label editing component for config panel
- users can now edit names of individual properties from config panel or revert to original name


https://github.com/awslabs/iot-app-kit/assets/145582655/e5653326-5aed-4d6b-840e-6998ffc0e7e6




## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
