### PR TITLE
fix(scene): fix regression in updateSceneNode for reparenting nodes

### DIFF
--- a/packages/scene-composer/src/store/helpers/sceneDocumentHelpers.ts
+++ b/packages/scene-composer/src/store/helpers/sceneDocumentHelpers.ts
@@ -163,15 +163,20 @@ export const updateSceneNode = (
   partial: RecursivePartial<ISceneNodeInternal>,
   skipEntityUpdate?: boolean,
 ): void => {
+  // cache these values before merge deep overwrites them
+  const nodeToMove = draft.document.nodeMap[ref];
+  const oldParentRef = nodeToMove?.parentRef;
+  const oldParent = draft.document.nodeMap[oldParentRef || ''];
+
+  // Ignore childRefs from partial since it's determined by parentRef and handled by this function
+  const filteredPartial = partial;
+  delete partial.childRefs;
+
   // update target node
-  mergeDeep(draft.document.nodeMap[ref], partial);
+  mergeDeep(draft.document.nodeMap[ref], filteredPartial);
 
   // Reorder logics
   if ('parentRef' in partial) {
-    const nodeToMove = draft.document.nodeMap[ref];
-    const oldParentRef = nodeToMove?.parentRef;
-    const oldParent = draft.document.nodeMap[oldParentRef || ''];
-
     const newParentRef = partial.parentRef;
 
     // remove target node from old parent


### PR DESCRIPTION
## Overview
Dynamic scene changes introduced a regression in updating scene nodes that change the nodes parent/child relationship such as when doing drag in drop. This impacts static & dynamic nodes equally.  

Observed behavior:  When you drag a node with a visual 3D element to a new parent the node is reparented in the scene hierarchy correctly but a second visual representing appears in the scene in the wrong location.

## Verifying Changes
Use a storybook scene with a hierarchy like
root -
  Model
     Model 2
         Tag
  Model 3

Drag Model 2 to be parented to Model 3.

No new models or tags should appear in the scene.  The existing models and tags should not change location.

You should be able to update the tag transform and only the tag changs.
You should be able to update the Model 2 transform and have both the Model 2 and Tag location update.
You should be able to update the Model 3 transform and have it update the location of Model 3, Model 2, and Tag.


https://github.com/awslabs/iot-app-kit/assets/109186219/b5e447d0-a064-41e9-a909-784ecabde960



### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
