### PR TITLE
fix(scene-composer): reverting zustand upgrade due to Grafana issues related to zustand, react, r3f

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -191,7 +191,7 @@
     "tslib": "^2.5.3",
     "typescript": "^4.5",
     "zundo": "1.6.0",
-    "zustand": "^4.5.2"
+    "zustand": "^3.7.2"
   },
   "jest": {
     "coverageThreshold": {

--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -330,21 +330,20 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
   // Subscribe to store update
   useEffect(() => {
     if (onSceneUpdated) {
-      return accessStore(sceneComposerId).subscribe((state, old: Pick<RootState, 'document' | 'sceneLoaded'>) => {
-        // Do not call onSceneUpdated when
-        //  - scene is not loaded
-        //  - scene is just loaded
-        //  - document is not changed
-        // Transient document update will also trigger onSceneUpdated, the app side will debounce the actual saving to S3 call.
-        if (!state.sceneLoaded || !old.sceneLoaded || state.document === old.document) {
-          return;
-        }
-        const rootId = state.document.properties?.sceneRootEntityId ?? null;
-        if (rootId) {
-          setSceneRootEntityId(rootId);
-        }
-        onSceneUpdated(sceneDocumentSnapshotCreator.create({ document: state.document }));
-      });
+      return accessStore(sceneComposerId).subscribe(
+        (state, old: Pick<RootState, 'document' | 'sceneLoaded'>) => {
+          // Do not call onSceneUpdated when
+          //  - scene is not loaded
+          //  - scene is just loaded
+          //  - document is not changed
+          // Transient document update will also trigger onSceneUpdated, the app side will debounce the actual saving to S3 call.
+          if (!state.sceneLoaded || !old.sceneLoaded || state.document === old.document) {
+            return;
+          }
+          onSceneUpdated(sceneDocumentSnapshotCreator.create({ document: state.document }));
+        },
+        (state) => ({ document: state.document, sceneLoaded: state.sceneLoaded }),
+      );
     }
   }, [onSceneUpdated]);
 

--- a/packages/scene-composer/src/components/three-fiber/hooks/useProgress.tsx
+++ b/packages/scene-composer/src/components/three-fiber/hooks/useProgress.tsx
@@ -1,4 +1,4 @@
-import { create } from 'zustand';
+import create from 'zustand';
 import { DefaultLoadingManager } from 'three';
 
 import { tmLoadingManagers } from '../../../common/loadingManagers';

--- a/packages/scene-composer/src/store/Store.ts
+++ b/packages/scene-composer/src/store/Store.ts
@@ -1,8 +1,7 @@
-import { create, StateCreator, StoreApi } from 'zustand';
-import { shallow } from 'zustand/shallow';
-import { immer } from 'zustand/middleware/immer';
+import create, { StateCreator, UseStore } from 'zustand';
+import shallow from 'zustand/shallow';
 
-import { log, undoMiddleware, UndoState } from './middlewares';
+import { log, immer, undoMiddleware, UndoState } from './middlewares';
 import { SceneComposerOperation } from './StoreOperations';
 import { createSceneDocumentSlice, ISceneDocumentSlice } from './slices/SceneDocumentSlice';
 import { createEditStateSlice, IEditorStateSlice } from './slices/EditorStateSlice';
@@ -63,33 +62,24 @@ export type RootState = ISharedState &
  * Core state management functions
  * TODO: make them into slices and better organized
  */
+const stateCreator: StateCreator<RootState> = (set, get, api) => ({
+  lastOperation: undefined,
+  ...createSceneDocumentSlice(set, get),
+  ...createEditStateSlice(set, get, api),
+  ...createDataStoreSlice(set, get, api),
+  noHistoryStates: {
+    ...createViewOptionStateSlice(set),
+  },
+  ...createNodeErrorStateSlice(set, get, api),
+});
 
-type StoreState<T> = {
-  (): T;
-  <U>(selector: (state: T) => U): U;
-  <U>(selector: (state: T) => U, equalityFn: (a: U, b: U) => boolean): U;
-} & StoreApi<T>;
-
-const createStateImpl: () => StoreState<RootState> = () =>
-  create<RootState>()(
-    undoMiddleware(
-      log(
-        immer((...args) => ({
-          ...createViewOptionStateSlice(...args),
-          ...createSceneDocumentSlice(...args),
-          ...createEditStateSlice(...args),
-          ...createDataStoreSlice(...args),
-          ...createNodeErrorStateSlice(...args),
-        })) as StateCreator<RootState>,
-      ),
-    ),
-  );
+const createStateImpl: () => UseStore<RootState> = () => create<RootState>(undoMiddleware(log(immer(stateCreator))));
 
 // TODO: currently undoMiddleware will record editor state changes, such as select/deselect object.
 // We may want to fine-tune the undo/redo experience.
-const stores = new Map<string, StoreState<RootState>>();
+const stores = new Map<string, UseStore<RootState>>();
 
-const accessStore = (id: string) => {
+const accessStore: (id: string) => UseStore<RootState> = (id: string) => {
   if (!stores.has(id)) {
     stores.set(id, createStateImpl());
   }

--- a/packages/scene-composer/src/store/middlewares.ts
+++ b/packages/scene-composer/src/store/middlewares.ts
@@ -1,4 +1,4 @@
-import { State, StateCreator, StoreMutatorIdentifier } from 'zustand';
+import { State, StateCreator } from 'zustand';
 import { produce, Draft } from 'immer';
 import createVanilla, { GetState, SetState, StoreApi } from 'zustand/vanilla';
 
@@ -29,20 +29,17 @@ export const log =
 /**
  * Make nested state update simple.
  */
-export type ImmerStateCreator<
-  T,
-  Mps extends [StoreMutatorIdentifier, unknown][] = [],
-  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
-> = StateCreator<T, [...Mps, ['zustand/immer', never]], Mcs>;
-
-export type AppStateCreator = ImmerStateCreator<RootState>;
-
-// Defines the type of a function used to create a slice of the store. The
-// slice has access to all the store's actions and state, but only returns
-// the actions and state necessary for the slice.
-export type SliceCreator<TSlice extends keyof RootState> = (
-  ...params: Parameters<AppStateCreator>
-) => Pick<ReturnType<AppStateCreator>, TSlice>;
+export const immer =
+  <T extends State>(config: StateCreator<T>): StateCreator<T> =>
+  (set, get, api) =>
+    config(
+      (partial, replace) => {
+        const nextState = typeof partial === 'function' ? produce(partial as (state: Draft<T>) => T) : (partial as T);
+        set(nextState, replace);
+      },
+      get,
+      api,
+    );
 
 /**
  * Undo/Redo, inspired by zundo
@@ -135,7 +132,7 @@ export const undoMiddleware =
             redo,
             getUndoState: getState,
             undoStore,
-          } as TState);
+          });
         }
 
         set(args);

--- a/packages/scene-composer/src/store/slices/DataStoreSlice.ts
+++ b/packages/scene-composer/src/store/slices/DataStoreSlice.ts
@@ -1,5 +1,7 @@
+import { GetState, SetState, StoreApi } from 'zustand';
+
 import { IDataInput, IDataBindingTemplate } from '../../interfaces';
-import { SliceCreator } from '../middlewares';
+import { RootState } from '../Store';
 
 export interface IDataStoreSlice {
   dataInput?: IDataInput;
@@ -9,7 +11,11 @@ export interface IDataStoreSlice {
   setDataBindingTemplate: (dataBindingTemplate: IDataBindingTemplate) => void;
 }
 
-export const createDataStoreSlice: SliceCreator<keyof IDataStoreSlice> = (set): IDataStoreSlice => ({
+export const createDataStoreSlice = (
+  set: SetState<RootState>,
+  _get: GetState<RootState>,
+  _api: StoreApi<RootState>,
+): IDataStoreSlice => ({
   dataInput: undefined,
 
   setDataInput: (dataInput) => {

--- a/packages/scene-composer/src/store/slices/EditorStateSlice.ts
+++ b/packages/scene-composer/src/store/slices/EditorStateSlice.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GetState, SetState, StoreApi } from 'zustand';
 
 import { TransformControls } from '../../three/TransformControls';
 import {
@@ -9,10 +10,10 @@ import {
   AddingWidgetInfo,
   CameraSettings,
 } from '../../interfaces';
+import { RootState } from '../Store';
 import { CursorStyle, IDisplayMessage, IEditorConfig } from '../internalInterfaces';
 import { DEFAULT_CAMERA_OPTIONS, DEFAULT_CAMERA_POSITION } from '../../common/constants';
 import { CameraType } from '../../models/SceneModels';
-import { SliceCreator } from '../middlewares';
 
 // The MappingWrapper is used to bypass immer's snapshotting/copy-on-write mechanism
 // Immer will make plain objects immutable which makes it impossible to update without
@@ -153,7 +154,11 @@ function createDefaultEditorState(): Partial<IEditorStateSlice> {
   };
 }
 
-export const createEditStateSlice: SliceCreator<keyof IEditorStateSlice> = (set, get): IEditorStateSlice =>
+export const createEditStateSlice = (
+  set: SetState<RootState>,
+  get: GetState<RootState>,
+  _api: StoreApi<RootState>,
+): IEditorStateSlice =>
   ({
     ...createDefaultEditorState(),
 

--- a/packages/scene-composer/src/store/slices/NodeErrorStateSlice.ts
+++ b/packages/scene-composer/src/store/slices/NodeErrorStateSlice.ts
@@ -1,4 +1,6 @@
-import { SliceCreator } from '../middlewares';
+import { GetState, SetState, StoreApi } from 'zustand';
+
+import { RootState } from '../Store';
 
 export interface INodeErrorStateSlice {
   nodeErrorMap: { [nodeRef: string]: string };
@@ -7,9 +9,10 @@ export interface INodeErrorStateSlice {
   removeNodeError: (nodeRef: string) => void;
 }
 
-export const createNodeErrorStateSlice: SliceCreator<keyof INodeErrorStateSlice> = (
-  set,
-  get,
+export const createNodeErrorStateSlice = (
+  set: SetState<RootState>,
+  get: GetState<RootState>,
+  _api: StoreApi<RootState>,
 ): INodeErrorStateSlice => ({
   nodeErrorMap: {},
 

--- a/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
+++ b/packages/scene-composer/src/store/slices/SceneDocumentSlice.ts
@@ -1,5 +1,6 @@
 import { isDataBindingTemplate } from '@iot-app-kit/source-iottwinmaker';
 import { cloneDeep, isEmpty, isString } from 'lodash';
+import { GetState, SetState } from 'zustand';
 import { ComponentUpdateType } from '@aws-sdk/client-iottwinmaker';
 
 import {
@@ -35,7 +36,6 @@ import { updateEntity } from '../../utils/entityModelUtils/updateNodeEntity';
 import { isDynamicNode, isDynamicScene } from '../../utils/entityModelUtils/sceneUtils';
 import { createNodeEntity } from '../../utils/entityModelUtils/createNodeEntity';
 import { getGlobalSettings } from '../../common/GlobalSettings';
-import { SliceCreator } from '../middlewares';
 import { RESERVED_LAYER_ID } from '../../common/entityModelConstants';
 
 const LOG = new DebugLogger('stateStore');
@@ -99,7 +99,7 @@ function createEmptyDocumentState(): ISceneDocumentInternal {
   };
 }
 
-export const createSceneDocumentSlice: SliceCreator<keyof ISceneDocumentSlice> = (set, get): ISceneDocumentSlice =>
+export const createSceneDocumentSlice = (set: SetState<RootState>, get: GetState<RootState>): ISceneDocumentSlice =>
   ({
     document: createEmptyDocumentState(),
 
@@ -202,7 +202,7 @@ export const createSceneDocumentSlice: SliceCreator<keyof ISceneDocumentSlice> =
               ]);
             });
         } else {
-          appendSceneNode(draft as RootState, node, disableAutoSelect);
+          appendSceneNode(draft, node, disableAutoSelect);
         }
       });
     },
@@ -223,7 +223,7 @@ export const createSceneDocumentSlice: SliceCreator<keyof ISceneDocumentSlice> =
 
     updateSceneNodeInternal: (ref, partial, isTransient, skipEntityUpdate) => {
       set((draft) => {
-        updateSceneNode(draft as RootState, ref, partial, skipEntityUpdate);
+        updateSceneNode(draft, ref, partial, skipEntityUpdate);
 
         draft.lastOperation = isTransient ? 'updateSceneNodeInternalTransient' : 'updateSceneNodeInternal';
       });
@@ -233,7 +233,7 @@ export const createSceneDocumentSlice: SliceCreator<keyof ISceneDocumentSlice> =
       set((draft) => {
         Object.keys(nodesMap).forEach((ref) => {
           const partial = nodesMap[ref];
-          updateSceneNode(draft as RootState, ref, partial, skipEntityUpdate);
+          updateSceneNode(draft, ref, partial, skipEntityUpdate);
         });
 
         draft.lastOperation = isTransient ? 'updateSceneNodeInternalBatchTransient' : 'updateSceneNodeInternalBatch';

--- a/packages/scene-composer/src/store/slices/ViewOptionStateSlice.spec.ts
+++ b/packages/scene-composer/src/store/slices/ViewOptionStateSlice.spec.ts
@@ -1,12 +1,7 @@
 import { ITagSettings, KnownComponentType } from '../../interfaces';
 import { Component } from '../../models/SceneModels';
 
-import { createViewOptionStateSlice as _createViewOptionStateSlice } from './ViewOptionStateSlice';
-
-const createViewOptionStateSlice = (set) => {
-  const { noHistoryStates } = _createViewOptionStateSlice(set);
-  return noHistoryStates;
-};
+import { createViewOptionStateSlice } from './ViewOptionStateSlice';
 
 describe('createViewOptionStateSlice', () => {
   it('should be able to change motion indicator visibility', () => {

--- a/packages/scene-composer/src/store/slices/ViewOptionStateSlice.ts
+++ b/packages/scene-composer/src/store/slices/ViewOptionStateSlice.ts
@@ -1,9 +1,9 @@
+import { SetState } from 'zustand';
 import { Viewport } from '@iot-app-kit/core';
 
 import { ITagSettings, KnownComponentType } from '../../interfaces';
 import { Component } from '../../models/SceneModels';
-import { ISharedState } from '../Store';
-import { SliceCreator } from '../middlewares';
+import { RootState } from '../Store';
 
 export interface IViewOptionStateSlice {
   componentVisibilities: Partial<{
@@ -23,53 +23,50 @@ export interface IViewOptionStateSlice {
   setConnectionNameForMatterportViewer: (connectionName?: string) => void;
 }
 
-export const createViewOptionStateSlice: SliceCreator<keyof ISharedState> = (set): ISharedState => ({
-  lastOperation: undefined,
-  noHistoryStates: {
-    componentVisibilities: {
-      [KnownComponentType.MotionIndicator]: true,
-      [KnownComponentType.Tag]: true,
-      [Component.DataOverlaySubType.TextAnnotation]: true,
-    },
-    tagSettings: undefined,
-    connectionNameForMatterportViewer: undefined,
+export const createViewOptionStateSlice = (set: SetState<RootState>): IViewOptionStateSlice => ({
+  componentVisibilities: {
+    [KnownComponentType.MotionIndicator]: true,
+    [KnownComponentType.Tag]: true,
+    [Component.DataOverlaySubType.TextAnnotation]: true,
+  },
+  tagSettings: undefined,
+  connectionNameForMatterportViewer: undefined,
 
-    setViewport: (viewport) => {
-      set((draft) => {
-        draft.noHistoryStates.viewport = viewport;
-        draft.lastOperation = 'setViewport';
-      });
-    },
-    setDataBindingQueryRefreshRate: (rate) => {
-      set((draft) => {
-        draft.noHistoryStates.dataBindingQueryRefreshRate = rate;
-        draft.lastOperation = 'setDataBindingQueryRefreshRate';
-      });
-    },
-    setAutoQueryEnabled: (autoQueryEnabled) => {
-      set((draft) => {
-        draft.noHistoryStates.autoQueryEnabled = autoQueryEnabled;
-        draft.lastOperation = 'setAutoQueryEnabled';
-      });
-    },
-    toggleComponentVisibility: (componentType) => {
-      set((draft) => {
-        draft.noHistoryStates.componentVisibilities[componentType] =
-          !draft.noHistoryStates.componentVisibilities[componentType];
-        draft.lastOperation = 'toggleComponentVisibility';
-      });
-    },
-    setTagSettings: (settings) => {
-      set((draft) => {
-        draft.noHistoryStates.tagSettings = settings;
-        draft.lastOperation = 'setTagSettings';
-      });
-    },
-    setConnectionNameForMatterportViewer: (connectionName?: string) => {
-      set((draft) => {
-        draft.noHistoryStates.connectionNameForMatterportViewer = connectionName;
-        draft.lastOperation = 'setConnectionNameForMatterportViewer';
-      });
-    },
+  setViewport: (viewport) => {
+    set((draft) => {
+      draft.noHistoryStates.viewport = viewport;
+      draft.lastOperation = 'setViewport';
+    });
+  },
+  setDataBindingQueryRefreshRate: (rate) => {
+    set((draft) => {
+      draft.noHistoryStates.dataBindingQueryRefreshRate = rate;
+      draft.lastOperation = 'setDataBindingQueryRefreshRate';
+    });
+  },
+  setAutoQueryEnabled: (autoQueryEnabled) => {
+    set((draft) => {
+      draft.noHistoryStates.autoQueryEnabled = autoQueryEnabled;
+      draft.lastOperation = 'setAutoQueryEnabled';
+    });
+  },
+  toggleComponentVisibility: (componentType) => {
+    set((draft) => {
+      draft.noHistoryStates.componentVisibilities[componentType] =
+        !draft.noHistoryStates.componentVisibilities[componentType];
+      draft.lastOperation = 'toggleComponentVisibility';
+    });
+  },
+  setTagSettings: (settings) => {
+    set((draft) => {
+      draft.noHistoryStates.tagSettings = settings;
+      draft.lastOperation = 'setTagSettings';
+    });
+  },
+  setConnectionNameForMatterportViewer: (connectionName?: string) => {
+    set((draft) => {
+      draft.noHistoryStates.connectionNameForMatterportViewer = connectionName;
+      draft.lastOperation = 'setConnectionNameForMatterportViewer';
+    });
   },
 });

--- a/packages/scene-composer/tests/utils/objectUtils.spec.ts
+++ b/packages/scene-composer/tests/utils/objectUtils.spec.ts
@@ -1,4 +1,4 @@
-//import * as shallow from 'zustand/shallow';
+import * as shallow from 'zustand/shallow';
 
 import { appendFunction, isObject, mergeDeep, shallowEqualsArray } from '../../src/utils/objectUtils';
 
@@ -29,27 +29,21 @@ describe('objectUtils', () => {
     expect(mergeDeep(a, b, c)).toEqual(expected);
   });
 
-  it('should call zustand shallow when calling shallowEqualsArray', () => {
-    // Remove unnecesary test on counting number of calls on low level library function.
-    // CONTEXT
-    //  Due to break change of zustand from 3.* to 4.*, the following line reached
-    //  compiler error:
-    //    "TypeError: Cannot assign to read only property 'default' of object '[object Object]'"
-
-    //jest.spyOn(shallow, 'default');
+  it('should call zustand shallow expected number of times when calling shallowEqualsArray', () => {
+    jest.spyOn(shallow, 'default');
     const a = { test: 'test' };
     const b = { test: 'test' };
     const c = { test: 'bad' };
 
     expect(shallowEqualsArray([a, b, a, b, a, b, a, b, a, b], [b, a, b, a, b, a, b, a, b, a])).toEqual(true);
 
-    //expect(shallow.default).toBeCalledTimes(10);
+    expect(shallow.default).toBeCalledTimes(10);
 
     expect(shallowEqualsArray([a], undefined as any)).toEqual(false);
     expect(shallowEqualsArray(undefined as any, [b])).toEqual(false);
     expect(shallowEqualsArray([a, b], [a])).toEqual(false);
     expect(shallowEqualsArray([a, b, a], [b, c, a])).toEqual(false);
-    //expect(shallow.default).toBeCalledTimes(12);
+    expect(shallow.default).toBeCalledTimes(12);
   });
 
   it('should append 2 functions with appendFunction', () => {


### PR DESCRIPTION
## Overview
The latest scene viewer panel in Grafana fails to load the scene canvas:
![image (15)](https://github.com/awslabs/iot-app-kit/assets/87385528/638fd408-bc54-49d3-b040-3041d74f27e2)

After digging deeper into this error I found that the latest AppKit version we added to Grafana upgrade zustand from v3 to v4 which uses `useSyncExternalStore` internally. Found a [thread online](https://github.com/pmndrs/zustand/issues/1164) that explained how this version of zustand, along with state from multiple renderers like React and react-three/fiber (r3f) causes issues. 

Since this is breaking existing Grafana customers I downgraded zustand back to v3. This should not introduce any breaking or impactful changes to the consuming packages of the AppKit (TwinMaker Console, Grafana plugin, etc.). Reverting this commit: https://github.com/awslabs/iot-app-kit/pull/2724

## Verifying Changes

1. Tested in storybook - loaded a dynamic scene
2. Tested in Grafana - copied over the dist build of the scene composer and the downgraded version of zustand in the plugin node_modules. Saw a dynamic scene load into the panel successfully.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
