### PR TITLE
feat(react-components): use historical asset property values

### DIFF
--- a/packages/react-components/src/queries/useHistoricalAssetPropertyValues/historicalAssetPropertyValueKeyFactory.ts
+++ b/packages/react-components/src/queries/useHistoricalAssetPropertyValues/historicalAssetPropertyValueKeyFactory.ts
@@ -1,0 +1,52 @@
+import { Viewport } from '@iot-app-kit/core';
+import { HistoricalAssetPropertyValueRequest } from './types';
+import { Quality, TimeOrdering } from '@aws-sdk/client-iotsitewise';
+
+export const HISTORICAL_ASSET_PROPERTY_VALUE_RESOURCE_KEY =
+  'historical asset property value';
+
+type HistoricalAssetPropertyValueKeyFactoryOptions =
+  HistoricalAssetPropertyValueRequest & { refreshRate?: number };
+
+export class HistoricalAssetPropertyValueKeyFactory {
+  #assetId?: string;
+  #propertyId?: string;
+  #propertyAlias?: string;
+  #qualities?: Quality[];
+  #timeOrdering?: TimeOrdering;
+
+  #viewport?: Viewport;
+
+  constructor({
+    assetId,
+    propertyId,
+    propertyAlias,
+    qualities,
+    timeOrdering,
+    viewport,
+  }: HistoricalAssetPropertyValueKeyFactoryOptions) {
+    this.#assetId = assetId;
+    this.#propertyId = propertyId;
+    this.#propertyAlias = propertyAlias;
+    this.#qualities = qualities;
+    this.#timeOrdering = timeOrdering;
+
+    this.#viewport = viewport;
+  }
+
+  create() {
+    const cacheKey = [
+      {
+        resource: HISTORICAL_ASSET_PROPERTY_VALUE_RESOURCE_KEY,
+        assetId: this.#assetId,
+        propertyId: this.#propertyId,
+        propertyAlias: this.#propertyAlias,
+        qualities: this.#qualities,
+        timeOrdering: this.#timeOrdering,
+        viewport: this.#viewport,
+      },
+    ] as const;
+
+    return cacheKey;
+  }
+}

--- a/packages/react-components/src/queries/useHistoricalAssetPropertyValues/requestExecution/batcher.ts
+++ b/packages/react-components/src/queries/useHistoricalAssetPropertyValues/requestExecution/batcher.ts
@@ -1,0 +1,168 @@
+import DataLoader from 'dataloader';
+import { nanoid } from 'nanoid';
+import {
+  BatchGetAssetPropertyValueHistory,
+  RequestResponse,
+  viewportEndDate,
+  viewportStartDate,
+} from '@iot-app-kit/core';
+import {
+  HistoricalAssetPropertyValueRequest,
+  HistoricalAssetPropertyValueResponse,
+} from '../types';
+import { anySignal } from '../../useAssetPropertyValues/requestExecution/utils/anySignal';
+import { BatchGetAssetPropertyValueHistoryErrorEntry } from '@aws-sdk/client-iotsitewise';
+
+type LoaderRequest = HistoricalAssetPropertyValueRequest & {
+  abortSignal: AbortSignal;
+};
+type LoaderResponse = HistoricalAssetPropertyValueResponse & {
+  error?: BatchGetAssetPropertyValueHistoryErrorEntry;
+};
+
+const createEntryId = () => nanoid(64);
+
+export type HistoricalAssetPropertyValuesBatcherOptions = {
+  batchGetAssetPropertyValueHistory: BatchGetAssetPropertyValueHistory;
+  batchSchedulerTimeout?: number;
+  batchSize?: number;
+};
+
+export class HistoricalAssetPropertyValueBatcher {
+  private static instance: HistoricalAssetPropertyValueBatcher;
+
+  private maxResults = 20000;
+
+  private batchSchedulerTimeout: number;
+  private batchSize: number;
+
+  private batchGetAssetPropertyValueHistory: BatchGetAssetPropertyValueHistory;
+
+  private loader: DataLoader<LoaderRequest, LoaderResponse>;
+
+  private constructor({
+    batchGetAssetPropertyValueHistory,
+    batchSchedulerTimeout = 100,
+    batchSize = 16,
+  }: HistoricalAssetPropertyValuesBatcherOptions) {
+    this.batchGetAssetPropertyValueHistory = batchGetAssetPropertyValueHistory;
+    this.batchSchedulerTimeout = batchSchedulerTimeout;
+    this.batchSize = batchSize;
+
+    this.loader = new DataLoader(this.batchLoaderFn.bind(this), {
+      batchScheduleFn: this.batchScheduleFn.bind(this),
+      cache: false, // utilize react-query cache instead
+      maxBatchSize: this.batchSize,
+    });
+  }
+
+  private handleError(
+    requests: readonly HistoricalAssetPropertyValueRequest[],
+    error: unknown
+  ): never {
+    console.error(`Failed to batch get asset property values. Error: ${error}`);
+    console.info('Request input:');
+    console.table(requests);
+
+    throw error;
+  }
+
+  private async batchLoaderFn(
+    requests: readonly LoaderRequest[]
+  ): Promise<LoaderResponse[]> {
+    let nextToken = undefined;
+
+    const entries = requests.map(({ viewport, ...request }) => ({
+      ...request,
+      startDate: viewport && viewportStartDate(viewport),
+      endDate: viewport && viewportEndDate(viewport),
+      entryId: createEntryId(),
+    }));
+
+    const abortSignal = anySignal(
+      requests.map(({ abortSignal: requestAbortSignal }) => requestAbortSignal)
+    );
+
+    let successEntries: RequestResponse<BatchGetAssetPropertyValueHistory>['successEntries'] =
+      [];
+    let errorEntries: RequestResponse<BatchGetAssetPropertyValueHistory>['errorEntries'] =
+      [];
+
+    try {
+      do {
+        abortSignal.throwIfAborted();
+
+        const response: RequestResponse<BatchGetAssetPropertyValueHistory> =
+          await this.batchGetAssetPropertyValueHistory(
+            {
+              entries,
+              maxResults: this.maxResults,
+              nextToken,
+            },
+            {
+              abortSignal,
+            }
+          );
+
+        successEntries = [
+          ...successEntries,
+          ...(response.successEntries ?? []),
+        ];
+        errorEntries = [...errorEntries, ...(response.errorEntries ?? [])];
+
+        nextToken = response.nextToken;
+      } while (nextToken);
+
+      // map this to match the response type of GetAssetPropertyValueHistoryResponse
+      // mask the fact that we're batching
+      return entries.map(({ entryId }) => {
+        return {
+          assetPropertyValueHistory: successEntries
+            ?.filter((successEntry) => successEntry.entryId === entryId)
+            .flatMap((entry) => entry.assetPropertyValueHistory ?? []),
+          error: errorEntries?.find(
+            (errorEntry) => errorEntry.entryId === entryId
+          ),
+        };
+      });
+    } catch (error) {
+      this.handleError(entries, error);
+    }
+  }
+
+  private batchScheduleFn(callback: () => void) {
+    return setTimeout(callback, this.batchSchedulerTimeout);
+  }
+
+  public static getInstance(
+    options: HistoricalAssetPropertyValuesBatcherOptions
+  ): HistoricalAssetPropertyValueBatcher {
+    if (!HistoricalAssetPropertyValueBatcher.instance) {
+      HistoricalAssetPropertyValueBatcher.instance =
+        new HistoricalAssetPropertyValueBatcher(options);
+    }
+    return HistoricalAssetPropertyValueBatcher.instance;
+  }
+
+  public async send(
+    request: HistoricalAssetPropertyValueRequest,
+    settings: { abortSignal: AbortSignal }
+  ): Promise<HistoricalAssetPropertyValueResponse> {
+    const { assetPropertyValueHistory, error } = await this.loader.load({
+      ...request,
+      ...settings,
+    });
+
+    /**
+     * Handle error for each individual invocation of
+     * the loader so that other requests can succeed
+     */
+    if (error) {
+      this.handleError([request], error);
+    }
+
+    return {
+      assetPropertyValueHistory,
+    };
+  }
+}

--- a/packages/react-components/src/queries/useHistoricalAssetPropertyValues/requestExecution/getHistoricalAssetPropertyValueRequest.ts
+++ b/packages/react-components/src/queries/useHistoricalAssetPropertyValues/requestExecution/getHistoricalAssetPropertyValueRequest.ts
@@ -1,0 +1,48 @@
+import {
+  GetAssetPropertyValueHistory,
+  viewportEndDate,
+  viewportStartDate,
+} from '@iot-app-kit/core';
+import { HistoricalAssetPropertyValueRequest } from '../types';
+
+export class GetHistoricalAssetPropertyValueRequest {
+  readonly #getAssetPropertyValueHistory: GetAssetPropertyValueHistory;
+  readonly #maxResults = 20000;
+
+  constructor({
+    getAssetPropertyValueHistory,
+  }: {
+    getAssetPropertyValueHistory: GetAssetPropertyValueHistory;
+  }) {
+    this.#getAssetPropertyValueHistory = getAssetPropertyValueHistory;
+  }
+
+  public async send(
+    { viewport, ...request }: HistoricalAssetPropertyValueRequest,
+    settings: { abortSignal: AbortSignal }
+  ) {
+    try {
+      const startDate = viewport && viewportStartDate(viewport);
+      const endDate = viewport && viewportEndDate(viewport);
+      return await this.#getAssetPropertyValueHistory(
+        { startDate, endDate, maxResults: this.#maxResults, ...request },
+        settings
+      );
+    } catch (error) {
+      this.#handleError(request, error);
+    }
+  }
+
+  #handleError(
+    request: HistoricalAssetPropertyValueRequest,
+    error: unknown
+  ): never {
+    console.error(
+      `Failed to get asset property value history. Error: ${error}`
+    );
+    console.info('Request input:');
+    console.table(request);
+
+    throw error;
+  }
+}

--- a/packages/react-components/src/queries/useHistoricalAssetPropertyValues/requestExecution/index.ts
+++ b/packages/react-components/src/queries/useHistoricalAssetPropertyValues/requestExecution/index.ts
@@ -1,0 +1,2 @@
+export * from './batcher';
+export * from './getHistoricalAssetPropertyValueRequest';

--- a/packages/react-components/src/queries/useHistoricalAssetPropertyValues/types.ts
+++ b/packages/react-components/src/queries/useHistoricalAssetPropertyValues/types.ts
@@ -1,0 +1,32 @@
+import {
+  RequestParameters,
+  RequestResponse,
+  GetAssetPropertyValueHistory,
+  BatchGetAssetPropertyValueHistory,
+  Viewport,
+} from '@iot-app-kit/core';
+import { UseIoTSiteWiseClientOptions } from '../../hooks/requestFunctions/useIoTSiteWiseClient';
+import { UseQueryOptions } from '@tanstack/react-query';
+
+export type QueryFnClient = {
+  getAssetPropertyValueHistory?: GetAssetPropertyValueHistory;
+  batchGetAssetPropertyValueHistory?: BatchGetAssetPropertyValueHistory;
+};
+
+export type HistoricalAssetPropertyValueRequest = Omit<
+  RequestParameters<GetAssetPropertyValueHistory>,
+  'startDate' | 'endDate'
+> & { viewport?: Viewport };
+
+export type HistoricalAssetPropertyValueResponse =
+  RequestResponse<GetAssetPropertyValueHistory>;
+
+export type QueryOptionsGlobal = Pick<UseQueryOptions, 'retry'>;
+
+export type UseHistoricalAssetPropertyValuesOptions =
+  UseIoTSiteWiseClientOptions & {
+    requests?: HistoricalAssetPropertyValueRequest[];
+    refreshRate?: number;
+    enabled?: boolean;
+    viewport?: Viewport;
+  } & QueryOptionsGlobal;

--- a/packages/react-components/src/queries/useHistoricalAssetPropertyValues/useHistoricalAssetPropertyValues.spec.ts
+++ b/packages/react-components/src/queries/useHistoricalAssetPropertyValues/useHistoricalAssetPropertyValues.spec.ts
@@ -1,0 +1,270 @@
+import {
+  BatchGetAssetPropertyValueHistoryResponse,
+  GetAssetPropertyValueHistoryResponse,
+  IoTSiteWise,
+} from '@aws-sdk/client-iotsitewise';
+import { renderHook, waitFor } from '@testing-library/react';
+import { queryClient } from '../queryClient';
+import { useHistoricalAssetPropertyValues } from './useHistoricalAssetPropertyValues';
+import merge from 'lodash.merge';
+
+const MOCK_ASSET_ID_1 = 'asset-1';
+
+const MOCK_PROPERTY_ID_1 = 'property-1';
+
+const MOCK_VIEWPORT = {
+  duration: '10m',
+};
+
+const createMockAssetPropertyValueHistoryResponse = (
+  response: Partial<GetAssetPropertyValueHistoryResponse> = {}
+) =>
+  merge(
+    {},
+    {
+      assetPropertyValueHistory: [
+        {
+          value: {
+            doubleValue: 10,
+          },
+          timestamp: {
+            timeInSeconds: 100,
+            offsetInNanos: 0,
+          },
+          quality: 'GOOD',
+        },
+        {
+          value: {
+            doubleValue: 11,
+          },
+          timestamp: {
+            timeInSeconds: 200,
+            offsetInNanos: 0,
+          },
+          quality: 'GOOD',
+        },
+      ],
+    },
+    response
+  );
+
+const createMockBatchAssetPropertyValueHistoryResponse = (
+  response: Partial<BatchGetAssetPropertyValueHistoryResponse> = {}
+) =>
+  merge(
+    {},
+    {
+      errorEntries: [],
+      successEntries: [
+        {
+          entryId: 'entry-1',
+          assetPropertyValueHistory: [
+            {
+              value: {
+                doubleValue: 10,
+              },
+              timestamp: {
+                timeInSeconds: 100,
+                offsetInNanos: 0,
+              },
+              quality: 'GOOD',
+            },
+            {
+              value: {
+                doubleValue: 11,
+              },
+              timestamp: {
+                timeInSeconds: 200,
+                offsetInNanos: 0,
+              },
+              quality: 'GOOD',
+            },
+          ],
+        },
+      ],
+      skippedEntries: [],
+    },
+    response
+  );
+
+const getAssetPropertyValueHistory = jest.fn();
+const batchGetAssetPropertyValueHistory = jest.fn();
+
+const iotSiteWiseClientMock = {
+  getAssetPropertyValueHistory,
+  batchGetAssetPropertyValueHistory,
+} as unknown as IoTSiteWise;
+
+const iotSiteWiseClientEdgeMock = {
+  getAssetPropertyValueHistory,
+} as unknown as IoTSiteWise;
+
+describe('useHistoricalAssetPropertyValues', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    queryClient.clear();
+  });
+
+  it('should prefer using BatchGetAssetPropertyValue in successful queries when calling useHistoricalAssetPropertyValues', async () => {
+    getAssetPropertyValueHistory.mockResolvedValue(
+      createMockAssetPropertyValueHistoryResponse()
+    );
+    batchGetAssetPropertyValueHistory.mockResolvedValue(
+      createMockBatchAssetPropertyValueHistoryResponse()
+    );
+
+    const { result: queriesResult } = renderHook(() =>
+      useHistoricalAssetPropertyValues({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        viewport: MOCK_VIEWPORT,
+        requests: [
+          { assetId: MOCK_ASSET_ID_1, propertyId: MOCK_PROPERTY_ID_1 },
+        ],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isSuccess).toBe(true));
+
+    expect(getAssetPropertyValueHistory).not.toBeCalled();
+    expect(batchGetAssetPropertyValueHistory).toBeCalled();
+  });
+
+  it('should batch requests together across multiple hooks', async () => {
+    batchGetAssetPropertyValueHistory.mockResolvedValue(
+      createMockBatchAssetPropertyValueHistoryResponse()
+    );
+
+    const { result: queriesResult } = renderHook(() =>
+      useHistoricalAssetPropertyValues({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        viewport: MOCK_VIEWPORT,
+        requests: [
+          { assetId: 'asset-1', propertyId: 'property-1' },
+          { assetId: 'asset-2', propertyId: 'property-2' },
+          { assetId: 'asset-3', propertyId: 'property-3' },
+          { assetId: 'asset-4', propertyId: 'property-4' },
+          { assetId: 'asset-5', propertyId: 'property-5' },
+          { assetId: 'asset-6', propertyId: 'property-6' },
+        ],
+      })
+    );
+
+    const { result: queriesResult2 } = renderHook(() =>
+      useHistoricalAssetPropertyValues({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        viewport: MOCK_VIEWPORT,
+        requests: [
+          { assetId: 'asset-7', propertyId: 'property-7' },
+          { assetId: 'asset-8', propertyId: 'property-8' },
+          { assetId: 'asset-9', propertyId: 'property-9' },
+          { assetId: 'asset-10', propertyId: 'property-10' },
+          { assetId: 'asset-11', propertyId: 'property-11' },
+          { assetId: 'asset-12', propertyId: 'property-12' },
+        ],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isSuccess).toBe(true));
+    await waitFor(() => expect(queriesResult2.current[0].isSuccess).toBe(true));
+
+    expect(queriesResult.current.length).toBe(6);
+    expect(queriesResult2.current.length).toBe(6);
+    expect(batchGetAssetPropertyValueHistory).toHaveBeenCalledOnce();
+  });
+
+  it('should call GetAssetPropertyValue in successful queries when calling useHistoricalAssetPropertyValues at the edge', async () => {
+    getAssetPropertyValueHistory.mockResolvedValue(
+      createMockAssetPropertyValueHistoryResponse()
+    );
+
+    const { result: queriesResult } = renderHook(() =>
+      useHistoricalAssetPropertyValues({
+        iotSiteWiseClient: iotSiteWiseClientEdgeMock,
+        viewport: MOCK_VIEWPORT,
+        requests: [
+          { assetId: MOCK_ASSET_ID_1, propertyId: MOCK_PROPERTY_ID_1 },
+        ],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isSuccess).toBe(true));
+
+    expect(getAssetPropertyValueHistory).toBeCalled();
+  });
+
+  it('does nothing if requests are invalid', async () => {
+    batchGetAssetPropertyValueHistory.mockResolvedValue(
+      createMockBatchAssetPropertyValueHistoryResponse()
+    );
+
+    const { result: queriesResult } = renderHook(() =>
+      useHistoricalAssetPropertyValues({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        viewport: MOCK_VIEWPORT,
+        requests: [{ assetId: undefined, propertyId: undefined }],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isPending).toBe(true));
+
+    expect(batchGetAssetPropertyValueHistory).not.toBeCalled();
+  });
+
+  it('does nothing if viewport is invalid', async () => {
+    batchGetAssetPropertyValueHistory.mockResolvedValue(
+      createMockBatchAssetPropertyValueHistoryResponse()
+    );
+
+    const { result: queriesResult } = renderHook(() =>
+      useHistoricalAssetPropertyValues({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        requests: [
+          { assetId: MOCK_ASSET_ID_1, propertyId: MOCK_PROPERTY_ID_1 },
+        ],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isPending).toBe(true));
+
+    expect(batchGetAssetPropertyValueHistory).not.toBeCalled();
+  });
+
+  it('does nothing if the client is invalid', async () => {
+    batchGetAssetPropertyValueHistory.mockResolvedValue(
+      createMockBatchAssetPropertyValueHistoryResponse()
+    );
+
+    const { result: queriesResult } = renderHook(() =>
+      useHistoricalAssetPropertyValues({
+        iotSiteWiseClient: {} as unknown as IoTSiteWise,
+        viewport: MOCK_VIEWPORT,
+        requests: [
+          { assetId: MOCK_ASSET_ID_1, propertyId: MOCK_PROPERTY_ID_1 },
+        ],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isPending).toBe(true));
+
+    expect(batchGetAssetPropertyValueHistory).not.toBeCalled();
+  });
+
+  it('handles sdk errors', async () => {
+    batchGetAssetPropertyValueHistory.mockImplementation(() => {
+      throw new Error('This should fail.');
+    });
+
+    const { result: queriesResult } = renderHook(() =>
+      useHistoricalAssetPropertyValues({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        viewport: MOCK_VIEWPORT,
+        requests: [
+          { assetId: MOCK_ASSET_ID_1, propertyId: MOCK_PROPERTY_ID_1 },
+        ],
+        retry: false,
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isError).toBe(true));
+  });
+});

--- a/packages/react-components/src/queries/useHistoricalAssetPropertyValues/useHistoricalAssetPropertyValues.ts
+++ b/packages/react-components/src/queries/useHistoricalAssetPropertyValues/useHistoricalAssetPropertyValues.ts
@@ -1,0 +1,208 @@
+import { useMemo } from 'react';
+import { QueryFunctionContext, useQueries } from '@tanstack/react-query';
+import invariant from 'tiny-invariant';
+
+import { useIoTSiteWiseClient } from '../../hooks/requestFunctions/useIoTSiteWiseClient';
+import { queryClient } from '../queryClient';
+import {
+  hasRequestFunction,
+  isAssetId,
+  isPropertyAlias,
+  isPropertyId,
+} from '../predicates';
+
+import {
+  HistoricalAssetPropertyValueRequest,
+  QueryFnClient,
+  UseHistoricalAssetPropertyValuesOptions,
+} from './types';
+import { HistoricalAssetPropertyValueKeyFactory } from './historicalAssetPropertyValueKeyFactory';
+import {
+  GetHistoricalAssetPropertyValueRequest,
+  HistoricalAssetPropertyValueBatcher,
+} from './requestExecution';
+import {
+  BatchGetAssetPropertyValueHistory,
+  GetAssetPropertyValueHistory,
+  isDurationViewport,
+  isHistoricalViewport,
+} from '@iot-app-kit/core';
+import { useRefreshRate } from './useRefreshRate';
+import { useSyncTimeSeriesDataQueries } from '../utils/useTimeSeriesDataQuerySync';
+
+const requestIsValid = ({
+  assetId,
+  propertyId,
+  propertyAlias,
+  viewport,
+}: HistoricalAssetPropertyValueRequest) =>
+  viewport != null &&
+  (isDurationViewport(viewport) || isHistoricalViewport(viewport)) &&
+  ((isAssetId(assetId) && isPropertyId(propertyId)) ||
+    isPropertyAlias(propertyAlias));
+
+const clientIsValid = ({
+  getAssetPropertyValueHistory,
+  batchGetAssetPropertyValueHistory,
+}: QueryFnClient = {}) =>
+  hasRequestFunction<GetAssetPropertyValueHistory>(
+    getAssetPropertyValueHistory
+  ) ||
+  hasRequestFunction<BatchGetAssetPropertyValueHistory>(
+    batchGetAssetPropertyValueHistory
+  );
+
+/**
+ * useHistoricalAssetPropertyValues is a hook used to call
+ * getAssetPropertyValueHistory or batchGetAssetPropertyValueHistory
+ * on a list of GetAssetPropertyValueHistoryRequest requests
+ *
+ * batch apis are preferred when available but may
+ * not be available on all clients. For example,
+ * clients at the edge currently don't support
+ * batch apis.
+ *
+ * @param iotSiteWiseClient is an AWS SDK IoT SiteWise client
+ * @param enabled will manually disable the hook
+ * @param requests list of GetAssetPropertyValueHistoryRequest
+ * @param refreshRate refresh rate for GetAssetPropertyValueHistoryRequest in ms
+ * @returns a list of QueryResults with GetAssetPropertyValueHistoryResponse data.
+ */
+export const useHistoricalAssetPropertyValues = ({
+  iotSiteWiseClient,
+  enabled = true,
+  requests = [],
+  refreshRate: passedInRefreshRate,
+  viewport,
+  retry,
+}: UseHistoricalAssetPropertyValuesOptions) => {
+  /**
+   * Normalize refresh rate for instances of useHistoricalAssetPropertyValues
+   * If refresh rate is not provided, one will be chosen based on the viewport
+   * in the useRefreshRate hook.
+   */
+  const refreshRate = useRefreshRate({
+    refreshRate: passedInRefreshRate,
+    viewport,
+  });
+
+  /**
+   * A single enabled flag for all useHistoricalAssetPropertyValues
+   * with the same refreshRate. This will toggle the queries
+   * off / on in a setTimeout so that the executions all
+   * happen in the same task and the resulting refetchInterval
+   * executes within the batch timeout window.
+   */
+  const syncFlag = useSyncTimeSeriesDataQueries({
+    enabled,
+    refreshRate,
+  });
+
+  const { getAssetPropertyValueHistory, batchGetAssetPropertyValueHistory } =
+    useIoTSiteWiseClient({ iotSiteWiseClient });
+
+  const queries = useMemo(() => {
+    return requests.map((request) => {
+      return {
+        enabled:
+          syncFlag &&
+          enabled &&
+          clientIsValid({
+            getAssetPropertyValueHistory,
+            batchGetAssetPropertyValueHistory,
+          }) &&
+          requestIsValid({ ...request, viewport }),
+        queryKey: new HistoricalAssetPropertyValueKeyFactory({
+          ...request,
+          viewport,
+        }).create(),
+        queryFn: createHistoricalAssetPropertyValueQueryFn({
+          getAssetPropertyValueHistory,
+          batchGetAssetPropertyValueHistory,
+        }),
+        refetchInterval: refreshRate,
+        retry,
+      };
+    });
+  }, [
+    getAssetPropertyValueHistory,
+    batchGetAssetPropertyValueHistory,
+    enabled,
+    syncFlag,
+    requests,
+    viewport,
+    refreshRate,
+    retry,
+  ]);
+
+  return useQueries(
+    {
+      queries,
+    },
+    queryClient
+  );
+};
+
+export const createHistoricalAssetPropertyValueQueryFn = (
+  client?: QueryFnClient
+) => {
+  return async ({
+    queryKey: [
+      { assetId, propertyId, propertyAlias, viewport, qualities, timeOrdering },
+    ],
+    signal,
+  }: QueryFunctionContext<
+    ReturnType<HistoricalAssetPropertyValueKeyFactory['create']>
+  >) => {
+    const { getAssetPropertyValueHistory, batchGetAssetPropertyValueHistory } =
+      client ?? {};
+
+    invariant(
+      clientIsValid(client),
+      'Expected getAssetPropertyValueHistory or batchGetAssetPropertyValueHistory to be defined as required by the enabled flag.'
+    );
+
+    invariant(
+      requestIsValid({ assetId, propertyId, propertyAlias, viewport }),
+      'Expected assetId and propertyId or propertyAlias and viewport to be defined as required by the enabled flag.'
+    );
+
+    if (batchGetAssetPropertyValueHistory) {
+      return await HistoricalAssetPropertyValueBatcher.getInstance({
+        batchGetAssetPropertyValueHistory,
+      }).send(
+        {
+          assetId,
+          propertyId,
+          propertyAlias,
+          qualities,
+          timeOrdering,
+          viewport,
+        },
+        {
+          abortSignal: signal,
+        }
+      );
+    }
+
+    if (getAssetPropertyValueHistory) {
+      return await new GetHistoricalAssetPropertyValueRequest({
+        getAssetPropertyValueHistory,
+      }).send(
+        {
+          assetId,
+          propertyId,
+          propertyAlias,
+          qualities,
+          timeOrdering,
+          viewport,
+        },
+        {
+          abortSignal: signal,
+        }
+      );
+    }
+
+    throw 'Expected request to be handled by one of the two client functions as required by the enabled flag.';
+  };
+};

--- a/packages/react-components/src/queries/useHistoricalAssetPropertyValues/useRefreshRate.ts
+++ b/packages/react-components/src/queries/useHistoricalAssetPropertyValues/useRefreshRate.ts
@@ -1,0 +1,56 @@
+import {
+  Viewport,
+  viewportEndDate,
+  viewportStartDate,
+} from '@iot-app-kit/core';
+import { useMemo } from 'react';
+
+/**
+ *
+ * Normalize optional refreshRate to a number.
+ * If a refreshRate is specified directly,
+ * that rate will be used. Otherwise, a refreshRate
+ * will be calculated based on a fraction of viewport.
+ * If no vewiport is specfied either, the refreshRate is
+ * assumed to be Infinity.
+ *
+ * @param refreshRate passed in refreshRate in ms
+ * @param viewport passed in viewport
+ * @param minimumRefreshRate smallest amount the refreshRate
+ * can be when calculating based on the viewport
+ * - default: 5000ms
+ * @param viewportRatePercentage the percentage of the viewport
+ * to use as the refreshRate
+ * - default: .5
+ *
+ * @returns a refreshRate in ms
+ */
+export const useRefreshRate = ({
+  refreshRate,
+  viewport,
+  minimumRefreshRate = 5000,
+  viewportRatePercentage = 0.5,
+}: {
+  refreshRate?: number;
+  viewport?: Viewport;
+  minimumRefreshRate?: number;
+  viewportRatePercentage?: number;
+}) => {
+  return useMemo(() => {
+    if (refreshRate != null) {
+      return refreshRate;
+    }
+
+    if (viewport != null) {
+      const startDate = viewportStartDate(viewport);
+      const endDate = viewportEndDate(viewport);
+
+      const viewportPercentageRate =
+        (endDate.getTime() - startDate.getTime()) * viewportRatePercentage;
+
+      return Math.max(viewportPercentageRate, minimumRefreshRate);
+    }
+
+    return Infinity;
+  }, [refreshRate, viewport, minimumRefreshRate, viewportRatePercentage]);
+};

--- a/packages/react-components/src/queries/useLatestAssetPropertyValues/latestAssetPropertyValueKeyFactory.ts
+++ b/packages/react-components/src/queries/useLatestAssetPropertyValues/latestAssetPropertyValueKeyFactory.ts
@@ -10,18 +10,15 @@ export class LatestAssetPropertyValueKeyFactory {
   #assetId?: string;
   #propertyId?: string;
   #propertyAlias?: string;
-  #refreshRate?: number;
 
   constructor({
     assetId,
     propertyId,
     propertyAlias,
-    refreshRate,
   }: LatestAssetPropertyValueKeyFactoryOptions) {
     this.#assetId = assetId;
     this.#propertyId = propertyId;
     this.#propertyAlias = propertyAlias;
-    this.#refreshRate = refreshRate;
   }
 
   create() {
@@ -31,7 +28,6 @@ export class LatestAssetPropertyValueKeyFactory {
         assetId: this.#assetId,
         propertyId: this.#propertyId,
         propertyAlias: this.#propertyAlias,
-        refreshRate: this.#refreshRate,
       },
     ] as const;
 

--- a/packages/react-components/src/queries/useLatestAssetPropertyValues/types.ts
+++ b/packages/react-components/src/queries/useLatestAssetPropertyValues/types.ts
@@ -5,6 +5,7 @@ import {
   RequestResponse,
 } from '@iot-app-kit/core';
 import { UseIoTSiteWiseClientOptions } from '../../hooks/requestFunctions/useIoTSiteWiseClient';
+import { UseQueryOptions } from '@tanstack/react-query';
 
 export type QueryFnClient = {
   getAssetPropertyValue?: GetAssetPropertyValue;
@@ -16,9 +17,11 @@ export type LatestAssetPropertyValueRequest =
 export type LatestAssetPropertyValueResponse =
   RequestResponse<GetAssetPropertyValue>;
 
+export type QueryOptionsGlobal = Pick<UseQueryOptions, 'retry'>;
+
 export type UseLatestAssetPropertyValuesOptions =
   UseIoTSiteWiseClientOptions & {
     requests?: LatestAssetPropertyValueRequest[];
     refreshRate?: number;
     enabled?: boolean;
-  };
+  } & QueryOptionsGlobal;

--- a/packages/react-components/src/queries/useLatestAssetPropertyValues/useLatestAssetPropertyValues.spec.ts
+++ b/packages/react-components/src/queries/useLatestAssetPropertyValues/useLatestAssetPropertyValues.spec.ts
@@ -195,4 +195,22 @@ describe('useLatestAssetPropertyValues', () => {
 
     expect(batchGetAssetPropertyValue).not.toBeCalled();
   });
+
+  it('handles sdk errors', async () => {
+    batchGetAssetPropertyValue.mockImplementation(() => {
+      throw new Error('This should fail.');
+    });
+
+    const { result: queriesResult } = renderHook(() =>
+      useLatestAssetPropertyValues({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        requests: [
+          { assetId: MOCK_ASSET_ID_1, propertyId: MOCK_PROPERTY_ID_1 },
+        ],
+        retry: false,
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isError).toBe(true));
+  });
 });

--- a/packages/react-components/src/queries/utils/useTimeSeriesDataQuerySync.ts
+++ b/packages/react-components/src/queries/utils/useTimeSeriesDataQuerySync.ts
@@ -2,18 +2,17 @@ import { useEffect } from 'react';
 import { StateCreator, create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
-export interface LatestAssetPropertyValueSync {
+export interface TimeSeriesDataSync {
   enabled: Record<number, boolean>;
 }
 
-export interface LatestAssetPropertyValueSyncState
-  extends LatestAssetPropertyValueSync {
+export interface TimeSeriesDataSyncState extends TimeSeriesDataSync {
   enable: (refreshRate: number) => void;
   disable: (refreshRate: number) => void;
 }
 
-export const createLatestAssetPropertyValueSyncSlice: StateCreator<
-  LatestAssetPropertyValueSyncState
+export const createTimeSeriesDataSyncSlice: StateCreator<
+  TimeSeriesDataSyncState
 > = (set) => ({
   enabled: {},
   enable: (refreshRate: number) =>
@@ -34,16 +33,15 @@ export const createLatestAssetPropertyValueSyncSlice: StateCreator<
     })),
 });
 
-export const useLatestAssetPropertyValueSyncStore =
-  create<LatestAssetPropertyValueSyncState>()(
-    devtools((...args) => ({
-      ...createLatestAssetPropertyValueSyncSlice(...args),
-    }))
-  );
+export const useTimeSeriesDataSyncStore = create<TimeSeriesDataSyncState>()(
+  devtools((...args) => ({
+    ...createTimeSeriesDataSyncSlice(...args),
+  }))
+);
 
 /**
  * Hook that will toggle a single enabled flag for
- * multiple usages of useLatestAssetPropertyValue
+ * multiple usages of time series data hooks
  * with the same refresh rate.
  *
  * This enabled flag is passed to useQueries
@@ -51,7 +49,7 @@ export const useLatestAssetPropertyValueSyncStore =
  * that the refetch intervals are synced and
  * batching can be fully utilized across multiple hooks.
  */
-export const useSyncLatestAssetPropertyValueQueries = ({
+export const useSyncTimeSeriesDataQueries = ({
   enabled,
   refreshRate,
 }: {
@@ -62,7 +60,7 @@ export const useSyncLatestAssetPropertyValueQueries = ({
     enabled: enabledFlags,
     enable,
     disable,
-  } = useLatestAssetPropertyValueSyncStore();
+  } = useTimeSeriesDataSyncStore();
 
   useEffect(() => {
     if (!enabled) return;

--- a/packages/react-components/stories/queries/queriesBase.stories.tsx
+++ b/packages/react-components/stories/queries/queriesBase.stories.tsx
@@ -16,6 +16,7 @@ import { useSiteWiseAnomalyDataSource } from '../../src/queries/useSiteWiseAnoma
 import { TimeSelection, TimeSync, useViewport } from '../../src';
 import { isDurationViewport } from '../../src/utils/isDurationViewport';
 import { useLatestAssetPropertyValues } from '../../src/queries/useLatestAssetPropertyValues/useLatestAssetPropertyValues';
+import { useHistoricalAssetPropertyValues } from '../../src/queries/useHistoricalAssetPropertyValues/useHistoricalAssetPropertyValues';
 
 const ASSET_MODEL_ID = '4c8e3da0-d3ec-4818-86b3-44a1e6b98531';
 const ASSET_MODEL_COMPOSITE_MODEL_ID = 'a85b0fb2-b259-441c-aacc-d7d7495214f5';
@@ -59,6 +60,58 @@ export default {
     ),
   ],
 } as ComponentMeta<typeof RenderQueries>;
+
+export const HistoricalAssetPropertyValues: ComponentStory<FC> = () => {
+  /**
+   * Demo component to illustrate that batching works
+   * across multiple hook usage no matter when
+   * the hooks actually mount.
+   */
+  const [e2, setE2] = useState(false);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setE2(true);
+    }, 6000);
+  });
+
+  const responses1 = useHistoricalAssetPropertyValues({
+    iotSiteWiseClient: client,
+    viewport: { duration: '10m' },
+    requests: [
+      {
+        assetId: '8ca28842-687c-45ac-ac74-6db7cf61a80a',
+        propertyId: 'b306e0cd-548d-4857-8c6d-9ec773420c6c',
+      },
+      {
+        assetId: '8ca28842-687c-45ac-ac74-6db7cf61a80a',
+        propertyId: 'b565acbd-bf96-4ce7-b5d3-d6822758619b',
+      },
+    ],
+  });
+
+  const responses2 = useHistoricalAssetPropertyValues({
+    enabled: e2,
+    iotSiteWiseClient: client,
+    viewport: { duration: '10m' },
+    requests: [
+      {
+        assetId: '8ca28842-687c-45ac-ac74-6db7cf61a80a',
+        propertyId: '585838b3-d755-4dd5-89ed-2abfd0d0feca',
+      },
+      {
+        assetId: '8ca28842-687c-45ac-ac74-6db7cf61a80a',
+        propertyId: 'f7117764-6c45-447b-9caf-0876bb211e2f',
+      },
+    ],
+  });
+
+  console.log([...responses1, ...responses2].map((r) => r.data));
+
+  return (
+    <RenderQueries json={[...responses1, ...responses2].map((r) => r.data)} />
+  );
+};
 
 export const LatestAssetPropertyValues: ComponentStory<FC> = () => {
   /**


### PR DESCRIPTION
## Overview
Tanstack wrapper around `getAssetPropertyValueHistory`, `batchGetAssetPropertyValueHistory`. These can be used to fetch historical asset property values by assetId + propertyId or propertyAlias for a given viewport.

Note: Caching works based on an entire request in this implementation. Partial request caching is not supported. Late data configuration is also not supported. Instead, a refreshRate can be given, or one will be determined based on a percentage of the provided viewport, and will refresh the whole viewport range.

This hook will work if the client provided implements either / both getAssetPropertyValueHistory, batchGetAssetPropertyValueHistory. The hook will prefer to use the batch api if both are provided.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
