### PR TITLE
fix(DynamicScenes): revert detect dynamic scenes missing their root entity

### DIFF
--- a/packages/scene-composer/src/components/SceneLayers.spec.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.spec.tsx
@@ -3,10 +3,8 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import { useQuery } from '@tanstack/react-query';
 
-import { getGlobalSettings } from '../common/GlobalSettings';
 import { accessStore } from '../store';
 import { processQueries } from '../utils/entityModelUtils/processQueries';
-import { checkIfEntityExists } from '../utils/entityModelUtils/sceneUtils';
 import { KnownSceneProperty } from '../interfaces';
 import { LAYER_DEFAULT_REFRESH_INTERVAL } from '../utils/entityModelUtils/sceneLayerUtils';
 import { SceneLayers } from './SceneLayers';
@@ -15,31 +13,19 @@ jest.mock('../utils/entityModelUtils/processQueries', () => ({
   processQueries: jest.fn(),
 }));
 
-jest.mock('../utils/entityModelUtils/sceneUtils', () => ({
-  ... jest.requireActual('../utils/entityModelUtils/sceneUtils'),
-  checkIfEntityExists: jest.fn(),
-}));
-
 jest.mock('@tanstack/react-query', () => ({
   useQuery: jest.fn(),
-}));
-
-jest.mock('../common/GlobalSettings', () => ({
-  getGlobalSettings: jest.fn(() => ({})),
 }));
 
 describe('SceneLayers', () => {
   const renderSceneNodesMock = jest.fn();
   const isViewingMock = jest.fn();
   const getScenePropertyMock = jest.fn();
-  const addMessagesMock = jest.fn();
   const baseState = {
     getSceneProperty: getScenePropertyMock,
     renderSceneNodes: renderSceneNodesMock,
     isViewing: isViewingMock,
-    addMessages: addMessagesMock,
   };
-  const mockSceneMetadataModule = {};
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -159,25 +145,5 @@ describe('SceneLayers', () => {
     expect(processQueries as jest.Mock).toBeCalledTimes(1);
     expect(renderSceneNodesMock).toBeCalledTimes(1);
     expect(renderSceneNodesMock).toBeCalledWith(['random']);
-  });
-
-  it('should detect no Scene Root Entity', async () => {
-    accessStore('default').setState(baseState);
-    const globalSettings = getGlobalSettings as jest.Mock;
-    globalSettings.mockImplementation(() => ({
-      twinMakerSceneMetadataModule: {},
-    }));
-    let queryFunction;
-    (useQuery as jest.Mock).mockImplementation(({ queryFn, ..._ }) => {
-      queryFunction = queryFn;
-      return { data: [] };
-    });
-    (checkIfEntityExists as jest.Mock).mockImplementation(() => { return false});
-    render(<SceneLayers />);
-    await queryFunction();
-
-    expect(processQueries as jest.Mock).toBeCalledTimes(1);
-    expect(renderSceneNodesMock).toBeCalledTimes(1);
-    expect(addMessagesMock).toBeCalledTimes(1);
   });
 });

--- a/packages/scene-composer/src/components/SceneLayers.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.tsx
@@ -1,16 +1,12 @@
-import React, { useCallback, useContext, useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useIntl } from 'react-intl';
 
-import { getGlobalSettings } from '../common/GlobalSettings';
 import { sceneComposerIdContext } from '../common/sceneComposerIdContext';
 import { accessStore } from '../store';
-import { checkIfEntityExists, fetchSceneNodes } from '../utils/entityModelUtils/sceneUtils';
+import { fetchSceneNodes } from '../utils/entityModelUtils/sceneUtils';
 import { KnownSceneProperty } from '../interfaces';
-import { DisplayMessageCategory } from '../store/internalInterfaces';
 
 export const SceneLayers: React.FC = () => {
-  const { formatMessage } = useIntl();
   const sceneComposerId = useContext(sceneComposerIdContext);
   const isViewing = accessStore(sceneComposerId)((state) => state.isViewing());
   const autoUpdateInterval = accessStore(sceneComposerId)(
@@ -22,7 +18,6 @@ export const SceneLayers: React.FC = () => {
   const sceneRootEntityId = accessStore(sceneComposerId)((state) =>
     state.getSceneProperty(KnownSceneProperty.SceneRootEntityId),
   ) as string;
-  const addMessages = accessStore(sceneComposerId)((state) => state.addMessages);
 
   const nodes = useQuery({
     enabled: !!sceneRootEntityId,
@@ -36,35 +31,11 @@ export const SceneLayers: React.FC = () => {
     refetchOnWindowFocus: false,
   });
 
-  const checkForSceneRootEntity = useCallback(async () => {
-    const sceneMetadataModule = getGlobalSettings().twinMakerSceneMetadataModule;
-    if (sceneMetadataModule) {
-      const doesRootEntityExist = await checkIfEntityExists(sceneRootEntityId, sceneMetadataModule);
-      if (!doesRootEntityExist) {
-        addMessages([
-          {
-            category: DisplayMessageCategory.Error,
-            messageText: formatMessage({
-              description: 'Scene Entity Error',
-              defaultMessage: 'Dynamic Scene is missing root scene entity',
-            }),
-          },
-        ]);
-      }
-    }
-  }, [sceneRootEntityId, addMessages, formatMessage]);
-
   useEffect(() => {
-    const doAsync = async () => {
-      if (nodes.data) {
-        if (nodes.data.length === 0) {
-          await checkForSceneRootEntity();
-        }
-        renderSceneNodes(nodes.data);
-      }
-    };
-    doAsync();
-  }, [nodes.data, renderSceneNodes, checkForSceneRootEntity]);
+    if (nodes.data) {
+      renderSceneNodes(nodes.data);
+    }
+  }, [nodes.data, renderSceneNodes]);
 
   return <></>;
 };

--- a/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
+++ b/packages/scene-composer/translations/IotAppKitSceneComposer.en_US.json
@@ -1299,10 +1299,6 @@
     "note": "Light Type in a dropdown menu",
     "text": "Directional"
   },
-  "ytZC0H": {
-    "note": "Scene Entity Error",
-    "text": "Dynamic Scene is missing root scene entity"
-  },
   "z4V95/": {
     "note": "Expandable Section title",
     "text": "Camera"


### PR DESCRIPTION
## Overview
Reverted the commit: https://github.com/awslabs/iot-app-kit/commit/c56522e05570157552f0df1184d219c14bcdc955

There was a bug where items added/removed from a dynamic scene would disappear. The entities would be updated correctly, but the scene state does not load correctly. 

## Verifying Changes
Verified by copying over the Scene Composer component local build to my local Console build.
Saw that I could add and remove widgets to the scene without issue.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
