### PR TITLE
chore(scene): detect dynamic scenes missing their root entity

### DIFF
--- a/packages/scene-composer/src/components/SceneLayers.spec.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.spec.tsx
@@ -3,8 +3,10 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import { useQuery } from '@tanstack/react-query';
 
+import { getGlobalSettings } from '../common/GlobalSettings';
 import { accessStore } from '../store';
 import { processQueries } from '../utils/entityModelUtils/processQueries';
+import { checkIfEntityExists } from '../utils/entityModelUtils/sceneUtils';
 import { KnownSceneProperty } from '../interfaces';
 import { LAYER_DEFAULT_REFRESH_INTERVAL } from '../utils/entityModelUtils/sceneLayerUtils';
 import { SceneLayers } from './SceneLayers';
@@ -13,19 +15,31 @@ jest.mock('../utils/entityModelUtils/processQueries', () => ({
   processQueries: jest.fn(),
 }));
 
+jest.mock('../utils/entityModelUtils/sceneUtils', () => ({
+  ... jest.requireActual('../utils/entityModelUtils/sceneUtils'),
+  checkIfEntityExists: jest.fn(),
+}));
+
 jest.mock('@tanstack/react-query', () => ({
   useQuery: jest.fn(),
+}));
+
+jest.mock('../common/GlobalSettings', () => ({
+  getGlobalSettings: jest.fn(() => ({})),
 }));
 
 describe('SceneLayers', () => {
   const renderSceneNodesMock = jest.fn();
   const isViewingMock = jest.fn();
   const getScenePropertyMock = jest.fn();
+  const addMessagesMock = jest.fn();
   const baseState = {
     getSceneProperty: getScenePropertyMock,
     renderSceneNodes: renderSceneNodesMock,
     isViewing: isViewingMock,
+    addMessages: addMessagesMock,
   };
+  const mockSceneMetadataModule = {};
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -145,5 +159,25 @@ describe('SceneLayers', () => {
     expect(processQueries as jest.Mock).toBeCalledTimes(1);
     expect(renderSceneNodesMock).toBeCalledTimes(1);
     expect(renderSceneNodesMock).toBeCalledWith(['random']);
+  });
+
+  it('should detect no Scene Root Entity', async () => {
+    accessStore('default').setState(baseState);
+    const globalSettings = getGlobalSettings as jest.Mock;
+    globalSettings.mockImplementation(() => ({
+      twinMakerSceneMetadataModule: {},
+    }));
+    let queryFunction;
+    (useQuery as jest.Mock).mockImplementation(({ queryFn, ..._ }) => {
+      queryFunction = queryFn;
+      return { data: [] };
+    });
+    (checkIfEntityExists as jest.Mock).mockImplementation(() => { return false});
+    render(<SceneLayers />);
+    await queryFunction();
+
+    expect(processQueries as jest.Mock).toBeCalledTimes(1);
+    expect(renderSceneNodesMock).toBeCalledTimes(0);
+    expect(addMessagesMock).toBeCalledTimes(1);
   });
 });

--- a/packages/scene-composer/src/components/SceneLayers.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.tsx
@@ -1,12 +1,16 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useIntl } from 'react-intl';
 
+import { getGlobalSettings } from '../common/GlobalSettings';
 import { sceneComposerIdContext } from '../common/sceneComposerIdContext';
 import { accessStore } from '../store';
-import { fetchSceneNodes } from '../utils/entityModelUtils/sceneUtils';
+import { checkIfEntityExists, fetchSceneNodes } from '../utils/entityModelUtils/sceneUtils';
 import { KnownSceneProperty } from '../interfaces';
+import { DisplayMessageCategory } from '../store/internalInterfaces';
 
 export const SceneLayers: React.FC = () => {
+  const { formatMessage } = useIntl();
   const sceneComposerId = useContext(sceneComposerIdContext);
   const isViewing = accessStore(sceneComposerId)((state) => state.isViewing());
   const autoUpdateInterval = accessStore(sceneComposerId)(
@@ -18,6 +22,7 @@ export const SceneLayers: React.FC = () => {
   const sceneRootEntityId = accessStore(sceneComposerId)((state) =>
     state.getSceneProperty(KnownSceneProperty.SceneRootEntityId),
   ) as string;
+  const addMessages = accessStore(sceneComposerId)((state) => state.addMessages);
 
   const nodes = useQuery({
     enabled: !!sceneRootEntityId,
@@ -31,11 +36,32 @@ export const SceneLayers: React.FC = () => {
     refetchOnWindowFocus: false,
   });
 
+  const checkForSceneRootEntity = useCallback(async () => {
+    const sceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
+    if (sceneMetadataModule) {
+      if (!(await checkIfEntityExists(sceneRootEntityId, sceneMetadataModule))) {
+        addMessages([
+          {
+            category: DisplayMessageCategory.Error,
+            messageText: formatMessage({
+              description: 'Scene Entity Error',
+              defaultMessage: 'Dynamic Scene is missing root scene entity',
+            }),
+          },
+        ]);
+      }
+    }
+  }, [sceneRootEntityId, addMessages, formatMessage]);
+
   useEffect(() => {
     if (nodes.data) {
-      renderSceneNodes(nodes.data);
+      if (nodes.data.length > 0) {
+        renderSceneNodes(nodes.data);
+      } else {
+        checkForSceneRootEntity();
+      }
     }
-  }, [nodes.data, renderSceneNodes]);
+  }, [nodes.data, renderSceneNodes, checkForSceneRootEntity]);
 
   return <></>;
 };

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -1299,6 +1299,10 @@
     "note": "Light Type in a dropdown menu",
     "text": "Directional"
   },
+  "ytZC0H": {
+    "note": "Scene Entity Error",
+    "text": "Dynamic Scene is missing root scene entity"
+  },
   "z4V95/": {
     "note": "Expandable Section title",
     "text": "Camera"


### PR DESCRIPTION
## Overview
When a dynamic scene has it's root entity deleted the scene no longer functions because it doesn't have a parent entity to attach other entities to.  The scene composer should detect this and provide an error message alerting the users instead of letting them attempt changes and then giving an error.

## Verifying Changes
Create a Dynamic Scene
Manually Delete the Sceen Root Entity
Open the scene in Storybook and observe the error message
![Screenshot 2024-05-23 at 11 57 24 AM](https://github.com/awslabs/iot-app-kit/assets/109186219/06eccce7-8794-44c1-8561-10fa7bb38d48)


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
