### PR TITLE
fix(DynamicScenes): copySceneNodes should take the new sceneId as an argument

### DIFF
--- a/packages/scene-composer/src/utils/entityModelUtils/copySceneNodes.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/copySceneNodes.spec.ts
@@ -37,7 +37,8 @@ describe('copySceneNodes', () => {
 
   it('should call related functions', async () => {
     const sourceSceneRootEntityId = 'src-scene-root-entity-id';
-    await copySceneNodes(sourceSceneRootEntityId);
+    const sceneCopyId = 'mockCopyScene';
+    await copySceneNodes({ sourceSceneRootEntityId, sceneCopyId });
 
     expect(createSceneRootEntity).toBeCalledTimes(1);
     expect(fetchSceneNodes).toBeCalledTimes(1);

--- a/packages/scene-composer/src/utils/entityModelUtils/copySceneNodes.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/copySceneNodes.ts
@@ -4,14 +4,16 @@ import { cloneSceneNodes, createSceneRootEntity, fetchSceneNodes, saveSceneNodes
 
 export const copySceneNodes = async ({
   sourceSceneRootEntityId,
+  sceneCopyId,
   onSuccess,
   onFailure,
 }: {
   sourceSceneRootEntityId: string;
+  sceneCopyId?: string;
   onSuccess?: (node: ISceneNodeInternal) => void;
   onFailure?: (node: ISceneNodeInternal, error: Error) => void;
 }): Promise<string> => {
-  const root = await createSceneRootEntity();
+  const root = await createSceneRootEntity(sceneCopyId);
   const targetSceneRootEntityId = root?.entityId as string;
 
   const sourceNodes = await fetchSceneNodes(sourceSceneRootEntityId);

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.spec.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.spec.ts
@@ -53,17 +53,35 @@ describe('createSceneEntityId', () => {
 });
 
 describe('createSceneRootEntity', () => {
-  const createSceneEntity = jest.fn();
-  const mockMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
-    createSceneEntity,
-    getSceneId: jest.fn().mockReturnValue('test'),
-  };
-
-  it('should call createSceneEntity with expected input', () => {
+  it('should call createSceneEntity with metadataModule sceneId', () => {
+    const createSceneEntity = jest.fn();
+    const mockMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
+      createSceneEntity,
+      getSceneId: jest.fn().mockReturnValue('test'),
+    };
     setTwinMakerSceneMetadataModule(mockMetadataModule as unknown as TwinMakerSceneMetadataModule);
     setFeatureConfig({});
 
     createSceneRootEntity();
+
+    expect(createSceneEntity).toBeCalledWith({
+      workspaceId: undefined,
+      entityId: createSceneEntityId('test'),
+      parentEntityId: SCENE_ROOT_ENTITY_ID,
+      entityName: createSceneEntityId('test'),
+    });
+    expect(createSceneEntityComponent).not.toBeCalled();
+  });
+
+  it('should call createSceneEntity with provided sceneName', () => {
+    const createSceneEntity = jest.fn();
+    const mockMetadataModule: Partial<TwinMakerSceneMetadataModule> = {
+      createSceneEntity,
+    };
+    setTwinMakerSceneMetadataModule(mockMetadataModule as unknown as TwinMakerSceneMetadataModule);
+    setFeatureConfig({});
+
+    createSceneRootEntity('test');
 
     expect(createSceneEntity).toBeCalledWith({
       workspaceId: undefined,

--- a/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
+++ b/packages/scene-composer/src/utils/entityModelUtils/sceneUtils.ts
@@ -29,13 +29,13 @@ export const createSceneEntityId = (sceneName: string): string => {
   return `SCENE_${sceneName}_${generateUUID()}`;
 };
 
-export const createSceneRootEntity = (): Promise<CreateEntityCommandOutput> | undefined => {
+export const createSceneRootEntity = (sceneId?: string): Promise<CreateEntityCommandOutput> | undefined => {
   if (!getGlobalSettings().twinMakerSceneMetadataModule) {
     return;
   }
 
-  const sceneName = getGlobalSettings().twinMakerSceneMetadataModule!.getSceneId();
-  const sceneEntityId = createSceneEntityId(sceneName);
+  const _sceneId = sceneId ?? getGlobalSettings().twinMakerSceneMetadataModule!.getSceneId();
+  const sceneEntityId = createSceneEntityId(_sceneId);
   const input: CreateEntityCommandInput = {
     workspaceId: undefined,
     entityId: sceneEntityId,


### PR DESCRIPTION
## Overview
The Console has a bug when copying scenes where the new scene root entity ID uses the same sceneId as the original scene.

## Verifying Changes

Verified by copying over the `dist/` folder to the Console code and copying over the scene with a more easily identifiable scene root entity using the copy sceneId.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
