### PR TITLE
fix(react-components): ensure enabled flag is never undefined for queries

### DIFF
--- a/packages/react-components/src/queries/useHistoricalAssetPropertyValues/useHistoricalAssetPropertyValues.spec.ts
+++ b/packages/react-components/src/queries/useHistoricalAssetPropertyValues/useHistoricalAssetPropertyValues.spec.ts
@@ -205,7 +205,11 @@ describe('useHistoricalAssetPropertyValues', () => {
       })
     );
 
-    await waitFor(() => expect(queriesResult.current[0].isPending).toBe(true));
+    await waitFor(() => {
+      expect(queriesResult.current[0].fetchStatus).toBe('idle');
+      expect(queriesResult.current[0].status).toBe('pending');
+      expect(queriesResult.current[0].isLoading).toBe(false);
+    });
 
     expect(batchGetAssetPropertyValueHistory).not.toBeCalled();
   });
@@ -224,7 +228,11 @@ describe('useHistoricalAssetPropertyValues', () => {
       })
     );
 
-    await waitFor(() => expect(queriesResult.current[0].isPending).toBe(true));
+    await waitFor(() => {
+      expect(queriesResult.current[0].fetchStatus).toBe('idle');
+      expect(queriesResult.current[0].status).toBe('pending');
+      expect(queriesResult.current[0].isLoading).toBe(false);
+    });
 
     expect(batchGetAssetPropertyValueHistory).not.toBeCalled();
   });
@@ -244,7 +252,11 @@ describe('useHistoricalAssetPropertyValues', () => {
       })
     );
 
-    await waitFor(() => expect(queriesResult.current[0].isPending).toBe(true));
+    await waitFor(() => {
+      expect(queriesResult.current[0].fetchStatus).toBe('idle');
+      expect(queriesResult.current[0].status).toBe('pending');
+      expect(queriesResult.current[0].isLoading).toBe(false);
+    });
 
     expect(batchGetAssetPropertyValueHistory).not.toBeCalled();
   });

--- a/packages/react-components/src/queries/useLatestAssetPropertyValues/useLatestAssetPropertyValues.spec.ts
+++ b/packages/react-components/src/queries/useLatestAssetPropertyValues/useLatestAssetPropertyValues.spec.ts
@@ -172,7 +172,11 @@ describe('useLatestAssetPropertyValues', () => {
       })
     );
 
-    await waitFor(() => expect(queriesResult.current[0].isPending).toBe(true));
+    await waitFor(() => {
+      expect(queriesResult.current[0].fetchStatus).toBe('idle');
+      expect(queriesResult.current[0].status).toBe('pending');
+      expect(queriesResult.current[0].isLoading).toBe(false);
+    });
 
     expect(batchGetAssetPropertyValue).not.toBeCalled();
   });
@@ -191,7 +195,11 @@ describe('useLatestAssetPropertyValues', () => {
       })
     );
 
-    await waitFor(() => expect(queriesResult.current[0].isPending).toBe(true));
+    await waitFor(() => {
+      expect(queriesResult.current[0].fetchStatus).toBe('idle');
+      expect(queriesResult.current[0].status).toBe('pending');
+      expect(queriesResult.current[0].isLoading).toBe(false);
+    });
 
     expect(batchGetAssetPropertyValue).not.toBeCalled();
   });

--- a/packages/react-components/src/queries/utils/useTimeSeriesDataQuerySync.ts
+++ b/packages/react-components/src/queries/utils/useTimeSeriesDataQuerySync.ts
@@ -71,5 +71,5 @@ export const useSyncTimeSeriesDataQueries = ({
     }, 0);
   }, [enabled, refreshRate, enable, disable]);
 
-  return enabledFlags[refreshRate];
+  return !!enabledFlags[refreshRate];
 };


### PR DESCRIPTION
## Overview
Bug fix for queries status. The enabled flag was possibly undefined due to the value of the sync variable. enabled = undefined is defaulted to true in react-query, meaning that the query could be enabled and disabled for a frame. This would allow the query to move from an idle fetch state into a fetching fetch state, causing the query to read as a status of loading even if that is not possible given the invariants.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
