### PR TITLE
fix: add timeZone prop to DashboardViewWrapper

### DIFF
--- a/packages/dashboard/src/components/dashboard/viewOnlyWrapper.tsx
+++ b/packages/dashboard/src/components/dashboard/viewOnlyWrapper.tsx
@@ -10,6 +10,7 @@ export const DashboardViewWrapper: React.FC<DashboardViewProperties> = ({
   currentViewport,
   onViewportChange,
   toolbar,
+  timeZone,
 }) => {
   /* eslint-disable react-hooks/exhaustive-deps */
   const stableOnViewportChange = useMemo(() => onViewportChange, []);
@@ -39,6 +40,7 @@ export const DashboardViewWrapper: React.FC<DashboardViewProperties> = ({
       currentViewport={currentViewport}
       onViewportChange={stableOnViewportChange}
       toolbar={stableToolbar}
+      timeZone={timeZone}
     />
   );
 };

--- a/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/mocked-dashboard.stories.tsx
@@ -73,3 +73,11 @@ export const ViewOnly: ComponentStory<typeof Dashboard> = () => (
     dashboardConfiguration={MOCK_DASHBOARD_CONFIG}
   />
 );
+
+export const ViewOnlyWithTimezone: ComponentStory<typeof Dashboard> = () => (
+  <DashboardView
+    {...emptyDashboardConfiguration}
+    dashboardConfiguration={MOCK_DASHBOARD_CONFIG}
+    timeZone='Asia/Tokyo'
+  />
+);


### PR DESCRIPTION
## Overview
* In a bug bash we discovered that the DashboardViewWrapper exposed to customers was missing the timeZone prop passing to support timezones. This change corrects this.

## Verifying Changes
* Pass `timeZone` prop to `DashboardViewWrapper` and check timestamps displayed
* Example of tokyo timezone provided to DashboardView:
<img width="1508" alt="Screenshot 2024-08-29 at 10 42 53 AM" src="https://github.com/user-attachments/assets/aef076ae-7928-4a8f-8c6f-0f9b4b3a7b1c">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
