### PR TITLE
fix(dashboard): migration migrates custom name for properties

### DIFF
--- a/packages/dashboard/src/migration/convert-monitor-to-app-defintion.ts
+++ b/packages/dashboard/src/migration/convert-monitor-to-app-defintion.ts
@@ -309,7 +309,14 @@ export const migrateDashboard: MigrateDashboard = async ({
     const monitorDashboardDefinitionString = response.dashboardDefinition;
     if (monitorDashboardDefinitionString) {
       const monitorDashboardDefinition: SiteWiseMonitorDashboardDefinition =
-        JSON.parse(monitorDashboardDefinitionString);
+        JSON.parse(
+          // sitewise dashboards with custom property names add a new line to the end of the string,
+          // which was erroring in JSON.parse. ex: "label":"Custom Name\n" would throw the error
+          // "JSON.parse: bad control character in string literal"
+
+          // eslint-disable-next-line no-control-regex
+          monitorDashboardDefinitionString.replace(/[\u0000-\u0019]+/g, '')
+        );
       if (monitorDashboardDefinition.widgets) {
         // run collision algorithm to remove overlaps
         monitorDashboardDefinition.widgets = removeCollisions(

--- a/packages/dashboard/src/migration/getters.ts
+++ b/packages/dashboard/src/migration/getters.ts
@@ -1,5 +1,5 @@
 import { colorPalette } from '@iot-app-kit/core-util';
-import { randomUUID } from 'crypto';
+import { v4 as uuid } from 'uuid';
 import {
   barChartProperties,
   defaultAggregationType,
@@ -40,6 +40,7 @@ export const getProperty = (
   let property: ApplicationProperty = {
     aggregationType: defaultAggregationType, // Monitor has no aggregationType and appliation defaults to AVERAGE
     propertyId: metric.propertyId,
+    name: metric.label,
     resolution: convertResolution(widgetType, metric.resolution),
   };
 
@@ -48,7 +49,7 @@ export const getProperty = (
     widgetType === MonitorWidgetType.StatusTimeline ||
     widgetType === MonitorWidgetType.Table
   ) {
-    const refId = randomUUID();
+    const refId = uuid();
     property = {
       ...property,
       refId,
@@ -57,7 +58,7 @@ export const getProperty = (
     widgetType === MonitorWidgetType.LineChart ||
     widgetType === MonitorWidgetType.ScatterChart
   ) {
-    const refId = randomUUID();
+    const refId = uuid();
     property = {
       ...property,
       refId,

--- a/packages/dashboard/src/migration/types.ts
+++ b/packages/dashboard/src/migration/types.ts
@@ -79,6 +79,7 @@ export interface ApplicationProperty {
   resolution?: string;
   refId?: string;
   color?: string;
+  name?: string;
 }
 
 interface ApplicationAsset {


### PR DESCRIPTION
## Overview
Update migration logic to use `metric.label` as the `property.name`
plus some minor bug fixes

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
