### PR TITLE
fix(dashboard): expand hitbox for widget action buttons

### DIFF
--- a/packages/dashboard/src/components/widgets/widgetActions.tsx
+++ b/packages/dashboard/src/components/widgets/widgetActions.tsx
@@ -112,7 +112,7 @@ const WidgetActions = ({ widget }: { widget: DashboardWidget }) => {
       className='widget-actions-container'
       aria-label='widget-actions-container'
       style={{
-        padding: `${spaceStaticXxxs} ${spaceStaticXs}`,
+        margin: `${spaceStaticXxxs} ${spaceStaticXs}`,
         height: `${spaceStaticXl}`,
         right: `${spaceStaticL}`,
         borderRadius: `${spaceStaticXs}`,
@@ -123,7 +123,6 @@ const WidgetActions = ({ widget }: { widget: DashboardWidget }) => {
     >
       {!isEdgeModeEnabled && widget.type !== 'text' && iotSiteWiseClient && (
         <CSVDownloadButton
-          variant='inline-icon'
           fileName={`${widget.properties.title ?? widget.type}`}
           client={iotSiteWiseClient}
           widgetType={widget.type}
@@ -133,10 +132,7 @@ const WidgetActions = ({ widget }: { widget: DashboardWidget }) => {
         />
       )}
       {!readOnly && (
-        <DeletableTileAction
-          variant='inline-icon'
-          handleDelete={handleDelete}
-        />
+        <DeletableTileAction variant='icon' handleDelete={handleDelete} />
       )}
       <ConfirmDeleteModal
         visible={visible}


### PR DESCRIPTION
## Overview
Changed button variant from inline-icon to icon and removed padding, so button hitbox spans entire container instead of just icon.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/9a1d4699-7183-4e62-85ce-95f3909055ef



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
