### PR TITLE
fix: label matches kpi name

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/components/dataStreamLabelComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/components/dataStreamLabelComponent.tsx
@@ -6,20 +6,22 @@ import {
   Input,
   ExpandableSection,
 } from '@cloudscape-design/components';
+import { PropertySummary } from '~/hooks/useAssetDescriptionQueries';
 
 type DataStreamTextBoxProps = {
   name?: string;
-  label: string;
+
+  propertyName: NonNullable<PropertySummary['name']>;
   updateName: (newName: string) => void;
 };
 
 export const DataStreamLabelComponent = ({
-  label,
   updateName,
   name,
+  propertyName,
 }: DataStreamTextBoxProps) => {
-  const [value, setValue] = useState(name ?? label);
-  const [checked, setChecked] = useState(value === label);
+  const [value, setValue] = useState(name ?? propertyName);
+  const [checked, setChecked] = useState(value === propertyName);
 
   return (
     <ExpandableSection headerText='Label' disableContentPaddings={true}>
@@ -29,8 +31,8 @@ export const DataStreamLabelComponent = ({
             onChange={({ detail }) => {
               setChecked(detail.checked);
               if (detail.checked) {
-                setValue(label);
-                updateName(label);
+                setValue(propertyName);
+                updateName(propertyName);
               }
             }}
             checked={checked}

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/getPropertyDisplay.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/getPropertyDisplay.tsx
@@ -11,14 +11,14 @@ export const getPropertyDisplay = (
   property: PropertySummary | undefined;
   label: string;
   display: DisplayType;
+  assetName?: string;
 } => {
   const property = properties?.find((prop) => prop.propertyId === propertyId);
   if (property) {
     return {
       display: 'property',
-      label:
-        (property?.name && assetName && `${property?.name} (${assetName})`) ||
-        propertyId,
+      label: property?.name ? `${property?.name}` : propertyId,
+      assetName: assetName,
       property,
     };
   }

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/propertyComponent.tsx
@@ -36,7 +36,10 @@ export const PropertyComponent: FC<PropertyComponentProps> = ({
   onUpdatePropertyName,
   colorable,
 }) => {
-  const { display, label } = getPropertyDisplay(propertyId, assetSummary);
+  const { display, label, property, assetName } = getPropertyDisplay(
+    propertyId,
+    assetSummary
+  );
 
   const color = styleSettings[refId]?.color;
   const name = styleSettings[refId]?.name;
@@ -56,7 +59,9 @@ export const PropertyComponent: FC<PropertyComponentProps> = ({
                   updateColor={onUpdatePropertyColor}
                 />
               )}
-              <span>{name ?? label}</span>
+              <span>
+                {name ?? label} {assetName && `(${assetName})`}
+              </span>
             </SpaceBetween>
           </Box>
         </SpaceBetween>
@@ -77,8 +82,8 @@ export const PropertyComponent: FC<PropertyComponentProps> = ({
           <div style={{ padding: `0 ${spaceStaticXl}` }}>
             <DataStreamLabelComponent
               name={name}
-              label={label}
               updateName={onUpdatePropertyName}
+              propertyName={property?.name ?? ''}
             />
           </div>
         </ExpandableSection>

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
@@ -293,7 +293,7 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
   onDeleteAssetQuery,
   colorable,
 }) => {
-  const { display, label } = getPropertyDisplay(
+  const { display, label, assetName } = getPropertyDisplay(
     property.propertyId,
     assetSummary
   );
@@ -331,7 +331,7 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
             style={{ marginBlock: spaceStaticXxs }}
             ref={labelRef}
           >
-            {name ?? label}
+            {name ?? label} ({assetName})
           </div>
         </Tooltip>
         <div style={{ float: 'right' }}>
@@ -357,7 +357,7 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
             <div style={{ padding: `0 ${spaceStaticXl}` }}>
               <DataStreamLabelComponent
                 name={name}
-                label={label}
+                propertyName={label}
                 updateName={(newName) => updateStyle({ name: newName })}
               />
               <LineStylePropertyConfig

--- a/packages/react-components/src/components/chart/hooks/useVisualizedDataStreams.ts
+++ b/packages/react-components/src/components/chart/hooks/useVisualizedDataStreams.ts
@@ -11,7 +11,6 @@ import isEqual from 'lodash.isequal';
 import { useTimeSeriesData } from '../../../hooks/useTimeSeriesData';
 import { useViewport } from '../../../hooks/useViewport';
 import { DEFAULT_VIEWPORT, StreamType } from '../../../common/constants';
-// import { ChartStyleSettings } from '../types';
 
 const isNotAlarmStream = ({ streamType }: DataStream) =>
   streamType !== StreamType.ALARM;
@@ -37,7 +36,6 @@ export const useVisualizedDataStreams = (
     settings: {
       fetchFromStartToEnd: true,
     },
-    // styles: styleSettings,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Overview
The default label matches the name of the data stream. It does not contain the assetName.

## Verifying Changes

<img width="1158" alt="Screenshot 2024-07-30 at 9 41 05 AM" src="https://github.com/user-attachments/assets/f6584670-67be-451c-ae54-5152559e454a">



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
