### PR TITLE
fix(react-components): gestures prop works

### DIFF
--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -59,6 +59,7 @@ const BaseChart = ({
   queries,
   onChartOptionsChange,
   size = { width: 650, height: 400 },
+  gestures = true,
   ...options
 }: ChartOptions) => {
   const {
@@ -152,6 +153,7 @@ const BaseChart = ({
     thresholds,
     visibleData,
     chartWidth,
+    gestures,
     ...options,
   });
 
@@ -166,13 +168,17 @@ const BaseChart = ({
   const { chartEventsKeyMap, chartEventsHandlers } =
     useHandleChartEvents(chartRef);
 
-  const hotKeyMap = {
-    ...chartEventsKeyMap,
-  };
+  const hotKeyMap = gestures
+    ? {
+        ...chartEventsKeyMap,
+      }
+    : {};
 
-  const hotKeyHandlers = {
-    ...chartEventsHandlers,
-  };
+  const hotKeyHandlers = gestures
+    ? {
+        ...chartEventsHandlers,
+      }
+    : {};
 
   const handleMouseDown = (e: MouseEvent) => {
     const target = e.target;

--- a/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
+++ b/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
@@ -16,6 +16,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import isEqual from 'lodash.isequal';
 import {
   DEFAULT_CHART_OPTION,
+  DEFAULT_DATA_ZOOM,
   PERFORMANCE_MODE_THRESHOLD,
 } from '../eChartsConstants';
 import { useSeriesAndYAxis } from './seriesAndYAxis/convertSeriesAndYAxis';
@@ -100,7 +101,9 @@ type ChartConfigurationOptions = Pick<
   dataStreams: DataStream[];
 } & { visibleData: DataPoint[] } & {
   thresholds: Threshold<ThresholdValue>[];
-} & { chartWidth: number } & ChartDataQuality;
+} & { chartWidth: number } & ChartDataQuality & {
+    gestures: boolean;
+  };
 
 export type DataStreamMetaData = ReturnType<
   typeof useChartConfiguration
@@ -122,6 +125,7 @@ export const useChartConfiguration = (
     visibleData,
     id,
     axis,
+    gestures,
     backgroundColor,
     significantDigits,
     styleSettings,
@@ -230,6 +234,7 @@ export const useChartConfiguration = (
         tooltip,
         series,
         yAxis,
+        dataZoom: gestures ? DEFAULT_DATA_ZOOM : { disabled: true },
       },
       {
         ...updateSettings,
@@ -244,6 +249,7 @@ export const useChartConfiguration = (
     xAxis,
     tooltip,
     series,
+    gestures,
     yAxis,
     dataSteamIdentifiers,
   ]);

--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -144,7 +144,6 @@ export const DEFAULT_CHART_OPTION: EChartsOption = {
   title: {
     top: 10,
   },
-  dataZoom: DEFAULT_DATA_ZOOM,
   animation: false,
   toolbox: DEFAULT_TOOLBOX_CONFIG,
   xAxis: DEFAULT_X_AXIS,


### PR DESCRIPTION
## Overview
The `gestures` prop actually enables/disables data zoom now!

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
