### PR TITLE
fix: fixed the status timeline properties tab child key errors

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.tsx
@@ -56,7 +56,7 @@ export const PropertyComponent: FC<PropertyComponentProps> = ({
                   updateColor={onUpdatePropertyColor}
                 />
               )}
-              {name ?? label}
+              <span>{name ?? label}</span>
             </SpaceBetween>
           </Box>
         </SpaceBetween>


### PR DESCRIPTION
This PR is for ticket https://github.com/awslabs/iot-app-kit/issues/2809 and fixed the child key errors for the status timeline properties tab.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/142866907/bbdc4400-3a5d-47cd-a7ac-c24f81cc6341


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
