### PR TITLE
fix(dashboard): update default cellsize in migration to 20

### DIFF
--- a/packages/dashboard/src/migration/constants.ts
+++ b/packages/dashboard/src/migration/constants.ts
@@ -3,7 +3,7 @@ import { MonitorWidgetType, MonitorMetric, MonitorAnnotations } from './types';
 export const defaultDisplaySettings = {
   numRows: 100,
   numColumns: 100,
-  cellSize: 10,
+  cellSize: 20,
   significantDigits: 4,
 };
 export const defaultResolution = '1m';


### PR DESCRIPTION
## Overview
Updating the default dashboard cell size in migration script to 20 as per edge2web request.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
