### PR TITLE
fix(react-components): time support

### DIFF
--- a/packages/react-components/src/queries/useSiteWiseAnomalyDataSource/parseAnomaly/parseAnomalyEvent.ts
+++ b/packages/react-components/src/queries/useSiteWiseAnomalyDataSource/parseAnomaly/parseAnomalyEvent.ts
@@ -2,6 +2,7 @@ import { AssetPropertyValue } from '@aws-sdk/client-iotsitewise';
 import { isAnomalyEvent } from './isAnomalyEvent';
 import { AnomalyEvent } from './types';
 import { parseDiagnostics } from './parseDiagnostics';
+import { toTimestamp } from '../../../utils/time';
 
 export const parseAnomalyEvent = (
   assetPropertyValue: AssetPropertyValue
@@ -13,7 +14,7 @@ export const parseAnomalyEvent = (
   if (!stringValueIsAnomalyEvent) return;
   return {
     ...parsedStringValue,
-    timestamp: (assetPropertyValue.timestamp?.timeInSeconds ?? 0) * 1000,
+    timestamp: toTimestamp(assetPropertyValue.timestamp),
     diagnostics: parseDiagnostics(parsedStringValue.diagnostics),
   };
 };

--- a/packages/react-components/src/utils/time.spec.ts
+++ b/packages/react-components/src/utils/time.spec.ts
@@ -6,6 +6,7 @@ import {
   MINUTE_IN_MS,
   MONTH_IN_MS,
   SECOND_IN_MS,
+  toTimestamp,
   YEAR_IN_MS,
 } from './time';
 
@@ -239,5 +240,48 @@ describe('display date', () => {
         })
       ).toBe('12/31/1999');
     });
+  });
+});
+
+describe('toTimestamp', () => {
+  it('can handle an undefined time', () => {
+    expect(toTimestamp(undefined)).toBe(0);
+    expect(
+      toTimestamp({
+        timeInSeconds: undefined,
+        offsetInNanos: undefined,
+      })
+    ).toBe(0);
+  });
+  it('converts a time with seconds and nanos to milliseconds', () => {
+    expect(
+      toTimestamp({
+        timeInSeconds: 0.1,
+        offsetInNanos: 1000000,
+      })
+    ).toBe(101);
+  });
+  it('converts a time with only seconds to milliseconds', () => {
+    expect(
+      toTimestamp({
+        timeInSeconds: 0.1,
+      })
+    ).toBe(100);
+  });
+  it('converts a time with only nanos to milliseconds', () => {
+    expect(
+      toTimestamp({
+        timeInSeconds: undefined,
+        offsetInNanos: 1000000,
+      })
+    ).toBe(1);
+  });
+  it('does not return fractional milliseconds', () => {
+    expect(
+      toTimestamp({
+        timeInSeconds: undefined,
+        offsetInNanos: 1000,
+      })
+    ).toBe(0);
   });
 });

--- a/packages/react-components/src/utils/time.ts
+++ b/packages/react-components/src/utils/time.ts
@@ -1,3 +1,5 @@
+import type { TimeInNanos } from '@aws-sdk/client-iotsitewise';
+import { NANO_SECOND_IN_MS } from '@iot-app-kit/core';
 import parse from 'parse-duration';
 
 export const SECOND_IN_MS = 1000;
@@ -155,3 +157,12 @@ export const parseDuration = (duration: number | string): number => {
   // if duration is a string but we cannot parse it, we default to 10 mins.
   return parsedTime != null ? parsedTime : 10 * MINUTE_IN_MS;
 };
+
+/** converts the TimeInNanos to milliseconds */
+export const toTimestamp = (time: TimeInNanos | undefined): number =>
+  (time &&
+    Math.floor(
+      (time.timeInSeconds || 0) * SECOND_IN_MS +
+        (time.offsetInNanos || 0) * NANO_SECOND_IN_MS
+    )) ||
+  0;


### PR DESCRIPTION
## Overview
Support data point time object that is constructed from seconds and nanoseconds.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
