### PR TITLE
feat(dashboard): add on configuration change

### DIFF
--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -4,7 +4,7 @@ import {
   createMockSiteWiseSDK,
 } from '@iot-app-kit/testing-util';
 
-import Dashboard from './index';
+import { DashboardWrapper as Dashboard } from './wrapper';
 import React from 'react';
 import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
@@ -120,7 +120,6 @@ it('passes the correct viewMode to onSave', function () {
       refreshRate: 5000 as RefreshRate,
     },
     widgets: [],
-    viewport: { duration: '5m' },
   };
 
   render(

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { Provider } from 'react-redux';
 import { DndProvider } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
@@ -14,6 +14,7 @@ import { useDashboardPlugins } from '~/customization/api';
 import type {
   DashboardClientConfiguration,
   DashboardConfiguration,
+  DashboardConfigurationChange,
   DashboardSave,
   ViewportChange,
   DashboardToolbar,
@@ -33,6 +34,7 @@ import { debounce } from 'lodash';
 
 export type DashboardProperties = {
   onSave: DashboardSave;
+  onDashboardConfigurationChange?: DashboardConfigurationChange;
   clientConfiguration: DashboardClientConfiguration;
   dashboardConfiguration: DashboardConfiguration;
   edgeMode?: EdgeMode;
@@ -54,6 +56,7 @@ const Dashboard: React.FC<DashboardProperties> = ({
   name,
   currentViewport,
   onViewportChange,
+  onDashboardConfigurationChange,
 }) => {
   useDashboardPlugins();
 
@@ -62,6 +65,7 @@ const Dashboard: React.FC<DashboardProperties> = ({
     : undefined;
 
   const readOnly = initialViewMode && initialViewMode === 'preview';
+
   return (
     <>
       {showFPSMonitor && <FpsView height={50} width={80} />}
@@ -99,6 +103,9 @@ const Dashboard: React.FC<DashboardProperties> = ({
                     propertiesPanel={<PropertiesPanel />}
                     defaultViewport={dashboardConfiguration.defaultViewport}
                     currentViewport={currentViewport}
+                    onDashboardConfigurationChange={
+                      onDashboardConfigurationChange
+                    }
                   />
                 </TimeSync>
               </DndProvider>
@@ -111,4 +118,4 @@ const Dashboard: React.FC<DashboardProperties> = ({
   );
 };
 
-export default Dashboard;
+export default memo(Dashboard);

--- a/packages/dashboard/src/components/dashboard/wrapper.tsx
+++ b/packages/dashboard/src/components/dashboard/wrapper.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useStableDashboardConfiguration } from '~/hooks/useStableDashboardConfiguration';
+import Dashboard, { DashboardProperties } from './index';
+
+export const DashboardWrapper: React.FC<DashboardProperties> = ({
+  onSave,
+  clientConfiguration,
+  dashboardConfiguration,
+  edgeMode = 'disabled',
+  initialViewMode,
+  name,
+  currentViewport,
+  onViewportChange,
+  onDashboardConfigurationChange,
+}) => {
+  /**
+   * The purpose of this component is to ensure that the dashboard configuration
+   * object is stable across onDashboardConfigurationChange events. These events
+   * will occur whenever the internal dashboard congifuration object
+   * changes. As a result, if the user decides to manage their own state,
+   * we want to protect against unnecessary re-renders, and will only
+   * pass a new property to the Dashboard if it is structurally different.
+   */
+  const { stableDashboardConfiguration, onStableDashboardConfigurationChange } =
+    useStableDashboardConfiguration({
+      dashboardConfiguration,
+      onDashboardConfigurationChange,
+    });
+
+  return (
+    <Dashboard
+      onSave={onSave}
+      clientConfiguration={clientConfiguration}
+      dashboardConfiguration={stableDashboardConfiguration}
+      edgeMode={edgeMode}
+      initialViewMode={initialViewMode}
+      name={name}
+      currentViewport={currentViewport}
+      onViewportChange={onViewportChange}
+      onDashboardConfigurationChange={onStableDashboardConfigurationChange}
+    />
+  );
+};

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -52,6 +52,7 @@ import type {
   Position,
   DashboardWidget,
   DashboardToolbar,
+  DashboardConfigurationChange,
 } from '~/types';
 import type { ContextMenuProps } from '../contextMenu';
 import type { DropEvent, GesturableGridProps } from '../grid';
@@ -69,6 +70,7 @@ import './index.css';
 import { useDashboardViewport } from '~/hooks/useDashboardViewport';
 import { parseViewport } from '~/util/parseViewport';
 import Actions from '../actions';
+import { useSyncDashboardConfiguration } from '~/hooks/useSyncDashboardConfiguration';
 
 type InternalDashboardProperties = {
   onSave?: DashboardSave;
@@ -78,6 +80,7 @@ type InternalDashboardProperties = {
   defaultViewport?: Viewport;
   currentViewport?: Viewport;
   toolbar?: DashboardToolbar;
+  onDashboardConfigurationChange?: DashboardConfigurationChange;
 };
 
 const defaultUserSelect: CSSProperties = { userSelect: 'initial' };
@@ -85,13 +88,17 @@ const disabledUserSelect: CSSProperties = { userSelect: 'none' };
 
 const InternalDashboard: React.FC<InternalDashboardProperties> = ({
   onSave,
+  onDashboardConfigurationChange,
   editable,
   name,
   propertiesPanel,
   currentViewport,
   toolbar,
 }) => {
+  useSyncDashboardConfiguration({ onDashboardConfigurationChange });
+
   const { iotSiteWiseClient, iotTwinMakerClient } = useClients();
+
   /**
    * disable user select styles on drag to prevent highlighting of text under the pointer
    */
@@ -332,8 +339,6 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
                 key='3'
                 defaultToolbar={false}
                 readOnly={readOnly}
-                dashboardConfiguration={dashboardConfiguration}
-                grid={grid}
                 editable={editable}
               />
             )}

--- a/packages/dashboard/src/hooks/useStableDashboardConfiguration.ts
+++ b/packages/dashboard/src/hooks/useStableDashboardConfiguration.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import noop from 'lodash/noop';
+import throttle from 'lodash/throttle';
+import isEqual from 'lodash/isEqual';
+import { DashboardConfiguration, DashboardConfigurationChange } from '~/types';
+
+export const useStableDashboardConfiguration = ({
+  dashboardConfiguration,
+  onDashboardConfigurationChange = noop,
+}: {
+  dashboardConfiguration: DashboardConfiguration;
+  onDashboardConfigurationChange?: DashboardConfigurationChange;
+}) => {
+  const [stableDashboardConfiguration, setStableDashboardconfiguration] =
+    useState(dashboardConfiguration);
+
+  const configRef = useRef(dashboardConfiguration);
+
+  const handleDashboardConfigurationChange = useCallback(
+    (dc: DashboardConfiguration) => {
+      onDashboardConfigurationChange(dc);
+      configRef.current = dc;
+    },
+    [onDashboardConfigurationChange, configRef]
+  );
+
+  const onStableDashboardConfigurationChange = useMemo(
+    () => throttle(handleDashboardConfigurationChange, 60, { trailing: true }),
+    [handleDashboardConfigurationChange]
+  );
+
+  useEffect(() => {
+    if (!isEqual(dashboardConfiguration, configRef.current)) {
+      setStableDashboardconfiguration(dashboardConfiguration);
+    }
+  }, [dashboardConfiguration]);
+
+  return {
+    stableDashboardConfiguration,
+    onStableDashboardConfigurationChange,
+  };
+};

--- a/packages/dashboard/src/hooks/useSyncDashboardConfiguration.ts
+++ b/packages/dashboard/src/hooks/useSyncDashboardConfiguration.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import noop from 'lodash/noop';
+import isEqual from 'lodash/isEqual';
+import { DashboardConfigurationChange } from '~/types';
+import { convertToDashboardConfiguration } from '~/util/convertToDashbaoardConfiguration';
+
+export const useSyncDashboardConfiguration = ({
+  onDashboardConfigurationChange = noop,
+}: {
+  onDashboardConfigurationChange?: DashboardConfigurationChange;
+}) => {
+  const mappedDashboardConfiguration = useSelector(
+    convertToDashboardConfiguration,
+    isEqual
+  );
+
+  useEffect(() => {
+    onDashboardConfigurationChange(mappedDashboardConfiguration);
+  }, [onDashboardConfigurationChange, mappedDashboardConfiguration]);
+};

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -1,4 +1,4 @@
-import Dashboard from './components/dashboard';
+import { DashboardWrapper as Dashboard } from './components/dashboard/wrapper';
 import DashboardView from './components/dashboard/view';
 import type { DashboardProperties } from './components/dashboard';
 import type { DashboardViewProperties } from './components/dashboard/view';

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -47,6 +47,10 @@ export type DashboardSave = (
 
 export type ViewportChange = (viewport: Viewport) => void;
 
+export type DashboardConfigurationChange = (
+  dashboardConfiguration: DashboardConfiguration
+) => void;
+
 export type DashboardWidget<
   Properties extends Record<string, unknown> = Record<string, unknown>
 > = {

--- a/packages/dashboard/src/util/convertToDashbaoardConfiguration.ts
+++ b/packages/dashboard/src/util/convertToDashbaoardConfiguration.ts
@@ -1,0 +1,18 @@
+import { DashboardState } from '~/store/state';
+import { DashboardConfiguration } from '~/types';
+import { parseViewport } from './parseViewport';
+
+export const convertToDashboardConfiguration = ({
+  grid,
+  significantDigits,
+  dashboardConfiguration,
+}: DashboardState): DashboardConfiguration => ({
+  displaySettings: {
+    numColumns: grid.width,
+    numRows: grid.height,
+    cellSize: grid.cellSize,
+    significantDigits,
+  },
+  ...dashboardConfiguration,
+  defaultViewport: parseViewport(dashboardConfiguration.defaultViewport),
+});

--- a/packages/dashboard/stories/dashboard/edge-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/edge-dashboard.stories.tsx
@@ -5,13 +5,12 @@ import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import { registerPlugin } from '@iot-app-kit/core';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import Dashboard from '../../src/components/dashboard';
+import { Dashboard, DashboardView } from '../../src';
 
 import {
   DashboardClientConfiguration,
   DashboardConfiguration,
 } from '../../src/types';
-import { DashboardView } from '~/index';
 
 import { getEnvCredentials } from '../../testing/getEnvCredentials';
 import { getEndpoints } from '../../testing/getEndpoints';

--- a/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerPlugin } from '@iot-app-kit/core';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import Dashboard, { DashboardProperties } from '../../src/components/dashboard';
+import { Dashboard, DashboardProperties } from '../../src';
 import { DashboardClientConfiguration } from '../../src/types';
 import { DEFAULT_REGION } from '~/msw/constants';
 import { useWorker } from '~/msw/useWorker';

--- a/packages/dashboard/stories/dashboard/sitewise-dashboard-no-toolbar.stories.tsx
+++ b/packages/dashboard/stories/dashboard/sitewise-dashboard-no-toolbar.stories.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Viewport, registerPlugin } from '@iot-app-kit/core';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import Dashboard from '../../src/components/dashboard';
+import { Dashboard, DashboardView } from '../../src';
 import { REGION } from '../../testing/siteWiseQueries';
 
 import { getEnvCredentials } from '../../testing/getEnvCredentials';
@@ -10,7 +10,6 @@ import {
   DashboardClientConfiguration,
   DashboardConfiguration,
 } from '../../src/types';
-import { DashboardView } from '~/index';
 import {
   DateRangePicker,
   DateRangePickerProps,

--- a/packages/dashboard/stories/dashboard/sitewise-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/sitewise-dashboard.stories.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { registerPlugin } from '@iot-app-kit/core';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import Dashboard from '../../src/components/dashboard';
+import { Dashboard, DashboardView } from '../../src';
 import { REGION } from '../../testing/siteWiseQueries';
 
 import { getEnvCredentials } from '../../testing/getEnvCredentials';
@@ -10,7 +10,6 @@ import {
   DashboardClientConfiguration,
   DashboardConfiguration,
 } from '../../src/types';
-import { DashboardView } from '~/index';
 
 const DASHBOARD_STORAGE_NAMESPACE = 'connected-dashboard';
 
@@ -58,22 +57,33 @@ export const Main: ComponentStory<typeof Dashboard> = () => {
 
   // on save not only updates local storage but forces the dashboard to reload given the updated config
   // this is done to more realistically match the dashboard implementation in iot-application
-  const onSave = async (
-    dashboard: DashboardConfiguration,
-    viewModeOnSave?: 'preview' | 'edit'
-  ) => {
-    viewModeOnSave && setInitialViewMode(viewModeOnSave);
-    window.localStorage.setItem(
-      DASHBOARD_STORAGE_NAMESPACE,
-      JSON.stringify(dashboard)
-    );
-    return new Promise(() => setDashboardConfig(dashboard)) as Promise<void>;
-  };
+  const onSave = useCallback(
+    async (
+      dashboard: DashboardConfiguration,
+      viewModeOnSave?: 'preview' | 'edit'
+    ) => {
+      viewModeOnSave && setInitialViewMode(viewModeOnSave);
+      window.localStorage.setItem(
+        DASHBOARD_STORAGE_NAMESPACE,
+        JSON.stringify(dashboard)
+      );
+      return new Promise(() => setDashboardConfig(dashboard)) as Promise<void>;
+    },
+    [setInitialViewMode, setDashboardConfig]
+  );
+
+  const onDashboardConfigurationChange = useCallback(
+    (dashboard: DashboardConfiguration) => {
+      setDashboardConfig(dashboard);
+    },
+    [setDashboardConfig]
+  );
 
   return (
     <Dashboard
       clientConfiguration={CLIENT_CONFIGURATION}
       onSave={onSave}
+      onDashboardConfigurationChange={onDashboardConfigurationChange}
       initialViewMode={initialViewMode}
       dashboardConfiguration={dashboardConfig}
     />


### PR DESCRIPTION
## Overview
Add new dashboard option that provides a callback for on dashboard configuration change. This allows consumers to manage the configuration object state locally.

Dashboard configuration can be changed in edit mode by modifying the dashboard display settings, the refresh rate, the widgets, or the default viewport. Primarily this is changed by modifying the widget. (Move / Resize / Add / Remove / Add query / Modify properties). 

In order to guard against unnecessary re-renders, this change introduces a wrapper to the dashboard which will track the internal dashboard configuration and the passed in dashboard configuration, and only re-render the dashboard if they are not structurally equal.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
