### PR TITLE
fix(dashboard): sanitize href input in text widget

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -60,12 +60,12 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/is-hotkey": "^0.1.7",
-    "@types/is-url": "^1.2.32",
     "@types/lodash": "^4.14.195",
     "@types/node": "^18.16.18",
     "@types/papaparse": "^5.3.10",
     "@types/react": "^18.2.12",
     "@types/react-dom": "^18.2.5",
+    "@types/validator": "^13.12.0",
     "css-loader": "6.8.1",
     "dotenv": "^16.3.1",
     "eslint-config-iot-app-kit": "10.10.1",
@@ -110,8 +110,8 @@
     "@tanstack/react-query": "^4.29.15",
     "aws-sdk-client-mock": "^3.0.0",
     "buffer": "^6.0.3",
+    "dompurify": "^3.1.6",
     "is-hotkey": "^0.2.0",
-    "is-url": "^1.2.4",
     "papaparse": "^5.4.1",
     "parse-duration": "^1.0.3",
     "react-dnd": "^16.0.1",
@@ -125,7 +125,8 @@
     "react-use": "17.4.0",
     "tiny-invariant": "^1.3.1",
     "turbowatch": "^2.29.4",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "validator": "^13.12.0"
   },
   "peerDependencies": {
     "@aws-sdk/client-iot-events": "^3.354.0",

--- a/packages/dashboard/src/customization/widgets/text/link/index.tsx
+++ b/packages/dashboard/src/customization/widgets/text/link/index.tsx
@@ -2,7 +2,8 @@ import type { CSSProperties } from 'react';
 import React from 'react';
 import { defaultFontSettings } from '../styledText/defaultFontSettings';
 import type { TextWidget } from '../../types';
-import isValidUrl from 'is-url';
+import DOMPurify from 'dompurify';
+import { isURL } from 'validator';
 
 type TextLinkProps = TextWidget;
 
@@ -23,7 +24,9 @@ const TextLink: React.FC<TextLinkProps> = (widget) => {
     color: fontColor,
   };
 
-  const renderedHref = href && isValidUrl(href) ? href : undefined;
+  const sanitizedHref = href ? DOMPurify.sanitize(href) : undefined;
+  const isValidUrl = sanitizedHref ? isURL(sanitizedHref) : false;
+  const renderedHref = isValidUrl ? sanitizedHref : undefined;
 
   return (
     <a href={renderedHref} className={className} style={style}>


### PR DESCRIPTION
## Overview
Validating urls for text widget.

## Verifying Changes

https://github.com/user-attachments/assets/ebf631c8-05d2-4408-a692-4cab6d67ee3c

Test cases used: 

javascript:prompt(1)
&#106&#97&#118&#97&#115&#99&#114&#105&#112&#116&#58&#99&#111&#110&#102&#105&#114&#109&#40&#49&#41
\x6A\x61\x76\x61\x73\x63\x72\x69\x70\x74\x3aalert(1)
javascript://%0Aalert(1)
javascript://anything%0D%0A%0D%0Awindow.alert(1)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
