### PR TITLE
feat(dashboard): support custom toolbar

### DIFF
--- a/packages/dashboard/src/components/actions/index.tsx
+++ b/packages/dashboard/src/components/actions/index.tsx
@@ -12,20 +12,40 @@ import { DashboardSave } from '~/types';
 import DashboardSettings from './settings';
 import CustomOrangeButton from '../customOrangeButton';
 import { parseViewport } from '~/util/parseViewport';
+import { RefreshRateDropDown } from '../refreshRate/refreshRateDropdown';
+import {
+  colorChartsLineGrid,
+  spaceScaledXs,
+  spaceScaledXxxl,
+  spaceScaledXxxs,
+} from '@cloudscape-design/design-tokens';
 
 const DEFAULT_VIEWPORT = { duration: '10m' };
 
 export type ActionsProps = {
   grid: DashboardState['grid'];
   readOnly: boolean;
+  defaultToolbar?: boolean;
   dashboardConfiguration: DashboardState['dashboardConfiguration'];
   onSave?: DashboardSave;
   editable?: boolean;
 };
 
+const Divider = () => (
+  <div
+    style={{
+      width: spaceScaledXxxs,
+      height: spaceScaledXxxl,
+      margin: `0 ${spaceScaledXs}`,
+      background: colorChartsLineGrid,
+    }}
+  />
+);
+
 const Actions: React.FC<ActionsProps> = ({
   dashboardConfiguration,
   editable,
+  defaultToolbar = true,
   grid,
   readOnly,
   onSave,
@@ -96,9 +116,13 @@ const Actions: React.FC<ActionsProps> = ({
         //eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
       >
-        <SpaceBetween size='s' direction='horizontal'>
-          {onSave && <Button onClick={handleOnSave}>Save</Button>}
-          {editable && (
+        <SpaceBetween size='s' direction='horizontal' alignItems='end'>
+          <RefreshRateDropDown />
+          {editable && <Divider />}
+          {onSave && editable && defaultToolbar && (
+            <Button onClick={handleOnSave}>Save</Button>
+          )}
+          {editable && defaultToolbar && (
             <CustomOrangeButton
               title={readOnly ? 'Edit' : 'Preview'}
               handleClick={handleOnReadOnly}
@@ -109,6 +133,7 @@ const Actions: React.FC<ActionsProps> = ({
               onClick={() => setSettingVisibility(true)}
               iconName='settings'
               variant='icon'
+              data-testid='dashboard-visibility-button'
               ariaLabel='Dashboard settings'
             />
           )}

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -16,6 +16,7 @@ import type {
   DashboardConfiguration,
   DashboardSave,
   ViewportChange,
+  DashboardToolbar,
 } from '~/types';
 import { ClientContext } from './clientContext';
 import { QueryContext } from './queryContext';
@@ -35,6 +36,7 @@ export type DashboardProperties = {
   clientConfiguration: DashboardClientConfiguration;
   dashboardConfiguration: DashboardConfiguration;
   edgeMode?: EdgeMode;
+  toolbar?: DashboardToolbar;
   initialViewMode?: 'preview' | 'edit';
   name?: string;
   onViewportChange?: ViewportChange;
@@ -48,6 +50,7 @@ const Dashboard: React.FC<DashboardProperties> = ({
   dashboardConfiguration,
   edgeMode = 'disabled',
   initialViewMode,
+  toolbar,
   name,
   currentViewport,
   onViewportChange,
@@ -89,6 +92,7 @@ const Dashboard: React.FC<DashboardProperties> = ({
                   onViewportChange={debounceOnViewportChange}
                 >
                   <InternalDashboard
+                    toolbar={toolbar}
                     onSave={onSave}
                     editable={true}
                     name={name}

--- a/packages/dashboard/src/components/dashboard/view.test.tsx
+++ b/packages/dashboard/src/components/dashboard/view.test.tsx
@@ -32,6 +32,6 @@ it('renders', function () {
   );
 
   expect(queryByText(/component library/i)).not.toBeInTheDocument();
-  expect(queryByTestId(/dashboard-actions/i)).not.toBeInTheDocument();
+  expect(queryByTestId(/dashboard-visibility-button/i)).not.toBeInTheDocument();
   expect(queryByTestId(/time-selection/i)).toBeInTheDocument();
 });

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -47,7 +47,12 @@ import { useGestures } from './gestures';
 import { useKeyboardShortcuts } from './keyboardShortcuts';
 
 import { DefaultDashboardMessages } from '~/messages';
-import type { DashboardSave, Position, DashboardWidget } from '~/types';
+import type {
+  DashboardSave,
+  Position,
+  DashboardWidget,
+  DashboardToolbar,
+} from '~/types';
 import type { ContextMenuProps } from '../contextMenu';
 import type { DropEvent, GesturableGridProps } from '../grid';
 import type { WidgetsProps } from '../widgets/list';
@@ -63,6 +68,7 @@ import '@iot-app-kit/components/styles.css';
 import './index.css';
 import { useDashboardViewport } from '~/hooks/useDashboardViewport';
 import { parseViewport } from '~/util/parseViewport';
+import Actions from '../actions';
 
 type InternalDashboardProperties = {
   onSave?: DashboardSave;
@@ -71,6 +77,7 @@ type InternalDashboardProperties = {
   propertiesPanel?: ReactNode;
   defaultViewport?: Viewport;
   currentViewport?: Viewport;
+  toolbar?: DashboardToolbar;
 };
 
 const defaultUserSelect: CSSProperties = { userSelect: 'initial' };
@@ -82,6 +89,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
   name,
   propertiesPanel,
   currentViewport,
+  toolbar,
 }) => {
   const { iotSiteWiseClient, iotTwinMakerClient } = useClients();
   /**
@@ -285,12 +293,10 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
       disableOverlap
       header={
         <DashboardHeader
-          name={name}
           editable={editable}
-          readOnly={readOnly}
-          dashboardConfiguration={dashboardConfiguration}
-          grid={grid}
+          toolbar={toolbar}
           onSave={onSave}
+          name={name}
         />
       }
     >
@@ -311,9 +317,27 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
           //eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
           tabIndex={0}
         >
-          <Box float='left' padding='s'>
+          <div
+            style={{
+              padding: '12px',
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
             <ComponentPalette onAddWidget={onAddWidgetFromPalette} />
-          </Box>
+            {toolbar && (
+              <Actions
+                key='3'
+                defaultToolbar={false}
+                readOnly={readOnly}
+                dashboardConfiguration={dashboardConfiguration}
+                grid={grid}
+                editable={editable}
+              />
+            )}
+          </div>
         </div>
         <ResizablePanes
           leftPane={
@@ -349,12 +373,10 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
       disableOverlap
       header={
         <DashboardHeader
-          name={name}
           editable={editable}
-          readOnly={readOnly}
-          dashboardConfiguration={dashboardConfiguration}
-          grid={grid}
+          toolbar={toolbar}
           onSave={onSave}
+          name={name}
         />
       }
     >

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -14,6 +14,7 @@ import {
 } from '@iot-app-kit/source-iotsitewise';
 import { RefreshRate } from './components/refreshRate/types';
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
+import { ReactElement } from 'react';
 
 export type DashboardClientCredentials = {
   awsCredentials: AwsCredentialIdentity | Provider<AwsCredentialIdentity>;
@@ -140,3 +141,13 @@ export type MigrateDashboard = (options: {
   parameters: { dashboardId: string };
   iotSiteWiseClient: { describeDashboard: DescribeDashboard };
 }) => Promise<DashboardConfiguration>;
+
+export type DashboardToolbar = ({
+  viewmode,
+  viewport,
+  dashboardConfiguration,
+}: {
+  viewmode: 'preview' | 'edit';
+  dashboardConfiguration: DashboardConfiguration;
+  viewport?: Viewport;
+}) => ReactElement;

--- a/packages/dashboard/stories/dashboard/mocked-dashboard-custom-toolbar.stories.tsx
+++ b/packages/dashboard/stories/dashboard/mocked-dashboard-custom-toolbar.stories.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { Viewport, registerPlugin } from '@iot-app-kit/core';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import Dashboard, { DashboardProperties } from '../../src/components/dashboard';
+import {
+  DashboardClientConfiguration,
+  DashboardConfiguration,
+} from '../../src/types';
+import { DEFAULT_REGION } from '~/msw/constants';
+import { useWorker } from '~/msw/useWorker';
+import { RefreshRate } from '~/components/refreshRate/types';
+
+/**
+ * Data is mocked by the service worker started above.
+ * No need for real credentials, but the region must match.
+ */
+const clientConfiguration: DashboardClientConfiguration = {
+  awsCredentials: {
+    accessKeyId: '',
+    secretAccessKey: '',
+  },
+  awsRegion: DEFAULT_REGION,
+};
+
+const displaySettings = {
+  numColumns: 100,
+  numRows: 100,
+};
+
+const defaultViewport = { duration: '10m' };
+const querySettings = { refreshRate: 5000 as RefreshRate };
+
+const emptyDashboardConfiguration: DashboardProperties = {
+  clientConfiguration,
+  dashboardConfiguration: {
+    displaySettings,
+    defaultViewport,
+    widgets: [],
+    querySettings,
+  },
+  onSave: () => Promise.resolve(),
+};
+
+registerPlugin('metricsRecorder', {
+  provider: () => ({
+    record: (...args) => console.log('record metric:', ...args),
+  }),
+});
+
+export default {
+  title: 'Dashboard/Mocked data with Custom Toolbar',
+  component: Dashboard,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  // Applies to all stories under Mocked data
+  decorators: [
+    (Story) => {
+      useWorker();
+      return <Story />;
+    },
+  ],
+} as ComponentMeta<typeof Dashboard>;
+
+export const Empty: ComponentStory<typeof Dashboard> = () => {
+  const [viewmode, setViewmode] = useState<'edit' | 'preview'>('edit');
+
+  const customToolbar = ({
+    viewmode,
+  }: {
+    viewmode: 'preview' | 'edit';
+    dashboardConfiguration: DashboardConfiguration;
+    viewport?: Viewport;
+  }) => {
+    return (
+      <div
+        style={{
+          color: 'pink',
+          fontWeight: 'bold',
+          height: '20px',
+          padding: '20px',
+          display: 'flex',
+          justifyContent: 'space-between',
+        }}
+      >
+        {viewmode === 'edit'
+          ? 'CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨ CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨CUSTOM TOOLBAR IN EDIT MODE! ✨✨✨✨'
+          : 'CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️CUSTOM TOOLBAR IN VIEW MODE ❤️❤️❤️❤️❤️'}
+        <button
+          onClick={() => setViewmode(viewmode === 'edit' ? 'preview' : 'edit')}
+        >
+          Change viewmode
+        </button>
+      </div>
+    );
+  };
+
+  return (
+    <Dashboard
+      {...emptyDashboardConfiguration}
+      initialViewMode={viewmode}
+      toolbar={customToolbar}
+    />
+  );
+};


### PR DESCRIPTION
## Overview
Users can now pass in their own toolbar render function which will replace the default toolbar. This will allow users to provide their own on save button, date picker, and viewmode switcher

the custom toolbar will be rendered in the same area as the default toolbar

video: custom toolbar and viewmode change button & showing a different dashbaord w default toolbar 

https://github.com/awslabs/iot-app-kit/assets/28601414/e6f1d514-fe90-4d01-af85-b7ff39fb5273




## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
