### PR TITLE
fix: filter component models from query editor

### DIFF
--- a/packages/dashboard/e2e/tests/resourceExplorer/resourceExplorer.spec.ts
+++ b/packages/dashboard/e2e/tests/resourceExplorer/resourceExplorer.spec.ts
@@ -8,6 +8,7 @@ import {
   WIDGET_EMPTY_STATE_TEXT,
 } from '../constants';
 import { resourceExplorerUtil } from '../utils/resourceExplorer';
+import { componentAssetModelName } from '../../../src/msw/iot-sitewise/resources/assetModels';
 
 test('can load resource explorer', async ({ page }) => {
   await page.goto(TEST_PAGE);
@@ -293,4 +294,26 @@ test(' changing widgets filters properties correctly (modeled)', async ({
 
   //find string property is not disabled
   await expect(validProperty2).not.toBeDisabled();
+});
+
+test('filters COMPONENT_MODEL from asset model results', async ({ page }) => {
+  await page.goto(TEST_PAGE);
+
+  const resourceExplorer = resourceExplorerUtil(page);
+
+  await resourceExplorer.open();
+
+  await expect(page.locator(MODELED_TAB)).toBeVisible();
+  await expect(page.locator(UNMODELED_TAB)).toBeVisible();
+  await expect(page.locator(ASSET_MODEL_TAB)).toBeVisible();
+
+  await resourceExplorer.tabTo('assetModel');
+
+  await page.getByLabel('Asset model', { exact: true }).click();
+  const searchBox = await page.getByPlaceholder('Find an asset model');
+  await searchBox.click();
+  await searchBox.fill(componentAssetModelName);
+
+  // check that composite model does not show up
+  await expect(page.getByText(componentAssetModelName)).not.toBeVisible();
 });

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelSelection/assetModelSelect.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelSelection/assetModelSelect.tsx
@@ -48,6 +48,7 @@ export const AssetModelSelect = ({
   selectedAssetModel,
   onSelectAssetModel,
 }: AssetModelSelectOptions) => {
+  // Filter composite models since they dont have properties to display
   const {
     assetModelSummaries,
     // status,
@@ -58,7 +59,7 @@ export const AssetModelSelect = ({
     hasNextPage = false,
     fetchNextPage,
     refetch,
-  } = useAssetModels({ client });
+  } = useAssetModels({ client, includeComposite: false });
 
   const selectedAssetModelOption = selectedAssetModel
     ? mapAssetModelToOption(selectedAssetModel)

--- a/packages/dashboard/src/msw/iot-sitewise/resources/assetModels/AssetModelFactory.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/resources/assetModels/AssetModelFactory.ts
@@ -23,6 +23,7 @@ export class AssetModelFactory {
       assetModelCreationDate,
       assetModelLastUpdateDate,
       assetModelStatus,
+      assetModelType,
     }: Partial<AssetModel> = {
       assetModelId: uuid(),
       assetModelName: 'Asset Model',
@@ -49,6 +50,7 @@ export class AssetModelFactory {
       assetModelCreationDate,
       assetModelLastUpdateDate,
       assetModelStatus,
+      assetModelType,
     };
 
     return defaults;

--- a/packages/dashboard/src/msw/iot-sitewise/resources/assetModels/index.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/resources/assetModels/index.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from 'uuid';
 import { AssetModelFactory } from './AssetModelFactory';
+import { AssetModelType } from '@aws-sdk/client-iotsitewise';
 
 const reactorAssetModelId = uuid();
 const reactorAssetModelTemperatureId = uuid();
@@ -125,6 +126,13 @@ export const STORAGE_TANK_ASSET_MODEL = assetModelFactory.create({
   ],
 });
 
+export const componentAssetModelName = 'Component Asset Model';
+export const COMPONENT_ASSET_MODEL = assetModelFactory.create({
+  assetModelId: uuid(),
+  assetModelName: componentAssetModelName,
+  assetModelType: AssetModelType.COMPONENT_MODEL,
+});
+
 const reactorAssetModelHeirarchyId = uuid();
 
 export const REACTOR_ASSET_MODEL_HIERARCHY = {
@@ -203,6 +211,7 @@ export const ASSET_MODELS = {
     PRODUCTION_LINE_ASSET_MODEL,
     REACTOR_ASSET_MODEL,
     STORAGE_TANK_ASSET_MODEL,
+    COMPONENT_ASSET_MODEL,
   ],
   getAll: function () {
     return this.models;

--- a/packages/dashboard/src/msw/iot-sitewise/resources/assetModels/summarizeAssetModel.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/resources/assetModels/summarizeAssetModel.ts
@@ -10,5 +10,6 @@ export function summarizeAssetModel(assetModel: AssetModel): AssetModelSummary {
     lastUpdateDate: assetModel.assetModelLastUpdateDate,
     name: assetModel.assetModelName,
     status: assetModel.assetModelStatus,
+    assetModelType: assetModel.assetModelType,
   };
 }


### PR DESCRIPTION
## Overview
* Since component asset models are not associated with any properties, they cannot be used in our query editor to add to dashboards, so this change filters component asset models from the selection in the dynamic assets tab.

## Verifying Changes
* Use the query editor when your account has a component asset model created. Check the dynamic assets tab and make sure no component asset models are displayed there.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
