### PR TITLE
fix(dashboard): add timezone support for new RE

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
@@ -27,6 +27,7 @@ export function IoTSiteWiseQueryEditor({
   const isEdgeModeEnabled = useSelector(
     (state: DashboardState) => state.isEdgeModeEnabled
   );
+  const timeZone = useSelector((state: DashboardState) => state.timeZone);
 
   const modeledTab = {
     label: 'Modeled',
@@ -38,6 +39,7 @@ export function IoTSiteWiseQueryEditor({
         correctSelectionMode={correctSelectionMode}
         addButtonDisabled={addButtonDisabled}
         selectedWidgets={selectedWidgets}
+        timeZone={timeZone}
       />
     ),
   };

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledExplorer/modeledExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledExplorer/modeledExplorer.tsx
@@ -24,6 +24,7 @@ type ModeledExplorerProps = {
   correctSelectionMode: SelectionMode;
   addButtonDisabled: boolean;
   selectedWidgets: DashboardWidget[];
+  timeZone?: string;
 };
 
 export const ModeledExplorer = ({
@@ -32,6 +33,7 @@ export const ModeledExplorer = ({
   correctSelectionMode,
   addButtonDisabled,
   selectedWidgets,
+  timeZone,
 }: ModeledExplorerProps) => {
   const [selectedAssets, setSelectedAssets] = useState<
     NonNullable<AssetExplorerProps['selectedAssets']>
@@ -108,6 +110,7 @@ export const ModeledExplorer = ({
               ),
           }}
           description='Select a modeled datastream to add to a selected widget'
+          timeZone={timeZone}
         />
       )}
       <ResourceExplorerFooter

--- a/packages/react-components/src/components/resource-explorers/constants/table-resource-definitions.ts
+++ b/packages/react-components/src/components/resource-explorers/constants/table-resource-definitions.ts
@@ -172,6 +172,27 @@ export const DEFAULT_TIME_SERIES_TABLE_DEFINITION: TableResourceDefinition<TimeS
     },
   ];
 
+export function createDefaultLatestValuesTableDefinition(
+  renderLatestValueTime: RenderTableResourceField<
+    DataStreamResourceWithLatestValue<unknown>
+  >
+): TableResourceDefinition<DataStreamResourceWithLatestValue<unknown>> {
+  return [
+    {
+      id: 'latestValue',
+      name: 'Latest value',
+      pluralName: 'Latest values',
+      render: ({ latestValue }) => latestValue,
+    },
+    {
+      id: 'latestValueTime',
+      name: 'Latest value time',
+      pluralName: 'Latest value times',
+      render: renderLatestValueTime,
+    },
+  ];
+}
+
 const LATEST_VALUES_TABLE_DEFINITION: TableResourceDefinition<
   DataStreamResourceWithLatestValue<unknown>
 > = [

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
@@ -26,10 +26,12 @@ import {
 import { AssetPropertyResource } from '../../types/resources';
 import {
   DEFAULT_ASSET_PROPERTY_TABLE_DEFINITION,
-  DEFAULT_ASSET_PROPERTY_WITH_LATEST_VALUES_TABLE_DEFINITION,
+  createDefaultLatestValuesTableDefinition,
 } from '../../constants/table-resource-definitions';
 import { DEFAULT_ASSET_PROPERTY_DROP_DOWN_DEFINITION } from '../../constants/drop-down-resource-definitions';
 import { useUserCustomization } from '../../helpers/use-user-customization';
+import { TableResourceDefinition } from '../../types/table';
+import { formatDate } from '../../../../utils/time';
 
 export function InternalAssetPropertyExplorer({
   requestFns,
@@ -43,12 +45,8 @@ export function InternalAssetPropertyExplorer({
   selectedAssetProperties = DEFAULT_SELECTED_RESOURCES,
   onSelectAssetProperty = DEFAULT_ON_SELECT_RESOURCE,
   selectionMode = DEFAULT_SELECTION_MODE,
-  tableResourceDefinition = requestFns?.batchGetAssetPropertyValue !== undefined
-    ? DEFAULT_ASSET_PROPERTY_WITH_LATEST_VALUES_TABLE_DEFINITION
-    : DEFAULT_ASSET_PROPERTY_TABLE_DEFINITION,
-  defaultTableUserSettings = createDefaultTableUserSettings(
-    tableResourceDefinition
-  ),
+  tableResourceDefinition: customTableResourceDefinition,
+  defaultTableUserSettings: customDefaultTableUserSettings,
   tableSettings: {
     isTitleEnabled = DEFAULT_IS_TABLE_ENABLED,
     isSearchEnabled = DEFAULT_IS_TABLE_SEARCH_ENABLED,
@@ -59,7 +57,26 @@ export function InternalAssetPropertyExplorer({
   dropDownSettings: { isFilterEnabled: isDropDownFilterEnabled = false } = {},
   ariaLabels,
   description = '',
+  timeZone,
 }: AssetPropertyExplorerProps) {
+  const tableResourceDefinition =
+    customTableResourceDefinition ??
+    requestFns?.batchGetAssetPropertyValue !== undefined
+      ? ([
+          ...DEFAULT_ASSET_PROPERTY_TABLE_DEFINITION,
+          ...createDefaultLatestValuesTableDefinition((latestValueResource) => {
+            return latestValueResource.latestValueTimestamp
+              ? formatDate(latestValueResource.latestValueTimestamp * 1000, {
+                  timeZone,
+                })
+              : '-';
+          }),
+        ] as TableResourceDefinition<AssetPropertyResource>)
+      : DEFAULT_ASSET_PROPERTY_TABLE_DEFINITION;
+
+  const defaultTableUserSettings =
+    customDefaultTableUserSettings ??
+    createDefaultTableUserSettings(tableResourceDefinition);
   const [userCustomization, setUserCutomization] = useUserCustomization({
     resourceName,
     defaultPageSize,

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
@@ -27,6 +27,7 @@ export interface AssetPropertyExplorerProps
   isAssetPropertyDisabled?: IsResourceDisabled<AssetPropertyResource>;
   ariaLabels?: TableProps.AriaLabels<AssetPropertyResource>;
   description?: string;
+  timeZone?: string;
 }
 
 export type AssetPropertyResourcesRequestParameters =

--- a/packages/react-components/src/components/resource-explorers/testing/table-variant/asset-property-table.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/table-variant/asset-property-table.spec.tsx
@@ -17,6 +17,7 @@ import {
 } from '@iot-app-kit/core';
 import { AssetPropertyResource } from '../../types/resources';
 import { DEFAULT_LATEST_VALUE_REQUEST_INTERVAL } from '../../constants/defaults';
+import { formatDate } from '../../../../utils/time';
 
 function SelectableAssetPropertyTable({
   selectionMode,
@@ -687,26 +688,26 @@ describe('asset property table', () => {
       ).toBeVisible();
       expect(
         screen.getByText(
-          new Date(
+          formatDate(
             assetProperty1SuccessEntry.assetPropertyValue.timestamp
               .timeInSeconds * 1000
-          ).toLocaleString()
+          )
         )
       ).toBeVisible();
       expect(
         screen.getByText(
-          new Date(
+          formatDate(
             assetProperty2SuccessEntry.assetPropertyValue.timestamp
               .timeInSeconds * 1000
-          ).toLocaleString()
+          )
         )
       ).toBeVisible();
       expect(
         screen.getByText(
-          new Date(
+          formatDate(
             assetProperty3SuccessEntry.assetPropertyValue.timestamp
               .timeInSeconds * 1000
-          ).toLocaleString()
+          )
         )
       ).toBeVisible();
     });


### PR DESCRIPTION
## Overview
We had added timezone support in the old RE [#2944](https://github.com/awslabs/iot-app-kit/pull/2944/files). Making the new RE component have feature parity with the old.

## Verifying Changes
Local:
<img width="532" alt="Screenshot 2024-09-10 at 1 37 03 PM" src="https://github.com/user-attachments/assets/72ec051a-a357-4a32-a208-23533df3cf53">

With Tokyo timezone:
<img width="532" alt="Screenshot 2024-09-10 at 1 35 27 PM" src="https://github.com/user-attachments/assets/357a6dc0-d5c8-4163-ba63-be247d58a1df">



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
