### PR TITLE
feat(react-components): useDescribeAssets and useDescribeAssetModels queries implemented

### DIFF
--- a/packages/react-components/src/queries/useDescribeAssetModels/describeAssetModelQueryKeyFactory.ts
+++ b/packages/react-components/src/queries/useDescribeAssetModels/describeAssetModelQueryKeyFactory.ts
@@ -1,0 +1,15 @@
+export class DescribeAssetModelCacheKeyFactory {
+  #assetModelId?: string;
+
+  constructor({ assetModelId }: { assetModelId?: string }) {
+    this.#assetModelId = assetModelId;
+  }
+
+  create() {
+    const cacheKey = [
+      { resource: 'describe asset model', assetModelId: this.#assetModelId },
+    ] as const;
+
+    return cacheKey;
+  }
+}

--- a/packages/react-components/src/queries/useDescribeAssetModels/index.ts
+++ b/packages/react-components/src/queries/useDescribeAssetModels/index.ts
@@ -1,0 +1,1 @@
+export * from './useDescribeAssetModels';

--- a/packages/react-components/src/queries/useDescribeAssetModels/useDescribeAssetModels.spec.ts
+++ b/packages/react-components/src/queries/useDescribeAssetModels/useDescribeAssetModels.spec.ts
@@ -1,0 +1,61 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useDescribeAssetModels } from './useDescribeAssetModels';
+import { IoTSiteWise } from '@aws-sdk/client-iotsitewise';
+import { queryClient } from '../queryClient';
+
+const MOCK_ASSET_MODEL_ID = 'assetModelId';
+const MOCK_ASSET_MODEL_ID_2 = 'assetModelId2';
+
+const describeAssetModelMock = jest.fn();
+const iotSiteWiseClientMock = {
+  describeAssetModel: describeAssetModelMock,
+} as unknown as IoTSiteWise;
+
+describe('useDescribeAssetModels', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    describeAssetModelMock.mockResolvedValue({});
+    queryClient.clear();
+  });
+
+  it('should call DescribeAssetModel in successful queries when calling useDescribeAssetModels', async () => {
+    const { result: queriesResult } = renderHook(() =>
+      useDescribeAssetModels({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        assetModelIds: [MOCK_ASSET_MODEL_ID],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isSuccess).toBe(true));
+
+    expect(describeAssetModelMock).toBeCalled();
+  });
+
+  it('should not call DescribeAssetModel when no assetIds passed into useDescribeAssetModels', async () => {
+    const { result: queriesResult } = renderHook(() =>
+      useDescribeAssetModels({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        assetModelIds: [],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current.length).toBe(0));
+
+    expect(describeAssetModelMock).not.toBeCalled();
+  });
+
+  it('should disable query when undefined assetId passed into useDescribeAssetModels', async () => {
+    const { result: queriesResult } = renderHook(() =>
+      useDescribeAssetModels({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        assetModelIds: [MOCK_ASSET_MODEL_ID, undefined, MOCK_ASSET_MODEL_ID_2],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isSuccess).toBe(true));
+    await waitFor(() => expect(queriesResult.current[1].isPending).toBe(true));
+    await waitFor(() => expect(queriesResult.current[2].isSuccess).toBe(true));
+
+    expect(describeAssetModelMock).toBeCalledTimes(2);
+  });
+});

--- a/packages/react-components/src/queries/useDescribeAssetModels/useDescribeAssetModels.ts
+++ b/packages/react-components/src/queries/useDescribeAssetModels/useDescribeAssetModels.ts
@@ -1,0 +1,83 @@
+import { IoTSiteWise, IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { QueryFunctionContext, useQueries } from '@tanstack/react-query';
+import invariant from 'tiny-invariant';
+import { queryClient } from '../queryClient';
+import { DescribeAssetModelCacheKeyFactory } from './describeAssetModelQueryKeyFactory';
+import { hasRequestFunction, isAssetModelId } from '../predicates';
+import { useIoTSiteWiseClient } from '../../hooks/requestFunctions/useIoTSiteWiseClient';
+import { DescribeAssetModel } from '@iot-app-kit/core';
+import { useMemo } from 'react';
+
+export interface UseDescribeAssetModelsOptions {
+  iotSiteWiseClient?: IoTSiteWiseClient | IoTSiteWise;
+  assetModelIds?: (string | undefined)[];
+}
+
+/**
+ * useDescribeAssetModels is a hook to call IoT SiteWise DescribeAssetModel on a list of assetModelIds
+ * AssetModelIds may not be defined in the list, which will disable its query
+ *
+ * @param client is an AWS SDK IoT SiteWise client
+ * @param assetModelIds is a list of assetModelIds where IoT SiteWise DescribeAssetModel API is called on each
+ * @returns list of tanstack query results with a DescribeAssetModelResponse
+ */
+export function useDescribeAssetModels({
+  iotSiteWiseClient,
+  assetModelIds = [],
+}: UseDescribeAssetModelsOptions) {
+  const { describeAssetModel } = useIoTSiteWiseClient({ iotSiteWiseClient });
+
+  // Memoize the queries to ensure they don't rerun if the same assetModelIds are used on a rerender
+  const queries = useMemo(
+    () =>
+      assetModelIds.map((assetModelId, index) => {
+        const cacheKeyFactory = new DescribeAssetModelCacheKeyFactory({
+          assetModelId,
+        });
+        return {
+          enabled: isEnabled({
+            assetModelId: assetModelIds[index],
+            describeAssetModel,
+          }),
+          queryKey: cacheKeyFactory.create(),
+          queryFn: createQueryFn(describeAssetModel),
+        };
+      }),
+    [assetModelIds, describeAssetModel]
+  );
+
+  return useQueries({ queries }, queryClient);
+}
+
+// Query is enabled if both an assetModelId and describeAssetModel request function is available
+const isEnabled = ({
+  assetModelId,
+  describeAssetModel,
+}: {
+  assetModelId?: string;
+  describeAssetModel?: DescribeAssetModel;
+}) =>
+  isAssetModelId(assetModelId) &&
+  hasRequestFunction<DescribeAssetModel>(describeAssetModel);
+
+// Query function calls describeAssetModel with the given assetModelId and request function
+const createQueryFn = (describeAssetModel?: DescribeAssetModel) => {
+  return async ({
+    queryKey: [{ assetModelId }],
+    signal,
+  }: QueryFunctionContext<
+    ReturnType<DescribeAssetModelCacheKeyFactory['create']>
+  >) => {
+    invariant(
+      hasRequestFunction<DescribeAssetModel>(describeAssetModel),
+      'Expected client with DescribeAssetModel to be defined as required by the enabled flag.'
+    );
+
+    invariant(
+      isAssetModelId(assetModelId),
+      'Expected assetModelId to be defined as required by the enabled flag.'
+    );
+
+    return await describeAssetModel({ assetModelId }, { abortSignal: signal });
+  };
+};

--- a/packages/react-components/src/queries/useDescribeAssets/index.ts
+++ b/packages/react-components/src/queries/useDescribeAssets/index.ts
@@ -1,0 +1,1 @@
+export * from './useDescribeAssets';

--- a/packages/react-components/src/queries/useDescribeAssets/useDescribeAssets.spec.tsx
+++ b/packages/react-components/src/queries/useDescribeAssets/useDescribeAssets.spec.tsx
@@ -1,0 +1,61 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useDescribeAssets } from './useDescribeAssets';
+import { IoTSiteWise } from '@aws-sdk/client-iotsitewise';
+import { queryClient } from '../queryClient';
+
+const MOCK_ASSET_ID = 'assetId';
+const MOCK_ASSET_ID_2 = 'assetId2';
+
+const describeAssetMock = jest.fn();
+const iotSiteWiseClientMock = {
+  describeAsset: describeAssetMock,
+} as unknown as IoTSiteWise;
+
+describe('useDescribeAssets', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    describeAssetMock.mockResolvedValue({});
+    queryClient.clear();
+  });
+
+  it('should call DescribeAsset in successful queries when calling useDescribeAssets', async () => {
+    const { result: queriesResult } = renderHook(() =>
+      useDescribeAssets({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        assetIds: [MOCK_ASSET_ID],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isSuccess).toBe(true));
+
+    expect(describeAssetMock).toBeCalled();
+  });
+
+  it('should not call DescribeAsset when no assetIds passed into useDescribeAssets', async () => {
+    const { result: queriesResult } = renderHook(() =>
+      useDescribeAssets({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        assetIds: [],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current.length).toBe(0));
+
+    expect(describeAssetMock).not.toBeCalled();
+  });
+
+  it('should disable query when undefined assetId passed into useDescribeAssets', async () => {
+    const { result: queriesResult } = renderHook(() =>
+      useDescribeAssets({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        assetIds: [MOCK_ASSET_ID, undefined, MOCK_ASSET_ID_2],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isSuccess).toBe(true));
+    await waitFor(() => expect(queriesResult.current[1].isPending).toBe(true));
+    await waitFor(() => expect(queriesResult.current[2].isSuccess).toBe(true));
+
+    expect(describeAssetMock).toBeCalledTimes(2);
+  });
+});

--- a/packages/react-components/src/queries/useDescribeAssets/useDescribeAssets.ts
+++ b/packages/react-components/src/queries/useDescribeAssets/useDescribeAssets.ts
@@ -1,0 +1,79 @@
+import { IoTSiteWise, IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { QueryFunctionContext, useQueries } from '@tanstack/react-query';
+import invariant from 'tiny-invariant';
+import { DescribeAssetCacheKeyFactory } from '../useDescribeAsset/describeAssetQueryKeyFactory';
+import { queryClient } from '../queryClient';
+import { hasRequestFunction, isAssetId } from '../predicates';
+import { useIoTSiteWiseClient } from '../../hooks/requestFunctions/useIoTSiteWiseClient';
+import { DescribeAsset } from '@iot-app-kit/core';
+import { useMemo } from 'react';
+
+export interface UseDescribeAssetsOptions {
+  iotSiteWiseClient?: IoTSiteWiseClient | IoTSiteWise;
+  assetIds?: (string | undefined)[];
+}
+
+/**
+ * useDescribeAssets is a hook to call IoT SiteWise DescribeAsset on a list of assetIds
+ * AssetIds may not be defined in the list, which will disable its query
+ *
+ * @param client is an AWS SDK IoT SiteWise client
+ * @param assetIds is a list of assetIds where IoT SiteWise DescribeAsset API is called on each
+ * @returns list of tanstack query results with a DescribeAssetResponse
+ */
+export function useDescribeAssets({
+  iotSiteWiseClient,
+  assetIds = [],
+}: UseDescribeAssetsOptions) {
+  const { describeAsset } = useIoTSiteWiseClient({ iotSiteWiseClient });
+
+  // Memoize the queries to ensure they don't rerun if the same assetIds are used on a rerender
+  const queries = useMemo(
+    () =>
+      assetIds.map((assetId, index) => {
+        const cacheKeyFactory = new DescribeAssetCacheKeyFactory({ assetId });
+        return {
+          enabled: isEnabled({
+            assetId: assetIds[index],
+            describeAsset,
+          }),
+          queryKey: cacheKeyFactory.create(),
+          queryFn: createQueryFn(describeAsset),
+        };
+      }),
+    [assetIds, describeAsset]
+  );
+
+  return useQueries({ queries }, queryClient);
+}
+
+// Query is enabled if both an assetId and describeAsset request function is available
+const isEnabled = ({
+  assetId,
+  describeAsset,
+}: {
+  assetId?: string;
+  describeAsset?: DescribeAsset;
+}) => isAssetId(assetId) && hasRequestFunction<DescribeAsset>(describeAsset);
+
+// Query function calls describeAsset with the given assetId and request function
+const createQueryFn = (describeAsset?: DescribeAsset) => {
+  return async ({
+    queryKey: [{ assetId }],
+    signal,
+  }: QueryFunctionContext<
+    ReturnType<DescribeAssetCacheKeyFactory['create']>
+  >) => {
+    invariant(
+      hasRequestFunction<DescribeAsset>(describeAsset),
+      'Expected client with DescribeAsset to be defined as required by the enabled flag.'
+    );
+
+    invariant(
+      isAssetId(assetId),
+      'Expected assetId to be defined as required by the enabled flag.'
+    );
+
+    return await describeAsset({ assetId }, { abortSignal: signal });
+  };
+};


### PR DESCRIPTION
## Overview
To support SiteWise alarms and the useAlarms hook we need to fetch the asset and asset model summaries for alarm requests. These hooks use tanstack `useQueries` to batch queries to describe the given assets and asset models.

The query hooks take an `IoTSiteWiseClient | IoTSiteWise` client type and uses `useIoTSiteWiseClient()` to generate a promise-like client to use. This aligns with our request function effort [here](https://github.com/awslabs/iot-app-kit/pull/2963).

The hooks are an extension of the existing `useDescribeAsset` [hook](https://github.com/awslabs/iot-app-kit/blob/main/packages/react-components/src/queries/useDescribeAsset/useDescribeAsset.ts).

## Verifying Changes

Unit tests and local build passes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
