### PR TITLE
fix(dashboard): add descriptions to all RE tables

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledExplorer/modeledExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledExplorer/modeledExplorer.tsx
@@ -107,6 +107,7 @@ export const ModeledExplorer = ({
                 selectedWidgets
               ),
           }}
+          description='Select a modeled datastream to add to a selected widget'
         />
       )}
       <ResourceExplorerFooter

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/timeSeriesExplorer/timeSeriesExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/timeSeriesExplorer/timeSeriesExplorer.tsx
@@ -58,6 +58,7 @@ export const UnmodeledExplorer = ({
           isFilterEnabled: true,
           isUserSettingsEnabled: true,
         }}
+        description='Select a unmodeled datastream to add to a selected widget'
       />
       <ResourceExplorerFooter
         addDisabled={addButtonDisabled}

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
@@ -58,6 +58,7 @@ export function InternalAssetPropertyExplorer({
   dropDownResourceDefinition = DEFAULT_ASSET_PROPERTY_DROP_DOWN_DEFINITION,
   dropDownSettings: { isFilterEnabled: isDropDownFilterEnabled = false } = {},
   ariaLabels,
+  description = '',
 }: AssetPropertyExplorerProps) {
   const [userCustomization, setUserCutomization] = useUserCustomization({
     resourceName,
@@ -116,6 +117,7 @@ export function InternalAssetPropertyExplorer({
           isFilterEnabled={isTableFilterEnabled}
           isUserSettingsEnabled={isUserSettingsEnabled}
           ariaLabels={ariaLabels}
+          description={description}
         />
       }
       dropDown={

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
@@ -26,6 +26,7 @@ export interface AssetPropertyExplorerProps
   selectedAssetProperties?: SelectedResources<AssetPropertyResource>;
   isAssetPropertyDisabled?: IsResourceDisabled<AssetPropertyResource>;
   ariaLabels?: TableProps.AriaLabels<AssetPropertyResource>;
+  description?: string;
 }
 
 export type AssetPropertyResourcesRequestParameters =

--- a/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/internal-time-series-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/internal-time-series-explorer.tsx
@@ -55,6 +55,7 @@ export function InternalTimeSeriesExplorer({
   } = {},
   dropDownResourceDefinition = DEFAULT_TIME_SERIES_DROP_DOWN_DEFINITION,
   dropDownSettings: { isFilterEnabled: isDropDownFilterEnabled = false } = {},
+  description = '',
 }: TimeSeriesExplorerProps) {
   const [userCustomization, setUserCutomization] = useUserCustomization({
     resourceName,
@@ -96,6 +97,7 @@ export function InternalTimeSeriesExplorer({
           isTitleEnabled={isTitleEnabled}
           isFilterEnabled={isTableFilterEnabled}
           isUserSettingsEnabled={isUserSettingsEnabled}
+          description={description}
         />
       }
       dropDown={

--- a/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/types.ts
@@ -20,6 +20,7 @@ export interface TimeSeriesExplorerProps
   onSelectTimeSeries?: OnSelectResource<TimeSeriesResource>;
   selectedTimeSeries?: SelectedResources<TimeSeriesResource>;
   isTimeSeriesDisabled?: IsResourceDisabled<TimeSeriesResource>;
+  description?: string;
 }
 
 export interface TimeSeriesRequestParameters {

--- a/packages/react-components/src/components/resource-explorers/variants/resource-table/resource-table-filter.css
+++ b/packages/react-components/src/components/resource-explorers/variants/resource-table/resource-table-filter.css
@@ -2,6 +2,7 @@
   flex: 1;
   display: flex;
   align-items: center;
+  margin-top: 5px;
 }
 
 .filter-field-input {


### PR DESCRIPTION
## Overview
Add description prop to all resource explorer tables. Pass in corresponding description from query editor. 

## Verifying Changes
<img width="541" alt="Screenshot 2024-09-06 at 5 11 34 PM" src="https://github.com/user-attachments/assets/ad2eb721-9377-4c9f-b476-15ece6e3073b">
<img width="541" alt="Screenshot 2024-09-06 at 5 11 45 PM" src="https://github.com/user-attachments/assets/34296634-794d-4379-9a2a-058e8e681262">
<img width="538" alt="Screenshot 2024-09-06 at 5 11 55 PM" src="https://github.com/user-attachments/assets/a765c666-15b7-4567-82c4-b22a21dbac4b">

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
