### PR TITLE
fix: make gauge widget default size smaller

### DIFF
--- a/packages/dashboard/src/customization/widgets/constants.ts
+++ b/packages/dashboard/src/customization/widgets/constants.ts
@@ -5,6 +5,9 @@ export const SVG_STROKE_DOTTED = '3,3';
 export const WIDGET_INITIAL_HEIGHT = 400;
 export const WIDGET_INITIAL_WIDTH = 650;
 
+export const GAUGE_WIDGET_INITIAL_HEIGHT = 400;
+export const GAUGE_WIDGET_INITIAL_WIDTH = 500;
+
 export const KPI_WIDGET_INITIAL_HEIGHT = 200;
 export const KPI_WIDGET_INITIAL_WIDTH = 350;
 

--- a/packages/dashboard/src/customization/widgets/gauge/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/gauge/plugin.tsx
@@ -3,7 +3,10 @@ import GaugeWidgetComponent from './component';
 import GaugeIcon from './icon';
 import type { DashboardPlugin } from '~/customization/api';
 import type { GaugeWidget } from '../types';
-import { WIDGET_INITIAL_HEIGHT, WIDGET_INITIAL_WIDTH } from '../constants';
+import {
+  GAUGE_WIDGET_INITIAL_HEIGHT,
+  GAUGE_WIDGET_INITIAL_WIDTH,
+} from '../constants';
 
 export const gaugePlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
@@ -28,8 +31,8 @@ export const gaugePlugin: DashboardPlugin = {
         thresholds: [],
       }),
       initialSize: {
-        height: WIDGET_INITIAL_HEIGHT,
-        width: WIDGET_INITIAL_WIDTH,
+        height: GAUGE_WIDGET_INITIAL_HEIGHT,
+        width: GAUGE_WIDGET_INITIAL_WIDTH,
       },
     });
   },


### PR DESCRIPTION
## Overview
* Make the default size for gauge widgets smaller on the dashboard so there is less white space

## Verifying Changes

### Before change
<img width="724" alt="Screenshot 2024-07-09 at 2 33 39 PM" src="https://github.com/awslabs/iot-app-kit/assets/66272633/353eafc2-cec8-4eda-bb50-b617d6c4ef9d">

### After change
![Screenshot 2024-07-09 at 2 30 47 PM](https://github.com/awslabs/iot-app-kit/assets/66272633/baf50042-2436-4cfb-997f-470b684c54f9)



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
