### PR TITLE
fix: update timezone doc based on writer feedback

### DIFF
--- a/packages/doc-site/stories/components/anomalyChart/AnomalyChart.mdx
+++ b/packages/doc-site/stories/components/anomalyChart/AnomalyChart.mdx
@@ -60,7 +60,7 @@ includes the following options:
 
 **gestures** (boolean, optional) Specifies whether gestures (pan, zoom and restrict time-span) are enabled. Defaults to `true`
 
-**timeZone** (string, optional): Timezone must be specified as an [IANA timezone string](https://ftp.iana.org/tz/tzdb-2020f/zone1970.tab). If this property is provided, the chart will display all dates in the provided timezone, otherwise it will use the browsers local timezone.
+**timeZone** (string, optional): Timezone must be specified as an [IANA timezone string](https://ftp.iana.org/tz/tzdb-2020f/zone1970.tab). If this property is provided, the chart displays all dates in the provided timezone. If not provided, it uses the browser's local timezone.
 
 ### Example
 

--- a/packages/doc-site/stories/components/chart/Docs.mdx
+++ b/packages/doc-site/stories/components/chart/Docs.mdx
@@ -64,7 +64,7 @@ The type must be one of `'line' | 'bar' | 'scatter' | 'step-start' | 'step-middl
 This includes the legend section when the legend section is selected. Example `{ width: Number, height: Number }`.
 Default value is `{ width: 500, height: 500 }`.
 
-**timeZone** (string, optional): Timezone must be specified as an [IANA timezone string](https://ftp.iana.org/tz/tzdb-2020f/zone1970.tab). If this property is provided, the chart will display all dates in the provided timezone, otherwise it will use the browsers local timezone.
+**timeZone** (string, optional): Timezone must be specified as an [IANA timezone string](https://ftp.iana.org/tz/tzdb-2020f/zone1970.tab). If this property is provided, the chart displays all dates in the provided timezone. If not provided, it uses the browser's local timezone.
 
 **styleSettings** (object, optional): This groups all the styling options available for the chart by `refId`. 
 [Learn more about reference IDs here](/docs/core-styles--docs). It has the following properties:

--- a/packages/doc-site/stories/components/kpi/Docs.mdx
+++ b/packages/doc-site/stories/components/kpi/Docs.mdx
@@ -23,7 +23,7 @@ If a ViewportManager, and a `viewport` is not defined, the default value is `{ d
 
 **query** (object, optional): This query specifies the time series data to visualize. [Learn more about time series data queries](/docs/core-time-series-data--docs).
 
-**timeZone** (string, optional): Timezone must be specified as an [IANA timezone string](https://ftp.iana.org/tz/tzdb-2020f/zone1970.tab). If this property is provided, the chart will display all dates in the provided timezone, otherwise it will use the browsers local timezone.
+**timeZone** (string, optional): Timezone must be specified as an [IANA timezone string](https://ftp.iana.org/tz/tzdb-2020f/zone1970.tab). If this property is provided, the chart displays all dates in the provided timezone. If not provided, it uses the browser's local timezone.
 
 **settings** (object, optional): This specifies the settings to customize the appearance of the widget. The settings object contains the following properties:
 


### PR DESCRIPTION
## Overview
* Update wording on timezone doc based on aws writer feedback,

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
