### PR TITLE
fix: disable equals and contains operators in gauge thresholds

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/comparisonOperators.ts
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/comparisonOperators.ts
@@ -1,13 +1,17 @@
 import { COMPARISON_OPERATOR } from '@iot-app-kit/core';
 
 export const getComparisonOperators = (
-  { supportsContains }: { supportsContains: boolean } = {
+  {
+    supportsContains,
+    supportsEquals,
+  }: { supportsContains: boolean; supportsEquals: boolean } = {
     supportsContains: false,
+    supportsEquals: true,
   }
 ) => [
   { label: '>', value: COMPARISON_OPERATOR.GT },
   { label: '<', value: COMPARISON_OPERATOR.LT },
-  { label: '=', value: COMPARISON_OPERATOR.EQ },
+  { label: '=', value: COMPARISON_OPERATOR.EQ, disabled: !supportsEquals },
   { label: '>=', value: COMPARISON_OPERATOR.GTE },
   { label: '<=', value: COMPARISON_OPERATOR.LTE },
   {

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/index.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/index.tsx
@@ -11,11 +11,12 @@ import { Maybe, maybeWithDefault } from '~/util/maybe';
 
 const thresholdsWithContainsOperator: readonly string[] = [
   'kpi',
-  'gauge',
   'status',
   'status-timeline',
   'table',
 ];
+// Only gauge has no equals operator, so list thresholds without instead of thresholds with
+const thresholdsWithoutEqualsOperator: readonly string[] = ['gauge'];
 const thresholdsWithAnnotations: readonly string[] = [
   'line-chart',
   'scatter-chart',
@@ -35,6 +36,7 @@ const isSupportedWidget = (w: DashboardWidget): w is ThresholdsWidget => {
   const allSupportedThresholds = [
     ...thresholdsWithAnnotations,
     ...thresholdsWithContainsOperator,
+    ...thresholdsWithoutEqualsOperator,
     ...thresholdsWithStyle,
   ];
   return allSupportedThresholds.some((t) => t === w.type);
@@ -53,6 +55,7 @@ const RenderThresholdsSettings = ({
 
   let doesSupportAnnotations;
   let doesSupportContainsOp;
+  let doesSupportEqualsOp;
   let doesSupportStyledThreshold;
 
   // Support setting thresholds for multiple widgets at once if they fall in the same type category
@@ -63,6 +66,9 @@ const RenderThresholdsSettings = ({
     doesSupportContainsOp = types.every((v) =>
       thresholdsWithContainsOperator.includes(v)
     );
+    doesSupportEqualsOp = !types.every((v) =>
+      thresholdsWithoutEqualsOperator.includes(v)
+    );
     doesSupportStyledThreshold = types.every((v) =>
       thresholdsWithStyle.includes(v)
     );
@@ -71,6 +77,9 @@ const RenderThresholdsSettings = ({
       (t) => t === widgetType
     );
     doesSupportContainsOp = thresholdsWithContainsOperator.some(
+      (t) => t === widgetType
+    );
+    doesSupportEqualsOp = !thresholdsWithoutEqualsOperator.some(
       (t) => t === widgetType
     );
     doesSupportStyledThreshold = thresholdsWithStyle.some(
@@ -94,7 +103,7 @@ const RenderThresholdsSettings = ({
   );
 
   let props = {};
-  if (doesSupportContainsOp) {
+  if (doesSupportContainsOp || !doesSupportEqualsOp) {
     props = {
       thresholds: thresholds,
       updateThresholds: updateThresholds,
@@ -119,6 +128,7 @@ const RenderThresholdsSettings = ({
       widgetType={widgetType}
       comparisonOperators={getComparisonOperators({
         supportsContains: doesSupportContainsOp,
+        supportsEquals: doesSupportEqualsOp,
       })}
       {...props}
     />

--- a/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/thresholdSettings/thresholdsSection.tsx
@@ -224,6 +224,13 @@ const ThresholdsSection: FC<ThresholdsSectionProps> = ({
    * which instructs the user to select a single widget to configure.
    */
   const renderThresholds = () => {
+    let comparisonOperator = 'EQ' as ComparisonOperator;
+
+    // Gauge threshold do not contain EQ
+    if (widgetType === 'gauge') {
+      comparisonOperator = 'GT';
+    }
+
     if (thresholdsEnabled || styledThresholdsEnabled) {
       const thresholdsValue = thresholds
         ? maybeWithDefault([], thresholds) ?? []
@@ -238,7 +245,7 @@ const ThresholdsSection: FC<ThresholdsSectionProps> = ({
           value: '',
           id: nanoid(),
           color: DEFAULT_THRESHOLD_COLOR,
-          comparisonOperator: `EQ`,
+          comparisonOperator: comparisonOperator,
         };
         if (thresholdsEnabled) {
           updateThresholds([...thresholdsValue, newThreshold]);


### PR DESCRIPTION
## Overview
* Currently, gauge widgets allow a threshold to be created using the `=` or `Contains` comparison operators. This was not intended since gauges conceptually don't support these.
   * This change makes `=` and `Contains` operators disabled for gauge widgets. 
   * It also makes the default operator `>` for gauge thresholds since the default for other charts (`=`) is disabled.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/66272633/c3918ac4-8895-4347-817d-aba517d68baf

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
