### PR TITLE
fix: corrected the spelling in refresh rate error documentation 

### DIFF
--- a/packages/core/src/data-module/subscription-store/refreshRate.ts
+++ b/packages/core/src/data-module/subscription-store/refreshRate.ts
@@ -16,7 +16,7 @@ export function getValidRefreshRate(refreshRate: number) {
   try {
     if (refreshRate && refreshRate < 1000) {
       throw new Error(
-        'Refresh rate has minimum value of 1000 miliseconds. Setting rerfesh rate to 1 second.'
+        'Refresh rate has minimum value of 1000 milliseconds. Setting refresh rate to 1 second.'
       );
     }
     return refreshRate;


### PR DESCRIPTION
Spelling correction in documentation as per #2777

