### PR TITLE
fix(DynamicScenes): fix bug to render empty scenes

### DIFF
--- a/packages/scene-composer/src/components/SceneLayers.spec.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.spec.tsx
@@ -177,7 +177,7 @@ describe('SceneLayers', () => {
     await queryFunction();
 
     expect(processQueries as jest.Mock).toBeCalledTimes(1);
-    expect(renderSceneNodesMock).toBeCalledTimes(0);
+    expect(renderSceneNodesMock).toBeCalledTimes(1);
     expect(addMessagesMock).toBeCalledTimes(1);
   });
 });

--- a/packages/scene-composer/src/components/SceneLayers.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.tsx
@@ -39,7 +39,8 @@ export const SceneLayers: React.FC = () => {
   const checkForSceneRootEntity = useCallback(async () => {
     const sceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
     if (sceneMetadataModule) {
-      if (!(await checkIfEntityExists(sceneRootEntityId, sceneMetadataModule))) {
+      const doesRootEntityExist = await checkIfEntityExists(sceneRootEntityId, sceneMetadataModule);
+      if (!doesRootEntityExist) {
         addMessages([
           {
             category: DisplayMessageCategory.Error,
@@ -54,13 +55,15 @@ export const SceneLayers: React.FC = () => {
   }, [sceneRootEntityId, addMessages, formatMessage]);
 
   useEffect(() => {
-    if (nodes.data) {
-      if (nodes.data.length > 0) {
+    const doAsync = async () => {
+      if (nodes.data) {
+        if (nodes.data.length === 0) {
+          await checkForSceneRootEntity();
+        }
         renderSceneNodes(nodes.data);
-      } else {
-        checkForSceneRootEntity();
       }
-    }
+    };
+    doAsync();
   }, [nodes.data, renderSceneNodes, checkForSceneRootEntity]);
 
   return <></>;


### PR DESCRIPTION
## Overview
Had a bug that did not render empty scenes at all - the grid/canvas did not appear.

## Verifying Changes
Verified by copying over the Scene Composer component local build to my local Console build.
Saw that I could interact with new empty scenes, and can add widgets to the scene without issue.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
