### PR TITLE
fix: properties panel not loading if some resources do not exist

### DIFF
--- a/packages/dashboard/src/data/listAssetPropertiesMap/query.tsx
+++ b/packages/dashboard/src/data/listAssetPropertiesMap/query.tsx
@@ -29,12 +29,21 @@ const listAssetProperties = (client: IoTSiteWiseClient, assetId: string) => {
 const listPropertiesSiteWiseAssetQuery = async (
   client: IoTSiteWiseClient,
   siteWiseQuery: Partial<SiteWiseAssetQuery & SiteWisePropertyAliasQuery>
-) =>
-  Promise.all(
-    siteWiseQuery.assets?.map(({ assetId }: { assetId: string }) =>
-      listAssetProperties(client, assetId)
-    ) ?? []
-  );
+) => {
+  const assetPropertiesPromises =
+    siteWiseQuery.assets?.map(async ({ assetId }: { assetId: string }) => {
+      try {
+        return await listAssetProperties(client, assetId);
+      } catch (error) {
+        console.error(
+          `Error retrieving asset properties for asset ID ${assetId}:`,
+          error
+        );
+        return [];
+      }
+    }) ?? [];
+  return Promise.all(assetPropertiesPromises);
+};
 
 export const createFetchSiteWiseAssetQueryDescription =
   (


### PR DESCRIPTION
This PR fixes the issue in #2808 
If some of the resources added in widget do not exist anymore, then the properties panel will load with currently existing resources only.

### Verifying changes:
[properties-panel-with-undefined-properties.webm](https://github.com/awslabs/iot-app-kit/assets/154328164/dff5ed24-394b-4c40-b4d4-453b41053d0c)
