### PR TITLE
feat(dashboard): move dashboard migration utility to app-kit

### DIFF
--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -8,6 +8,7 @@ import type {
   DashboardClientConfiguration,
   DashboardWidget,
 } from './types';
+import { migrateDashboard } from './migration/convert-monitor-to-app-defintion';
 
 export {
   Dashboard,
@@ -18,4 +19,5 @@ export {
   DashboardDisplaySettings,
   DashboardClientConfiguration,
   DashboardWidget,
+  migrateDashboard,
 };

--- a/packages/dashboard/src/migration/constants.ts
+++ b/packages/dashboard/src/migration/constants.ts
@@ -1,0 +1,83 @@
+export const defaultDisplaySettings = {
+  numRows: 100,
+  numColumns: 100,
+  cellSize: 10,
+  significantDigits: 4,
+};
+export const defaultResolution = '1m';
+export const defaultAggregationType = 'AVERAGE';
+
+/**
+ * Default Monitor size is 3x3 squares
+ * A similar sized application dashboard is 42x24 cells (if cellSize = 20)
+ */
+export const appCellsPerMonitorSquareWidth = 14; // 42 / 3
+export const appCellPerMonitorSquareHeight = 8; // 24 / 3
+
+export const minWidth = appCellsPerMonitorSquareWidth - 0.5;
+export const minHeight = appCellPerMonitorSquareHeight - 0.5;
+
+const defaultProperties = {
+  aggregationType: defaultAggregationType,
+};
+
+export const barChartProperties = {
+  ...defaultProperties,
+  axis: {
+    showY: true,
+    showX: true,
+  },
+};
+
+export const lineChartProperties = {
+  ...defaultProperties,
+  axis: {
+    yVisible: true,
+    xVisible: true,
+  },
+  symbol: {
+    style: 'filled-circle',
+  },
+  line: {
+    connectionStyle: 'linear',
+    style: 'solid',
+  },
+  legend: {
+    width: '30%',
+    visibleContent: {
+      unit: true,
+      latestValue: true,
+      minValue: false,
+      asset: true,
+      maxValue: false,
+    },
+    visible: true,
+    position: 'right',
+    height: '30%',
+  },
+};
+
+export const scatterChartProperties = {
+  ...defaultProperties,
+  axis: {
+    yVisible: true,
+    xVisible: true,
+  },
+  symbol: {
+    style: 'filled-circle',
+  },
+  line: {
+    connectionStyle: 'none',
+    style: 'solid',
+  },
+  legend: {
+    visible: true,
+  },
+};
+
+export const timelineProperties = {
+  axis: {
+    showY: true,
+    showX: true,
+  },
+};

--- a/packages/dashboard/src/migration/convert-monitor-to-app-defintion.spec.ts
+++ b/packages/dashboard/src/migration/convert-monitor-to-app-defintion.spec.ts
@@ -1,0 +1,866 @@
+import {
+  DashboardWidgetType,
+  MonitorAnnotations,
+  MonitorMetric,
+  MonitorWidgetType,
+  SiteWiseMonitorDashboardDefinition,
+} from './types';
+import { migrateDashboard } from './convert-monitor-to-app-defintion';
+
+const createMonitorChartWidget = (
+  widgetType: MonitorWidgetType,
+  metrics: MonitorMetric[],
+  annotations?: MonitorAnnotations,
+  title?: string,
+  x?: number,
+  y?: number
+) => {
+  return {
+    type: widgetType,
+    title: title ?? 'test',
+    x: x ?? 0,
+    y: y ?? 0,
+    height: 3,
+    width: 3,
+    metrics,
+    alarms: [],
+    properties: {
+      colorDataAcrossThresholds: true,
+    },
+    annotations,
+  };
+};
+
+const createApplicationChartDefinition = (
+  widgetType: string,
+  properties: object,
+  height = 23.5,
+  width = 41.5,
+  x = 0,
+  y = 0,
+  z = 0
+) => {
+  return {
+    type: widgetType,
+    x,
+    y,
+    z,
+    width,
+    height,
+    properties,
+  };
+};
+
+describe('Dashboard definition conversion', () => {
+  it('converts a single SiteWise Monitor line chart into an application line chart', async () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+    const lineChartDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [createMonitorChartWidget(MonitorWidgetType.LineChart, metrics)],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      symbol: {
+        style: 'filled-circle',
+      },
+      axis: {
+        yVisible: true,
+        xVisible: true,
+      },
+      line: {
+        connectionStyle: 'linear',
+        style: 'solid',
+      },
+      legend: {
+        visible: true,
+      },
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  aggregationType: 'AVERAGE',
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '1m',
+                  color: '#7d2105',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const expectedDefinition = {
+      widgets: [
+        createApplicationChartDefinition('xy-plot', expectedProperties),
+      ],
+    };
+
+    const describeDashboard = jest.fn().mockResolvedValue({
+      dashboardDefinition: JSON.stringify(lineChartDefinition),
+    });
+
+    const applicationDefinition = await migrateDashboard(
+      { dashboardId: 'test-id' },
+      { describeDashboard: describeDashboard }
+    );
+
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('converts a single SiteWise Monitor line chart with multiple properties into an application line chart', async () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+      {
+        type: 'iotsitewise',
+        label: 'Other metric',
+        assetId: '12345678-85db-4c90-854f-4e29d579b898',
+        propertyId: '12345678-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const lineChartDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [createMonitorChartWidget(MonitorWidgetType.LineChart, metrics)],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      symbol: {
+        style: 'filled-circle',
+      },
+      axis: {
+        yVisible: true,
+        xVisible: true,
+      },
+      line: {
+        connectionStyle: 'linear',
+        style: 'solid',
+      },
+      legend: {
+        visible: true,
+      },
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  aggregationType: 'AVERAGE',
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '1m',
+                  color: '#7d2105',
+                },
+              ],
+            },
+            {
+              assetId: '12345678-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  aggregationType: 'AVERAGE',
+                  propertyId: '12345678-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '1m',
+                  color: '#3184c2',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const expectedDefinition = {
+      widgets: [
+        createApplicationChartDefinition(
+          DashboardWidgetType.XYPlot,
+          expectedProperties
+        ),
+      ],
+    };
+
+    const describeDashboard = jest.fn().mockResolvedValue({
+      dashboardDefinition: JSON.stringify(lineChartDefinition),
+    });
+
+    const applicationDefinition = await migrateDashboard(
+      { dashboardId: 'test-id' },
+      { describeDashboard: describeDashboard }
+    );
+
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('convers a single SiteWise Monitor bar chart into an application bar chart', async () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const barChartDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [createMonitorChartWidget(MonitorWidgetType.BarChart, metrics)],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      axis: {
+        showX: true,
+        showY: true,
+      },
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  aggregationType: 'AVERAGE',
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '1m',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      styleSettings: {}, // refId is randomly generated so we are just asserting that styleSettings exists
+    };
+    const expectedDefinition = {
+      widgets: [
+        createApplicationChartDefinition('bar-chart', expectedProperties),
+      ],
+    };
+
+    const describeDashboard = jest.fn().mockResolvedValue({
+      dashboardDefinition: JSON.stringify(barChartDefinition),
+    });
+
+    const applicationDefinition = await migrateDashboard(
+      { dashboardId: 'test-id' },
+      { describeDashboard: describeDashboard }
+    );
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('convers a single SiteWise Monitor scatter chart into an application scatter chart', async () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const lineChartDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [
+        createMonitorChartWidget(MonitorWidgetType.ScatterChart, metrics),
+      ],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      symbol: {
+        style: 'filled-circle',
+      },
+      axis: {
+        yVisible: true,
+        xVisible: true,
+      },
+      line: {
+        connectionStyle: 'none',
+        style: 'solid',
+      },
+      legend: {
+        visible: true,
+      },
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  aggregationType: 'AVERAGE',
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '1m',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const expectedDefinition = {
+      widgets: [
+        createApplicationChartDefinition('xy-plot', expectedProperties),
+      ],
+    };
+    const describeDashboard = jest.fn().mockResolvedValue({
+      dashboardDefinition: JSON.stringify(lineChartDefinition),
+    });
+
+    const applicationDefinition = await migrateDashboard(
+      { dashboardId: 'test-id' },
+      { describeDashboard: describeDashboard }
+    );
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('convers a single SiteWise Monitor timeline chart into an application timeline chart', async () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const timelineChartDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [
+        createMonitorChartWidget(MonitorWidgetType.StatusTimeline, metrics),
+      ],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  aggregationType: 'AVERAGE',
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '0',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      styleSettings: {}, // refId is randomly generated so we are just asserting that styleSettings exists
+    };
+    const expectedDefinition = {
+      widgets: [
+        createApplicationChartDefinition('status-timeline', expectedProperties),
+      ],
+    };
+    const describeDashboard = jest.fn().mockResolvedValue({
+      dashboardDefinition: JSON.stringify(timelineChartDefinition),
+    });
+
+    const applicationDefinition = await migrateDashboard(
+      { dashboardId: 'test-id' },
+      { describeDashboard: describeDashboard }
+    );
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('convers a single SiteWise Monitor table chart into an application table chart', async () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const lineChartDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [createMonitorChartWidget(MonitorWidgetType.Table, metrics)],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  aggregationType: 'AVERAGE',
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '0',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      styleSettings: {}, // refId is randomly generated so we are just asserting that styleSettings exists
+    };
+    const expectedDefinition = {
+      widgets: [createApplicationChartDefinition('table', expectedProperties)],
+    };
+    const describeDashboard = jest.fn().mockResolvedValue({
+      dashboardDefinition: JSON.stringify(lineChartDefinition),
+    });
+
+    const applicationDefinition = await migrateDashboard(
+      { dashboardId: 'test-id' },
+      { describeDashboard: describeDashboard }
+    );
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('convers a single SiteWise Monitor KPI widget into an application KPI', async () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const kpiDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [createMonitorChartWidget(MonitorWidgetType.Kpi, metrics)],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '0',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const expectedDefinition = {
+      widgets: [createApplicationChartDefinition('kpi', expectedProperties)],
+    };
+    const describeDashboard = jest.fn().mockResolvedValue({
+      dashboardDefinition: JSON.stringify(kpiDefinition),
+    });
+
+    const applicationDefinition = await migrateDashboard(
+      { dashboardId: 'test-id' },
+      { describeDashboard: describeDashboard }
+    );
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('convers a SiteWise Monitor KPI widget with many properties into many application KPIs', async () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const kpiDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [createMonitorChartWidget(MonitorWidgetType.Kpi, metrics)],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '0',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const expectedDefinition = {
+      widgets: [
+        createApplicationChartDefinition(
+          'kpi',
+          expectedProperties,
+          7.5,
+          13.5,
+          0,
+          0,
+          0
+        ),
+        createApplicationChartDefinition(
+          'kpi',
+          expectedProperties,
+          7.5,
+          13.5,
+          14,
+          0,
+          1
+        ),
+        createApplicationChartDefinition(
+          'kpi',
+          expectedProperties,
+          7.5,
+          13.5,
+          28,
+          0,
+          2
+        ),
+        createApplicationChartDefinition(
+          'kpi',
+          expectedProperties,
+          7.5,
+          13.5,
+          0,
+          8,
+          3
+        ),
+        createApplicationChartDefinition(
+          'kpi',
+          expectedProperties,
+          7.5,
+          13.5,
+          14,
+          8,
+          4
+        ),
+      ],
+    };
+    const describeDashboard = jest.fn().mockResolvedValue({
+      dashboardDefinition: JSON.stringify(kpiDefinition),
+    });
+
+    const applicationDefinition = await migrateDashboard(
+      { dashboardId: 'test-id' },
+      { describeDashboard: describeDashboard }
+    );
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('convers a single SiteWise Monitor status grid widget into an application status widget', async () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const lineChartDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [
+        createMonitorChartWidget(MonitorWidgetType.StatusGrid, metrics),
+      ],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '0',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const expectedDefinition = {
+      widgets: [createApplicationChartDefinition('status', expectedProperties)],
+    };
+    const describeDashboard = jest.fn().mockResolvedValue({
+      dashboardDefinition: JSON.stringify(lineChartDefinition),
+    });
+
+    const applicationDefinition = await migrateDashboard(
+      { dashboardId: 'test-id' },
+      { describeDashboard: describeDashboard }
+    );
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('converts Monitor annotations into Application thresholds', async () => {
+    const color = '#5e87b5';
+    const comparisonOperator = 'LT';
+    const showValue = true;
+    const value = 100;
+
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const annotations = {
+      y: [
+        {
+          color,
+          comparisonOperator,
+          showValue,
+          value,
+        },
+      ],
+    };
+
+    const lineChartDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [
+        createMonitorChartWidget(
+          MonitorWidgetType.LineChart,
+          metrics,
+          annotations
+        ),
+      ],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      thresholds: [
+        {
+          color,
+          comparisonOperator,
+          value,
+          visible: showValue,
+        },
+      ],
+      symbol: {
+        style: 'filled-circle',
+      },
+      axis: {
+        yVisible: true,
+        xVisible: true,
+      },
+      line: {
+        connectionStyle: 'linear',
+        style: 'solid',
+      },
+      legend: {
+        visible: true,
+      },
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  aggregationType: 'AVERAGE',
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '1m',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const expectedDefinition = {
+      widgets: [
+        createApplicationChartDefinition('xy-plot', expectedProperties),
+      ],
+    };
+
+    const describeDashboard = jest.fn().mockResolvedValue({
+      dashboardDefinition: JSON.stringify(lineChartDefinition),
+    });
+
+    const applicationDefinition = await migrateDashboard(
+      { dashboardId: 'test-id' },
+      { describeDashboard: describeDashboard }
+    );
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+
+  it('Dropping widgets in SWM can cause overlap', async () => {
+    const metrics = [
+      {
+        type: 'iotsitewise',
+        label: 'Total Average Power (Demo Wind Farm Asset)',
+        assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+        propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+        dataType: 'DOUBLE',
+      },
+    ];
+
+    const lineChartDefinition: SiteWiseMonitorDashboardDefinition = {
+      widgets: [
+        createMonitorChartWidget(
+          MonitorWidgetType.LineChart,
+          metrics,
+          undefined,
+          undefined,
+          0,
+          0
+        ),
+        createMonitorChartWidget(
+          MonitorWidgetType.LineChart,
+          metrics,
+          undefined,
+          undefined,
+          1,
+          2
+        ),
+      ],
+    };
+
+    const expectedProperties = {
+      title: 'test',
+      symbol: {
+        style: 'filled-circle',
+      },
+      axis: {
+        yVisible: true,
+        xVisible: true,
+      },
+      line: {
+        connectionStyle: 'linear',
+        style: 'solid',
+      },
+      legend: {
+        visible: true,
+      },
+      queryConfig: {
+        source: 'iotsitewise',
+        query: {
+          properties: [],
+          assets: [
+            {
+              assetId: '3d196ab5-85db-4c90-854f-4e29d579b898',
+              properties: [
+                {
+                  aggregationType: 'AVERAGE',
+                  propertyId: 'c07c2fa5-265e-4ed4-bbf0-e94fe01e4d54',
+                  resolution: '1m',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const expectedDefinition = {
+      widgets: [
+        createApplicationChartDefinition(
+          'xy-plot',
+          expectedProperties,
+          23.5,
+          41.5,
+          0,
+          0,
+          0
+        ),
+        createApplicationChartDefinition(
+          'xy-plot',
+          expectedProperties,
+          23.5,
+          41.5,
+          14,
+          16,
+          1
+        ),
+      ],
+    };
+
+    const describeDashboard = jest.fn().mockResolvedValue({
+      dashboardDefinition: JSON.stringify(lineChartDefinition),
+    });
+
+    const applicationDefinition = await migrateDashboard(
+      { dashboardId: 'test-id' },
+      { describeDashboard: describeDashboard }
+    );
+    expect(applicationDefinition).toMatchObject(expectedDefinition);
+  });
+});

--- a/packages/dashboard/src/migration/convert-monitor-to-app-defintion.ts
+++ b/packages/dashboard/src/migration/convert-monitor-to-app-defintion.ts
@@ -1,0 +1,318 @@
+import {
+  DashboardConfiguration,
+  DashboardWidget,
+  MigrateDashboard,
+} from '../types';
+import {
+  DashboardWidgetType,
+  MonitorWidgetType,
+  MonitorMetric,
+  SiteWiseMonitorDashboardDefinition,
+  MonitorAnnotations,
+  MonitorWidget,
+  QueryConfig,
+  AssetMap,
+} from './types';
+import { nanoid } from 'nanoid';
+import {
+  appCellPerMonitorSquareHeight,
+  appCellsPerMonitorSquareWidth,
+  defaultDisplaySettings,
+  defaultResolution,
+  minHeight,
+  minWidth,
+} from './constants';
+import {
+  getKPIAndGridData,
+  getProperty,
+  getStaticProperties,
+  getStyleSettings,
+} from './getters';
+
+const convertType = (monitorChartType: string) => {
+  switch (monitorChartType) {
+    case MonitorWidgetType.LineChart:
+      return DashboardWidgetType.XYPlot;
+    case MonitorWidgetType.BarChart:
+      return DashboardWidgetType.BarChart;
+    case MonitorWidgetType.ScatterChart:
+      return DashboardWidgetType.XYPlot;
+    case MonitorWidgetType.StatusTimeline:
+      return DashboardWidgetType.StatusTimeline;
+    case MonitorWidgetType.Table:
+      return DashboardWidgetType.Table;
+    case MonitorWidgetType.Kpi:
+      return DashboardWidgetType.Kpi;
+    case MonitorWidgetType.StatusGrid:
+      return DashboardWidgetType.Status;
+    default:
+      return DashboardWidgetType.XYPlot;
+  }
+};
+
+const convertHeight = (height: number) => {
+  // Add some space between widgets by subtracting 0.5
+  return Math.max(height * appCellPerMonitorSquareHeight - 0.5, minHeight);
+};
+
+const convertWidth = (width: number) => {
+  // Add some space between widgets by subtracting 0.5
+  return Math.max(width * appCellsPerMonitorSquareWidth - 0.5, minWidth);
+};
+
+const convertX = (x: number) => {
+  return x * appCellsPerMonitorSquareWidth;
+};
+
+const convertY = (y: number) => {
+  return y * appCellPerMonitorSquareHeight;
+};
+
+export const convertResolution = (
+  widgetType: MonitorWidgetType,
+  resolution?: string
+) => {
+  if (
+    widgetType === MonitorWidgetType.StatusTimeline ||
+    widgetType === MonitorWidgetType.Table
+  ) {
+    // Timeline has resolution set to 0
+    return '0';
+  }
+
+  if (resolution) {
+    if (resolution === 'raw') {
+      return defaultResolution;
+    }
+    return resolution;
+  }
+  return defaultResolution;
+};
+
+const convertThresholds = (monitorAnnotations?: MonitorAnnotations) => {
+  // Annotations are only added to the y axis array in Monitor
+  if (monitorAnnotations?.y) {
+    const applicationThresholds = [];
+    for (const annotation of monitorAnnotations.y) {
+      const newThreshold = {
+        id: nanoid(12),
+        visible: annotation.showValue,
+        color: annotation.color,
+        value: annotation.value,
+        comparisonOperator: annotation.comparisonOperator,
+      };
+      applicationThresholds.push(newThreshold);
+    }
+
+    if (applicationThresholds.length !== 0) {
+      return { thresholds: applicationThresholds };
+    }
+  }
+  return undefined;
+};
+
+const convertMetricsToQueryConfig = (
+  monitorMetrics: MonitorMetric[],
+  widgetType: MonitorWidgetType
+) => {
+  const assetMap: AssetMap = {};
+  const refIds = [];
+
+  for (const [index, metric] of monitorMetrics.entries()) {
+    const property = getProperty(metric, widgetType, index);
+
+    let newProperties = [property];
+    const existingAssetIds = Object.keys(assetMap);
+
+    if (existingAssetIds.includes(metric.assetId)) {
+      const existingProperties = assetMap[metric.assetId];
+      if (existingProperties) {
+        newProperties = [...existingProperties, property];
+      }
+    }
+
+    // Map each assetId to the array of associated properties
+    assetMap[metric.assetId] = newProperties;
+
+    if (property.refId) {
+      refIds.push(property.refId);
+    }
+  }
+
+  const assets = [];
+  const assetIds = Object.keys(assetMap);
+  for (const assetId of assetIds) {
+    const properties = assetMap[assetId];
+    if (properties) {
+      assets.push({ assetId, properties });
+    }
+  }
+
+  const queryConfig: QueryConfig = {
+    queryConfig: {
+      source: 'iotsitewise',
+      query: {
+        properties: [],
+        assets,
+      },
+    },
+  };
+
+  return { queryConfig, refIds };
+};
+
+const convertProperties = (
+  widgetType: MonitorWidgetType,
+  monitorMetrics?: MonitorMetric[],
+  monitorAnnotations?: MonitorAnnotations,
+  monitorTitle?: string
+) => {
+  if (monitorMetrics) {
+    const staticProperties = getStaticProperties(widgetType);
+    const { queryConfig, refIds } = convertMetricsToQueryConfig(
+      monitorMetrics,
+      widgetType
+    );
+    const thresholds = convertThresholds(monitorAnnotations);
+    const styleSettings = getStyleSettings(widgetType, refIds);
+
+    return {
+      ...staticProperties,
+      ...queryConfig,
+      ...thresholds,
+      ...styleSettings,
+      title: monitorTitle,
+    };
+  }
+  return getStaticProperties(widgetType);
+};
+
+const convertKpiAndGridWidget = (
+  monitorWidget: MonitorWidget
+): DashboardWidget[] => {
+  // For each metric in a monitor widget, create an application widget
+  if (monitorWidget.metrics) {
+    const appWidgets = [];
+    const { widgetWidth, widgetHeight, maxXCoord } =
+      getKPIAndGridData(monitorWidget);
+
+    let row = monitorWidget.y;
+    let column = monitorWidget.x;
+
+    const rowLength = widgetHeight;
+    const columnLength = widgetWidth;
+
+    for (const [index, metric] of monitorWidget.metrics.entries()) {
+      const queryConfig: QueryConfig = {
+        queryConfig: {
+          source: 'iotsitewise',
+          query: {
+            properties: [],
+            assets: [
+              {
+                assetId: metric.assetId,
+                properties: [
+                  {
+                    propertyId: metric.propertyId,
+                    resolution: '0',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      };
+
+      const newAppWidget: DashboardWidget = {
+        type: convertType(monitorWidget.type),
+        id: nanoid(12),
+        x: convertX(column),
+        y: convertY(row),
+        z: index, // Stack widgets in case of overlap
+        width: convertWidth(widgetWidth),
+        height: convertHeight(widgetHeight),
+        properties: {
+          primaryFont: {},
+          secondaryFont: {},
+          title: monitorWidget.title,
+          ...queryConfig,
+          showTimestamp: true,
+          showAggregationAndResolution: true,
+          resolution: '0',
+          showUnit: true,
+        },
+      };
+      appWidgets.push(newAppWidget);
+
+      // At end of widget width, reset to row below and start at left-most column
+      if (column >= maxXCoord) {
+        row = row + rowLength;
+        column = monitorWidget.x;
+      } else {
+        column = column + columnLength;
+      }
+    }
+
+    return appWidgets;
+  }
+  return [];
+};
+
+export const convertWidget = (
+  widget: MonitorWidget,
+  index?: number
+): DashboardWidget[] => {
+  // One-to-many relationship for KPI and Status Timeline in Monitor-to-Application conversion
+  if (
+    widget.type === MonitorWidgetType.Kpi ||
+    widget.type === MonitorWidgetType.StatusGrid
+  ) {
+    return convertKpiAndGridWidget(widget);
+  } else {
+    return [
+      {
+        type: convertType(widget.type),
+        id: nanoid(12),
+        x: convertX(widget.x),
+        y: convertY(widget.y),
+        z: index ?? 0, // Stack widgets in case of overlap
+        width: convertWidth(widget.width),
+        height: convertHeight(widget.height),
+        properties: convertProperties(
+          widget.type,
+          widget.metrics,
+          widget.annotations,
+          widget.title
+        ),
+      },
+    ];
+  }
+};
+
+export const migrateDashboard: MigrateDashboard = async (
+  params,
+  requestFns
+) => {
+  const newDashboardDefinition: DashboardConfiguration = {
+    widgets: [],
+    displaySettings: defaultDisplaySettings,
+  };
+  if (params.dashboardId && requestFns && requestFns.describeDashboard) {
+    const response = await requestFns.describeDashboard({
+      dashboardId: params.dashboardId,
+    });
+    const monitorDashboardDefinitionString = response.dashboardDefinition;
+    if (monitorDashboardDefinitionString) {
+      const monitorDashboardDefinition: SiteWiseMonitorDashboardDefinition =
+        JSON.parse(monitorDashboardDefinitionString);
+      if (monitorDashboardDefinition.widgets)
+        for (const [
+          index,
+          widget,
+        ] of monitorDashboardDefinition.widgets.entries()) {
+          newDashboardDefinition.widgets.push(...convertWidget(widget, index));
+        }
+    }
+  }
+  return newDashboardDefinition;
+};

--- a/packages/dashboard/src/migration/types.ts
+++ b/packages/dashboard/src/migration/types.ts
@@ -1,0 +1,103 @@
+export enum DashboardWidgetType {
+  XYPlot = 'xy-plot',
+  LineScatterChart = 'line-scatter-chart',
+  LineChart = 'line-chart',
+  ScatterChart = 'scatter-chart',
+  BarChart = 'bar-chart',
+  Kpi = 'kpi',
+  Status = 'status',
+  StatusTimeline = 'status-timeline',
+  Table = 'table',
+  Text = 'text',
+}
+
+export enum MonitorWidgetType {
+  LineChart = 'sc-line-chart',
+  ScatterChart = 'sc-scatter-chart',
+  BarChart = 'sc-bar-chart',
+  StatusTimeline = 'sc-status-timeline',
+  Kpi = 'sc-kpi',
+  StatusGrid = 'sc-status-grid',
+  Table = 'sc-table',
+}
+
+export interface MonitorTrend {
+  type: string;
+  color: string;
+}
+
+export interface MonitorAnalysis {
+  trends?: string[]; // We don't currently support trend lines but Monitor does
+}
+
+export interface MonitorMetric {
+  type: string;
+  label: string;
+  assetId: string;
+  propertyId: string;
+  dataType: string;
+  resolution?: string;
+  analysis?: MonitorAnalysis;
+}
+
+export interface MonitorAnnotation {
+  color: string;
+  comparisonOperator: string;
+  showValue: boolean;
+  value: number;
+}
+
+export interface MonitorAnnotations {
+  x?: MonitorAnnotation[];
+  y?: MonitorAnnotation[];
+}
+
+export interface MonitorProperties {
+  colorDataAcrossThresholds: boolean;
+}
+
+export interface MonitorWidget {
+  type: MonitorWidgetType;
+  title: string;
+  x: number;
+  y: number;
+  height: number;
+  width: number;
+  properties?: MonitorProperties;
+  metrics?: MonitorMetric[];
+  annotations?: MonitorAnnotations;
+  alarms?: string[]; // We don't currently support alarms but Monitor does
+}
+
+export interface SiteWiseMonitorDashboardDefinition {
+  widgets?: MonitorWidget[];
+}
+
+export interface ApplicationProperty {
+  propertyId: string;
+  aggregationType?: string;
+  resolution?: string;
+  refId?: string;
+  color?: string;
+}
+
+interface ApplicationAsset {
+  assetId: string;
+  properties: ApplicationProperty[];
+}
+
+interface ApplicationQuery {
+  properties: string[];
+  assets: ApplicationAsset[];
+}
+
+interface ApplicationQueryConfig {
+  source: string;
+  query: ApplicationQuery;
+}
+
+export interface QueryConfig {
+  queryConfig: ApplicationQueryConfig;
+}
+
+export type AssetMap = Record<string, ApplicationProperty[]>;

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -1,5 +1,9 @@
 import type { Viewport } from '@iot-app-kit/core';
-import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import {
+  IoTSiteWiseClient,
+  DescribeDashboardRequest,
+  DescribeDashboardResponse,
+} from '@aws-sdk/client-iotsitewise';
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
 import type { AwsCredentialIdentity, Provider } from '@aws-sdk/types';
 import {
@@ -107,3 +111,30 @@ export type PickRequiredOptional<
   TRequired extends keyof T,
   TOptional extends keyof T
 > = Pick<T, TRequired> & RecursivePartial<Pick<T, TOptional>>;
+
+export type RequestTimeout = number;
+
+/** First-class function used to send requests to AWS. */
+export type RequestFunction<Request, Response> = (
+  request: Request,
+  options?: {
+    abortSignal?: AbortSignal;
+    requestTimeout?: RequestTimeout;
+  }
+) => PromiseLike<Response>;
+
+/**
+ * First-class function for requesting IoT SiteWise asset model summary
+ * resources from AWS.
+ *
+ * @see {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DescribeDashboard.html}
+ */
+export type DescribeDashboard = RequestFunction<
+  DescribeDashboardRequest,
+  DescribeDashboardResponse
+>;
+
+export type MigrateDashboard = (
+  params: { dashboardId?: string },
+  requestFns?: { describeDashboard?: DescribeDashboard } //request fucntion type for call
+) => Promise<DashboardConfiguration>;


### PR DESCRIPTION
## Overview
Moving over the migration script used by centurion into app-kit so it can be used by multiple consumers.

## Verifying Changes

All tests passing should verify this change.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
