### PR TITLE
chore(dashboard): add story for edge2web testing

### DIFF
--- a/packages/dashboard/src/customization/widgets/constants.ts
+++ b/packages/dashboard/src/customization/widgets/constants.ts
@@ -5,6 +5,9 @@ export const SVG_STROKE_DOTTED = '3,3';
 export const WIDGET_INITIAL_HEIGHT = 400;
 export const WIDGET_INITIAL_WIDTH = 650;
 
+export const GAUGE_WIDGET_INITIAL_HEIGHT = 400;
+export const GAUGE_WIDGET_INITIAL_WIDTH = 500;
+
 export const KPI_WIDGET_INITIAL_HEIGHT = 200;
 export const KPI_WIDGET_INITIAL_WIDTH = 350;
 

--- a/packages/dashboard/src/customization/widgets/gauge/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/gauge/plugin.tsx
@@ -3,7 +3,10 @@ import GaugeWidgetComponent from './component';
 import GaugeIcon from './icon';
 import type { DashboardPlugin } from '~/customization/api';
 import type { GaugeWidget } from '../types';
-import { WIDGET_INITIAL_HEIGHT, WIDGET_INITIAL_WIDTH } from '../constants';
+import {
+  GAUGE_WIDGET_INITIAL_HEIGHT,
+  GAUGE_WIDGET_INITIAL_WIDTH,
+} from '../constants';
 
 export const gaugePlugin: DashboardPlugin = {
   install: ({ registerWidget }) => {
@@ -28,8 +31,8 @@ export const gaugePlugin: DashboardPlugin = {
         thresholds: [],
       }),
       initialSize: {
-        height: WIDGET_INITIAL_HEIGHT,
-        width: WIDGET_INITIAL_WIDTH,
+        height: GAUGE_WIDGET_INITIAL_HEIGHT,
+        width: GAUGE_WIDGET_INITIAL_WIDTH,
       },
     });
   },

--- a/packages/dashboard/src/migration/constants.ts
+++ b/packages/dashboard/src/migration/constants.ts
@@ -3,7 +3,7 @@ import { MonitorWidgetType, MonitorMetric, MonitorAnnotations } from './types';
 export const defaultDisplaySettings = {
   numRows: 100,
   numColumns: 100,
-  cellSize: 10,
+  cellSize: 20,
   significantDigits: 4,
 };
 export const defaultResolution = '1m';

--- a/packages/dashboard/stories/dashboard/mocked-edge2web.stories.tsx
+++ b/packages/dashboard/stories/dashboard/mocked-edge2web.stories.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { Dashboard } from '../../src/index';
+import {
+  DashboardClientConfiguration,
+  DashboardConfiguration,
+} from '../../src/types';
+import { DEFAULT_REGION } from '~/msw/constants';
+import { useWorker } from '~/msw/useWorker';
+import { RefreshRate } from '~/components/refreshRate/types';
+
+const clientConfiguration: DashboardClientConfiguration = {
+  awsCredentials: {
+    accessKeyId: '',
+    secretAccessKey: '',
+  },
+  awsRegion: DEFAULT_REGION,
+};
+
+export default {
+  title: 'Dashboard/Edge2Web Mocked Dashboard',
+  component: Dashboard,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  // Applies to all stories under Mocked data
+  decorators: [
+    (Story) => {
+      useWorker();
+      return <Story />;
+    },
+  ],
+} as ComponentMeta<typeof Dashboard>;
+
+const displaySettings = {
+  numColumns: 100,
+  numRows: 100,
+};
+
+const defaultViewport = { duration: '10m' };
+const querySettings = { refreshRate: 5000 as RefreshRate };
+const emptyDashboardConfiguration = {
+  clientConfiguration,
+};
+
+export const EditableDashboard: ComponentStory<typeof Dashboard> = () => {
+  const [dashboardConfiguration, setDashboardConfiguration] =
+    useState<DashboardConfiguration>({
+      displaySettings,
+      defaultViewport,
+      widgets: [],
+      querySettings,
+    });
+
+  const onConfigChange = (config: DashboardConfiguration) => {
+    console.log('### onConfigChange', config);
+    setDashboardConfiguration(config);
+  };
+
+  return (
+    <Dashboard
+      {...emptyDashboardConfiguration}
+      dashboardConfiguration={dashboardConfiguration}
+      onDashboardConfigurationChange={onConfigChange}
+    />
+  );
+};

--- a/packages/doc-site/stories/components/kpi/Kpi.stories.tsx
+++ b/packages/doc-site/stories/components/kpi/Kpi.stories.tsx
@@ -5,7 +5,7 @@ import {
   mockTimeSeriesDataQueryWithError,
   mockTimeSeriesDataQueryLoading,
 } from '@iot-app-kit/testing-util';
-import { mockSinWaveData } from '../../mockSinWaveData';
+import { mockSinWaveData, mockSinWaveDataWithQuality } from '../../mockSinWaveData';
 
 // More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
 const meta: Meta<typeof KPI> = {
@@ -47,5 +47,20 @@ export const Loading: Story = {
 export const Empty: Story = {
   args: {
     query: mockTimeSeriesDataQuery([]),
+  },
+};
+
+export const UncertainDataQuality: Story = {
+  args: {
+    query: mockSinWaveDataWithQuality({
+      frequency: '5s',
+      quality: 'UNCERTAIN',
+    }),
+  },
+};
+
+export const BadDataQuality: Story = {
+  args: {
+    query: mockSinWaveDataWithQuality({ frequency: '5s', quality: 'BAD' }),
   },
 };

--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -59,6 +59,7 @@ const BaseChart = ({
   queries,
   onChartOptionsChange,
   size = { width: 650, height: 400 },
+  gestures = true,
   ...options
 }: ChartOptions) => {
   const {
@@ -152,6 +153,7 @@ const BaseChart = ({
     thresholds,
     visibleData,
     chartWidth,
+    gestures,
     ...options,
   });
 
@@ -166,13 +168,17 @@ const BaseChart = ({
   const { chartEventsKeyMap, chartEventsHandlers } =
     useHandleChartEvents(chartRef);
 
-  const hotKeyMap = {
-    ...chartEventsKeyMap,
-  };
+  const hotKeyMap = gestures
+    ? {
+        ...chartEventsKeyMap,
+      }
+    : {};
 
-  const hotKeyHandlers = {
-    ...chartEventsHandlers,
-  };
+  const hotKeyHandlers = gestures
+    ? {
+        ...chartEventsHandlers,
+      }
+    : {};
 
   const handleMouseDown = (e: MouseEvent) => {
     const target = e.target;

--- a/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
+++ b/packages/react-components/src/components/chart/chartOptions/useChartConfiguration.ts
@@ -16,6 +16,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import isEqual from 'lodash.isequal';
 import {
   DEFAULT_CHART_OPTION,
+  DEFAULT_DATA_ZOOM,
   PERFORMANCE_MODE_THRESHOLD,
 } from '../eChartsConstants';
 import { useSeriesAndYAxis } from './seriesAndYAxis/convertSeriesAndYAxis';
@@ -100,7 +101,9 @@ type ChartConfigurationOptions = Pick<
   dataStreams: DataStream[];
 } & { visibleData: DataPoint[] } & {
   thresholds: Threshold<ThresholdValue>[];
-} & { chartWidth: number } & ChartDataQuality;
+} & { chartWidth: number } & ChartDataQuality & {
+    gestures: boolean;
+  };
 
 export type DataStreamMetaData = ReturnType<
   typeof useChartConfiguration
@@ -122,6 +125,7 @@ export const useChartConfiguration = (
     visibleData,
     id,
     axis,
+    gestures,
     backgroundColor,
     significantDigits,
     styleSettings,
@@ -230,6 +234,7 @@ export const useChartConfiguration = (
         tooltip,
         series,
         yAxis,
+        dataZoom: gestures ? DEFAULT_DATA_ZOOM : { disabled: true },
       },
       {
         ...updateSettings,
@@ -244,6 +249,7 @@ export const useChartConfiguration = (
     xAxis,
     tooltip,
     series,
+    gestures,
     yAxis,
     dataSteamIdentifiers,
   ]);

--- a/packages/react-components/src/components/chart/eChartsConstants.ts
+++ b/packages/react-components/src/components/chart/eChartsConstants.ts
@@ -144,7 +144,6 @@ export const DEFAULT_CHART_OPTION: EChartsOption = {
   title: {
     top: 10,
   },
-  dataZoom: DEFAULT_DATA_ZOOM,
   animation: false,
   toolbox: DEFAULT_TOOLBOX_CONFIG,
   xAxis: DEFAULT_X_AXIS,

--- a/packages/react-components/src/components/data-quality/data-quality-text.tsx
+++ b/packages/react-components/src/components/data-quality/data-quality-text.tsx
@@ -3,13 +3,9 @@ import { Quality } from '@aws-sdk/client-iotsitewise';
 import Box from '@cloudscape-design/components/box';
 import Icon from '@cloudscape-design/components/icon';
 import {
-  spaceScaledXxs,
-  colorBackgroundStatusError,
-  colorBackgroundStatusWarning,
-  borderRadiusBadge,
   colorBorderStatusError,
   colorBorderStatusWarning,
-  spaceScaledXs,
+  spaceScaledXxs,
 } from '@cloudscape-design/design-tokens';
 
 import './data-quality-text.css';
@@ -25,29 +21,29 @@ export const DataQualityText = ({ quality }: DataQualityTextOptions) => {
   let icon = null;
   let text = null;
   let styles: React.CSSProperties = {
-    padding: `${spaceScaledXxs} ${spaceScaledXs}`,
-    border: '1px solid',
-    borderRadius: borderRadiusBadge,
     gap: spaceScaledXxs,
+    textDecoration: 'none',
   };
+
+  let borderBottom = '1px dashed ';
 
   switch (quality) {
     case 'BAD':
       icon = <Icon name='status-negative' variant='error' />;
       text = <Box color='text-status-error'>Bad Quality</Box>;
+      borderBottom += colorBorderStatusError;
       styles = {
         ...styles,
-        borderColor: colorBorderStatusError,
-        backgroundColor: colorBackgroundStatusError,
+        borderBottom: borderBottom,
       };
       break;
     case 'UNCERTAIN':
       icon = <Icon name='status-warning' variant='warning' />;
       text = <Box color='text-status-warning'>Uncertain Quality</Box>;
+      borderBottom += colorBorderStatusWarning;
       styles = {
         ...styles,
-        borderColor: colorBorderStatusWarning,
-        backgroundColor: colorBackgroundStatusWarning,
+        borderBottom: borderBottom,
       };
       break;
   }


### PR DESCRIPTION
## Overview
Created a story that simply passed in the dashboard config everytime onConfigChange handler is called. This is to try and find the root cause of edge2web bugs which only show themselves when you intercept dashboard config changes on the fly and pass them back into the dashboard.

## Verifying Changes

https://github.com/awslabs/iot-app-kit/assets/145582655/c0b5fd25-88c0-4c09-8f03-2899f7fa8819

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
