### PR TITLE
fix(dashboard): assetName displays conditionally in config panel for linechart

### DIFF
--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledPropertyComponent.tsx
@@ -331,7 +331,7 @@ export const StyledPropertyComponent: FC<StyledPropertyComponentProps> = ({
             style={{ marginBlock: spaceStaticXxs }}
             ref={labelRef}
           >
-            {name ?? label} ({assetName})
+            {name ?? label} {assetName && `(${assetName})`}
           </div>
         </Tooltip>
         <div style={{ float: 'right' }}>


### PR DESCRIPTION
## Overview
Add conditional assetName in case of unmodeled data for configPanel of line chart

## Verifying C
![Screenshot 2024-07-31 at 10 11 28 AM](https://github.com/user-attachments/assets/5c74fda0-1b1f-4217-898c-a3086eed5f71)
hanges


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
