### PR TITLE
fix(react-components): anomaly chart move loading state

### DIFF
--- a/packages/react-components/src/components/anomaly-chart/anomalyChartStyles.css
+++ b/packages/react-components/src/components/anomaly-chart/anomalyChartStyles.css
@@ -1,0 +1,6 @@
+.anomaly-chart-loading-icon {
+  position: absolute;
+  right: 64px;
+  top: 3px;
+  z-index: 1;
+}

--- a/packages/react-components/src/components/anomaly-chart/constants.ts
+++ b/packages/react-components/src/components/anomaly-chart/constants.ts
@@ -49,12 +49,6 @@ export const ANOMALY_LEGEND = {
   selectedMode: false,
 };
 
-export const ANOMALY_LEGEND_LOADING_PADDING = [
-  5, // up
-  42, // right
-  10, // down
-  15, // left
-];
 export const ANOMALY_LEGEND_PADDING = [
   5, // up
   15, // right
@@ -91,5 +85,8 @@ export const ANOMALY_TOOLTIP = {
 
 export const DEFAULT_ANOMALY_WIDGET_SETTINGS = {
   animation: false,
+  aria: {
+    enabled: true,
+  },
   ...ANOMALY_X_AXIS,
 };

--- a/packages/react-components/src/components/anomaly-chart/converters/convertLegend.ts
+++ b/packages/react-components/src/components/anomaly-chart/converters/convertLegend.ts
@@ -1,13 +1,6 @@
-import {
-  ANOMALY_LEGEND,
-  ANOMALY_LEGEND_LOADING_PADDING,
-  ANOMALY_LEGEND_PADDING,
-} from '../constants';
-import { ConfigurationOptions } from '../hooks/types';
+import { ANOMALY_LEGEND, ANOMALY_LEGEND_PADDING } from '../constants';
 
-export const convertLegend = ({
-  loading,
-}: Pick<ConfigurationOptions, 'loading'>) => ({
+export const convertLegend = () => ({
   ...ANOMALY_LEGEND,
-  padding: loading ? ANOMALY_LEGEND_LOADING_PADDING : ANOMALY_LEGEND_PADDING,
+  padding: ANOMALY_LEGEND_PADDING,
 });

--- a/packages/react-components/src/components/anomaly-chart/hooks/useAnomalyEchart.ts
+++ b/packages/react-components/src/components/anomaly-chart/hooks/useAnomalyEchart.ts
@@ -61,7 +61,7 @@ const reducer = (
     return {
       ...state,
       series,
-      legend: convertLegend({ loading }),
+      legend: convertLegend(),
       tooltip: convertTooltip({ decimalPlaces, tooltipSort }),
       yAxis: convertYAxis({ axis }),
       xAxis: convertXAxis({ axis }),
@@ -75,7 +75,6 @@ const reducer = (
 
 const initialState = ({
   description,
-  loading,
   decimalPlaces,
   tooltipSort,
   data,
@@ -84,7 +83,7 @@ const initialState = ({
 }: AnomalyEChartOptions): Omit<AnomalyChartOptionState, 'chartRef'> => ({
   dataset: convertDataset(data),
   series: convertSeries({ description }),
-  legend: convertLegend({ loading }),
+  legend: convertLegend(),
   tooltip: convertTooltip({ decimalPlaces, tooltipSort }),
   yAxis: convertYAxis({ axis }),
   xAxis: convertXAxis({ axis }),

--- a/packages/react-components/src/components/anomaly-chart/loading-icon.tsx
+++ b/packages/react-components/src/components/anomaly-chart/loading-icon.tsx
@@ -1,14 +1,34 @@
-import Button from '@cloudscape-design/components/button';
+import { Box, Popover, Spinner } from '@awsui/components-react';
+import {
+  colorTextBodyDefault,
+  fontFamilyBase,
+} from '@cloudscape-design/design-tokens';
 import React from 'react';
+import './anomalyChartStyles.css';
 
 export const LoadingIcon = ({ loading }: { loading?: boolean }) => {
   if (!loading) return null;
 
   return (
-    <div style={{ position: 'absolute', right: 8, bottom: 2, zIndex: 1 }}>
-      <Button loading variant='icon' loadingText='Loading'>
-        Loading
-      </Button>
+    <div
+      className='anomaly-chart-loading-icon'
+      style={{
+        fontFamily: `${fontFamilyBase}`,
+        color: colorTextBodyDefault,
+      }}
+    >
+      <Box color='text-label'>
+        <Popover
+          size='small'
+          content='Data may be inaccurate until loading completes.'
+          dismissButton={false}
+        >
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <Spinner />
+            <span style={{ marginLeft: '5px' }}>Loading</span>
+          </div>
+        </Popover>
+      </Box>
     </div>
   );
 };


### PR DESCRIPTION
## Overview
Move loading state for anomaly widget 

<img width="684" alt="Screenshot 2024-07-01 at 14 56 01" src="https://github.com/awslabs/iot-app-kit/assets/28601414/8a5f12f5-6cf8-4ff0-8f47-a1098d5e7176">
<img width="685" alt="Screenshot 2024-07-01 at 14 56 18" src="https://github.com/awslabs/iot-app-kit/assets/28601414/cd266984-2896-48db-917b-8efc5925309d">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
