### PR TITLE
chore(scene composer): addressing react-hook linter warnings

### DIFF
--- a/packages/scene-composer/src/SceneViewer.tsx
+++ b/packages/scene-composer/src/SceneViewer.tsx
@@ -54,7 +54,7 @@ export const SceneViewer: React.FC<SceneViewerProps> = ({ sceneComposerId, confi
     } else {
       composerApis.setSelectedSceneNodeRef(undefined);
     }
-  }, [props.selectedDataBinding, sceneLoaded]);
+  }, [props.selectedDataBinding, sceneLoaded, composerApis]);
 
   const onSceneLoaded = useCallback(() => {
     setSceneLoaded(true);

--- a/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
+++ b/packages/scene-composer/src/augmentations/components/three-fiber/anchor/AnchorWidget.tsx
@@ -105,7 +105,7 @@ export function AsyncLoadedAnchorWidget({
 
   useEffect(() => {
     setParent(node.parentRef ? getObject3DFromSceneNodeRef(node.parentRef) : undefined);
-  }, [node.parentRef]);
+  }, [node.parentRef, getObject3DFromSceneNodeRef]);
   // Evaluate visual state based on data binding
   const visualState = useMemo(() => {
     // Anchor widget only accepts icon, otherwise, default to Info icon
@@ -142,7 +142,7 @@ export function AsyncLoadedAnchorWidget({
       return ruleTargetInfo.value;
     }
     return defaultIcon;
-  }, [ruleResult]);
+  }, [ruleResult, defaultIcon, overrideCustomColor, overrideCustomIcon]);
 
   const visualRuleCustomColor = overrideCustomColor !== undefined ? overrideCustomColor : chosenColor;
   const visualCustomIcon =
@@ -195,17 +195,21 @@ export function AsyncLoadedAnchorWidget({
     });
   }, [
     autoRescale,
-    CustomIconSvgString,
     visualRuleCustomColor,
-    visualCustomIcon,
     newCustomIcon,
     tagSettings.enableOcclusion,
+    newIconHeight,
+    newIconWidth,
+    node.properties.alwaysVisible,
   ]);
 
-  const isAnchor = (nodeRef?: string) => {
-    const node = getSceneNodeByRef(nodeRef);
-    return findComponentByType(node, KnownComponentType.Tag) ?? false;
-  };
+  const isAnchor = useCallback(
+    (nodeRef?: string) => {
+      const node = getSceneNodeByRef(nodeRef);
+      return findComponentByType(node, KnownComponentType.Tag) ?? false;
+    },
+    [getSceneNodeByRef],
+  );
 
   useEffect(() => {
     // Initialize isSelected to false on mount
@@ -228,14 +232,16 @@ export function AsyncLoadedAnchorWidget({
       }
     }
   }, [
-    selectedSceneNodeRef,
     highlightedSceneNodeRef,
+    isAnchor,
     isViewing,
+    navLink,
+    newCustomIcon,
     node,
     valueDataBinding,
-    navLink,
+    selectedSceneNodeRef,
+    setHighlightedSceneNodeRef,
     visualRuleCustomColor,
-    newCustomIcon,
     visualCustomIcon,
   ]);
 
@@ -263,7 +269,17 @@ export function AsyncLoadedAnchorWidget({
         }
       }
     },
-    [onWidgetClick, selectedSceneNodeRef],
+    [
+      onWidgetClick,
+      chosenColor,
+      customIcon,
+      dataBindingTemplate,
+      isViewing,
+      navLink,
+      node.components,
+      node.ref,
+      valueDataBinding,
+    ],
   );
 
   const position = useMemo(() => {
@@ -285,7 +301,7 @@ export function AsyncLoadedAnchorWidget({
       const points = [new THREE.Vector3(), position];
       geometry.setFromPoints(points);
     }
-  }, [position, bufferGeometryRef.current]);
+  }, [position]);
 
   useEffect(() => {
     const lines = linesRef.current;
@@ -294,7 +310,7 @@ export function AsyncLoadedAnchorWidget({
       lines.layers.disable(Layers.RaycastAndRender);
       lines.layers.enable(Layers.RenderOnly);
     }
-  }, [linesRef.current]);
+  }, []);
 
   const finalScale = new THREE.Vector3(1, 1, 1);
 

--- a/packages/scene-composer/src/enhancers/draggable.tsx
+++ b/packages/scene-composer/src/enhancers/draggable.tsx
@@ -1,18 +1,18 @@
-import React, { ForwardRefExoticComponent, useCallback } from 'react';
+import React, { forwardRef, ForwardRefExoticComponent, RefAttributes, useCallback } from 'react';
 import { useDrag } from 'react-dnd';
 import './draggable.scss';
 
 export interface DraggableProps {
   dataType: string;
-  data: {};
+  data: NonNullable<unknown>;
   draggable?: boolean;
   className?: string;
 }
 
 const draggable = function <TProps, TBaseElement>(
-  Component: ForwardRefExoticComponent<TProps & React.RefAttributes<TBaseElement>>,
+  Component: ForwardRefExoticComponent<TProps & RefAttributes<TBaseElement>>,
 ) {
-  const DraggableComponent = React.forwardRef<TBaseElement, DraggableProps & TProps>(
+  const DraggableComponent = forwardRef<TBaseElement, DraggableProps & TProps>(
     // eslint-disable-next-line react/prop-types
     ({ draggable = true, dataType, data, className = '', ...props }, ref) => {
       const [collected, dragRef] = useDrag(() => ({

--- a/packages/scene-composer/src/enhancers/droppable.tsx
+++ b/packages/scene-composer/src/enhancers/droppable.tsx
@@ -1,5 +1,5 @@
 import { TargetType } from 'dnd-core';
-import React, { ForwardRefExoticComponent, useCallback } from 'react';
+import React, { forwardRef, ForwardRefExoticComponent, RefAttributes, useCallback } from 'react';
 
 import useDropMonitor from '../hooks/useDropMonitor';
 
@@ -10,10 +10,8 @@ export interface DroppableProps {
   className?: string;
 }
 
-function droppable<TProps, TBaseElement>(
-  Component: ForwardRefExoticComponent<TProps & React.RefAttributes<TBaseElement>>,
-) {
-  const DroppableComponent = React.forwardRef<TBaseElement, DroppableProps & TProps>(
+function droppable<TProps, TBaseElement>(Component: ForwardRefExoticComponent<TProps & RefAttributes<TBaseElement>>) {
+  const DroppableComponent = forwardRef<TBaseElement, DroppableProps & TProps>(
     ({ acceptDrop, onDropped: onDrop, className = '', droppable = true, ...props }: DroppableProps & TProps, ref) => {
       const { isOverCurrent, dropRef } = useDropMonitor(acceptDrop, onDrop);
 

--- a/packages/scene-composer/src/hooks/useKeyPress.ts
+++ b/packages/scene-composer/src/hooks/useKeyPress.ts
@@ -84,7 +84,7 @@ const useKeyPress = (
       window.removeEventListener('keydown', downHandler);
       window.removeEventListener('keyup', upHandler);
     };
-  }, [enabled]); // We don't pass more than enabled here, because it adds unnecessary event listeners. This ensures we only bind once, and we unbind when disabled.
+  }, [downHandler, enabled, upHandler]); // We don't pass more than enabled here, because it adds unnecessary event listeners. This ensures we only bind once, and we unbind when disabled.
 
   return keyPressed;
 };

--- a/packages/scene-composer/src/hooks/useSelectedNode.ts
+++ b/packages/scene-composer/src/hooks/useSelectedNode.ts
@@ -15,7 +15,10 @@ const useSelectedNode = () => {
 
   const getSceneNodeByRef = accessStore(sceneComposerId)((state) => state.getSceneNodeByRef);
 
-  const selectedSceneNode = useMemo(() => getSceneNodeByRef(selectedSceneNodeRef), [selectedSceneNodeRef]);
+  const selectedSceneNode = useMemo(
+    () => getSceneNodeByRef(selectedSceneNodeRef),
+    [selectedSceneNodeRef, getSceneNodeByRef],
+  );
 
   // callback, not memo because this object could be very large, and we want to avoid creating multiple copies in memory
   const getSelectedObject = useCallback(() => {
@@ -32,7 +35,7 @@ const useSelectedNode = () => {
 
       return object3D.getObjectByName(selectedSceneSubmodelRef as string);
     }
-  }, [selectedSceneSubmodelRef]);
+  }, [selectedSceneSubmodelRef, getSelectedObject]);
 
   return {
     selectedSceneNodeRef,

--- a/packages/scene-composer/src/hooks/useTwinMakerTextureLoader.tsx
+++ b/packages/scene-composer/src/hooks/useTwinMakerTextureLoader.tsx
@@ -53,7 +53,7 @@ const useTwinMakerTextureLoader: (options?: TwinMakerTextureLoaderOptions) => {
         textureLoader.setGetSceneObjectFunction(globalSettings.getSceneObjectFunction);
       }
     }
-  }, [globalSettings.getSceneObjectFunction, textureLoader]);
+  }, [globalSettings.getSceneObjectFunction, textureLoader, sceneComposerId]);
 
   const loadTexture = useCallback(
     (uri: string, onLoadCallback: OnFileLoaderLoadFunc) => {
@@ -62,7 +62,7 @@ const useTwinMakerTextureLoader: (options?: TwinMakerTextureLoaderOptions) => {
         textureLoader.load(path, onLoadCallback);
       }
     },
-    [textureLoader],
+    [textureLoader, uriModifier],
   );
 
   const loadTextureOnMesh = useCallback(

--- a/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/SceneLayout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment, ReactNode, Suspense, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { FC, Fragment, ReactNode, Suspense, useContext, useEffect, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import styled, { ThemeContext } from 'styled-components';
 import { Canvas, ThreeEvent, useThree } from '@react-three/fiber';
@@ -88,7 +88,7 @@ const R3FWrapper = (props: { matterportConfig?: MatterportConfig; children?: Rea
       This is required to revert/reset the changes done by the Matterport viewer. */
       window.THREE.Cache.clear();
     }
-  }, [loadMatterport]);
+  }, [loadMatterport, sceneComposerId]);
 
   if (!sceneLoaded) {
     return null;
@@ -142,7 +142,7 @@ const SceneLayout: FC<SceneLayoutProps> = ({ isViewing, LoadingView = null, exte
 
   const shouldShowPreview = useMemo(() => {
     return isViewing ? false : !!findComponentByType(selectedNode.selectedSceneNode, KnownComponentType.Camera);
-  }, [selectedNode]);
+  }, [selectedNode, isViewing]);
 
   const dynamicSceneEnabled = useDynamicScene();
 

--- a/packages/scene-composer/src/layouts/SceneLayout/components/FoldableContainer.tsx
+++ b/packages/scene-composer/src/layouts/SceneLayout/components/FoldableContainer.tsx
@@ -26,7 +26,7 @@ const FoldableContainer: React.FC<FoldableContainerProps> = ({
 
   useEffect(() => {
     setIsOpen(!fold);
-  }, [fold]);
+  }, [fold, setIsOpen]);
 
   return (
     <div className={wrapper}>

--- a/packages/scene-composer/src/logger/react-logger/log-provider/index.tsx
+++ b/packages/scene-composer/src/logger/react-logger/log-provider/index.tsx
@@ -32,7 +32,7 @@ const LogProvider: FC<LogProviderProps> = ({ namespace, logger: overrideLogger, 
     return /* istanbul ignore next */ () => {
       logger?.verbose('unloaded');
     };
-  }, []);
+  }, [logger]);
 
   return (
     <LoggingContext.Provider

--- a/packages/scene-composer/src/store/middlewares.ts
+++ b/packages/scene-composer/src/store/middlewares.ts
@@ -1,5 +1,4 @@
 import { State, StateCreator, StoreMutatorIdentifier } from 'zustand';
-import { produce, Draft } from 'immer';
 import createVanilla, { GetState, SetState, StoreApi } from 'zustand/vanilla';
 
 import DebugLogger from '../logger/DebugLogger';

--- a/packages/scene-composer/src/store/slices/SceneDocumentSlice.spec.ts
+++ b/packages/scene-composer/src/store/slices/SceneDocumentSlice.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable dot-notation, jest/no-conditional-expect */
 import { cloneDeep } from 'lodash';
 import flushPromises from 'flush-promises';
-import { Object3D, Vector3 } from 'three';
+import { Object3D } from 'three';
 
 import { IAnchorComponentInternal, IDataOverlayComponentInternal, ISceneNodeInternal } from '..';
 import { COMPOSER_FEATURES, IErrorDetails, KnownComponentType, KnownSceneProperty } from '../..';

--- a/packages/scene-composer/src/three/transformUtils.ts
+++ b/packages/scene-composer/src/three/transformUtils.ts
@@ -63,7 +63,7 @@ export function useSnapObjectToFloor(
     if (node?.parentRef) {
       return getObject3DBySceneNodeRef(node.parentRef);
     }
-  }, [node]);
+  }, [node, getObject3DBySceneNodeRef]);
 
   function applyConstraint() {
     setState(true);
@@ -87,7 +87,7 @@ export function useSnapObjectToFloor(
         }
       }
     }
-  }, [state, node, nodeObject3D, parentObject3D]);
+  }, [state, node, nodeObject3D, parentObject3D, callback]);
 
   return applyConstraint;
 }

--- a/packages/scene-composer/src/utils/controlUtils.ts
+++ b/packages/scene-composer/src/utils/controlUtils.ts
@@ -2,7 +2,6 @@ import { MapControls, OrbitControls } from '../three/OrbitControls';
 import { PointerLockControls } from '../three/PointerLockControls';
 import { CameraControlsType } from '../interfaces';
 import { CameraControlImpl } from '../store/internalInterfaces';
-import { Pan } from '../assets/auto-gen/icons';
 
 export const isPointerLockControl = (controlType: CameraControlsType): boolean => {
   return controlType === 'pointerLock' ? true : false;

--- a/packages/scene-composer/stories/Trees.stories.tsx
+++ b/packages/scene-composer/stories/Trees.stories.tsx
@@ -1,7 +1,6 @@
 import Box from '@cloudscape-design/components/box';
 import React, { FC, ReactNode, useCallback, useState } from 'react';
 import * as awsui from '@cloudscape-design/design-tokens';
-import { applyMode, Mode } from '@cloudscape-design/global-styles';
 import styled, { ThemeProvider } from 'styled-components';
 import Container from '@cloudscape-design/components/container';
 import { DndProvider } from 'react-dnd';

--- a/packages/scene-composer/stories/components/argTypes.ts
+++ b/packages/scene-composer/stories/components/argTypes.ts
@@ -1,5 +1,3 @@
-import { Density, Mode } from '@cloudscape-design/global-styles';
-
 import { AssetType, COMPOSER_FEATURES } from '../../src';
 import scenes from '../scenes';
 

--- a/packages/scene-composer/stories/components/hooks/useLoader.ts
+++ b/packages/scene-composer/stories/components/hooks/useLoader.ts
@@ -28,14 +28,14 @@ const useLoader = (
         },
         getSceneObject,
       } as SceneLoader),
-    [scene],
+    [scene, getSceneObject],
   );
 
   const awsLoader = useMemo(() => {
     const loader = dataSource.s3SceneLoader(sceneId!);
 
     return loader as SceneLoader;
-  }, [dataSource.s3SceneLoader, sceneId]);
+  }, [dataSource, sceneId]);
 
   const loader = useMemo(() => {
     switch (source) {
@@ -44,7 +44,7 @@ const useLoader = (
       default:
         return scene ? localLoader : null;
     }
-  }, [scene, awsLoader, sceneId, source]);
+  }, [scene, awsLoader, sceneId, source, localLoader]);
 
   const awsBindingProvider = useMemo(() => {
     return dataSource.valueDataBindingProviders();
@@ -59,7 +59,7 @@ const useLoader = (
       default:
         return scene ? { TwinMakerEntityProperty: localBindingProvider } : undefined;
     }
-  }, [scene, source]);
+  }, [awsBindingProvider, scene, source, localBindingProvider]);
 
   return { loader, bindingProvider };
 };

--- a/packages/scene-composer/stories/components/hooks/useSceneMetadataModule.ts
+++ b/packages/scene-composer/stories/components/hooks/useSceneMetadataModule.ts
@@ -15,7 +15,7 @@ const useSceneMetadataModule = (
     const sceneMetadataModule = dataSource.sceneMetadataModule(sceneMetadatModuleProps.sceneId!);
 
     return sceneMetadataModule as TwinMakerSceneMetadataModule;
-  }, [sceneMetadatModuleProps]);
+  }, [sceneMetadatModuleProps, dataSource]);
 
   const sceneMetadataModule = useMemo(() => {
     switch (sceneMetadatModuleProps.source) {
@@ -24,7 +24,7 @@ const useSceneMetadataModule = (
       default:
         return undefined;
     }
-  }, [sceneMetadatModuleProps.sceneId, sceneMetadatModuleProps.source]);
+  }, [sceneMetadatModuleProps.source, awsSceneMetadataModule]);
 
   return sceneMetadataModule;
 };

--- a/packages/scene-composer/stories/components/scene-composer.tsx
+++ b/packages/scene-composer/stories/components/scene-composer.tsx
@@ -129,10 +129,13 @@ const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
     };
   }
 
-  const handleSceneUpdated: OnSceneUpdateCallback = useCallback((sceneSnapshot) => {
-    stagedScene.current = sceneSnapshot;
-    onSceneUpdated(sceneSnapshot);
-  }, []);
+  const handleSceneUpdated: OnSceneUpdateCallback = useCallback(
+    (sceneSnapshot) => {
+      stagedScene.current = sceneSnapshot;
+      onSceneUpdated(sceneSnapshot);
+    },
+    [onSceneUpdated],
+  );
 
   const defaultAssetBrowserCallback = (cb: AssetBrowserResultCallback) => {
     cb(null, 'PALLET_JACK.glb');
@@ -161,7 +164,7 @@ const SceneComposerWrapper: FC<SceneComposerWrapperProps> = ({
         cb(null, 'CookieFactoryMixer.glb'); // Update the string to a model available in your S3 bucket
       }
     },
-    [source, assetType],
+    [source, assetType, actionRecorderShowAssetBrowserCallback],
   );
 
   if (loader) {

--- a/packages/scene-composer/tests/three/transformUtils.spec.tsx
+++ b/packages/scene-composer/tests/three/transformUtils.spec.tsx
@@ -86,7 +86,7 @@ describe('snapObjectToFloor', () => {
         useEffect(() => {
           activate();
           setIsDone(true);
-        });
+        }, [activate]);
 
         if (isDone) {
           return <div data-testid='rendered' />;


### PR DESCRIPTION
## Overview
Addressing a portion of the linter warnings from the implementation of `react-hook` linter on Scene Composer. Takes us from 712 to 672 warnings. 

Updates include:
- Removing unused imports
- Removing unused dependencies in hooks
- Adding missing dependencies in hooks to prevent infinite loops & ensure accurate executions

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
