### PR TITLE
fix(dashboard): migration for sitewise component + blackpearl widget types

### DIFF
--- a/packages/dashboard/src/migration/convert-monitor-to-app-defintion.ts
+++ b/packages/dashboard/src/migration/convert-monitor-to-app-defintion.ts
@@ -6,6 +6,7 @@ import {
 import {
   DashboardWidgetType,
   MonitorWidgetType,
+  SiteWiseWidgetType,
   MonitorMetric,
   SiteWiseMonitorDashboardDefinition,
   MonitorAnnotations,
@@ -32,18 +33,25 @@ import { removeCollisions } from './collision-logic';
 
 const convertType = (monitorChartType: string) => {
   switch (monitorChartType) {
+    case SiteWiseWidgetType.LINE_CHART:
     case MonitorWidgetType.LineChart:
       return DashboardWidgetType.XYPlot;
+    case SiteWiseWidgetType.BAR_CHART:
     case MonitorWidgetType.BarChart:
       return DashboardWidgetType.BarChart;
+    case SiteWiseWidgetType.SCATTER_CHART:
     case MonitorWidgetType.ScatterChart:
       return DashboardWidgetType.XYPlot;
+    case SiteWiseWidgetType.STATUS_TIMELINE:
     case MonitorWidgetType.StatusTimeline:
       return DashboardWidgetType.StatusTimeline;
+    case SiteWiseWidgetType.TABLE:
     case MonitorWidgetType.Table:
       return DashboardWidgetType.Table;
+    case SiteWiseWidgetType.KPI:
     case MonitorWidgetType.Kpi:
       return DashboardWidgetType.Kpi;
+    case SiteWiseWidgetType.STATUS_GRID:
     case MonitorWidgetType.StatusGrid:
       return DashboardWidgetType.Status;
     default:
@@ -70,7 +78,7 @@ const convertY = (y: number) => {
 };
 
 export const convertResolution = (
-  widgetType: MonitorWidgetType,
+  widgetType: MonitorWidgetType | SiteWiseWidgetType,
   resolution?: string
 ) => {
   if (
@@ -114,7 +122,7 @@ const convertThresholds = (monitorAnnotations?: MonitorAnnotations) => {
 
 const convertMetricsToQueryConfig = (
   monitorMetrics: MonitorMetric[],
-  widgetType: MonitorWidgetType
+  widgetType: MonitorWidgetType | SiteWiseWidgetType
 ) => {
   const assetMap: AssetMap = {};
   const refIds = [];
@@ -163,7 +171,7 @@ const convertMetricsToQueryConfig = (
 };
 
 const convertProperties = (
-  widgetType: MonitorWidgetType,
+  widgetType: MonitorWidgetType | SiteWiseWidgetType,
   monitorMetrics?: MonitorMetric[],
   monitorAnnotations?: MonitorAnnotations,
   monitorTitle?: string
@@ -266,7 +274,9 @@ export const convertWidget = (
   // One-to-many relationship for KPI and Status Timeline in Monitor-to-Application conversion
   if (
     widget.type === MonitorWidgetType.Kpi ||
-    widget.type === MonitorWidgetType.StatusGrid
+    widget.type === MonitorWidgetType.StatusGrid ||
+    widget.type === SiteWiseWidgetType.KPI ||
+    widget.type === SiteWiseWidgetType.STATUS_GRID
   ) {
     return convertKpiAndGridWidget(widget);
   } else {

--- a/packages/dashboard/src/migration/getters.ts
+++ b/packages/dashboard/src/migration/getters.ts
@@ -12,10 +12,13 @@ import {
   MonitorMetric,
   MonitorWidget,
   MonitorWidgetType,
+  SiteWiseWidgetType,
 } from './types';
 import { convertResolution } from './convert-monitor-to-app-defintion';
 
-export const getStaticProperties = (widgetType: MonitorWidgetType) => {
+export const getStaticProperties = (
+  widgetType: MonitorWidgetType | SiteWiseWidgetType
+) => {
   switch (widgetType) {
     case MonitorWidgetType.LineChart:
       return lineChartProperties;
@@ -34,7 +37,7 @@ export const getStaticProperties = (widgetType: MonitorWidgetType) => {
 
 export const getProperty = (
   metric: MonitorMetric,
-  widgetType: MonitorWidgetType,
+  widgetType: MonitorWidgetType | SiteWiseWidgetType,
   index: number
 ) => {
   let property: ApplicationProperty = {
@@ -69,7 +72,7 @@ export const getProperty = (
 };
 
 export const getStyleSettings = (
-  widgetType: MonitorWidgetType,
+  widgetType: MonitorWidgetType | SiteWiseWidgetType,
   refIds: string[]
 ) => {
   let styleSettings = {};

--- a/packages/dashboard/src/migration/types.ts
+++ b/packages/dashboard/src/migration/types.ts
@@ -21,6 +21,15 @@ export enum MonitorWidgetType {
   Table = 'sc-table',
 }
 
+export enum SiteWiseWidgetType {
+  LINE_CHART = 'monitor-line-chart',
+  BAR_CHART = 'monitor-bar-chart',
+  SCATTER_CHART = 'monitor-scatter-chart',
+  STATUS_TIMELINE = 'monitor-status-timeline',
+  KPI = 'monitor-kpi',
+  STATUS_GRID = 'monitor-status-grid',
+  TABLE = 'monitor-table',
+}
 export interface MonitorTrend {
   type: string;
   color: string;
@@ -57,7 +66,7 @@ export interface MonitorProperties {
 }
 
 export interface MonitorWidget {
-  type: MonitorWidgetType;
+  type: MonitorWidgetType | SiteWiseWidgetType;
   title: string;
   x: number;
   y: number;


### PR DESCRIPTION
## Overview
Edge2Web uses the SiteWiseWidgetType instead of the MonitorWidgetType. Migration script now supports both.
For reference: https://code.amazon.com/packages/IotBlackPearlApp/blobs/mainline/--/src/views/Dashboards/originalDashboardDefinitionShim.ts

## Verifying Changes
Before: 
<img width="1327" alt="Screenshot 2024-08-02 at 12 41 31 PM" src="https://github.com/user-attachments/assets/0d73cce8-0319-4bfc-9200-d31df7ba21e1">

Migrated: 
<img width="1366" alt="Screenshot 2024-08-02 at 11 45 19 AM" src="https://github.com/user-attachments/assets/9cdac2d9-1e9a-43d6-b171-a191d0be6083">




## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
