### PR TITLE
feat(dashboard): use react-components RE components to update dashboard RE for modeled and unmodeled data

### DIFF
--- a/packages/dashboard/e2e/tests/widgets/kpi.spec.ts
+++ b/packages/dashboard/e2e/tests/widgets/kpi.spec.ts
@@ -42,16 +42,18 @@ test.describe('Test KPI Widget', () => {
     resourceExplorer,
   }) => {
     //select 3 properties
-    await resourceExplorer.selectProperties([
+    await resourceExplorer.addModeledProperties([
       'Max Temperature',
       'Min Temperature',
       'Temperature',
     ]);
     dashboardWithKPIWidget.gridArea.locator('.kpi-widget-empty-state');
 
-    //check that add button is disabled
-    const addButton = await resourceExplorer.getAddButton();
-    await expect(addButton).toBeDisabled();
+    const widget =
+      dashboardWithKPIWidget.gridArea.getByTestId('kpi-base-component');
+    expect(await widget.textContent()).toBe('Temperature');
+    expect(await widget.textContent()).not.toContain('Max Temperature');
+    expect(await widget.textContent()).not.toContain('Min Temperature');
   });
 
   test('KPI Widget supports show/hide several properties', async ({

--- a/packages/dashboard/src/components/dashboard/getClients.ts
+++ b/packages/dashboard/src/components/dashboard/getClients.ts
@@ -1,5 +1,5 @@
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
-import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { IoTSiteWise, IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import {
   DashboardClientConfiguration,
@@ -31,10 +31,15 @@ export const getClients = (
     credentials: dashboardClientConfiguration.awsCredentials,
     region: dashboardClientConfiguration.awsRegion,
   });
+  const iotSiteWise = new IoTSiteWise({
+    credentials: dashboardClientConfiguration.awsCredentials,
+    region: dashboardClientConfiguration.awsRegion,
+  });
 
   return {
     iotEventsClient,
     iotSiteWiseClient,
     iotTwinMakerClient,
+    iotSiteWise,
   };
 };

--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -7,7 +7,10 @@ import {
 import { DashboardWrapper as Dashboard } from './wrapper';
 import React from 'react';
 import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
-import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import {
+  IoTSiteWise,
+  type IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
 import { RefreshRate } from '../refreshRate/types';
 
 it('renders', function () {
@@ -29,6 +32,7 @@ it('renders', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );
@@ -57,6 +61,7 @@ it('renders in readonly initially', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
       initialViewMode='preview'
     />
@@ -93,6 +98,7 @@ it('renders in edit initially', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
       initialViewMode='edit'
     />
@@ -133,6 +139,7 @@ it('passes the correct viewMode to onSave', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
       initialViewMode='edit'
     />
@@ -168,6 +175,7 @@ it('renders dashboard name', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );
@@ -193,6 +201,7 @@ it('renders without dashboard name', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );

--- a/packages/dashboard/src/components/dashboard/view.test.tsx
+++ b/packages/dashboard/src/components/dashboard/view.test.tsx
@@ -4,7 +4,10 @@ import {
   createMockSiteWiseSDK,
 } from '@iot-app-kit/testing-util';
 import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
-import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import {
+  IoTSiteWise,
+  type IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
 
 import DashboardView from './view';
 import React from 'react';
@@ -27,6 +30,7 @@ it('renders', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -97,7 +97,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
 }) => {
   useSyncDashboardConfiguration({ onDashboardConfigurationChange });
 
-  const { iotSiteWiseClient, iotTwinMakerClient } = useClients();
+  const { iotSiteWiseClient, iotTwinMakerClient, iotSiteWise } = useClients();
 
   /**
    * disable user select styles on drag to prevent highlighting of text under the pointer
@@ -291,7 +291,11 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
     backgroundColor: colorBackgroundLayoutMain,
   };
 
-  if (iotSiteWiseClient == null || iotTwinMakerClient == null) {
+  if (
+    iotSiteWiseClient == null ||
+    iotTwinMakerClient == null ||
+    iotSiteWise == null
+  ) {
     return null;
   }
 
@@ -349,6 +353,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
             <QueryEditor
               iotSiteWiseClient={iotSiteWiseClient}
               iotTwinMakerClient={iotTwinMakerClient}
+              iotSiteWise={iotSiteWise}
             />
           }
           centerPane={

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/footer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/footer.tsx
@@ -9,7 +9,6 @@ import {
   colorBorderDividerDefault,
   spaceStaticXxxs,
 } from '@cloudscape-design/design-tokens';
-import { STICKY_BUTTON_WIDTH_FACTOR } from '../constants';
 import './index.css';
 
 export type ResourceExplorerFooterOptions = {
@@ -29,7 +28,7 @@ export const ResourceExplorerFooter = ({
   const stickyFooter = {
     backgroundColor: colorBackgroundContainerContent,
     bottom: spaceStaticXxxs,
-    width: width + STICKY_BUTTON_WIDTH_FACTOR,
+    width: width,
     borderTop: `${spaceStaticXxxs} solid ${colorBorderDividerDefault}`,
   };
 

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
@@ -1,32 +1,72 @@
-import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
-import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
+import {
+  IoTSiteWise,
+  IoTSiteWiseClient,
+  PropertyDataType,
+} from '@aws-sdk/client-iotsitewise';
 import Tabs from '@cloudscape-design/components/tabs';
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-
 import type { DashboardState } from '~/store/state';
-import { ModeledDataStreamQueryEditor } from './modeledDataStreamQueryEditor';
-import { UnmodeledDataStreamQueryEditor } from './unmodeledDataStreamExplorer';
 import { QueryExtender } from './queryExtender';
 import type { ModeledDataStream } from './modeledDataStreamQueryEditor/modeledDataStreamExplorer/types';
 import type { UnmodeledDataStream } from './unmodeledDataStreamExplorer/types';
 import { useQuery } from '../useQuery';
 import { AssetModelDataStreamExplorer } from './assetModelDataStreamExplorer/assetModelDataStreamExplorer';
+import {
+  AssetExplorer,
+  type AssetExplorerProps,
+  AssetPropertyExplorer,
+  type AssetPropertyExplorerProps,
+  TimeSeriesExplorer,
+  type TimeSeriesExplorerProps,
+} from '@iot-app-kit/react-components';
+import { DEFAULT_TIME_SERIES_WITH_LATEST_VALUES_TABLE_DEFINITION } from '@iot-app-kit/react-components/dist/es/components/resource-explorers';
+import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
+import { ResourceExplorerFooter } from './footer/footer';
+import { getPlugin } from '@iot-app-kit/core/dist/es/plugins/pluginsRegistry';
+import Box from '@cloudscape-design/components/box';
+import { useSelectedWidgets } from '~/hooks/useSelectedWidgets';
+import { isModeledPropertyInvalid } from '../helpers/isModeledPropertyInvalid';
+import {
+  AssetPropertyResource,
+  AssetResource,
+} from '@iot-app-kit/react-components/dist/es/components/resource-explorers/types/resources';
 
 export interface IoTSiteWiseQueryEditorProps {
   onUpdateQuery: ReturnType<typeof useQuery>[1];
+  iotSiteWise: IoTSiteWise;
   iotSiteWiseClient: IoTSiteWiseClient;
   iotTwinMakerClient: IoTTwinMakerClient;
 }
 
 export function IoTSiteWiseQueryEditor({
   onUpdateQuery,
-  iotSiteWiseClient,
-  iotTwinMakerClient,
+  iotSiteWise,
 }: IoTSiteWiseQueryEditorProps) {
   const isEdgeModeEnabled = useSelector(
     (state: DashboardState) => state.isEdgeModeEnabled
   );
+
+  const selectedWidgets = useSelectedWidgets();
+  console.log(selectedWidgets);
+  const correctSelectionMode =
+    selectedWidgets.at(0)?.type === 'kpi' ? 'single' : 'multi';
+  const metricsRecorder = getPlugin('metricsRecorder');
+
+  const [selectedAssets, setSelectedAssets] = useState<
+    NonNullable<AssetExplorerProps['selectedAssets']>
+  >([]);
+
+  const [selectedAssetProperties, setSelectedAssetProperties] = useState<
+    NonNullable<AssetPropertyExplorerProps['selectedAssetProperties']>
+  >([]);
+
+  const [selectedTimeSeries, setSelectedTimeSeries] = useState<
+    NonNullable<TimeSeriesExplorerProps['selectedTimeSeries']>
+  >([]);
+
+  const addButtonDisabled =
+    selectedTimeSeries.length === 0 || selectedWidgets.length === 0;
 
   function handleClickAddModeledDataStreams(
     newModeledDataStreams: ModeledDataStream[]
@@ -54,25 +94,128 @@ export function IoTSiteWiseQueryEditor({
     });
   }
 
+  function propertySelectionLabel(
+    selectedItems: AssetPropertyExplorerProps['selectedAssetProperties'],
+    modeledDataStream: AssetPropertyResource
+  ) {
+    const isPropertySelected = selectedItems?.find(
+      (item) => item.propertyId === modeledDataStream.propertyId
+    );
+
+    if (
+      isModeledPropertyInvalid(
+        modeledDataStream.dataType as PropertyDataType,
+        selectedWidgets?.at(0)?.type
+      )
+    ) {
+      return `${modeledDataStream.dataType} data not supported for the selected widget`;
+    } else if (!isPropertySelected) {
+      return `Select modeled data stream ${modeledDataStream.name}`;
+    } else {
+      return `Deselect modeled data stream ${modeledDataStream.name}`;
+    }
+  }
+
   const modeledTab = {
     label: 'Modeled',
     id: 'explore-modeled-tab',
     content: (
-      <ModeledDataStreamQueryEditor
-        onClickAdd={handleClickAddModeledDataStreams}
-        iotSiteWiseClient={iotSiteWiseClient}
-        iotTwinMakerClient={iotTwinMakerClient}
-      />
+      <Box padding={{ horizontal: 's' }}>
+        <AssetExplorer
+          requestFns={iotSiteWise}
+          onSelectAsset={setSelectedAssets}
+          selectedAssets={selectedAssets}
+          selectionMode='single'
+          tableSettings={{
+            isSearchEnabled: true,
+            isFilterEnabled: true,
+            isUserSettingsEnabled: true,
+          }}
+          description='Browse through your asset hierarchy and select an asset to view its associated data streams.'
+          ariaLabels={{
+            resizerRoleDescription: 'Resize button',
+            itemSelectionLabel: (isNotSelected, asset: AssetResource) =>
+              isNotSelected
+                ? `Select asset ${asset.name}`
+                : `Deselect asset ${asset.name}`,
+          }}
+        />
+        {selectedAssets.length > 0 && (
+          <AssetPropertyExplorer
+            requestFns={iotSiteWise}
+            parameters={selectedAssets}
+            selectionMode={correctSelectionMode}
+            onSelectAssetProperty={setSelectedAssetProperties}
+            selectedAssetProperties={selectedAssetProperties}
+            tableSettings={{
+              isFilterEnabled: true,
+              isUserSettingsEnabled: true,
+            }}
+            isAssetPropertyDisabled={(item) =>
+              isModeledPropertyInvalid(
+                item.dataType as PropertyDataType,
+                selectedWidgets.at(0)?.type
+              )
+            }
+            ariaLabels={{
+              resizerRoleDescription: 'Resize button',
+              itemSelectionLabel: ({ selectedItems }, modeledDataStream) =>
+                propertySelectionLabel([...selectedItems], modeledDataStream),
+            }}
+          />
+        )}
+        <ResourceExplorerFooter
+          addDisabled={addButtonDisabled}
+          onReset={() => setSelectedAssetProperties([])}
+          onAdd={() => {
+            handleClickAddModeledDataStreams(
+              selectedAssetProperties as ModeledDataStream[]
+            );
+            setSelectedAssetProperties([]); //clear table after adding it to widget
+            metricsRecorder?.record({
+              metricName: 'ModeledDataStreamAdd',
+              metricValue: 1,
+            });
+          }}
+        />
+      </Box>
     ),
   };
+
   const unmodeledTab = {
     label: 'Unmodeled',
     id: 'explore-unmodeled-tab',
     content: (
-      <UnmodeledDataStreamQueryEditor
-        onClickAdd={handleClickAddUnmodeledDataStreams}
-        client={iotSiteWiseClient}
-      />
+      <Box padding={{ horizontal: 's' }}>
+        <TimeSeriesExplorer
+          selectionMode={correctSelectionMode}
+          requestFns={iotSiteWise}
+          onSelectTimeSeries={setSelectedTimeSeries}
+          selectedTimeSeries={selectedTimeSeries}
+          parameters={[{ timeSeriesType: 'DISASSOCIATED' }]}
+          tableSettings={{
+            isFilterEnabled: true,
+            isUserSettingsEnabled: true,
+          }}
+          tableResourceDefinition={
+            DEFAULT_TIME_SERIES_WITH_LATEST_VALUES_TABLE_DEFINITION
+          }
+        />
+        <ResourceExplorerFooter
+          addDisabled={addButtonDisabled}
+          onReset={() => setSelectedAssetProperties([])}
+          onAdd={() => {
+            handleClickAddUnmodeledDataStreams(
+              selectedTimeSeries as unknown as UnmodeledDataStream[]
+            );
+            setSelectedAssetProperties([]); //clear table after adding it to widget
+            metricsRecorder?.record({
+              metricName: 'UnmodeledDataStreamAdd',
+              metricValue: 1,
+            });
+          }}
+        />
+      </Box>
     ),
     disabled: isEdgeModeEnabled,
   };
@@ -80,7 +223,7 @@ export function IoTSiteWiseQueryEditor({
   const assetModeledTab = {
     label: 'Dynamic assets',
     id: 'explore-asset-model-tab',
-    content: <AssetModelDataStreamExplorer client={iotSiteWiseClient} />,
+    content: <AssetModelDataStreamExplorer client={iotSiteWise} />,
   };
 
   const defaultTabs = [modeledTab, unmodeledTab, assetModeledTab];

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/queryExtender/queryExtender.spec.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/queryExtender/queryExtender.spec.ts
@@ -114,7 +114,7 @@ describe(QueryExtender.name, () => {
       };
       const queryExtender = new QueryExtender(currentQuery);
       const unmodeledDataStreams = [
-        { propertyAlias: 'property-2' },
+        { alias: 'property-2' },
       ] as UnmodeledDataStream[];
 
       const extendedQuery =
@@ -140,8 +140,8 @@ describe(QueryExtender.name, () => {
       };
       const queryExtender = new QueryExtender(currentQuery);
       const unmodeledDataStreams = [
-        { propertyAlias: 'property-1' },
-        { propertyAlias: 'property-2' },
+        { alias: 'property-1' },
+        { alias: 'property-2' },
       ] as UnmodeledDataStream[];
 
       const extendedQuery =

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/queryExtender/queryExtender.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/queryExtender/queryExtender.ts
@@ -101,7 +101,7 @@ export class QueryExtender {
   #createPropertyAliasQueries(unmodeledDataStreams: UnmodeledDataStream[]) {
     const propertyAliasQueries = unmodeledDataStreams.map(
       (unmodeledDataStream) => ({
-        propertyAlias: unmodeledDataStream.propertyAlias ?? '',
+        propertyAlias: unmodeledDataStream.alias ?? '',
       })
     );
 

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/types.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/types.ts
@@ -1,7 +1,7 @@
 import type { TimeSeriesSummary } from '@aws-sdk/client-iotsitewise';
 
 export type UnmodeledDataStream = {
-  propertyAlias: TimeSeriesSummary['alias'];
+  alias: TimeSeriesSummary['alias'];
   dataType: TimeSeriesSummary['dataType'];
   dataTypeSpec: TimeSeriesSummary['dataTypeSpec'];
 };

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
@@ -144,7 +144,7 @@ export function UnmodeledDataStreamTable({
         {
           id: 'propertyAlias',
           header: 'Alias',
-          cell: ({ propertyAlias }) => propertyAlias,
+          cell: ({ alias }) => alias,
           sortingField: 'propertyAlias',
         },
         {

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/useUnmodeledDataStreams/listUnmodeledDataStreamsRequest.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/useUnmodeledDataStreams/listUnmodeledDataStreamsRequest.ts
@@ -57,8 +57,8 @@ export class ListUnmodeledDataStreamsRequest {
 
   #formatDataStreams(rawDataStreams: TimeSeriesSummary[]) {
     const cookedDataStreams = rawDataStreams.map<UnmodeledDataStream>(
-      ({ alias: propertyAlias, dataType, dataTypeSpec }) => ({
-        propertyAlias,
+      ({ alias, dataType, dataTypeSpec }) => ({
+        alias,
         dataType,
         dataTypeSpec,
       })

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/useLatestValues/entryIdFactory.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/useLatestValues/entryIdFactory.ts
@@ -27,12 +27,12 @@ export class EntryIdFactory {
 
   #createEntryId(): string {
     // Remove dashes from any UUIDs
-    const { assetId, propertyId, propertyAlias } =
+    const { assetId, propertyId, alias } =
       this.#extractIdentifiersFromDataStream();
     const entryId = this.#formatIdentifiers({
       assetId,
       propertyId,
-      propertyAlias,
+      alias,
     });
 
     return entryId;
@@ -45,24 +45,22 @@ export class EntryIdFactory {
       'propertyId' in this.#dataStream
         ? this.#dataStream.propertyId
         : undefined;
-    const propertyAlias =
-      'propertyAlias' in this.#dataStream
-        ? this.#dataStream.propertyAlias
-        : undefined;
+    const alias =
+      'alias' in this.#dataStream ? this.#dataStream.alias : undefined;
 
-    return { assetId, propertyId, propertyAlias };
+    return { assetId, propertyId, alias };
   }
 
   #formatIdentifiers({
     assetId,
     propertyId,
-    propertyAlias,
+    alias,
   }: {
     assetId?: string;
     propertyId?: string;
-    propertyAlias?: string;
+    alias?: string;
   }) {
-    const trimmedAlias = this.#trimPropertyAlias(propertyAlias);
+    const trimmedAlias = this.#trimPropertyAlias(alias);
     const aliasWithoutSlashes =
       this.#removeSlashesFromPropertyAlias(trimmedAlias);
     const joinedIdentifiers = Object.values({

--- a/packages/dashboard/src/components/queryEditor/queryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/queryEditor.tsx
@@ -3,15 +3,17 @@ import React from 'react';
 import { IoTSiteWiseQueryEditor } from './iotSiteWiseQueryEditor';
 import { QueryEditorErrorBoundary } from './queryEditorErrorBoundary';
 import { useQuery } from './useQuery';
-import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { IoTSiteWise, IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 
 export function QueryEditor({
   iotSiteWiseClient,
   iotTwinMakerClient,
+  iotSiteWise,
 }: {
   iotSiteWiseClient: IoTSiteWiseClient;
   iotTwinMakerClient: IoTTwinMakerClient;
+  iotSiteWise: IoTSiteWise;
 }) {
   const [_query, setQuery] = useQuery();
 
@@ -21,6 +23,7 @@ export function QueryEditor({
         onUpdateQuery={setQuery}
         iotSiteWiseClient={iotSiteWiseClient}
         iotTwinMakerClient={iotTwinMakerClient}
+        iotSiteWise={iotSiteWise}
       />
     </QueryEditorErrorBoundary>
   );

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
@@ -1,4 +1,7 @@
-import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import {
+  IoTSiteWise,
+  type IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
 import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import React from 'react';
 import {
@@ -105,6 +108,7 @@ const renderTestComponentAsync = async (
     }) as unknown as IoTSiteWiseClient,
     iotEventsClient: createMockIoTEventsSDK(),
     iotTwinMakerClient: { send: jest.fn() } as unknown as IoTTwinMakerClient,
+    iotSiteWise: new IoTSiteWise(),
   };
 
   await act(async () => {

--- a/packages/dashboard/src/msw/iot-sitewise/handlers/listAssociatedAssets/listAssociatedAssetsHandler.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/handlers/listAssociatedAssets/listAssociatedAssetsHandler.ts
@@ -15,9 +15,6 @@ export function listAssociatedAssetsHandler() {
       const { assetId } = req.params as {
         assetId: ListAssociatedAssetsRequest['assetId'];
       };
-      const hierarchyId = req.url.searchParams.get(
-        'hierarchyId'
-      ) as ListAssociatedAssetsRequest['hierarchyId'];
       const traversalDirection =
         (req.url.searchParams.get(
           'traversalDirection'
@@ -31,17 +28,11 @@ export function listAssociatedAssetsHandler() {
         return res(ctx.status(400));
       }
 
-      if (traversalDirection === 'CHILD' && !hierarchyId) {
-        return res(ctx.status(400));
-      }
-
       let assetSummaries: ListAssociatedAssetsResponse['assetSummaries'] = [];
 
       if (traversalDirection === 'CHILD') {
-        const childAssets =
-          ASSET_HIERARCHY.findChildren(assetId, hierarchyId ?? '') ?? [];
+        const childAssets = ASSET_HIERARCHY.findChildren(assetId) ?? [];
         const childAssetSummaries = childAssets.map(summarizeAsset);
-
         assetSummaries = childAssetSummaries;
       } else if (traversalDirection === 'PARENT') {
         const parentAsset = ASSET_HIERARCHY.findParentAsset(assetId);

--- a/packages/dashboard/src/msw/iot-sitewise/resources/assets/index.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/resources/assets/index.ts
@@ -5,7 +5,7 @@ import {
   REACTOR_ASSET_MODEL,
   STORAGE_TANK_ASSET_MODEL,
 } from '../assetModels';
-import type { Asset, AssetModel } from '../types';
+import type { Asset } from '../types';
 
 const siteAssetFactory = new AssetFactory(SITE_ASSET_MODEL);
 const productionLineAssetFactory = new AssetFactory(
@@ -44,22 +44,11 @@ class AssetHierarchyClient {
     return asset;
   }
 
-  public findChildren(assetId: string, hierarchyId: string): Asset[] {
+  public findChildren(assetId: string): Asset[] {
     const node = this.#searchById(assetId, this.#assetHierarchy);
-    const hierarchy = node?.asset.assetHierarchies?.find(
-      ({ id }) => id === hierarchyId
-    );
-    // childAssetModelId is not on Assets - We keep it in the translation from AssetModel to Asset to enable this search.
-    const hierarchyAsAssetModelHierarchy = hierarchy as NonNullable<
-      AssetModel['assetModelHierarchies']
-    >[number];
-    const childAssetModelId = hierarchyAsAssetModelHierarchy.childAssetModelId;
     const children = node?.children?.map(({ asset }) => asset) ?? [];
-    const childrenOfHierachy = children.filter(
-      ({ assetModelId }) => assetModelId === childAssetModelId
-    );
 
-    return childrenOfHierachy;
+    return children;
   }
 
   public findParentAsset(assetId: string): Asset | undefined {

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -3,6 +3,7 @@ import {
   IoTSiteWiseClient,
   DescribeDashboardRequest,
   DescribeDashboardResponse,
+  IoTSiteWise,
 } from '@aws-sdk/client-iotsitewise';
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
 import type { AwsCredentialIdentity, Provider } from '@aws-sdk/types';
@@ -25,6 +26,7 @@ export type DashboardIotSiteWiseClients = {
   iotSiteWiseClient: IoTSiteWiseClient;
   iotEventsClient: IoTEventsClient;
   iotTwinMakerClient: IoTTwinMakerClient;
+  iotSiteWise: IoTSiteWise;
 };
 
 export type DashboardIotSiteWiseQueries = {

--- a/packages/dashboard/stories/dashboard/edge-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/edge-dashboard.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { IoTSiteWise, IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import { registerPlugin } from '@iot-app-kit/core';
@@ -27,6 +27,7 @@ const clientConfig = {
 const iotSiteWiseClient = new IoTSiteWiseClient(clientConfig);
 const iotEventsClient = new IoTEventsClient(clientConfig);
 const iotTwinMakerClient = new IoTTwinMakerClient(clientConfig);
+const iotSiteWise = new IoTSiteWise(clientConfig);
 
 const DEFAULT_DASHBOARD_CONFIG = {
   displaySettings: {
@@ -41,6 +42,7 @@ const CLIENT_CONFIGURATION: DashboardClientConfiguration = {
   iotSiteWiseClient,
   iotEventsClient,
   iotTwinMakerClient,
+  iotSiteWise,
 };
 
 registerPlugin('metricsRecorder', {

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/internal-asset-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/internal-asset-explorer.tsx
@@ -53,6 +53,8 @@ export function InternalAssetExplorer({
   } = {},
   dropDownResourceDefinition = DEFAULT_ASSET_DROP_DOWN_DEFINITION,
   dropDownSettings: { isFilterEnabled: isDropDownFilterEnabled = false } = {},
+  description = '',
+  ariaLabels,
 }: AssetExplorerProps) {
   const tableResourceDefinition =
     customTableResourceDefinition ??
@@ -146,6 +148,8 @@ export function InternalAssetExplorer({
               />
             )
           }
+          description={description}
+          ariaLabels={ariaLabels}
         />
       }
       dropDown={

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/types.ts
@@ -1,3 +1,4 @@
+import { TableProps } from '@cloudscape-design/components';
 import type {
   IsResourceDisabled,
   OnSelectResource,
@@ -22,6 +23,8 @@ export interface AssetExplorerProps
   onSelectAsset?: OnSelectResource<AssetResource>;
   selectedAssets?: SelectedResources<AssetResource>;
   isAssetDisabled?: IsResourceDisabled<AssetResource>;
+  description?: string;
+  ariaLabels?: TableProps.AriaLabels<AssetResource>;
 }
 
 export type AssetResourcesRequestParameters =

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
@@ -57,6 +57,7 @@ export function InternalAssetPropertyExplorer({
   } = {},
   dropDownResourceDefinition = DEFAULT_ASSET_PROPERTY_DROP_DOWN_DEFINITION,
   dropDownSettings: { isFilterEnabled: isDropDownFilterEnabled = false } = {},
+  ariaLabels,
 }: AssetPropertyExplorerProps) {
   const [userCustomization, setUserCutomization] = useUserCustomization({
     resourceName,
@@ -114,6 +115,7 @@ export function InternalAssetPropertyExplorer({
           isSearchEnabled={isSearchEnabled}
           isFilterEnabled={isTableFilterEnabled}
           isUserSettingsEnabled={isUserSettingsEnabled}
+          ariaLabels={ariaLabels}
         />
       }
       dropDown={

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
@@ -1,3 +1,4 @@
+import { TableProps } from '@cloudscape-design/components';
 import type {
   IsResourceDisabled,
   OnSelectResource,
@@ -24,6 +25,7 @@ export interface AssetPropertyExplorerProps
   onSelectAssetProperty?: OnSelectResource<AssetPropertyResource>;
   selectedAssetProperties?: SelectedResources<AssetPropertyResource>;
   isAssetPropertyDisabled?: IsResourceDisabled<AssetPropertyResource>;
+  ariaLabels?: TableProps.AriaLabels<AssetPropertyResource>;
 }
 
 export type AssetPropertyResourcesRequestParameters =

--- a/packages/react-components/src/components/resource-explorers/index.ts
+++ b/packages/react-components/src/components/resource-explorers/index.ts
@@ -9,4 +9,7 @@ export {
   type TimeSeriesExplorerProps,
 } from './explorers';
 
+export { DEFAULT_STRING_FILTER_OPERATORS } from './constants/defaults';
+export { DEFAULT_TIME_SERIES_WITH_LATEST_VALUES_TABLE_DEFINITION } from './constants/table-resource-definitions';
+
 // TODO: Export additional necessary types for customers to use

--- a/packages/react-components/src/components/resource-explorers/types/table.ts
+++ b/packages/react-components/src/components/resource-explorers/types/table.ts
@@ -1,3 +1,4 @@
+import { TableProps } from '@cloudscape-design/components';
 import type {
   ResourceName,
   PluralResourceName,
@@ -88,6 +89,8 @@ export interface ResourceTableProps<Resource> {
   isFilterEnabled?: IsTableFilterEnabled;
   isUserSettingsEnabled?: IsTableUserSettingsEnabled;
   titleExtension?: React.ReactNode;
+  description?: string;
+  ariaLabels?: TableProps.AriaLabels<Resource>;
 }
 
 export type OnUpdateTableUserCustomization = (

--- a/packages/react-components/src/components/resource-explorers/variants/resource-table/resource-table-title.tsx
+++ b/packages/react-components/src/components/resource-explorers/variants/resource-table/resource-table-title.tsx
@@ -6,6 +6,7 @@ export interface ResourceTableTitleProps {
   totalResourceCount: number;
   pluralResourceName: string;
   titleExtension?: React.ReactNode;
+  description?: string;
 }
 
 export function ResourceTableTitle({
@@ -13,6 +14,7 @@ export function ResourceTableTitle({
   totalResourceCount,
   pluralResourceName,
   titleExtension,
+  description,
 }: ResourceTableTitleProps) {
   return (
     <>
@@ -23,6 +25,7 @@ export function ResourceTableTitle({
             ? `(${selectedResourceCount}/${totalResourceCount})`
             : `(${totalResourceCount})`
         }
+        description={description}
       >
         {pluralResourceName}
       </CloudscapeHeader>

--- a/packages/react-components/src/components/resource-explorers/variants/resource-table/resource-table.tsx
+++ b/packages/react-components/src/components/resource-explorers/variants/resource-table/resource-table.tsx
@@ -43,6 +43,8 @@ export function ResourceTable<Resource>({
   isUserSettingsEnabled,
   isSearchEnabled,
   titleExtension,
+  description,
+  ariaLabels,
 }: ResourceTableProps<Resource>) {
   const {
     items,
@@ -116,6 +118,7 @@ export function ResourceTable<Resource>({
               totalResourceCount={collectionProps.totalItemsCount ?? 0}
               pluralResourceName={pluralResourceName}
               titleExtension={titleExtension}
+              description={description}
             />
           )
         }
@@ -173,11 +176,14 @@ export function ResourceTable<Resource>({
         }) => {
           onSelectResource(updatedSelectedResources);
         }}
-        selectedItems={selectedResources}
+        selectedItems={selectedResources.filter(
+          (resource) => !isResourceDisabled(resource)
+        )}
         loading={isLoading}
         loadingText={`Loading ${pluralResourceName.toLowerCase()}...`}
         selectionType={selectionMode}
         resizableColumns
+        ariaLabels={ariaLabels}
       />
     </>
   );

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -48,3 +48,20 @@ export type {
   TableItem,
   TableItemRef,
 } from './components/table';
+
+export {
+  AssetModelExplorer,
+  AssetExplorer,
+  AssetPropertyExplorer,
+  TimeSeriesExplorer,
+  type AssetModelExplorerProps,
+  type AssetExplorerProps,
+  type AssetPropertyExplorerProps,
+  type TimeSeriesExplorerProps,
+} from './components/resource-explorers';
+
+export { type TableResourceDefinition } from './components/resource-explorers/types/table';
+
+export { type TimeSeriesResourceWithLatestValue } from './components/resource-explorers/types/resources';
+
+export { type ResourceFieldFilterOperator } from './components/resource-explorers/types/common';


### PR DESCRIPTION
## Overview
- updated RE to use new RE components in react-components package for modeled and unmodeled tab
- hooked up new RE footer to each tab to update query accordingly
- perform correct disabling/selection of buttons and selection states based on amount of widgets selected + selected widget type
- added prop to allow for descriptions to be added for explorer table headers and added it to the modeled RE component to match current RE implementation
- added ariaLabel to each row of table to allow UI testing helpers to remain the same
- edited MSW to work with new RE components in listAssociatedTimeSeriesCall
- removed 2 kpi tests regarding multiselect since selection for KPI properties is now singular through new components

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/536f5405-7106-4fe8-9989-bdead370d9f7

<img width="469" alt="Screenshot 2024-07-11 at 8 42 27 AM" src="https://github.com/awslabs/iot-app-kit/assets/145582655/952167cb-03ce-4450-a040-1f51aa90d26b">

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
