### PR TITLE
feat(dashboard): use react-components RE components to update dashboard RE for modeled and unmodeled data

### DIFF
--- a/packages/dashboard/e2e/tests/widgets/kpi.spec.ts
+++ b/packages/dashboard/e2e/tests/widgets/kpi.spec.ts
@@ -42,16 +42,15 @@ test.describe('Test KPI Widget', () => {
     resourceExplorer,
   }) => {
     //select 3 properties
-    await resourceExplorer.selectProperties([
-      'Max Temperature',
+    await resourceExplorer.addModeledProperties([
       'Min Temperature',
-      'Temperature',
+      'Max Temperature',
     ]);
     dashboardWithKPIWidget.gridArea.locator('.kpi-widget-empty-state');
-
-    //check that add button is disabled
-    const addButton = await resourceExplorer.getAddButton();
-    await expect(addButton).toBeDisabled();
+    const widget =
+      dashboardWithKPIWidget.gridArea.getByTestId('kpi-base-component');
+    expect(await widget.textContent()).toContain('Max Temperature');
+    expect(await widget.textContent()).not.toContain('Min Temperature');
   });
 
   test('KPI Widget supports show/hide several properties', async ({

--- a/packages/dashboard/e2e/tests/widgets/text.spec.ts
+++ b/packages/dashboard/e2e/tests/widgets/text.spec.ts
@@ -276,9 +276,10 @@ test.describe('Test Text Widget', () => {
       // go to preview
       await page.getByRole('button', { name: 'preview' }).click();
 
-      // clicking on the link
-      await page.getByText(TEXT_WIDGET_CONTENT).click();
-      await page.waitForURL(`**${url}`);
+      await expect(page.getByText(TEXT_WIDGET_CONTENT)).toHaveAttribute(
+        'href',
+        'https://www.validurl.com/test'
+      );
     });
 
     test('when link is enabled, it should sanitize href and not link if dangerous', async ({

--- a/packages/dashboard/jest-setup.js
+++ b/packages/dashboard/jest-setup.js
@@ -20,9 +20,9 @@ afterAll(() => {
 
 /** Disable logging during tests to keep the test runner clean. Comment out lines as needed. */
 function disableLogging() {
-  console.error = () => {};
-  console.info = () => {};
-  console.log = () => {};
-  console.table = () => {};
-  console.warn = () => {};
+  // console.error = () => {};
+  // console.info = () => {};
+  // console.log = () => {};
+  // console.table = () => {};
+  // console.warn = () => {};
 }

--- a/packages/dashboard/src/components/dashboard/getClients.ts
+++ b/packages/dashboard/src/components/dashboard/getClients.ts
@@ -1,5 +1,5 @@
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
-import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { IoTSiteWise, IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import {
   DashboardClientConfiguration,
@@ -31,10 +31,15 @@ export const getClients = (
     credentials: dashboardClientConfiguration.awsCredentials,
     region: dashboardClientConfiguration.awsRegion,
   });
+  const iotSiteWise = new IoTSiteWise({
+    credentials: dashboardClientConfiguration.awsCredentials,
+    region: dashboardClientConfiguration.awsRegion,
+  });
 
   return {
     iotEventsClient,
     iotSiteWiseClient,
     iotTwinMakerClient,
+    iotSiteWise,
   };
 };

--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -7,7 +7,10 @@ import {
 import { DashboardWrapper as Dashboard } from './wrapper';
 import React from 'react';
 import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
-import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import {
+  IoTSiteWise,
+  type IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
 import { RefreshRate } from '../refreshRate/types';
 
 it('renders', function () {
@@ -29,6 +32,7 @@ it('renders', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );
@@ -57,6 +61,7 @@ it('renders in readonly initially', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
       initialViewMode='preview'
     />
@@ -93,6 +98,7 @@ it('renders in edit initially', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
       initialViewMode='edit'
     />
@@ -133,6 +139,7 @@ it('passes the correct viewMode to onSave', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
       initialViewMode='edit'
     />
@@ -168,6 +175,7 @@ it('renders dashboard name', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );
@@ -193,6 +201,7 @@ it('renders without dashboard name', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );

--- a/packages/dashboard/src/components/dashboard/view.test.tsx
+++ b/packages/dashboard/src/components/dashboard/view.test.tsx
@@ -4,7 +4,10 @@ import {
   createMockSiteWiseSDK,
 } from '@iot-app-kit/testing-util';
 import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
-import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import {
+  IoTSiteWise,
+  type IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
 
 import DashboardView from './view';
 import React from 'react';
@@ -27,6 +30,7 @@ it('renders', function () {
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
+        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -97,7 +97,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
 }) => {
   useSyncDashboardConfiguration({ onDashboardConfigurationChange });
 
-  const { iotSiteWiseClient, iotTwinMakerClient } = useClients();
+  const { iotSiteWiseClient, iotTwinMakerClient, iotSiteWise } = useClients();
 
   /**
    * disable user select styles on drag to prevent highlighting of text under the pointer
@@ -291,7 +291,11 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
     backgroundColor: colorBackgroundLayoutMain,
   };
 
-  if (iotSiteWiseClient == null || iotTwinMakerClient == null) {
+  if (
+    iotSiteWiseClient == null ||
+    iotTwinMakerClient == null ||
+    iotSiteWise == null
+  ) {
     return null;
   }
 
@@ -347,8 +351,8 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
         <ResizablePanes
           leftPane={
             <QueryEditor
-              iotSiteWiseClient={iotSiteWiseClient}
-              iotTwinMakerClient={iotTwinMakerClient}
+              iotSiteWise={iotSiteWise}
+              selectedWidgets={selectedWidgets}
             />
           }
           centerPane={

--- a/packages/dashboard/src/components/queryEditor/helpers/getCorrectSelectionMode.spec.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/getCorrectSelectionMode.spec.ts
@@ -1,0 +1,34 @@
+import { DashboardWidget } from '~/types';
+import { getCorrectSelectionMode } from './getCorrectSelectionMode';
+
+const createMockWidget = (widgetType: string): DashboardWidget => {
+  return {
+    type: widgetType,
+    id: 'test-id',
+    x: 0,
+    y: 0,
+    z: 0,
+    height: 20,
+    width: 20,
+    properties: {},
+  };
+};
+
+describe('Get correct selection mode', () => {
+  it('returns single if kpi', () => {
+    expect(getCorrectSelectionMode([createMockWidget('kpi')])).toBe('single');
+  });
+  it('returns single if gauge', () => {
+    expect(getCorrectSelectionMode([createMockWidget('gauge')])).toBe('single');
+  });
+  it('returns multi if line', () => {
+    expect(getCorrectSelectionMode([createMockWidget('xy-plot')])).toBe(
+      'multi'
+    );
+  });
+  it('returns multi if bar', () => {
+    expect(getCorrectSelectionMode([createMockWidget('bar-chart')])).toBe(
+      'multi'
+    );
+  });
+});

--- a/packages/dashboard/src/components/queryEditor/helpers/getCorrectSelectionMode.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/getCorrectSelectionMode.ts
@@ -1,0 +1,8 @@
+import { DashboardWidget } from '~/types';
+
+export const getCorrectSelectionMode = (selectedWidgets: DashboardWidget[]) => {
+  return selectedWidgets.at(0)?.type === 'kpi' ||
+    selectedWidgets.at(0)?.type === 'gauge'
+    ? 'single'
+    : 'multi';
+};

--- a/packages/dashboard/src/components/queryEditor/helpers/isModeledPropertyInvalid.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/isModeledPropertyInvalid.ts
@@ -1,7 +1,5 @@
-import type { PropertyDataType } from '@aws-sdk/client-iotsitewise';
-
 export const isModeledPropertyInvalid = (
-  dataType?: PropertyDataType,
+  dataType?: string,
   widgetType?: string
 ) => {
   if (!widgetType || !dataType) return false;

--- a/packages/dashboard/src/components/queryEditor/helpers/propertySelectionLabel.spec.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/propertySelectionLabel.spec.ts
@@ -1,0 +1,53 @@
+import { DashboardWidget } from '~/types';
+import { propertySelectionLabel } from './propertySelectionLabel';
+
+const createMockWidget = (widgetType: string): DashboardWidget => {
+  return {
+    type: widgetType,
+    id: 'test-id',
+    x: 0,
+    y: 0,
+    z: 0,
+    height: 20,
+    width: 20,
+    properties: {},
+  };
+};
+
+const mockAssetProperty = {
+  propertyId: 'test-property',
+  name: 'Test Property',
+  assetId: '12345',
+  dataType: 'INTEGER',
+};
+
+const mockInvalidAssetProperty = {
+  propertyId: 'test-property2',
+  name: 'Test Property 2',
+  assetId: '123456',
+  dataType: 'STRING',
+};
+
+describe('Selection Labels for asset (model) properties', () => {
+  it('Unselected Property', () => {
+    expect(
+      propertySelectionLabel([], mockAssetProperty, [
+        createMockWidget('xy-plot'),
+      ])
+    ).toBe('Select modeled data stream Test Property');
+  });
+  it('Selected Property', () => {
+    expect(
+      propertySelectionLabel([mockAssetProperty], mockAssetProperty, [
+        createMockWidget('xy-plot'),
+      ])
+    ).toBe('Deselect modeled data stream Test Property');
+  });
+  it('Invalid Property', () => {
+    expect(
+      propertySelectionLabel([], mockInvalidAssetProperty, [
+        createMockWidget('xy-plot'),
+      ])
+    ).toBe('STRING data not supported for the selected widget');
+  });
+});

--- a/packages/dashboard/src/components/queryEditor/helpers/propertySelectionLabel.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/propertySelectionLabel.ts
@@ -1,0 +1,29 @@
+import {
+  AssetPropertyExplorerProps,
+  AssetPropertyResource,
+} from '@iot-app-kit/react-components';
+import { isModeledPropertyInvalid } from './isModeledPropertyInvalid';
+import { DashboardWidget } from '~/types';
+
+export function propertySelectionLabel(
+  selectedItems: AssetPropertyExplorerProps['selectedAssetProperties'],
+  modeledDataStream: AssetPropertyResource,
+  selectedWidgets: DashboardWidget[]
+) {
+  const isPropertySelected = selectedItems?.find(
+    (item) => item.propertyId === modeledDataStream.propertyId
+  );
+
+  if (
+    isModeledPropertyInvalid(
+      modeledDataStream.dataType,
+      selectedWidgets?.at(0)?.type
+    )
+  ) {
+    return `${modeledDataStream.dataType} data not supported for the selected widget`;
+  } else if (!isPropertySelected) {
+    return `Select modeled data stream ${modeledDataStream.name}`;
+  } else {
+    return `Deselect modeled data stream ${modeledDataStream.name}`;
+  }
+}

--- a/packages/dashboard/src/components/queryEditor/helpers/useIsAddButtonDisabled.spec.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/useIsAddButtonDisabled.spec.ts
@@ -1,0 +1,57 @@
+import { type DashboardWidget } from '~/types';
+import { useIsAddButtonDisabled } from './useIsAddButtonDisabled';
+import { DataStreamQuery } from '@iot-app-kit/core';
+import { AssetQuery } from '@iot-app-kit/source-iotsitewise';
+
+const createMockWidget = (widgetType: string): DashboardWidget => {
+  return {
+    type: widgetType,
+    id: 'test-id',
+    x: 0,
+    y: 0,
+    z: 0,
+    height: 20,
+    width: 20,
+    properties: {},
+  };
+};
+type Query =
+  | Partial<
+      DataStreamQuery & {
+        assets: AssetQuery[];
+      }
+    >
+  | undefined;
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => jest.fn(),
+  useSelector: () => jest.fn(),
+}));
+
+const queryObject: {
+  query: Query;
+  setQuery: (query: Query) => void;
+} = { query: undefined, setQuery: jest.fn() };
+
+jest.mock('../useQuery', () => ({
+  useQuery: jest.fn(() => [queryObject.query, queryObject.setQuery]),
+}));
+
+it('Enabled with no widgets', () => {
+  expect(useIsAddButtonDisabled([])).toBe(false);
+});
+
+it('Enabled with line widget', () => {
+  expect(useIsAddButtonDisabled([createMockWidget('xy-plot')])).toBe(false);
+});
+
+it('Enabled with KPI with no query', () => {
+  expect(useIsAddButtonDisabled([createMockWidget('kpi')])).toBe(false);
+});
+
+it('Disabled with KPI with query', () => {
+  queryObject.query = { assets: [{ assetId: '1234', properties: [] }] };
+  useIsAddButtonDisabled([createMockWidget('kpi')]);
+  expect(useIsAddButtonDisabled([createMockWidget('kpi')])).toBe(true);
+});

--- a/packages/dashboard/src/components/queryEditor/helpers/useIsAddButtonDisabled.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/useIsAddButtonDisabled.ts
@@ -1,0 +1,20 @@
+import { DashboardWidget } from '~/types';
+import { useQuery } from '../useQuery';
+
+export const useIsAddButtonDisabled = (selectedWidgets: DashboardWidget[]) => {
+  const selectedWidget = selectedWidgets.at(0);
+  const [query, _useQuery] = useQuery();
+
+  if (!selectedWidget || !query) return false;
+
+  if (selectedWidget.type === 'kpi' || selectedWidget.type === 'gauge') {
+    if (
+      query.assetModels?.length ||
+      query.assets?.length ||
+      query.properties?.length
+    )
+      return true;
+  }
+
+  return selectedWidgets.length === 0;
+};

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/footer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/footer.tsx
@@ -9,7 +9,6 @@ import {
   colorBorderDividerDefault,
   spaceStaticXxxs,
 } from '@cloudscape-design/design-tokens';
-import { STICKY_BUTTON_WIDTH_FACTOR } from '../constants';
 import './index.css';
 
 export type ResourceExplorerFooterOptions = {
@@ -29,7 +28,7 @@ export const ResourceExplorerFooter = ({
   const stickyFooter = {
     backgroundColor: colorBackgroundContainerContent,
     bottom: spaceStaticXxxs,
-    width: width + STICKY_BUTTON_WIDTH_FACTOR,
+    width: width,
     borderTop: `${spaceStaticXxxs} solid ${colorBorderDividerDefault}`,
   };
 

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.spec.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.spec.tsx
@@ -1,0 +1,439 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IoTSiteWiseQueryEditor } from './iotSiteWiseQueryEditor';
+import { resourceExplorerQueryClient } from '@iot-app-kit/react-components';
+import {
+  AssetModelPropertySummary,
+  AssetPropertySummary,
+  AssetSummary,
+  IoTSiteWise,
+  ListAssetsResponse,
+  ListAssetPropertiesResponse,
+  ListAssetModelPropertiesResponse,
+} from '@aws-sdk/client-iotsitewise';
+import { configureDashboardStore } from '~/store';
+import { Provider } from 'react-redux';
+
+export async function waitForLoadingToFinish() {
+  await waitFor(() => {
+    expect(screen.getByText(/Loading/)).toBeVisible();
+  });
+
+  await waitFor(() => {
+    expect(screen.queryByText(/Loading/)).not.toBeInTheDocument();
+  });
+}
+
+export function createListAssetsPage(
+  pageSize: number,
+  startIndex = 0,
+  nextToken?: string
+) {
+  const assetSummaries = new Array(pageSize).fill(null).map((_, index) => {
+    const uniqueId = index + startIndex;
+
+    return {
+      arn: 'arn',
+      id: `asset-${uniqueId}`,
+      name: `Asset ${uniqueId}`,
+      assetModelId: `asset-model-${uniqueId}`,
+      description: `Description ${uniqueId}`,
+      hierarchies: [],
+      creationDate: new Date(0),
+      lastUpdateDate: new Date(1),
+      status: {
+        state: 'ACTIVE',
+      },
+    };
+  }) satisfies AssetSummary[];
+
+  return {
+    assetSummaries,
+    nextToken,
+  } satisfies Awaited<PromiseLike<ListAssetsResponse>>;
+}
+
+export function createListAssetPropertiesPage(
+  pageSize: number,
+  startIndex = 0,
+  nextToken?: string
+) {
+  const assetPropertySummaries = new Array(pageSize)
+    .fill(null)
+    .map((_, index) => {
+      const uniqueId = index + startIndex;
+
+      return {
+        id: `asset-property-${uniqueId}`,
+      };
+    }) satisfies AssetPropertySummary[];
+
+  return {
+    assetPropertySummaries,
+    nextToken,
+  } satisfies Awaited<PromiseLike<ListAssetPropertiesResponse>>;
+}
+
+export function createListAssetModelPropertiesPage(
+  pageSize: number,
+  startIndex = 0,
+  nextToken?: string
+) {
+  const assetModelPropertySummaries = new Array(pageSize)
+    .fill(null)
+    .map((_, index) => {
+      const uniqueId = index + startIndex;
+
+      return {
+        id: `asset-property-${uniqueId}`,
+        name: `Asset Property ${uniqueId}`,
+        dataType: 'STRING',
+        type: {
+          measurement: {},
+        },
+      };
+    }) satisfies AssetModelPropertySummary[];
+
+  return {
+    assetModelPropertySummaries,
+    nextToken,
+  } satisfies Awaited<PromiseLike<ListAssetModelPropertiesResponse>>;
+}
+
+const {
+  assetSummaries: [asset1, asset2, asset3],
+} = createListAssetsPage(3);
+const asset1WithHierarchy = {
+  ...asset1,
+  hierarchies: [{ id: 'hierachy-id', name: 'Hierarchy' }],
+};
+
+const listAssetPropertiesResponse = createListAssetPropertiesPage(3);
+const listAssetModelPropertiesResponse = createListAssetModelPropertiesPage(3);
+const assetProperty1 = {
+  ...listAssetPropertiesResponse.assetPropertySummaries[0],
+  unit: 'm/s',
+};
+const assetModelProperty1 = {
+  ...listAssetModelPropertiesResponse.assetModelPropertySummaries[0],
+  dataType: 'STRING',
+};
+const assetProperty2 = {
+  ...listAssetPropertiesResponse.assetPropertySummaries[1],
+  unit: 'km/s',
+};
+const assetModelProperty2 = {
+  ...listAssetModelPropertiesResponse.assetModelPropertySummaries[1],
+  dataType: 'DOUBLE',
+};
+const assetProperty3 = {
+  ...listAssetPropertiesResponse.assetPropertySummaries[2],
+  unit: 'cm/s',
+};
+const assetModelProperty3 = {
+  ...listAssetModelPropertiesResponse.assetModelPropertySummaries[2],
+  dataType: 'INTEGER',
+};
+
+describe('Query editor tests', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    resourceExplorerQueryClient.clear();
+  });
+
+  test('Renders query', async () => {
+    const listAssets = jest.fn().mockResolvedValue({
+      assetSummaries: [asset1WithHierarchy, asset2, asset3],
+    });
+    const listAssetProperties = jest.fn().mockResolvedValue({
+      assetPropertySummaries: [assetProperty1, assetProperty2, assetProperty3],
+    });
+    const listAssetModelProperties = jest.fn().mockResolvedValue({
+      assetModelPropertySummaries: [
+        assetModelProperty1,
+        assetModelProperty2,
+        assetModelProperty3,
+      ],
+    });
+    render(
+      <Provider store={configureDashboardStore()}>
+        <IoTSiteWiseQueryEditor
+          onUpdateQuery={() => {}}
+          iotSiteWise={
+            {
+              ...new IoTSiteWise({
+                credentials: {
+                  accessKeyId: '',
+                  secretAccessKey: '',
+                  sessionToken: '',
+                },
+                region: 'us-east-1',
+              }),
+              listAssets,
+              listAssetProperties,
+              listAssetModelProperties,
+            } as unknown as IoTSiteWise
+          }
+          selectedWidgets={[]}
+          addButtonDisabled={false}
+          correctSelectionMode='single'
+        />
+      </Provider>
+    );
+
+    await waitForLoadingToFinish();
+
+    const asset = screen.getByText('Asset 0');
+    expect(asset).toBeInTheDocument();
+  });
+
+  test('Single select calls update query one time', async () => {
+    const listAssets = jest.fn().mockResolvedValue({
+      assetSummaries: [asset1WithHierarchy, asset2, asset3],
+    });
+    const listAssetProperties = jest.fn().mockResolvedValue({
+      assetPropertySummaries: [assetProperty1, assetProperty2, assetProperty3],
+    });
+    const listAssetModelProperties = jest.fn().mockResolvedValue({
+      assetModelPropertySummaries: [
+        assetModelProperty1,
+        assetModelProperty2,
+        assetModelProperty3,
+      ],
+    });
+    const user = userEvent.setup();
+    const onUpdateQuery = jest.fn();
+    render(
+      <Provider store={configureDashboardStore()}>
+        <IoTSiteWiseQueryEditor
+          onUpdateQuery={onUpdateQuery}
+          iotSiteWise={
+            {
+              ...new IoTSiteWise({
+                credentials: {
+                  accessKeyId: '',
+                  secretAccessKey: '',
+                  sessionToken: '',
+                },
+                region: 'us-east-1',
+              }),
+              listAssets,
+              listAssetProperties,
+              listAssetModelProperties,
+            } as unknown as IoTSiteWise
+          }
+          selectedWidgets={[]}
+          addButtonDisabled={false}
+          correctSelectionMode='single'
+        />
+      </Provider>
+    );
+
+    await waitForLoadingToFinish();
+
+    const asset = screen.getByText('Asset 0');
+    expect(asset).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Select asset Asset 0'));
+
+    const tableTitle = screen.getByText('Asset properties');
+    expect(tableTitle).toBeInTheDocument();
+
+    await user.click(
+      screen.getByLabelText('Select modeled data stream Asset Property 0')
+    );
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    expect(onUpdateQuery).toBeCalledTimes(1);
+  });
+
+  test('Adding multiselected properties at once calls update query one time', async () => {
+    const listAssets = jest.fn().mockResolvedValue({
+      assetSummaries: [asset1WithHierarchy, asset2, asset3],
+    });
+    const listAssetProperties = jest.fn().mockResolvedValue({
+      assetPropertySummaries: [assetProperty1, assetProperty2, assetProperty3],
+    });
+    const listAssetModelProperties = jest.fn().mockResolvedValue({
+      assetModelPropertySummaries: [
+        assetModelProperty1,
+        assetModelProperty2,
+        assetModelProperty3,
+      ],
+    });
+    const user = userEvent.setup();
+    const onUpdateQuery = jest.fn();
+    render(
+      <Provider store={configureDashboardStore()}>
+        <IoTSiteWiseQueryEditor
+          onUpdateQuery={onUpdateQuery}
+          iotSiteWise={
+            {
+              ...new IoTSiteWise({
+                credentials: {
+                  accessKeyId: '',
+                  secretAccessKey: '',
+                  sessionToken: '',
+                },
+                region: 'us-east-1',
+              }),
+              listAssets,
+              listAssetProperties,
+              listAssetModelProperties,
+            } as unknown as IoTSiteWise
+          }
+          selectedWidgets={[]}
+          addButtonDisabled={false}
+          correctSelectionMode='single'
+        />
+      </Provider>
+    );
+
+    await waitForLoadingToFinish();
+
+    const asset = screen.getByText('Asset 0');
+    expect(asset).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Select asset Asset 0'));
+
+    const tableTitle = screen.getByText('Asset properties');
+    expect(tableTitle).toBeInTheDocument();
+
+    await user.click(
+      screen.getByLabelText('Select modeled data stream Asset Property 0')
+    );
+    await user.click(
+      screen.getByLabelText('Select modeled data stream Asset Property 1')
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    expect(onUpdateQuery).toBeCalledTimes(1);
+  });
+
+  test('Adding multiselected properties mulitiple times calls update query multiple times', async () => {
+    const listAssets = jest.fn().mockResolvedValue({
+      assetSummaries: [asset1WithHierarchy, asset2, asset3],
+    });
+    const listAssetProperties = jest.fn().mockResolvedValue({
+      assetPropertySummaries: [assetProperty1, assetProperty2, assetProperty3],
+    });
+    const listAssetModelProperties = jest.fn().mockResolvedValue({
+      assetModelPropertySummaries: [
+        assetModelProperty1,
+        assetModelProperty2,
+        assetModelProperty3,
+      ],
+    });
+    const user = userEvent.setup();
+    const onUpdateQuery = jest.fn();
+    render(
+      <Provider store={configureDashboardStore()}>
+        <IoTSiteWiseQueryEditor
+          onUpdateQuery={onUpdateQuery}
+          iotSiteWise={
+            {
+              ...new IoTSiteWise({
+                credentials: {
+                  accessKeyId: '',
+                  secretAccessKey: '',
+                  sessionToken: '',
+                },
+                region: 'us-east-1',
+              }),
+              listAssets,
+              listAssetProperties,
+              listAssetModelProperties,
+            } as unknown as IoTSiteWise
+          }
+          selectedWidgets={[]}
+          addButtonDisabled={false}
+          correctSelectionMode='single'
+        />
+      </Provider>
+    );
+
+    await waitForLoadingToFinish();
+
+    const asset = screen.getByText('Asset 0');
+    expect(asset).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Select asset Asset 0'));
+
+    const tableTitle = screen.getByText('Asset properties');
+    expect(tableTitle).toBeInTheDocument();
+
+    await user.click(
+      screen.getByLabelText('Select modeled data stream Asset Property 0')
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    expect(onUpdateQuery).toBeCalledTimes(1);
+
+    await user.click(
+      screen.getByLabelText('Select modeled data stream Asset Property 1')
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    expect(onUpdateQuery).toBeCalledTimes(2);
+  });
+
+  // test('Adding multiselected properties mulitiple times calls update query multiple times', async () => {
+  //   const listAssets = jest.fn().mockResolvedValue({
+  //     assetSummaries: [asset1WithHierarchy, asset2, asset3],
+  //   });
+  //   const listAssetProperties = jest.fn().mockResolvedValue({
+  //     assetPropertySummaries: [assetProperty1, assetProperty2, assetProperty3],
+  //   });
+  //   const listAssetModelProperties = jest.fn().mockResolvedValue({
+  //     assetModelPropertySummaries: [
+  //       assetModelProperty1,
+  //       assetModelProperty2,
+  //       assetModelProperty3,
+  //     ],
+  //   });
+  //   const onUpdateQuery = jest.fn();
+  //   render(
+  //     <Provider store={configureDashboardStore()}>
+  //       <IoTSiteWiseQueryEditor
+  //         onUpdateQuery={onUpdateQuery}
+  //         iotSiteWise={
+  //           {
+  //             listAssets,
+  //             listAssetProperties,
+  //             listAssetModelProperties,
+  //           } as unknown as IoTSiteWise
+  //         }
+  //         selectedWidgets={[]}
+  //         addButtonDisabled={false}
+  //         correctSelectionMode='multi'
+  //       />
+  //     </Provider>
+  //   );
+
+  //   await waitForLoadingToFinish();
+
+  //   const asset = screen.getByText('Asset 0');
+  //   expect(asset).toBeInTheDocument();
+
+  //   screen.getByLabelText('Select asset Asset 0').click();
+
+  //   const tableTitle = screen.getByText('Asset properties');
+  //   expect(tableTitle).toBeInTheDocument();
+
+  //   await waitForLoadingToFinish();
+
+  //   const addButton = screen.getByRole('button', { name: 'Add' });
+
+  //   screen
+  //     .getByLabelText('Select modeled data stream Asset Property 0')
+  //     .click();
+  //   addButton.click();
+  //   expect(onUpdateQuery).toBeCalledTimes(1);
+
+  //   screen
+  //     .getByLabelText('Select modeled data stream Asset Property 1')
+  //     .click();
+  //   addButton.click();
+  //   expect(onUpdateQuery).toBeCalledTimes(2);
+  // });
+});

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
@@ -1,77 +1,57 @@
-import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
-import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
-import Tabs from '@cloudscape-design/components/tabs';
 import React from 'react';
+import { IoTSiteWise } from '@aws-sdk/client-iotsitewise';
+import Tabs from '@cloudscape-design/components/tabs';
 import { useSelector } from 'react-redux';
-
 import type { DashboardState } from '~/store/state';
-import { ModeledDataStreamQueryEditor } from './modeledDataStreamQueryEditor';
-import { UnmodeledDataStreamQueryEditor } from './unmodeledDataStreamExplorer';
-import { QueryExtender } from './queryExtender';
-import type { ModeledDataStream } from './modeledDataStreamQueryEditor/modeledDataStreamExplorer/types';
-import type { UnmodeledDataStream } from './unmodeledDataStreamExplorer/types';
 import { useQuery } from '../useQuery';
 import { AssetModelDataStreamExplorer } from './assetModelDataStreamExplorer/assetModelDataStreamExplorer';
+import { ModeledExplorer } from './modeledExplorer/modeledExplorer';
+import { DashboardWidget } from '~/types';
+import { UnmodeledExplorer } from './timeSeriesExplorer/timeSeriesExplorer';
 
 export interface IoTSiteWiseQueryEditorProps {
   onUpdateQuery: ReturnType<typeof useQuery>[1];
-  iotSiteWiseClient: IoTSiteWiseClient;
-  iotTwinMakerClient: IoTTwinMakerClient;
+  iotSiteWise: IoTSiteWise;
+  selectedWidgets: DashboardWidget[];
+  addButtonDisabled: boolean;
+  correctSelectionMode: 'single' | 'multi';
 }
 
 export function IoTSiteWiseQueryEditor({
   onUpdateQuery,
-  iotSiteWiseClient,
-  iotTwinMakerClient,
+  iotSiteWise,
+  selectedWidgets,
+  addButtonDisabled,
+  correctSelectionMode,
 }: IoTSiteWiseQueryEditorProps) {
   const isEdgeModeEnabled = useSelector(
     (state: DashboardState) => state.isEdgeModeEnabled
   );
 
-  function handleClickAddModeledDataStreams(
-    newModeledDataStreams: ModeledDataStream[]
-  ) {
-    onUpdateQuery((currentQuery) => {
-      const queryExtender = new QueryExtender(currentQuery);
-      const updatedQuery = queryExtender.extendAssetQueries(
-        newModeledDataStreams
-      );
-
-      return updatedQuery;
-    });
-  }
-
-  function handleClickAddUnmodeledDataStreams(
-    newUnmodeledDataStreams: UnmodeledDataStream[]
-  ) {
-    onUpdateQuery((currentQuery) => {
-      const queryExtender = new QueryExtender(currentQuery);
-      const updatedQuery = queryExtender.extendPropertyAliasQueries(
-        newUnmodeledDataStreams
-      );
-
-      return updatedQuery;
-    });
-  }
-
   const modeledTab = {
     label: 'Modeled',
     id: 'explore-modeled-tab',
     content: (
-      <ModeledDataStreamQueryEditor
-        onClickAdd={handleClickAddModeledDataStreams}
-        iotSiteWiseClient={iotSiteWiseClient}
-        iotTwinMakerClient={iotTwinMakerClient}
+      <ModeledExplorer
+        onUpdateQuery={onUpdateQuery}
+        iotSiteWise={iotSiteWise}
+        correctSelectionMode={correctSelectionMode}
+        addButtonDisabled={addButtonDisabled}
+        selectedWidgets={selectedWidgets}
       />
     ),
   };
+
   const unmodeledTab = {
     label: 'Unmodeled',
     id: 'explore-unmodeled-tab',
     content: (
-      <UnmodeledDataStreamQueryEditor
-        onClickAdd={handleClickAddUnmodeledDataStreams}
-        client={iotSiteWiseClient}
+      <UnmodeledExplorer
+        onUpdateQuery={onUpdateQuery}
+        iotSiteWise={iotSiteWise}
+        correctSelectionMode={correctSelectionMode}
+        addButtonDisabled={addButtonDisabled}
+        selectedWidgets={selectedWidgets}
       />
     ),
     disabled: isEdgeModeEnabled,
@@ -80,7 +60,7 @@ export function IoTSiteWiseQueryEditor({
   const assetModeledTab = {
     label: 'Dynamic assets',
     id: 'explore-asset-model-tab',
-    content: <AssetModelDataStreamExplorer client={iotSiteWiseClient} />,
+    content: <AssetModelDataStreamExplorer client={iotSiteWise} />,
   };
 
   const defaultTabs = [modeledTab, unmodeledTab, assetModeledTab];

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledExplorer/modeledExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledExplorer/modeledExplorer.tsx
@@ -1,0 +1,126 @@
+import { Box } from '@cloudscape-design/components';
+import {
+  AssetExplorer,
+  AssetExplorerProps,
+  AssetPropertyExplorer,
+  AssetPropertyExplorerProps,
+  AssetPropertyResource,
+  AssetResource,
+  SelectionMode,
+} from '@iot-app-kit/react-components';
+import React, { useState } from 'react';
+import { isModeledPropertyInvalid } from '../../helpers/isModeledPropertyInvalid';
+import { ResourceExplorerFooter } from '../footer/footer';
+import { QueryExtender } from '../queryExtender';
+import { getPlugin } from '@iot-app-kit/core';
+import { useQuery } from '../../useQuery';
+import { IoTSiteWise } from '@aws-sdk/client-iotsitewise';
+import { DashboardWidget } from '~/types';
+import { propertySelectionLabel } from '../../helpers/propertySelectionLabel';
+
+type ModeledExplorerProps = {
+  onUpdateQuery: ReturnType<typeof useQuery>[1];
+  iotSiteWise: IoTSiteWise;
+  correctSelectionMode: SelectionMode;
+  addButtonDisabled: boolean;
+  selectedWidgets: DashboardWidget[];
+};
+
+export const ModeledExplorer = ({
+  onUpdateQuery,
+  iotSiteWise,
+  correctSelectionMode,
+  addButtonDisabled,
+  selectedWidgets,
+}: ModeledExplorerProps) => {
+  const [selectedAssets, setSelectedAssets] = useState<
+    NonNullable<AssetExplorerProps['selectedAssets']>
+  >([]);
+
+  const [selectedAssetProperties, setSelectedAssetProperties] = useState<
+    NonNullable<AssetPropertyExplorerProps['selectedAssetProperties']>
+  >([]);
+
+  const metricsRecorder = getPlugin('metricsRecorder');
+
+  function handleSelectAssets(
+    assets: NonNullable<AssetExplorerProps['selectedAssets']>
+  ) {
+    setSelectedAssets(assets);
+    setSelectedAssetProperties([]);
+  }
+
+  function handleClickAddModeledDataStreams(
+    newModeledDataStreams: readonly AssetPropertyResource[]
+  ) {
+    onUpdateQuery((currentQuery) => {
+      const queryExtender = new QueryExtender(currentQuery);
+      const updatedQuery = queryExtender.extendAssetQueries(
+        newModeledDataStreams
+      );
+
+      return updatedQuery;
+    });
+  }
+
+  return (
+    <Box padding={{ horizontal: 's' }}>
+      <AssetExplorer
+        requestFns={iotSiteWise}
+        onSelectAsset={handleSelectAssets}
+        selectedAssets={selectedAssets}
+        selectionMode='single'
+        tableSettings={{
+          isSearchEnabled: true,
+          isFilterEnabled: true,
+          isUserSettingsEnabled: true,
+        }}
+        description='Browse through your asset hierarchy and select an asset to view its associated data streams.'
+        ariaLabels={{
+          resizerRoleDescription: 'Resize button',
+          itemSelectionLabel: (isNotSelected, asset: AssetResource) =>
+            isNotSelected
+              ? `Select asset ${asset.name}`
+              : `Deselect asset ${asset.name}`,
+        }}
+      />
+      {selectedAssets.length > 0 && (
+        <AssetPropertyExplorer
+          requestFns={iotSiteWise}
+          parameters={selectedAssets}
+          selectionMode={correctSelectionMode}
+          onSelectAssetProperty={setSelectedAssetProperties}
+          selectedAssetProperties={selectedAssetProperties}
+          tableSettings={{
+            isFilterEnabled: true,
+            isUserSettingsEnabled: true,
+          }}
+          isAssetPropertyDisabled={(item) =>
+            isModeledPropertyInvalid(item.dataType, selectedWidgets.at(0)?.type)
+          }
+          ariaLabels={{
+            resizerRoleDescription: 'Resize button',
+            itemSelectionLabel: ({ selectedItems }, modeledDataStream) =>
+              propertySelectionLabel(
+                [...selectedItems],
+                modeledDataStream,
+                selectedWidgets
+              ),
+          }}
+        />
+      )}
+      <ResourceExplorerFooter
+        addDisabled={addButtonDisabled}
+        onReset={() => setSelectedAssetProperties([])}
+        onAdd={() => {
+          handleClickAddModeledDataStreams(selectedAssetProperties);
+          setSelectedAssetProperties([]); //clear table after adding it to widget
+          metricsRecorder?.record({
+            metricName: 'ModeledDataStreamAdd',
+            metricValue: 1,
+          });
+        }}
+      />
+    </Box>
+  );
+};

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/queryExtender/queryExtender.spec.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/queryExtender/queryExtender.spec.ts
@@ -1,5 +1,5 @@
+import { TimeSeriesResource } from '@iot-app-kit/react-components/dist/es/components/resource-explorers/types/resources';
 import { ModeledDataStream } from '../modeledDataStreamQueryEditor/modeledDataStreamExplorer/types';
-import { UnmodeledDataStream } from '../unmodeledDataStreamExplorer/types';
 import { QueryExtender } from './queryExtender';
 
 describe(QueryExtender.name, () => {
@@ -114,8 +114,8 @@ describe(QueryExtender.name, () => {
       };
       const queryExtender = new QueryExtender(currentQuery);
       const unmodeledDataStreams = [
-        { propertyAlias: 'property-2' },
-      ] as UnmodeledDataStream[];
+        { alias: 'property-2' },
+      ] as TimeSeriesResource[];
 
       const extendedQuery =
         queryExtender.extendPropertyAliasQueries(unmodeledDataStreams);
@@ -140,9 +140,9 @@ describe(QueryExtender.name, () => {
       };
       const queryExtender = new QueryExtender(currentQuery);
       const unmodeledDataStreams = [
-        { propertyAlias: 'property-1' },
-        { propertyAlias: 'property-2' },
-      ] as UnmodeledDataStream[];
+        { alias: 'property-1' },
+        { alias: 'property-2' },
+      ] as TimeSeriesResource[];
 
       const extendedQuery =
         queryExtender.extendPropertyAliasQueries(unmodeledDataStreams);

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/queryExtender/queryExtender.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/queryExtender/queryExtender.ts
@@ -1,5 +1,7 @@
-import type { ModeledDataStream } from '../modeledDataStreamQueryEditor/modeledDataStreamExplorer/types';
-import type { UnmodeledDataStream } from '../unmodeledDataStreamExplorer/types';
+import {
+  AssetPropertyResource,
+  TimeSeriesResource,
+} from '@iot-app-kit/react-components';
 import type { IoTSiteWiseDataStreamQuery } from '~/types';
 
 type Query = IoTSiteWiseDataStreamQuery;
@@ -11,7 +13,9 @@ export class QueryExtender {
     this.#currentQuery = currentQuery;
   }
 
-  public extendAssetQueries(modeledDataStreams: ModeledDataStream[]): Query {
+  public extendAssetQueries(
+    modeledDataStreams: readonly AssetPropertyResource[]
+  ): Query {
     const currentAssetQueries = this.#currentQuery.assets ?? [];
     const newAssetQueries = this.#createAssetQueries(modeledDataStreams);
     const dedupedAssetQueries = this.#dedupeAssetQueries([
@@ -27,7 +31,7 @@ export class QueryExtender {
   }
 
   #createAssetQueries(
-    modeledDataStreams: ModeledDataStream[]
+    modeledDataStreams: readonly AssetPropertyResource[]
   ): NonNullable<Query['assets']> {
     const assetQueriesWithProperties = modeledDataStreams
       .filter(this.#isModeledDataStream)
@@ -42,8 +46,8 @@ export class QueryExtender {
   }
 
   #isModeledDataStream(
-    dataStream: ModeledDataStream | UnmodeledDataStream
-  ): dataStream is ModeledDataStream {
+    dataStream: AssetPropertyResource | TimeSeriesResource
+  ): dataStream is AssetPropertyResource {
     return (
       Object.hasOwn(dataStream, 'propertyId') &&
       Object.hasOwn(dataStream, 'assetId')
@@ -81,7 +85,7 @@ export class QueryExtender {
   }
 
   public extendPropertyAliasQueries(
-    unmodeledDataStreams: UnmodeledDataStream[]
+    unmodeledDataStreams: readonly TimeSeriesResource[]
   ): Query {
     const currentPropertyAliasQueries = this.#currentQuery.properties ?? [];
     const newPropertyAliasQueries =
@@ -98,10 +102,12 @@ export class QueryExtender {
     return extendedQuery;
   }
 
-  #createPropertyAliasQueries(unmodeledDataStreams: UnmodeledDataStream[]) {
+  #createPropertyAliasQueries(
+    unmodeledDataStreams: readonly TimeSeriesResource[]
+  ) {
     const propertyAliasQueries = unmodeledDataStreams.map(
       (unmodeledDataStream) => ({
-        propertyAlias: unmodeledDataStream.propertyAlias ?? '',
+        propertyAlias: unmodeledDataStream.alias ?? '',
       })
     );
 

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/timeSeriesExplorer/timeSeriesExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/timeSeriesExplorer/timeSeriesExplorer.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { Box } from '@cloudscape-design/components';
+import { ResourceExplorerFooter } from '../footer/footer';
+import { QueryExtender } from '../queryExtender';
+import { useQuery } from '../../useQuery';
+import { IoTSiteWise } from '@aws-sdk/client-iotsitewise';
+import { DashboardWidget } from '~/types';
+import {
+  TimeSeriesExplorer,
+  TimeSeriesExplorerProps,
+  TimeSeriesResource,
+  SelectionMode,
+} from '@iot-app-kit/react-components';
+import { getPlugin } from '@iot-app-kit/core';
+
+type UnmodeledExplorerProps = {
+  onUpdateQuery: ReturnType<typeof useQuery>[1];
+  iotSiteWise: IoTSiteWise;
+  correctSelectionMode: SelectionMode;
+  addButtonDisabled: boolean;
+  selectedWidgets: DashboardWidget[];
+};
+
+export const UnmodeledExplorer = ({
+  onUpdateQuery,
+  iotSiteWise,
+  correctSelectionMode,
+  addButtonDisabled,
+}: UnmodeledExplorerProps) => {
+  const [selectedTimeSeries, setSelectedTimeSeries] = useState<
+    NonNullable<TimeSeriesExplorerProps['selectedTimeSeries']>
+  >([]);
+
+  const metricsRecorder = getPlugin('metricsRecorder');
+
+  function handleClickAddUnmodeledDataStreams(
+    newUnmodeledDataStreams: readonly TimeSeriesResource[]
+  ) {
+    onUpdateQuery((currentQuery) => {
+      const queryExtender = new QueryExtender(currentQuery);
+      const updatedQuery = queryExtender.extendPropertyAliasQueries(
+        newUnmodeledDataStreams
+      );
+
+      return updatedQuery;
+    });
+  }
+
+  return (
+    <Box padding={{ horizontal: 's' }}>
+      <TimeSeriesExplorer
+        selectionMode={correctSelectionMode}
+        requestFns={iotSiteWise}
+        onSelectTimeSeries={setSelectedTimeSeries}
+        selectedTimeSeries={selectedTimeSeries}
+        parameters={[{ timeSeriesType: 'DISASSOCIATED' }]}
+        tableSettings={{
+          isFilterEnabled: true,
+          isUserSettingsEnabled: true,
+        }}
+      />
+      <ResourceExplorerFooter
+        addDisabled={addButtonDisabled}
+        onReset={() => setSelectedTimeSeries([])}
+        onAdd={() => {
+          handleClickAddUnmodeledDataStreams(selectedTimeSeries);
+          setSelectedTimeSeries([]); //clear table after adding it to widget
+          metricsRecorder?.record({
+            metricName: 'UnmodeledDataStreamAdd',
+            metricValue: 1,
+          });
+        }}
+      />
+    </Box>
+  );
+};

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/types.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/types.ts
@@ -1,7 +1,7 @@
 import type { TimeSeriesSummary } from '@aws-sdk/client-iotsitewise';
 
 export type UnmodeledDataStream = {
-  propertyAlias: TimeSeriesSummary['alias'];
+  alias: TimeSeriesSummary['alias'];
   dataType: TimeSeriesSummary['dataType'];
   dataTypeSpec: TimeSeriesSummary['dataTypeSpec'];
 };

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/unmodeledDataStreamTable/unmodeledDataStreamTable.tsx
@@ -146,7 +146,7 @@ export function UnmodeledDataStreamTable({
         {
           id: 'propertyAlias',
           header: 'Alias',
-          cell: ({ propertyAlias }) => propertyAlias,
+          cell: ({ alias }) => alias,
           sortingField: 'propertyAlias',
         },
         {

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/useUnmodeledDataStreams/listUnmodeledDataStreamsRequest.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/unmodeledDataStreamExplorer/useUnmodeledDataStreams/listUnmodeledDataStreamsRequest.ts
@@ -57,8 +57,8 @@ export class ListUnmodeledDataStreamsRequest {
 
   #formatDataStreams(rawDataStreams: TimeSeriesSummary[]) {
     const cookedDataStreams = rawDataStreams.map<UnmodeledDataStream>(
-      ({ alias: propertyAlias, dataType, dataTypeSpec }) => ({
-        propertyAlias,
+      ({ alias, dataType, dataTypeSpec }) => ({
+        alias,
         dataType,
         dataTypeSpec,
       })

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/useLatestValues/entryIdFactory.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/useLatestValues/entryIdFactory.ts
@@ -27,12 +27,12 @@ export class EntryIdFactory {
 
   #createEntryId(): string {
     // Remove dashes from any UUIDs
-    const { assetId, propertyId, propertyAlias } =
+    const { assetId, propertyId, alias } =
       this.#extractIdentifiersFromDataStream();
     const entryId = this.#formatIdentifiers({
       assetId,
       propertyId,
-      propertyAlias,
+      alias,
     });
 
     return entryId;
@@ -45,24 +45,22 @@ export class EntryIdFactory {
       'propertyId' in this.#dataStream
         ? this.#dataStream.propertyId
         : undefined;
-    const propertyAlias =
-      'propertyAlias' in this.#dataStream
-        ? this.#dataStream.propertyAlias
-        : undefined;
+    const alias =
+      'alias' in this.#dataStream ? this.#dataStream.alias : undefined;
 
-    return { assetId, propertyId, propertyAlias };
+    return { assetId, propertyId, alias };
   }
 
   #formatIdentifiers({
     assetId,
     propertyId,
-    propertyAlias,
+    alias,
   }: {
     assetId?: string;
     propertyId?: string;
-    propertyAlias?: string;
+    alias?: string;
   }) {
-    const trimmedAlias = this.#trimPropertyAlias(propertyAlias);
+    const trimmedAlias = this.#trimPropertyAlias(alias);
     const aliasWithoutSlashes =
       this.#removeSlashesFromPropertyAlias(trimmedAlias);
     const joinedIdentifiers = Object.values({

--- a/packages/dashboard/src/components/queryEditor/queryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/queryEditor.tsx
@@ -3,24 +3,30 @@ import React from 'react';
 import { IoTSiteWiseQueryEditor } from './iotSiteWiseQueryEditor';
 import { QueryEditorErrorBoundary } from './queryEditorErrorBoundary';
 import { useQuery } from './useQuery';
-import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
-import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
+import { IoTSiteWise } from '@aws-sdk/client-iotsitewise';
+import { DashboardWidget } from '~/types';
+import { useIsAddButtonDisabled } from './helpers/useIsAddButtonDisabled';
+import { getCorrectSelectionMode } from './helpers/getCorrectSelectionMode';
 
 export function QueryEditor({
-  iotSiteWiseClient,
-  iotTwinMakerClient,
+  iotSiteWise,
+  selectedWidgets,
 }: {
-  iotSiteWiseClient: IoTSiteWiseClient;
-  iotTwinMakerClient: IoTTwinMakerClient;
+  iotSiteWise: IoTSiteWise;
+  selectedWidgets: DashboardWidget[];
 }) {
   const [_query, setQuery] = useQuery();
+  const addButtonDisabled = useIsAddButtonDisabled(selectedWidgets);
+  const correctSelectionMode = getCorrectSelectionMode(selectedWidgets);
 
   return (
     <QueryEditorErrorBoundary>
       <IoTSiteWiseQueryEditor
         onUpdateQuery={setQuery}
-        iotSiteWiseClient={iotSiteWiseClient}
-        iotTwinMakerClient={iotTwinMakerClient}
+        iotSiteWise={iotSiteWise}
+        selectedWidgets={selectedWidgets}
+        addButtonDisabled={addButtonDisabled}
+        correctSelectionMode={correctSelectionMode}
       />
     </QueryEditorErrorBoundary>
   );

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
@@ -1,4 +1,4 @@
-import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { IoTSiteWise, IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import React from 'react';
 import {
@@ -105,6 +105,7 @@ const renderTestComponentAsync = async (
     }) as unknown as IoTSiteWiseClient,
     iotEventsClient: createMockIoTEventsSDK(),
     iotTwinMakerClient: { send: jest.fn() } as unknown as IoTTwinMakerClient,
+    iotSiteWise: new IoTSiteWise(),
   };
 
   await act(async () => {

--- a/packages/dashboard/src/msw/iot-sitewise/handlers/listAssociatedAssets/listAssociatedAssetsHandler.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/handlers/listAssociatedAssets/listAssociatedAssetsHandler.ts
@@ -15,9 +15,6 @@ export function listAssociatedAssetsHandler() {
       const { assetId } = req.params as {
         assetId: ListAssociatedAssetsRequest['assetId'];
       };
-      const hierarchyId = req.url.searchParams.get(
-        'hierarchyId'
-      ) as ListAssociatedAssetsRequest['hierarchyId'];
       const traversalDirection =
         (req.url.searchParams.get(
           'traversalDirection'
@@ -31,17 +28,11 @@ export function listAssociatedAssetsHandler() {
         return res(ctx.status(400));
       }
 
-      if (traversalDirection === 'CHILD' && !hierarchyId) {
-        return res(ctx.status(400));
-      }
-
       let assetSummaries: ListAssociatedAssetsResponse['assetSummaries'] = [];
 
       if (traversalDirection === 'CHILD') {
-        const childAssets =
-          ASSET_HIERARCHY.findChildren(assetId, hierarchyId ?? '') ?? [];
+        const childAssets = ASSET_HIERARCHY.findChildren(assetId) ?? [];
         const childAssetSummaries = childAssets.map(summarizeAsset);
-
         assetSummaries = childAssetSummaries;
       } else if (traversalDirection === 'PARENT') {
         const parentAsset = ASSET_HIERARCHY.findParentAsset(assetId);

--- a/packages/dashboard/src/msw/iot-sitewise/resources/assets/index.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/resources/assets/index.ts
@@ -5,7 +5,7 @@ import {
   REACTOR_ASSET_MODEL,
   STORAGE_TANK_ASSET_MODEL,
 } from '../assetModels';
-import type { Asset, AssetModel } from '../types';
+import type { Asset } from '../types';
 
 const siteAssetFactory = new AssetFactory(SITE_ASSET_MODEL);
 const productionLineAssetFactory = new AssetFactory(
@@ -44,22 +44,10 @@ class AssetHierarchyClient {
     return asset;
   }
 
-  public findChildren(assetId: string, hierarchyId: string): Asset[] {
+  public findChildren(assetId: string): Asset[] {
     const node = this.#searchById(assetId, this.#assetHierarchy);
-    const hierarchy = node?.asset.assetHierarchies?.find(
-      ({ id }) => id === hierarchyId
-    );
-    // childAssetModelId is not on Assets - We keep it in the translation from AssetModel to Asset to enable this search.
-    const hierarchyAsAssetModelHierarchy = hierarchy as NonNullable<
-      AssetModel['assetModelHierarchies']
-    >[number];
-    const childAssetModelId = hierarchyAsAssetModelHierarchy.childAssetModelId;
     const children = node?.children?.map(({ asset }) => asset) ?? [];
-    const childrenOfHierachy = children.filter(
-      ({ assetModelId }) => assetModelId === childAssetModelId
-    );
-
-    return childrenOfHierachy;
+    return children;
   }
 
   public findParentAsset(assetId: string): Asset | undefined {

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -3,6 +3,7 @@ import {
   IoTSiteWiseClient,
   DescribeDashboardRequest,
   DescribeDashboardResponse,
+  IoTSiteWise,
 } from '@aws-sdk/client-iotsitewise';
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
 import type { AwsCredentialIdentity, Provider } from '@aws-sdk/types';
@@ -25,6 +26,7 @@ export type DashboardIotSiteWiseClients = {
   iotSiteWiseClient: IoTSiteWiseClient;
   iotEventsClient: IoTEventsClient;
   iotTwinMakerClient: IoTTwinMakerClient;
+  iotSiteWise: IoTSiteWise;
 };
 
 export type DashboardIotSiteWiseQueries = {

--- a/packages/dashboard/stories/dashboard/edge-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/edge-dashboard.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { IoTSiteWiseClient, IoTSiteWise } from '@aws-sdk/client-iotsitewise';
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import { registerPlugin } from '@iot-app-kit/core';
@@ -27,6 +27,7 @@ const clientConfig = {
 const iotSiteWiseClient = new IoTSiteWiseClient(clientConfig);
 const iotEventsClient = new IoTEventsClient(clientConfig);
 const iotTwinMakerClient = new IoTTwinMakerClient(clientConfig);
+const iotSiteWise = new IoTSiteWise(clientConfig);
 
 const DEFAULT_DASHBOARD_CONFIG = {
   displaySettings: {
@@ -41,6 +42,7 @@ const CLIENT_CONFIGURATION: DashboardClientConfiguration = {
   iotSiteWiseClient,
   iotEventsClient,
   iotTwinMakerClient,
+  iotSiteWise,
 };
 
 registerPlugin('metricsRecorder', {

--- a/packages/react-components/src/components/resource-explorers/constants/table-resource-definitions.ts
+++ b/packages/react-components/src/components/resource-explorers/constants/table-resource-definitions.ts
@@ -126,6 +126,13 @@ export const DEFAULT_ASSET_PROPERTY_TABLE_DEFINITION: TableResourceDefinition<As
 export const DEFAULT_TIME_SERIES_TABLE_DEFINITION: TableResourceDefinition<TimeSeriesResource> =
   [
     {
+      id: 'alias',
+      name: 'Alias',
+      pluralName: 'Aliases',
+      render: ({ alias }) => alias,
+      filterOperators: DEFAULT_STRING_FILTER_OPERATORS,
+    },
+    {
       id: 'timeSeriesId',
       name: 'ID',
       pluralName: 'IDs',
@@ -144,14 +151,6 @@ export const DEFAULT_TIME_SERIES_TABLE_DEFINITION: TableResourceDefinition<TimeS
       name: 'Data type spec',
       pluralName: 'Data type specs',
       render: ({ dataTypeSpec }) => dataTypeSpec,
-      defaultIsVisible: false,
-      filterOperators: DEFAULT_STRING_FILTER_OPERATORS,
-    },
-    {
-      id: 'alias',
-      name: 'Alias',
-      pluralName: 'Aliases',
-      render: ({ alias }) => alias,
       defaultIsVisible: false,
       filterOperators: DEFAULT_STRING_FILTER_OPERATORS,
     },

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/internal-asset-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/internal-asset-explorer.tsx
@@ -53,6 +53,8 @@ export function InternalAssetExplorer({
   } = {},
   dropDownResourceDefinition = DEFAULT_ASSET_DROP_DOWN_DEFINITION,
   dropDownSettings: { isFilterEnabled: isDropDownFilterEnabled = false } = {},
+  description = '',
+  ariaLabels,
 }: AssetExplorerProps) {
   const tableResourceDefinition =
     customTableResourceDefinition ??
@@ -146,6 +148,8 @@ export function InternalAssetExplorer({
               />
             )
           }
+          description={description}
+          ariaLabels={ariaLabels}
         />
       }
       dropDown={

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/types.ts
@@ -1,3 +1,4 @@
+import { TableProps } from '@cloudscape-design/components';
 import type {
   IsResourceDisabled,
   OnSelectResource,
@@ -22,6 +23,8 @@ export interface AssetExplorerProps
   onSelectAsset?: OnSelectResource<AssetResource>;
   selectedAssets?: SelectedResources<AssetResource>;
   isAssetDisabled?: IsResourceDisabled<AssetResource>;
+  description?: string;
+  ariaLabels?: TableProps.AriaLabels<AssetResource>;
 }
 
 export type AssetResourcesRequestParameters =

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
@@ -57,6 +57,7 @@ export function InternalAssetPropertyExplorer({
   } = {},
   dropDownResourceDefinition = DEFAULT_ASSET_PROPERTY_DROP_DOWN_DEFINITION,
   dropDownSettings: { isFilterEnabled: isDropDownFilterEnabled = false } = {},
+  ariaLabels,
 }: AssetPropertyExplorerProps) {
   const [userCustomization, setUserCutomization] = useUserCustomization({
     resourceName,
@@ -114,6 +115,7 @@ export function InternalAssetPropertyExplorer({
           isSearchEnabled={isSearchEnabled}
           isFilterEnabled={isTableFilterEnabled}
           isUserSettingsEnabled={isUserSettingsEnabled}
+          ariaLabels={ariaLabels}
         />
       }
       dropDown={

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
@@ -1,3 +1,4 @@
+import { TableProps } from '@cloudscape-design/components';
 import type {
   IsResourceDisabled,
   OnSelectResource,
@@ -24,6 +25,7 @@ export interface AssetPropertyExplorerProps
   onSelectAssetProperty?: OnSelectResource<AssetPropertyResource>;
   selectedAssetProperties?: SelectedResources<AssetPropertyResource>;
   isAssetPropertyDisabled?: IsResourceDisabled<AssetPropertyResource>;
+  ariaLabels?: TableProps.AriaLabels<AssetPropertyResource>;
 }
 
 export type AssetPropertyResourcesRequestParameters =

--- a/packages/react-components/src/components/resource-explorers/index.ts
+++ b/packages/react-components/src/components/resource-explorers/index.ts
@@ -9,4 +9,13 @@ export {
   type TimeSeriesExplorerProps,
 } from './explorers';
 
+export { DEFAULT_STRING_FILTER_OPERATORS } from './constants/defaults';
+export { DEFAULT_TIME_SERIES_WITH_LATEST_VALUES_TABLE_DEFINITION } from './constants/table-resource-definitions';
+export { resourceExplorerQueryClient } from './requests';
+export {
+  type AssetPropertyResource,
+  type AssetResource,
+  type TimeSeriesResource,
+} from './types/resources';
+export { type SelectionMode } from './types/common';
 // TODO: Export additional necessary types for customers to use

--- a/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/asset-drop-down.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/asset-drop-down.spec.tsx
@@ -143,6 +143,13 @@ describe('asset drop-down', () => {
 
       await waitFor(() => expect(listAssets).toHaveBeenCalledTimes(4));
     });
+
+    it('renders description of table', async () => {
+      const { getByText } = render(
+        <AssetExplorer description='This is a test asset explorer' />
+      );
+      expect(getByText('This is a test asset explorer')).toBeInTheDocument();
+    });
   });
 
   describe('selection', () => {

--- a/packages/react-components/src/components/resource-explorers/testing/table-variant/time-series-table.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/table-variant/time-series-table.spec.tsx
@@ -130,8 +130,8 @@ describe('time series table', () => {
 
       expect(screen.getByText('ID')).toBeVisible();
       expect(screen.getByText('Data type')).toBeVisible();
+      expect(screen.getByText('Alias')).toBeVisible();
       expect(screen.queryByText('Data type spec')).not.toBeInTheDocument();
-      expect(screen.queryByText('Alias')).not.toBeInTheDocument();
       expect(screen.queryByText('Asset ID')).not.toBeInTheDocument();
       expect(screen.queryByText('Property ID')).not.toBeInTheDocument();
       expect(screen.queryByText('Latest value')).not.toBeInTheDocument();
@@ -148,9 +148,9 @@ describe('time series table', () => {
       expect(screen.getByText('ID')).toBeVisible();
       expect(screen.getByText('Data type')).toBeVisible();
       expect(screen.getByText('Latest value')).toBeVisible();
+      expect(screen.getByText('Alias')).toBeVisible();
       expect(screen.getByText('Latest value time')).toBeVisible();
       expect(screen.queryByText('Data type spec')).not.toBeInTheDocument();
-      expect(screen.queryByText('Alias')).not.toBeInTheDocument();
       expect(screen.queryByText('Asset ID')).not.toBeInTheDocument();
       expect(screen.queryByText('Property ID')).not.toBeInTheDocument();
     });
@@ -670,14 +670,14 @@ describe('time series table', () => {
       expect(table.getColumnDisplayCheckbox('Data type')).toBeVisible();
       expect(table.getColumnDisplayCheckbox('Data type')).toBeChecked();
       expect(table.getColumnDisplayCheckbox('Data type')).toBeEnabled();
+      expect(table.getColumnDisplayCheckbox('Alias')).toBeVisible();
+      expect(table.getColumnDisplayCheckbox('Alias')).toBeChecked();
+      expect(table.getColumnDisplayCheckbox('Alias')).toBeEnabled();
       expect(table.getColumnDisplayCheckbox('Data type spec')).toBeVisible();
       expect(
         table.getColumnDisplayCheckbox('Data type spec')
       ).not.toBeChecked();
       expect(table.getColumnDisplayCheckbox('Data type spec')).toBeEnabled();
-      expect(table.getColumnDisplayCheckbox('Alias')).toBeVisible();
-      expect(table.getColumnDisplayCheckbox('Alias')).not.toBeChecked();
-      expect(table.getColumnDisplayCheckbox('Alias')).toBeEnabled();
       expect(table.getColumnDisplayCheckbox('Asset ID')).toBeVisible();
       expect(table.getColumnDisplayCheckbox('Asset ID')).not.toBeChecked();
       expect(table.getColumnDisplayCheckbox('Asset ID')).toBeEnabled();

--- a/packages/react-components/src/components/resource-explorers/types/table.ts
+++ b/packages/react-components/src/components/resource-explorers/types/table.ts
@@ -1,3 +1,4 @@
+import { TableProps } from '@cloudscape-design/components';
 import type {
   ResourceName,
   PluralResourceName,
@@ -88,6 +89,8 @@ export interface ResourceTableProps<Resource> {
   isFilterEnabled?: IsTableFilterEnabled;
   isUserSettingsEnabled?: IsTableUserSettingsEnabled;
   titleExtension?: React.ReactNode;
+  description?: string;
+  ariaLabels?: TableProps.AriaLabels<Resource>;
 }
 
 export type OnUpdateTableUserCustomization = (

--- a/packages/react-components/src/components/resource-explorers/variants/resource-table/resource-table-title.tsx
+++ b/packages/react-components/src/components/resource-explorers/variants/resource-table/resource-table-title.tsx
@@ -6,6 +6,7 @@ export interface ResourceTableTitleProps {
   totalResourceCount: number;
   pluralResourceName: string;
   titleExtension?: React.ReactNode;
+  description?: string;
 }
 
 export function ResourceTableTitle({
@@ -13,6 +14,7 @@ export function ResourceTableTitle({
   totalResourceCount,
   pluralResourceName,
   titleExtension,
+  description,
 }: ResourceTableTitleProps) {
   return (
     <>
@@ -23,6 +25,7 @@ export function ResourceTableTitle({
             ? `(${selectedResourceCount}/${totalResourceCount})`
             : `(${totalResourceCount})`
         }
+        description={description}
       >
         {pluralResourceName}
       </CloudscapeHeader>

--- a/packages/react-components/src/components/resource-explorers/variants/resource-table/resource-table.tsx
+++ b/packages/react-components/src/components/resource-explorers/variants/resource-table/resource-table.tsx
@@ -43,6 +43,8 @@ export function ResourceTable<Resource>({
   isUserSettingsEnabled,
   isSearchEnabled,
   titleExtension,
+  description,
+  ariaLabels,
 }: ResourceTableProps<Resource>) {
   const {
     items,
@@ -116,6 +118,7 @@ export function ResourceTable<Resource>({
               totalResourceCount={collectionProps.totalItemsCount ?? 0}
               pluralResourceName={pluralResourceName}
               titleExtension={titleExtension}
+              description={description}
             />
           )
         }
@@ -173,11 +176,14 @@ export function ResourceTable<Resource>({
         }) => {
           onSelectResource(updatedSelectedResources);
         }}
-        selectedItems={selectedResources}
+        selectedItems={selectedResources.filter(
+          (resource) => !isResourceDisabled(resource)
+        )}
         loading={isLoading}
         loadingText={`Loading ${pluralResourceName.toLowerCase()}...`}
         selectionType={selectionMode}
         resizableColumns
+        ariaLabels={ariaLabels}
       />
     </>
   );

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -50,3 +50,25 @@ export type {
 } from './components/table';
 
 export { formatDate } from './utils/time';
+
+export {
+  AssetModelExplorer,
+  AssetExplorer,
+  AssetPropertyExplorer,
+  TimeSeriesExplorer,
+  type AssetModelExplorerProps,
+  type AssetExplorerProps,
+  type AssetPropertyExplorerProps,
+  type TimeSeriesExplorerProps,
+  type AssetPropertyResource,
+  type AssetResource,
+  type TimeSeriesResource,
+  type SelectionMode,
+  resourceExplorerQueryClient,
+} from './components/resource-explorers';
+
+export { type TableResourceDefinition } from './components/resource-explorers/types/table';
+
+export { type TimeSeriesResourceWithLatestValue } from './components/resource-explorers/types/resources';
+
+export { type ResourceFieldFilterOperator } from './components/resource-explorers/types/common';

--- a/packages/react-components/stories/resource-explorers/data-source.ts
+++ b/packages/react-components/stories/resource-explorers/data-source.ts
@@ -5,5 +5,5 @@ export const client = new IoTSiteWise({
     accessKeyId: '',
     secretAccessKey: '',
   },
-  region: '',
+  region: 'us-west-2',
 });

--- a/packages/source-iotsitewise/src/index.ts
+++ b/packages/source-iotsitewise/src/index.ts
@@ -19,4 +19,5 @@ export type {
   AssetModelQuery,
   AssetPropertyQuery,
   PropertyAliasQuery,
+  AssetQuery,
 } from './time-series-data/types';


### PR DESCRIPTION
## Overview
- updated RE to use new RE components in react-components package for modeled and unmodeled tab
- hooked up new RE footer to each tab to update query accordingly
- perform correct disabling/selection of buttons and selection states based on amount of widgets selected + selected widget type
- added prop to allow for descriptions to be added for explorer table headers and added it to the modeled RE component to match current RE implementation
- added ariaLabel to each row of table to allow UI testing helpers to remain the same
- edited MSW to work with new RE components in listAssociatedTimeSeriesCall

## Verifying Changes
https://github.com/awslabs/iot-app-kit/assets/145582655/536f5405-7106-4fe8-9989-bdead370d9f7

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
