### PR TITLE
fix(dashboard): fast follow to clean up messy code for table cell render

### DIFF
--- a/packages/react-components/src/components/resource-explorers/constants/defaults.ts
+++ b/packages/react-components/src/components/resource-explorers/constants/defaults.ts
@@ -21,6 +21,9 @@ import type {
   ResourceTableUserSettings,
   TableResourceField,
 } from '../types/table';
+import { DataStreamResourceWithLatestValue } from '../types/resources';
+import { formatDate } from '../../../utils/time';
+import { isNumeric, round } from '@iot-app-kit/core-util';
 
 const NO_OP = () => {};
 
@@ -80,6 +83,28 @@ export function createDefaultTableUserSettings<Resource>(
     contentDensity: 'comfortable',
   };
 }
+
+export const latestValueTimeCellRenderer = (timeZone?: string) => {
+  return (latestValueResource: DataStreamResourceWithLatestValue<unknown>) => {
+    return latestValueResource.latestValueTimestamp
+      ? formatDate(latestValueResource.latestValueTimestamp * 1000, {
+          timeZone,
+        })
+      : '-';
+  };
+};
+
+export const latestValueCellRenderer = (significantDigits?: number) => {
+  return (latestValueResource: DataStreamResourceWithLatestValue<unknown>) => {
+    if (
+      latestValueResource.latestValue &&
+      isNumeric(latestValueResource.latestValue)
+    ) {
+      return round(latestValueResource.latestValue, significantDigits);
+    }
+    return latestValueResource.latestValue;
+  };
+};
 
 export const DEFAULT_STRING_FILTER_OPERATORS = [
   '=',

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
@@ -22,6 +22,8 @@ import {
   DEFAULT_SELECTION_MODE,
   DEFAULT_SHOULD_PERSIST_USER_CUSTOMIZATION,
   createDefaultTableUserSettings,
+  latestValueCellRenderer,
+  latestValueTimeCellRenderer,
 } from '../../constants/defaults';
 import { AssetPropertyResource } from '../../types/resources';
 import {
@@ -31,8 +33,6 @@ import {
 import { DEFAULT_ASSET_PROPERTY_DROP_DOWN_DEFINITION } from '../../constants/drop-down-resource-definitions';
 import { useUserCustomization } from '../../helpers/use-user-customization';
 import { TableResourceDefinition } from '../../types/table';
-import { formatDate } from '../../../../utils/time';
-import { isNumeric, round } from '@iot-app-kit/core-util';
 
 export function InternalAssetPropertyExplorer({
   requestFns,
@@ -67,25 +67,8 @@ export function InternalAssetPropertyExplorer({
       ? ([
           ...DEFAULT_ASSET_PROPERTY_TABLE_DEFINITION,
           ...createDefaultLatestValuesTableDefinition(
-            (latestValueResource) => {
-              return latestValueResource.latestValueTimestamp
-                ? formatDate(latestValueResource.latestValueTimestamp * 1000, {
-                    timeZone,
-                  })
-                : '-';
-            },
-            (latestValueResource) => {
-              if (
-                latestValueResource.latestValue &&
-                isNumeric(latestValueResource.latestValue)
-              ) {
-                return round(
-                  latestValueResource.latestValue,
-                  significantDigits
-                );
-              }
-              return latestValueResource.latestValue;
-            }
+            latestValueTimeCellRenderer(timeZone),
+            latestValueCellRenderer(significantDigits)
           ),
         ] as TableResourceDefinition<AssetPropertyResource>)
       : DEFAULT_ASSET_PROPERTY_TABLE_DEFINITION;

--- a/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/internal-time-series-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/internal-time-series-explorer.tsx
@@ -22,6 +22,8 @@ import {
   DEFAULT_SELECTION_MODE,
   DEFAULT_SHOULD_PERSIST_USER_CUSTOMIZATION,
   DEFAULT_TIME_SERIES_RESOURCE_NAME,
+  latestValueCellRenderer,
+  latestValueTimeCellRenderer,
 } from '../../constants/defaults';
 import type { TimeSeriesResource } from '../../types/resources';
 import {
@@ -30,8 +32,6 @@ import {
 } from '../../constants/table-resource-definitions';
 import { DEFAULT_TIME_SERIES_DROP_DOWN_DEFINITION } from '../../constants/drop-down-resource-definitions';
 import { TableResourceDefinition } from '../../types/table';
-import { formatDate } from '../../../../utils/time';
-import { isNumeric, round } from '@iot-app-kit/core-util';
 
 export function InternalTimeSeriesExplorer({
   requestFns,
@@ -64,25 +64,8 @@ export function InternalTimeSeriesExplorer({
       ? ([
           ...DEFAULT_TIME_SERIES_TABLE_DEFINITION,
           ...createDefaultLatestValuesTableDefinition(
-            (latestValueResource) => {
-              return latestValueResource.latestValueTimestamp
-                ? formatDate(latestValueResource.latestValueTimestamp * 1000, {
-                    timeZone,
-                  })
-                : '-';
-            },
-            (latestValueResource) => {
-              if (
-                latestValueResource.latestValue &&
-                isNumeric(latestValueResource.latestValue)
-              ) {
-                return round(
-                  latestValueResource.latestValue,
-                  significantDigits
-                );
-              }
-              return latestValueResource.latestValue;
-            }
+            latestValueTimeCellRenderer(timeZone),
+            latestValueCellRenderer(significantDigits)
           ),
         ] as TableResourceDefinition<TimeSeriesResource>)
       : DEFAULT_TIME_SERIES_TABLE_DEFINITION;


### PR DESCRIPTION
## Overview
Moved render functions defined in internal property explorers into default file, wrapped in a higher order function that takes in either timezone/significant digits to render latest value or latest value time.

## Verifying Changes

https://github.com/user-attachments/assets/b52b89b8-19af-4609-89e3-424ebc6fd5b9



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
