### PR TITLE
fix: anomaly data zoom

### DIFF
--- a/packages/react-components/src/components/anomaly-chart/constants.ts
+++ b/packages/react-components/src/components/anomaly-chart/constants.ts
@@ -65,6 +65,7 @@ export const ANOMALY_LEGEND_PADDING = [
 export const ANOMALY_BAR_SERIES_CONFIGURATION = {
   barMinWidth: 2,
   barMaxWidth: 10,
+  sampling: 'lttb',
   stack: 'Total',
   type: 'bar',
   animation: false,


### PR DESCRIPTION
## Overview
Fix for 2 bugs related to anomaly chart datazoom
1. bar flickering on tick. To fix this we apply a sampling function when the data density is larger than the pixel size. This ensures that there are not z-index issues when rendering the points.
2. toolbox datazoom does nothing. To fix this, all zoom handling in the datazoom hook is throttled using request animation frame. This ensures the correct ordering of events and allows us to cancel zoom handling that no longer applies.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
