### PR TITLE
fix(dashboard): add apply and cancel buttons to settings modal

### DIFF
--- a/packages/dashboard/src/components/dashboard/viewOnlyWrapper.tsx
+++ b/packages/dashboard/src/components/dashboard/viewOnlyWrapper.tsx
@@ -2,14 +2,12 @@ import React, { useMemo } from 'react';
 import { useStableDashboardConfiguration } from '~/hooks/useStableDashboardConfiguration';
 import DashboardView, { DashboardViewProperties } from './view';
 
-const DEFAULT_DASHBOARD_VIEWPORT = { duration: '10m' };
-
 export const DashboardViewWrapper: React.FC<DashboardViewProperties> = ({
   clientConfiguration,
   dashboardConfiguration,
   edgeMode = 'disabled',
   name,
-  currentViewport = DEFAULT_DASHBOARD_VIEWPORT,
+  currentViewport,
   onViewportChange,
   toolbar,
 }) => {

--- a/packages/dashboard/src/components/dashboard/wrapper.tsx
+++ b/packages/dashboard/src/components/dashboard/wrapper.tsx
@@ -2,8 +2,6 @@ import React, { useMemo } from 'react';
 import { useStableDashboardConfiguration } from '~/hooks/useStableDashboardConfiguration';
 import Dashboard, { DashboardProperties } from './index';
 
-const DEFAULT_DASHBOARD_VIEWPORT = { duration: '10m' };
-
 export const DashboardWrapper: React.FC<DashboardProperties> = ({
   onSave,
   clientConfiguration,
@@ -11,7 +9,7 @@ export const DashboardWrapper: React.FC<DashboardProperties> = ({
   edgeMode = 'disabled',
   initialViewMode,
   name,
-  currentViewport = DEFAULT_DASHBOARD_VIEWPORT,
+  currentViewport,
   onViewportChange,
   toolbar,
   onDashboardConfigurationChange,

--- a/packages/dashboard/src/components/defaultViewport/defaultViewport.tsx
+++ b/packages/dashboard/src/components/defaultViewport/defaultViewport.tsx
@@ -9,11 +9,14 @@ import { Viewport } from '@iot-app-kit/core';
 import React, { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { messages } from './constants';
-import { useDefaultViewport } from './useDefaultViewport';
 
-export const DefaultViewport = () => {
-  const { defaultViewport, onUpdateDefaultViewport } = useDefaultViewport();
-
+export const DefaultViewport = ({
+  defaultViewport,
+  onViewportChange,
+}: {
+  defaultViewport: Viewport;
+  onViewportChange: (viewport: Viewport) => void;
+}) => {
   const { control, setValue, clearErrors } = useForm<{
     defaultViewport: Viewport | undefined;
   }>({
@@ -38,10 +41,8 @@ export const DefaultViewport = () => {
               expandToViewport={true}
               onChange={({ detail: { value } }) => {
                 if (!value) return;
+                onViewportChange(dateRangeToViewport(value));
                 field.onChange(value);
-                onUpdateDefaultViewport(
-                  JSON.stringify(dateRangeToViewport(value))
-                );
               }}
               value={viewportToDateRange(defaultViewport)}
               showClearButton={false}


### PR DESCRIPTION
## Overview
Update the Dashboard Settings Modal to have a `cancel` and `apply changes` button so that updating the grid on the fly doesn't mess up the layout

https://github.com/awslabs/iot-app-kit/assets/28601414/e1603cd6-4844-44af-abad-77349f062c02

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
