### PR TITLE
fix(react-components): fix error state display

### DIFF
--- a/packages/react-components/src/components/anomaly-widget/anomalyWidgetError.tsx
+++ b/packages/react-components/src/components/anomaly-widget/anomalyWidgetError.tsx
@@ -15,10 +15,11 @@ export const AnomalyWidgetError = () => {
         background: colorBackgroundContainerContent,
         width: '100%',
         height: '100%',
-        position: 'relative',
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
+        position: 'absolute',
+        zIndex: 1,
       }}
     >
       <Box margin={{ vertical: 's', horizontal: 's' }}>

--- a/packages/react-components/src/components/anomaly-widget/converters/convertXAxis.ts
+++ b/packages/react-components/src/components/anomaly-widget/converters/convertXAxis.ts
@@ -1,9 +1,10 @@
+import merge from 'lodash.merge';
 import { ANOMALY_X_AXIS } from '../constants';
 import { ConfigurationOptions } from '../hooks/types';
 
-export const convertXAxis = ({ axis }: Pick<ConfigurationOptions, 'axis'>) => ({
-  ...ANOMALY_X_AXIS,
-  axisLabel: {
-    show: axis?.showX ?? true,
-  },
-});
+export const convertXAxis = ({ axis }: Pick<ConfigurationOptions, 'axis'>) =>
+  merge({}, ANOMALY_X_AXIS.xAxis, {
+    axisLabel: {
+      show: axis?.showX ?? true,
+    },
+  });

--- a/packages/react-components/src/components/anomaly-widget/index.tsx
+++ b/packages/react-components/src/components/anomaly-widget/index.tsx
@@ -59,7 +59,6 @@ export const AnomalyWidget = (options: AnomalyWidgetOptions) => {
         style={{
           width: '100%',
           height: '100%',
-          display: error ? 'none' : 'default',
         }}
       />
       {showTimestamp && !error && (


### PR DESCRIPTION
## Overview
Fix component display bug when toggling error. This implementation prefers not to hide the chart so that we do not need to recreate a chart instance. Instead we overlay the error state onto the empty chart. **Note: leaving the chart element does not cause extra api calls to be made**

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
