### PR TITLE
fix: anomaly data filter

### DIFF
--- a/packages/react-components/src/components/anomaly-chart/tests/mockDataSources.ts
+++ b/packages/react-components/src/components/anomaly-chart/tests/mockDataSources.ts
@@ -11,6 +11,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
     data: [
       {
         timestamp: 1714909732438,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -40,6 +41,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714419170826,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -69,6 +71,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714578429305,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -98,6 +101,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714643198943,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -127,6 +131,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714480555677,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -156,6 +161,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714411937923,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -185,6 +191,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714627287904,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -214,6 +221,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714999072631,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -243,6 +251,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714628340330,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -272,6 +281,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714731287864,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -301,6 +311,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714822944244,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -330,6 +341,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714933880365,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -359,6 +371,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714632308567,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -388,6 +401,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714757072072,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -417,6 +431,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714455343258,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -446,6 +461,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714409979348,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -475,6 +491,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714459669203,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -504,6 +521,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714511393770,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -533,6 +551,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714464450991,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',
@@ -562,6 +581,7 @@ export const MOCK_DATA_SOURCE_SUCCESS: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1714660199070,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Average Power',

--- a/packages/react-components/src/data/dataSourceLoader/dataSourceLoader.spec.ts
+++ b/packages/react-components/src/data/dataSourceLoader/dataSourceLoader.spec.ts
@@ -14,6 +14,7 @@ const validAnomalyObjectDataSource: AnomalyObjectDataSource = {
     data: [
       {
         timestamp: 1711078622000,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Diagnostic Name 1',
@@ -31,6 +32,7 @@ const validAnomalyObjectDataSource: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1711165022000,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Diagnostic Name 1',

--- a/packages/react-components/src/data/transformers/anomaly/object/input.ts
+++ b/packages/react-components/src/data/transformers/anomaly/object/input.ts
@@ -14,6 +14,7 @@ export type Diagnostics = Diagnostic[];
 
 export type AnomalyObjectDataInput = {
   timestamp: number;
+  prediction: number;
   diagnostics: Diagnostics;
 }[];
 

--- a/packages/react-components/src/data/transformers/anomaly/object/transformer.spec.ts
+++ b/packages/react-components/src/data/transformers/anomaly/object/transformer.spec.ts
@@ -11,6 +11,7 @@ const validDataSource: AnomalyObjectDataSource = {
     data: [
       {
         timestamp: 1711078622000,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Diagnostic Name 1',
@@ -28,6 +29,7 @@ const validDataSource: AnomalyObjectDataSource = {
       },
       {
         timestamp: 1711165022000,
+        prediction: 1,
         diagnostics: [
           {
             name: 'Diagnostic Name 1',
@@ -46,6 +48,54 @@ const validDataSource: AnomalyObjectDataSource = {
     ],
   },
 };
+
+const validDataSourceDataTypesWithOneAnomalousDataPoint: AnomalyObjectDataSource =
+  {
+    state: 'success',
+    value: {
+      styles: {
+        color: ['pink'],
+      },
+      data: [
+        {
+          timestamp: 1711078622000,
+          prediction: 0,
+          diagnostics: [
+            {
+              name: 'Diagnostic Name 1',
+              value: 0.25,
+            },
+            {
+              name: 'Diagnostic Name 2',
+              value: 0.25,
+            },
+            {
+              name: 'Diagnostic Name 3',
+              value: 0.5,
+            },
+          ],
+        },
+        {
+          timestamp: 1711165022000,
+          prediction: 1,
+          diagnostics: [
+            {
+              name: 'Diagnostic Name 1',
+              value: 0.25,
+            },
+            {
+              name: 'Diagnostic Name 2',
+              value: 0.25,
+            },
+            {
+              name: 'Diagnostic Name 3',
+              value: 0.5,
+            },
+          ],
+        },
+      ],
+    },
+  };
 
 const invalidDataSourcePropertyNames: DataSource = {
   state: 'success',
@@ -143,5 +193,15 @@ describe('Anomaly Object transformer', () => {
         ]),
       })
     );
+  });
+
+  it('does not include points that are not anomalous', () => {
+    const transformer = new AnomalyObjectDataSourceTransformer();
+
+    const transformedData = transformer.transform(
+      validDataSourceDataTypesWithOneAnomalousDataPoint
+    );
+
+    expect(transformedData).toBeArrayOfSize(1);
   });
 });

--- a/packages/react-components/stories/anomaly/mockData.ts
+++ b/packages/react-components/stories/anomaly/mockData.ts
@@ -58,6 +58,7 @@ export const mockDatasource: AnomalyObjectDataSource = {
   value: {
     data: times.map((t) => ({
       timestamp: t,
+      prediction: 1,
       diagnostics: BaseAnomalyResult.value.diagnostics.map((d) => ({
         id: d.name,
         name: d.name,


### PR DESCRIPTION
## Overview
It is possible for there to be data points where no anomaly was detected, but where it has an anomaly score with diagnostics. We are specifically removing these points from the dataset as we do not have a UI to support displaying these types of points.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
