### PR TITLE
fix: move data quality widget on gauge to be closer to value

### DIFF
--- a/packages/react-components/src/components/gauge/gauge.css
+++ b/packages/react-components/src/components/gauge/gauge.css
@@ -12,7 +12,7 @@
   position: absolute;
   left: 50%;
   transform: translate(-50%, -50%);
-  bottom: 2%;
+  bottom: 20%;
 }
 
 .gauge-info-text {


### PR DESCRIPTION
## Overview
* Change the gauge css so its rendered from the bottom 20% of the widget
* I looking at echarts gauge configuration to add a rich text label to make data quality party of the echarts settings, but I wasn't able to figure it out and from testing this css change it seems like it will be sufficient. I would like feedback on if this could go wrong though. The problem with this approach is we don't guarantee the data quality won't overlap with the value, but with our current default it does work.

## Verifying Changes

### Before Change

<img width="285" alt="Screenshot 2024-07-10 at 4 52 45 PM" src="https://github.com/awslabs/iot-app-kit/assets/66272633/6d2eecfe-b072-4c26-8c33-8efee61e69fb">


### After Change

<img width="680" alt="Screenshot 2024-07-10 at 4 48 47 PM" src="https://github.com/awslabs/iot-app-kit/assets/66272633/7cf1470d-eb86-4944-b46c-b3e19f06af9f">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
