### PR TITLE
fix: prevent creating new chart when icon is dragged over different …

### DIFF
--- a/packages/dashboard/src/components/palette/component.tsx
+++ b/packages/dashboard/src/components/palette/component.tsx
@@ -44,7 +44,7 @@ const PaletteComponent: React.FC<PaletteComponentProps> = ({
   // isDragging updates before the click event is captured and the handler executes
   // the pointer up event fires before the hook value updates.
   // this because it's what ReactDnD uses to indicate drag start / drag end
-  const handlePointerUp = () => {
+  const handleClick = () => {
     if (isDragging) return;
     onAddWidget(componentTag);
   };
@@ -64,8 +64,8 @@ const PaletteComponent: React.FC<PaletteComponentProps> = ({
         className='palette-button'
         ref={dragRef}
         draggable='true'
-        onPointerUp={handlePointerUp}
         onKeyDown={handleKeyDown}
+        onClick={handleClick}
       >
         <PaletteComponentIcon widgetName={name} Icon={IconComponent} />
       </button>

--- a/packages/dashboard/src/components/palette/index.test.tsx
+++ b/packages/dashboard/src/components/palette/index.test.tsx
@@ -48,7 +48,7 @@ describe('Component Palette', () => {
     const lineWidget = screen.getByLabelText(/add line widget/i);
 
     act(() => {
-      fireEvent.pointerUp(lineWidget);
+      fireEvent.click(lineWidget);
     });
 
     expect(onAddWidgetStub).toBeCalledWith('xy-plot');


### PR DESCRIPTION
## Overview
* Bug - when dragging a new widget, if widget is dropped over a different widget icon, a chart is added to the dashboard when it shouldnt. This changes fixes this.
* This bug resulted from adding keyboard shortcuts. To fix I changed the mouse event from onPointerUp to onClick which prevents the bug from occurring. From my testing this seems to work as intended but let me know if there's other reasons to use onPointerUp.

## Verifying Changes
* Start dragging a new chart onto the grid. Move your mouse back to another chart type. Lift mouse and confirm that a new chart isn't created

https://github.com/user-attachments/assets/539c6d3c-17cb-4c7c-b52f-a34ec311b916

https://github.com/user-attachments/assets/e437ac25-fcc4-4998-8568-92595fde4083


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
