### PR TITLE
chore: add dataType to RE

### DIFF
--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/use-asset-properties/use-asset-property-search.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/use-asset-properties/use-asset-property-search.ts
@@ -23,7 +23,7 @@ export function useAssetPropertySearch({
 }: UseAssetPropertySearchOptions): UseAssetPropertySearchResult {
   const executeQueryParameters = parameters.map(({ searchStatement }) => {
     const queryStatement = `
-      SELECT p.property_id, p.property_name, p.asset_id, p.property_alias
+      SELECT p.property_id, p.property_name, p.asset_id, p.property_alias, p.property_data_type
       FROM asset_property p
       WHERE p.property_name LIKE '%${searchStatement}%'
     `;
@@ -47,6 +47,7 @@ export function useAssetPropertySearch({
               { scalarValue?: string },
               { scalarValue?: string },
               { scalarValue?: string },
+              { scalarValue?: string },
               { scalarValue?: string }
             ];
           };
@@ -56,7 +57,7 @@ export function useAssetPropertySearch({
             name: searchResult.data[1].scalarValue ?? '',
             assetId: searchResult.data[2].scalarValue ?? '',
             alias: searchResult.data[3].scalarValue ?? undefined,
-            dataType: '',
+            dataType: searchResult.data[4].scalarValue ?? '',
           } satisfies AssetPropertyResource;
 
           return assetProperty;

--- a/packages/react-components/src/components/resource-explorers/testing/table-variant/asset-property-table.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/table-variant/asset-property-table.spec.tsx
@@ -378,7 +378,7 @@ describe('asset property table', () => {
       // White space is removed to match
       expect(queryStatement.replace(/\s/g, '')).toEqual(
         `
-          SELECT p.property_id, p.property_name, p.asset_id, p.property_alias
+          SELECT p.property_id, p.property_name, p.asset_id, p.property_alias, p.property_data_type
           FROM asset_property p
           WHERE p.property_name LIKE '%Asset Property%'
         `.replace(/\s/g, '')
@@ -392,6 +392,7 @@ describe('asset property table', () => {
           { scalarValue: 'Asset Property 1' },
           { scalarValue: 'asset-id-1' },
           { scalarValue: 'alias-1' },
+          { scalarValue: 'STRING' },
         ],
       };
       const assetPropertyRow2 = {
@@ -400,6 +401,7 @@ describe('asset property table', () => {
           { scalarValue: 'Asset Property 2' },
           { scalarValue: 'asset-id-2' },
           { scalarValue: 'alias-2' },
+          { scalarValue: 'INTEGER' },
         ],
       };
       const assetPropertyRow3 = {
@@ -408,6 +410,7 @@ describe('asset property table', () => {
           { scalarValue: 'Asset Property 3' },
           { scalarValue: 'asset-id-3' },
           { scalarValue: 'alias-3' },
+          { scalarValue: 'DOUBLE' },
         ],
       };
 
@@ -464,6 +467,16 @@ describe('asset property table', () => {
       expect(
         screen.queryByText(assetPropertyRow3.data[3].scalarValue)
       ).not.toBeInTheDocument();
+      // DataType is rendered by default
+      expect(
+        screen.queryByText(assetPropertyRow1.data[4].scalarValue)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(assetPropertyRow2.data[4].scalarValue)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(assetPropertyRow3.data[4].scalarValue)
+      ).toBeInTheDocument();
     });
 
     it('supports searching for asset properties with parameters', async () => {
@@ -473,6 +486,7 @@ describe('asset property table', () => {
           { scalarValue: 'Asset Property 1' },
           { scalarValue: 'asset-id-1' },
           { scalarValue: 'alias-1' },
+          { scalarValue: 'STRING' },
         ],
       };
       const assetPropertyRow2 = {
@@ -481,6 +495,7 @@ describe('asset property table', () => {
           { scalarValue: 'Asset Property 2' },
           { scalarValue: 'asset-id-2' },
           { scalarValue: 'alias-2' },
+          { scalarValue: 'INTEGER' },
         ],
       };
       const assetPropertyRow3 = {
@@ -489,6 +504,7 @@ describe('asset property table', () => {
           { scalarValue: 'Asset Property 3' },
           { scalarValue: 'asset-id-3' },
           { scalarValue: 'alias-3' },
+          { scalarValue: 'DOUBLE' },
         ],
       };
 
@@ -545,6 +561,16 @@ describe('asset property table', () => {
       expect(
         screen.queryByText(assetPropertyRow3.data[3].scalarValue)
       ).not.toBeInTheDocument();
+      // DataType is rendered by default
+      expect(
+        screen.queryByText(assetPropertyRow1.data[4].scalarValue)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(assetPropertyRow2.data[4].scalarValue)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(assetPropertyRow3.data[4].scalarValue)
+      ).toBeInTheDocument();
     });
 
     it('initiates search when user presses enter/return key', async () => {


### PR DESCRIPTION
## Overview
Adding `property_data_type` to SW executeQuery query to allow for check for unsupported types when adding to widget.

## Verifying Changes
![Screenshot 2024-05-29 at 2 43 08 PM](https://github.com/awslabs/iot-app-kit/assets/145582655/3c7126a0-2582-469d-97c4-f268f97de283)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
