### PR TITLE
fix(dashboard): re reflects significant digits + timezone support for unmodeled

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
@@ -28,6 +28,9 @@ export function IoTSiteWiseQueryEditor({
     (state: DashboardState) => state.isEdgeModeEnabled
   );
   const timeZone = useSelector((state: DashboardState) => state.timeZone);
+  const significantDigits = useSelector(
+    (state: DashboardState) => state.significantDigits
+  );
 
   const modeledTab = {
     label: 'Modeled',
@@ -40,6 +43,7 @@ export function IoTSiteWiseQueryEditor({
         addButtonDisabled={addButtonDisabled}
         selectedWidgets={selectedWidgets}
         timeZone={timeZone}
+        significantDigits={significantDigits}
       />
     ),
   };
@@ -54,6 +58,8 @@ export function IoTSiteWiseQueryEditor({
         correctSelectionMode={correctSelectionMode}
         addButtonDisabled={addButtonDisabled}
         selectedWidgets={selectedWidgets}
+        timeZone={timeZone}
+        significantDigits={significantDigits}
       />
     ),
     disabled: isEdgeModeEnabled,

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledExplorer/modeledExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledExplorer/modeledExplorer.tsx
@@ -25,6 +25,7 @@ type ModeledExplorerProps = {
   addButtonDisabled: boolean;
   selectedWidgets: DashboardWidget[];
   timeZone?: string;
+  significantDigits?: number;
 };
 
 export const ModeledExplorer = ({
@@ -34,6 +35,7 @@ export const ModeledExplorer = ({
   addButtonDisabled,
   selectedWidgets,
   timeZone,
+  significantDigits,
 }: ModeledExplorerProps) => {
   const [selectedAssets, setSelectedAssets] = useState<
     NonNullable<AssetExplorerProps['selectedAssets']>
@@ -111,6 +113,7 @@ export const ModeledExplorer = ({
           }}
           description='Select a modeled datastream to add to a selected widget'
           timeZone={timeZone}
+          significantDigits={significantDigits}
         />
       )}
       <ResourceExplorerFooter

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/timeSeriesExplorer/timeSeriesExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/timeSeriesExplorer/timeSeriesExplorer.tsx
@@ -19,6 +19,8 @@ type UnmodeledExplorerProps = {
   correctSelectionMode: SelectionMode;
   addButtonDisabled: boolean;
   selectedWidgets: DashboardWidget[];
+  timeZone?: string;
+  significantDigits?: number;
 };
 
 export const UnmodeledExplorer = ({
@@ -26,6 +28,8 @@ export const UnmodeledExplorer = ({
   iotSiteWise,
   correctSelectionMode,
   addButtonDisabled,
+  timeZone,
+  significantDigits,
 }: UnmodeledExplorerProps) => {
   const [selectedTimeSeries, setSelectedTimeSeries] = useState<
     NonNullable<TimeSeriesExplorerProps['selectedTimeSeries']>
@@ -59,6 +63,8 @@ export const UnmodeledExplorer = ({
           isUserSettingsEnabled: true,
         }}
         description='Select a unmodeled datastream to add to a selected widget'
+        timeZone={timeZone}
+        significantDigits={significantDigits}
       />
       <ResourceExplorerFooter
         addDisabled={addButtonDisabled}

--- a/packages/react-components/src/components/resource-explorers/constants/table-resource-definitions.ts
+++ b/packages/react-components/src/components/resource-explorers/constants/table-resource-definitions.ts
@@ -175,6 +175,9 @@ export const DEFAULT_TIME_SERIES_TABLE_DEFINITION: TableResourceDefinition<TimeS
 export function createDefaultLatestValuesTableDefinition(
   renderLatestValueTime: RenderTableResourceField<
     DataStreamResourceWithLatestValue<unknown>
+  >,
+  renderLatestValue: RenderTableResourceField<
+    DataStreamResourceWithLatestValue<unknown>
   >
 ): TableResourceDefinition<DataStreamResourceWithLatestValue<unknown>> {
   return [
@@ -182,7 +185,7 @@ export function createDefaultLatestValuesTableDefinition(
       id: 'latestValue',
       name: 'Latest value',
       pluralName: 'Latest values',
-      render: ({ latestValue }) => latestValue,
+      render: renderLatestValue,
     },
     {
       id: 'latestValueTime',

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
@@ -32,6 +32,7 @@ import { DEFAULT_ASSET_PROPERTY_DROP_DOWN_DEFINITION } from '../../constants/dro
 import { useUserCustomization } from '../../helpers/use-user-customization';
 import { TableResourceDefinition } from '../../types/table';
 import { formatDate } from '../../../../utils/time';
+import { isNumeric, round } from '@iot-app-kit/core-util';
 
 export function InternalAssetPropertyExplorer({
   requestFns,
@@ -58,19 +59,34 @@ export function InternalAssetPropertyExplorer({
   ariaLabels,
   description = '',
   timeZone,
+  significantDigits,
 }: AssetPropertyExplorerProps) {
   const tableResourceDefinition =
     customTableResourceDefinition ??
     requestFns?.batchGetAssetPropertyValue !== undefined
       ? ([
           ...DEFAULT_ASSET_PROPERTY_TABLE_DEFINITION,
-          ...createDefaultLatestValuesTableDefinition((latestValueResource) => {
-            return latestValueResource.latestValueTimestamp
-              ? formatDate(latestValueResource.latestValueTimestamp * 1000, {
-                  timeZone,
-                })
-              : '-';
-          }),
+          ...createDefaultLatestValuesTableDefinition(
+            (latestValueResource) => {
+              return latestValueResource.latestValueTimestamp
+                ? formatDate(latestValueResource.latestValueTimestamp * 1000, {
+                    timeZone,
+                  })
+                : '-';
+            },
+            (latestValueResource) => {
+              if (
+                latestValueResource.latestValue &&
+                isNumeric(latestValueResource.latestValue)
+              ) {
+                return round(
+                  latestValueResource.latestValue,
+                  significantDigits
+                );
+              }
+              return latestValueResource.latestValue;
+            }
+          ),
         ] as TableResourceDefinition<AssetPropertyResource>)
       : DEFAULT_ASSET_PROPERTY_TABLE_DEFINITION;
 

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
@@ -28,6 +28,7 @@ export interface AssetPropertyExplorerProps
   ariaLabels?: TableProps.AriaLabels<AssetPropertyResource>;
   description?: string;
   timeZone?: string;
+  significantDigits?: number;
 }
 
 export type AssetPropertyResourcesRequestParameters =

--- a/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/types.ts
@@ -21,6 +21,8 @@ export interface TimeSeriesExplorerProps
   selectedTimeSeries?: SelectedResources<TimeSeriesResource>;
   isTimeSeriesDisabled?: IsResourceDisabled<TimeSeriesResource>;
   description?: string;
+  timeZone?: string;
+  significantDigits?: number;
 }
 
 export interface TimeSeriesRequestParameters {

--- a/packages/react-components/src/components/resource-explorers/testing/table-variant/time-series-table.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/table-variant/time-series-table.spec.tsx
@@ -9,6 +9,7 @@ import { BatchGetAssetPropertyValue, ListTimeSeries } from '@iot-app-kit/core';
 import { TimeSeriesResource } from '../../types/resources';
 import { SelectionMode } from '../../types/common';
 import { DEFAULT_LATEST_VALUE_REQUEST_INTERVAL } from '../../constants/defaults';
+import { formatDate } from '../../../../utils/time';
 
 function SelectableTimeSeriesTable({
   selectionMode,
@@ -361,26 +362,26 @@ describe('time series table', () => {
       ).toBeVisible();
       expect(
         screen.getByText(
-          new Date(
+          formatDate(
             timeSeries1SuccessEntry.assetPropertyValue.timestamp.timeInSeconds *
               1000
-          ).toLocaleString()
+          )
         )
       ).toBeVisible();
       expect(
         screen.getByText(
-          new Date(
+          formatDate(
             timeSeries2SuccessEntry.assetPropertyValue.timestamp.timeInSeconds *
               1000
-          ).toLocaleString()
+          )
         )
       ).toBeVisible();
       expect(
         screen.getByText(
-          new Date(
+          formatDate(
             timeSeries3SuccessEntry.assetPropertyValue.timestamp.timeInSeconds *
               1000
-          ).toLocaleString()
+          )
         )
       ).toBeVisible();
     });


### PR DESCRIPTION
## Overview
Adding support for significant digits in the RE as well as adding in required changes for timezone support on unmodeled datastreams, a miss on previous PR.

## Verifying Changes

https://github.com/user-attachments/assets/7a71485d-eb33-4af6-bd0d-98bfd3d0f5df

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
