### PR TITLE
fix(scene): fix possible undefined query state

### DIFF
--- a/packages/scene-composer/src/components/SceneLayers.tsx
+++ b/packages/scene-composer/src/components/SceneLayers.tsx
@@ -26,7 +26,7 @@ export const SceneLayers: React.FC = () => {
       return await fetchSceneNodes(sceneRootEntityId);
     },
     refetchInterval: (_, query) => {
-      return !query.state.error && isViewing ? autoUpdateInterval : 0;
+      return !query?.state?.error && isViewing ? autoUpdateInterval : 0;
     },
     refetchOnWindowFocus: false,
   });


### PR DESCRIPTION
## Overview
In some applications the query for the refetch interval can be undefined when the interval is evaluated.

## Verifying Changes
Try to load a scene using the examples/react app.  It should not  have the scene composer block out with an error message of: 
Cannot read properties of undefined (reading ‘state’)

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
