### PR TITLE
fix(react-components): gauge thresholds with negative ranges

### DIFF
--- a/packages/react-components/src/components/gauge/utils/getThresholdRangeFromMinMax.ts
+++ b/packages/react-components/src/components/gauge/utils/getThresholdRangeFromMinMax.ts
@@ -20,14 +20,14 @@ export const getThresholdRangeFromMinMax = ({
     case 'GTE':
       // if the GT/GTE threshold is out of range (beyond the y-max), don't display it
       if (value >= max) return [1, 1];
-      return [value / range, undefined];
+      return [(value - min) / range, undefined];
     case 'LT':
     case 'LTE':
       // if the LT/LTE threshold is past the y-max, threshold should have a range 0%-100%
       if (value >= max) return [undefined, 1];
       // if the LT/LTE threshold is out of range (beyond the y-min), don't display it
       if (value <= min) return [0, 0];
-      return [undefined, value / range];
+      return [undefined, (value - min) / range];
     default:
       // any other comparisonOperator
       return [0, 0];


### PR DESCRIPTION
## Overview
Before: negative thresholds were not working properly when y-axis min was a negative value
<img width="1200" alt="Screenshot 2024-07-23 at 15 10 43" src="https://github.com/user-attachments/assets/3f7da14a-3d47-4b7e-a537-a9f3ea459af8">


Now: all y-axis properly render the thresholds
<img width="600" alt="Screenshot 2024-07-24 at 13 34 54" src="https://github.com/user-attachments/assets/2cef5d1f-c141-4562-bf36-acd66469ea40">
<img width="600" alt="Screenshot 2024-07-24 at 13 35 13" src="https://github.com/user-attachments/assets/0eddb008-1e7a-4c72-8072-969369f61d40">
<img width="600" alt="Screenshot 2024-07-24 at 13 35 43" src="https://github.com/user-attachments/assets/d2ebb38f-2c45-4523-be05-060cf9f8d79d">




## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
