### PR TITLE
chore(dashboard): remove requestFns and use iotSiteWise as prop name for any client in RE

### DIFF
--- a/packages/dashboard/src/components/assetModelSelection/assetModelSelect.tsx
+++ b/packages/dashboard/src/components/assetModelSelection/assetModelSelect.tsx
@@ -16,7 +16,7 @@ import { AssetResource } from '@iot-app-kit/react-components';
 import { useAssetsForAssetModel } from '../queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetsForAssetModelSelect/useAssetsForAssetModel/useAssetsForAssetModel';
 
 type AssetModelSelectOptions = {
-  client: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
   assetModelId: string;
   selectedAssetId?: string;
   hideTitle?: boolean;
@@ -24,7 +24,7 @@ type AssetModelSelectOptions = {
   updateSelectedAsset: (asset: AssetResource | undefined) => void;
 };
 export const AssetModelSelect = ({
-  client,
+  iotSiteWiseClient,
   hideTitle = false,
   selectedAssetId,
   assetModelId,
@@ -36,7 +36,7 @@ export const AssetModelSelect = ({
 
   const { assetSummaries } = useAssetsForAssetModel({
     assetModelId,
-    client,
+    iotSiteWiseClient,
     fetchAll: true,
   });
 
@@ -65,7 +65,7 @@ export const AssetModelSelect = ({
         selectedAssetModel={selectedAssetModel}
         selectedAsset={selectedAsset}
         onSelectAsset={selectAsset}
-        client={client}
+        iotSiteWiseClient={iotSiteWiseClient}
       />
     </FormField>
   );

--- a/packages/dashboard/src/components/assetModelSelection/assetModelSelection.tsx
+++ b/packages/dashboard/src/components/assetModelSelection/assetModelSelection.tsx
@@ -14,10 +14,12 @@ import { useModelBasedQuery } from '../queryEditor/iotSiteWiseQueryEditor/assetM
 import './assetModelSelection.css';
 
 type AssetModelSelectionOptions = {
-  client: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
 };
 
-export const AssetModelSelection = ({ client }: AssetModelSelectionOptions) => {
+export const AssetModelSelection = ({
+  iotSiteWiseClient,
+}: AssetModelSelectionOptions) => {
   const { assetModelId, assetIds, hasModelBasedQuery, updateSelectedAsset } =
     useModelBasedQuery();
   const selectedAssetId = assetIds?.at(0);
@@ -47,7 +49,7 @@ export const AssetModelSelection = ({ client }: AssetModelSelectionOptions) => {
         <AssetModelSelect
           assetModelId={assetModelId}
           selectedAssetId={selectedAssetId}
-          client={client}
+          iotSiteWiseClient={iotSiteWiseClient}
           controlId={assetModelSelectionControlId}
           updateSelectedAsset={updateSelectedAsset}
           hideTitle

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -351,7 +351,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
         <ResizablePanes
           leftPane={
             <QueryEditor
-              iotSiteWise={iotSiteWise}
+              iotSiteWiseClient={iotSiteWise}
               selectedWidgets={selectedWidgets}
             />
           }
@@ -399,7 +399,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
             tabIndex={0}
           >
             <Box float='left' padding='s'>
-              <AssetModelSelection client={iotSiteWise} />
+              <AssetModelSelection iotSiteWiseClient={iotSiteWise} />
             </Box>
           </div>
         )}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelDataStreamExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelDataStreamExplorer.tsx
@@ -30,14 +30,14 @@ import { AssetResource } from '@iot-app-kit/react-components';
 import { useAssetsForAssetModel } from './assetsForAssetModelSelect/useAssetsForAssetModel/useAssetsForAssetModel';
 
 export interface AssetModelDataStreamExplorerProps {
-  client: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
   selectedWidgets: DashboardWidget[];
   addButtonDisabled: boolean;
   correctSelectionMode: 'single' | 'multi';
 }
 
 export const AssetModelDataStreamExplorer = ({
-  client,
+  iotSiteWiseClient,
   selectedWidgets,
   addButtonDisabled,
   correctSelectionMode,
@@ -52,7 +52,7 @@ export const AssetModelDataStreamExplorer = ({
 
   const { assetSummaries } = useAssetsForAssetModel({
     assetModelId,
-    client,
+    iotSiteWiseClient,
     fetchAll: true,
   });
 
@@ -122,7 +122,7 @@ export const AssetModelDataStreamExplorer = ({
   };
 
   const assetModelPropertiesExplorerProps = {
-    client,
+    iotSiteWiseClient,
     selectedAsset,
     selectAssetModelProperties,
     selectedAssetModelProperties,
@@ -134,7 +134,7 @@ export const AssetModelDataStreamExplorer = ({
     <Box padding={{ horizontal: 's' }}>
       <AssetModelExplorer
         onResetSelectedAssetModel={onReset}
-        client={client}
+        iotSiteWiseClient={iotSiteWiseClient}
         selectedAssetModel={selectedAssetModel}
         setSelectedAssetModel={selectAssetModel}
         selectedAsset={selectedAsset}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelExplorer.tsx
@@ -15,7 +15,7 @@ type AssetModelExplorerOptions = {
   selectedAsset: SelectedAsset;
   setSelectedAsset: UpdateSelectedAsset;
   onResetSelectedAssetModel: () => void;
-  client: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
 };
 
 export const AssetModelExplorer = ({
@@ -24,11 +24,11 @@ export const AssetModelExplorer = ({
   selectedAsset,
   setSelectedAsset,
   onResetSelectedAssetModel,
-  client,
+  iotSiteWiseClient,
 }: AssetModelExplorerOptions) => {
   return selectedAssetModel.length > 0 ? (
     <AssetModelSelected
-      client={client}
+      iotSiteWiseClient={iotSiteWiseClient}
       selectedAssetModel={selectedAssetModel}
       selectedAsset={selectedAsset}
       setSelectedAsset={setSelectedAsset}
@@ -36,7 +36,7 @@ export const AssetModelExplorer = ({
     />
   ) : (
     <AssetModelSelection
-      client={client}
+      iotSiteWiseClient={iotSiteWiseClient}
       onSelectAssetModel={setSelectedAssetModel}
       selectedAssetModel={selectedAssetModel}
       selectedAsset={selectedAsset}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelSelection/assetModelSelect.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelSelection/assetModelSelect.tsx
@@ -11,11 +11,11 @@ import { AssetModelExplorer } from '@iot-app-kit/react-components';
 type AssetModelSelectOptions = {
   selectedAssetModel?: SelectedAssetModel;
   onSelectAssetModel: UpdateSelectedAssetModel;
-  client: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
 };
 
 export const AssetModelSelect = ({
-  client,
+  iotSiteWiseClient,
   selectedAssetModel,
   onSelectAssetModel,
 }: AssetModelSelectOptions) => {
@@ -25,7 +25,7 @@ export const AssetModelSelect = ({
       description='Select an asset model to add the associated properties into your dynamic display.'
     >
       <AssetModelExplorer
-        requestFns={client}
+        iotSiteWiseClient={iotSiteWiseClient}
         onSelectAssetModel={onSelectAssetModel}
         selectedAssetModels={selectedAssetModel}
         selectionMode='single'

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelSelection/assetModelSelected.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelSelection/assetModelSelected.tsx
@@ -24,7 +24,7 @@ type AssetModelSelectedOptions = {
   selectedAsset: SelectedAsset;
   setSelectedAsset: UpdateSelectedAsset;
   onResetSelectedAssetModel?: () => void;
-  client: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
 };
 
 export const AssetModelSelected = ({
@@ -32,13 +32,13 @@ export const AssetModelSelected = ({
   selectedAssetModel,
   setSelectedAsset,
   onResetSelectedAssetModel,
-  client,
+  iotSiteWiseClient,
 }: AssetModelSelectedOptions) => {
   const { visible, onHide, onShow } = useModalVisibility();
 
   const { assetModel } = useAssetModel({
     assetModelId: selectedAssetModel?.at(0)?.assetModelId,
-    client,
+    iotSiteWiseClient,
   });
 
   return (
@@ -66,7 +66,7 @@ export const AssetModelSelected = ({
           selectedAssetModel={selectedAssetModel}
           selectedAsset={selectedAsset}
           onSelectAsset={setSelectedAsset}
-          client={client}
+          iotSiteWiseClient={iotSiteWiseClient}
         />
       </Box>
       <ResetAssetModelModal

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelSelection/assetModelSelection.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelExplorer/assetModelSelection/assetModelSelection.tsx
@@ -25,7 +25,7 @@ type AssetModelSelectionOptions = {
   onSelectAssetModel: UpdateSelectedAssetModel;
   selectedAsset: SelectedAsset;
   setSelectedAsset: UpdateSelectedAsset;
-  client: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
 };
 
 export const AssetModelSelection = ({
@@ -33,7 +33,7 @@ export const AssetModelSelection = ({
   onSelectAssetModel,
   selectedAsset,
   setSelectedAsset,
-  client,
+  iotSiteWiseClient,
 }: AssetModelSelectionOptions) => {
   const [currentSelectedAssetModel, selectCurrentAssetModel] =
     useSelectedAssetModel(selectedAssetModel);
@@ -61,13 +61,13 @@ export const AssetModelSelection = ({
       <AssetModelSelect
         selectedAssetModel={currentSelectedAssetModel}
         onSelectAssetModel={selectCurrentAssetModel}
-        client={client}
+        iotSiteWiseClient={iotSiteWiseClient}
       />
       <AssetForAssetModelSelectForm
         selectedAsset={currentSelectedAsset}
         onSelectAsset={selectCurrentAsset}
         selectedAssetModel={currentSelectedAssetModel}
-        client={client}
+        iotSiteWiseClient={iotSiteWiseClient}
       />
       <HorizontalDivider />
       <AssetModelSave disabled={!currentSelectedAssetModel} onSave={onSave} />

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesExplorer.tsx
@@ -13,14 +13,14 @@ import { DashboardWidget } from '~/types';
 
 export interface AssetExplorerProps {
   selectedAssetModelProperties: SelectedAssetModelProperties;
-  client: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
   selectedAsset: SelectedAsset;
   selectAssetModelProperties: UpdateSelectedAssetModelProperties;
   selectedWidgets: DashboardWidget[];
 }
 
 export const AssetModelPropertiesExplorer = ({
-  client,
+  iotSiteWiseClient,
   selectedAsset,
   selectedAssetModelProperties,
   selectAssetModelProperties,
@@ -28,7 +28,7 @@ export const AssetModelPropertiesExplorer = ({
 }: AssetExplorerProps) => {
   return (
     <AssetPropertyExplorer
-      requestFns={client}
+      iotSiteWiseClient={iotSiteWiseClient}
       parameters={selectedAsset}
       selectionMode='multi'
       onSelectAssetProperty={selectAssetModelProperties}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetsForAssetModelSelect/assetForAssetModelSelect.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetsForAssetModelSelect/assetForAssetModelSelect.tsx
@@ -15,18 +15,18 @@ export type AssetForAssetModelSelectOptions = {
   selectedAsset: SelectedAsset;
   selectedAssetModel: SelectedAssetModel;
   onSelectAsset: UpdateSelectedAsset;
-  client: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
 };
 
 export const AssetForAssetModelSelect = ({
-  client,
+  iotSiteWiseClient,
   selectedAsset,
   selectedAssetModel,
   onSelectAsset,
 }: AssetForAssetModelSelectOptions) => {
   return (
     <AssetExplorer
-      requestFns={client}
+      iotSiteWiseClient={iotSiteWiseClient}
       parameters={selectedAssetModel}
       variant='drop-down'
       onSelectAsset={onSelectAsset}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetsForAssetModelSelect/useAssetsForAssetModel/useAssetsForAssetModel.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetsForAssetModelSelect/useAssetsForAssetModel/useAssetsForAssetModel.ts
@@ -6,14 +6,14 @@ import invariant from 'tiny-invariant';
 import { GetAssetsForAssetModelRequest } from './getAssetsForAssetModelRequest';
 
 export interface UseAssetModelsOptions {
-  client: IoTSiteWiseClient;
+  iotSiteWiseClient: IoTSiteWiseClient;
   assetModelId?: string;
   fetchAll?: boolean;
 }
 
 /** Use an AWS IoT SiteWise asset description. */
 export function useAssetsForAssetModel({
-  client,
+  iotSiteWiseClient,
   assetModelId,
   fetchAll,
 }: UseAssetModelsOptions) {
@@ -33,7 +33,7 @@ export function useAssetsForAssetModel({
   } = useInfiniteQuery({
     enabled: isEnabled(assetModelId),
     queryKey: cacheKeyFactory.create(),
-    queryFn: createQueryFn(client),
+    queryFn: createQueryFn(iotSiteWiseClient),
     getNextPageParam: ({ nextToken }) => nextToken,
   });
 

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.spec.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.spec.tsx
@@ -160,7 +160,7 @@ describe('Query editor tests', () => {
       <Provider store={configureDashboardStore()}>
         <IoTSiteWiseQueryEditor
           onUpdateQuery={() => {}}
-          iotSiteWise={
+          iotSiteWiseClient={
             {
               ...new IoTSiteWise({
                 credentials: {
@@ -208,7 +208,7 @@ describe('Query editor tests', () => {
       <Provider store={configureDashboardStore()}>
         <IoTSiteWiseQueryEditor
           onUpdateQuery={onUpdateQuery}
-          iotSiteWise={
+          iotSiteWiseClient={
             {
               ...new IoTSiteWise({
                 credentials: {
@@ -267,7 +267,7 @@ describe('Query editor tests', () => {
       <Provider store={configureDashboardStore()}>
         <IoTSiteWiseQueryEditor
           onUpdateQuery={onUpdateQuery}
-          iotSiteWise={
+          iotSiteWiseClient={
             {
               ...new IoTSiteWise({
                 credentials: {
@@ -330,7 +330,7 @@ describe('Query editor tests', () => {
       <Provider store={configureDashboardStore()}>
         <IoTSiteWiseQueryEditor
           onUpdateQuery={onUpdateQuery}
-          iotSiteWise={
+          iotSiteWiseClient={
             {
               ...new IoTSiteWise({
                 credentials: {

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
@@ -11,7 +11,7 @@ import { UnmodeledExplorer } from './timeSeriesExplorer/timeSeriesExplorer';
 
 export interface IoTSiteWiseQueryEditorProps {
   onUpdateQuery: ReturnType<typeof useQuery>[1];
-  iotSiteWise: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
   selectedWidgets: DashboardWidget[];
   addButtonDisabled: boolean;
   correctSelectionMode: 'single' | 'multi';
@@ -19,7 +19,7 @@ export interface IoTSiteWiseQueryEditorProps {
 
 export function IoTSiteWiseQueryEditor({
   onUpdateQuery,
-  iotSiteWise,
+  iotSiteWiseClient,
   selectedWidgets,
   addButtonDisabled,
   correctSelectionMode,
@@ -38,7 +38,7 @@ export function IoTSiteWiseQueryEditor({
     content: (
       <ModeledExplorer
         onUpdateQuery={onUpdateQuery}
-        iotSiteWise={iotSiteWise}
+        iotSiteWiseClient={iotSiteWiseClient}
         correctSelectionMode={correctSelectionMode}
         addButtonDisabled={addButtonDisabled}
         selectedWidgets={selectedWidgets}
@@ -54,7 +54,7 @@ export function IoTSiteWiseQueryEditor({
     content: (
       <UnmodeledExplorer
         onUpdateQuery={onUpdateQuery}
-        iotSiteWise={iotSiteWise}
+        iotSiteWiseClient={iotSiteWiseClient}
         correctSelectionMode={correctSelectionMode}
         addButtonDisabled={addButtonDisabled}
         selectedWidgets={selectedWidgets}
@@ -70,7 +70,7 @@ export function IoTSiteWiseQueryEditor({
     id: 'explore-asset-model-tab',
     content: (
       <AssetModelDataStreamExplorer
-        client={iotSiteWise}
+        iotSiteWiseClient={iotSiteWiseClient}
         correctSelectionMode={correctSelectionMode}
         addButtonDisabled={addButtonDisabled}
         selectedWidgets={selectedWidgets}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledExplorer/modeledExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/modeledExplorer/modeledExplorer.tsx
@@ -20,7 +20,7 @@ import { propertySelectionLabel } from '../../helpers/propertySelectionLabel';
 
 type ModeledExplorerProps = {
   onUpdateQuery: ReturnType<typeof useQuery>[1];
-  iotSiteWise: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
   correctSelectionMode: SelectionMode;
   addButtonDisabled: boolean;
   selectedWidgets: DashboardWidget[];
@@ -30,7 +30,7 @@ type ModeledExplorerProps = {
 
 export const ModeledExplorer = ({
   onUpdateQuery,
-  iotSiteWise,
+  iotSiteWiseClient,
   correctSelectionMode,
   addButtonDisabled,
   selectedWidgets,
@@ -70,7 +70,7 @@ export const ModeledExplorer = ({
   return (
     <Box padding={{ horizontal: 's' }}>
       <AssetExplorer
-        requestFns={iotSiteWise}
+        iotSiteWiseClient={iotSiteWiseClient}
         onSelectAsset={handleSelectAssets}
         selectedAssets={selectedAssets}
         selectionMode='single'
@@ -90,7 +90,7 @@ export const ModeledExplorer = ({
       />
       {selectedAssets.length > 0 && (
         <AssetPropertyExplorer
-          requestFns={iotSiteWise}
+          iotSiteWiseClient={iotSiteWiseClient}
           parameters={selectedAssets}
           selectionMode={correctSelectionMode}
           onSelectAssetProperty={setSelectedAssetProperties}

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/timeSeriesExplorer/timeSeriesExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/timeSeriesExplorer/timeSeriesExplorer.tsx
@@ -15,7 +15,7 @@ import { getPlugin } from '@iot-app-kit/core';
 
 type UnmodeledExplorerProps = {
   onUpdateQuery: ReturnType<typeof useQuery>[1];
-  iotSiteWise: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
   correctSelectionMode: SelectionMode;
   addButtonDisabled: boolean;
   selectedWidgets: DashboardWidget[];
@@ -25,7 +25,7 @@ type UnmodeledExplorerProps = {
 
 export const UnmodeledExplorer = ({
   onUpdateQuery,
-  iotSiteWise,
+  iotSiteWiseClient,
   correctSelectionMode,
   addButtonDisabled,
   timeZone,
@@ -54,7 +54,7 @@ export const UnmodeledExplorer = ({
     <Box padding={{ horizontal: 's' }}>
       <TimeSeriesExplorer
         selectionMode={correctSelectionMode}
-        requestFns={iotSiteWise}
+        iotSiteWiseClient={iotSiteWiseClient}
         onSelectTimeSeries={setSelectedTimeSeries}
         selectedTimeSeries={selectedTimeSeries}
         parameters={[{ timeSeriesType: 'DISASSOCIATED' }]}

--- a/packages/dashboard/src/components/queryEditor/queryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/queryEditor.tsx
@@ -9,10 +9,10 @@ import { useIsAddButtonDisabled } from './helpers/useIsAddButtonDisabled';
 import { getCorrectSelectionMode } from './helpers/getCorrectSelectionMode';
 
 export function QueryEditor({
-  iotSiteWise,
+  iotSiteWiseClient,
   selectedWidgets,
 }: {
-  iotSiteWise: IoTSiteWise;
+  iotSiteWiseClient: IoTSiteWise;
   selectedWidgets: DashboardWidget[];
 }) {
   const [_query, setQuery] = useQuery();
@@ -23,7 +23,7 @@ export function QueryEditor({
     <QueryEditorErrorBoundary>
       <IoTSiteWiseQueryEditor
         onUpdateQuery={setQuery}
-        iotSiteWise={iotSiteWise}
+        iotSiteWiseClient={iotSiteWiseClient}
         selectedWidgets={selectedWidgets}
         addButtonDisabled={addButtonDisabled}
         correctSelectionMode={correctSelectionMode}

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/section.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/section.tsx
@@ -58,7 +58,10 @@ export const GeneralPropertiesAlarmsSection: FC<
   const assetModelIds = (siteWiseAssetQuery?.assetModels ?? []).map(
     ({ assetModelId }) => assetModelId
   );
-  const { assetModels } = useAssetModel({ assetModelIds, client });
+  const { assetModels } = useAssetModel({
+    assetModelIds,
+    iotSiteWiseClient: client,
+  });
 
   const getComponents = () => {
     if (mustEditAsSingle) return <SelectOneWidget />;

--- a/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledSection.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesAndAlarmsSettings/styledSection.tsx
@@ -51,7 +51,10 @@ export const StyledPropertiesAlarmsSection: FC<
   const assetModelIds = (styledAssetQuery?.assetModels ?? []).map(
     ({ assetModelId }) => assetModelId
   );
-  const { assetModels } = useAssetModel({ assetModelIds, client });
+  const { assetModels } = useAssetModel({
+    assetModelIds,
+    iotSiteWiseClient: client,
+  });
 
   const getComponents = () => {
     if (mustEditAsSingle) return <SelectOneWidget />;

--- a/packages/dashboard/src/hooks/useAssetModel/useAssetModel.ts
+++ b/packages/dashboard/src/hooks/useAssetModel/useAssetModel.ts
@@ -19,14 +19,14 @@ type MultiAssetRequest = {
 };
 
 export type UseAssetModelOptions = {
-  client: IoTSiteWiseClient;
+  iotSiteWiseClient: IoTSiteWiseClient;
 } & (SingleAssetRequest | MultiAssetRequest);
 
 /** Use the list of child assets for an asset with a given asset ID. */
 export function useAssetModel({
   assetModelId,
   assetModelIds,
-  client,
+  iotSiteWiseClient,
 }: UseAssetModelOptions) {
   const isEdgeModeEnabled = useSelector(
     (state: DashboardState) => state.isEdgeModeEnabled
@@ -43,8 +43,8 @@ export function useAssetModel({
         enabled: isEnabled(id),
         queryKey: cacheKeyFactory.create(id),
         queryFn: isEdgeModeEnabled
-          ? createQueryFn(client)
-          : createModelPropertyQueryFn(client),
+          ? createQueryFn(iotSiteWiseClient)
+          : createModelPropertyQueryFn(iotSiteWiseClient),
       })),
     }) ?? [];
 

--- a/packages/doc-site/stories/core/RequestFunctions.mdx
+++ b/packages/doc-site/stories/core/RequestFunctions.mdx
@@ -39,7 +39,7 @@ the SDK client for SiteWise.
 ```
 export interface AssetPropertyExplorerProps
   extends CommonResourceExplorerProps<AssetPropertyResource> {
-  requestFns?: {
+  iotSiteWiseClient?: {
     batchGetAssetPropertyValue?: BatchGetAssetPropertyValue;
     executeQuery?: ExecuteQuery;
     listAssetProperties?: ListAssetProperties;
@@ -62,7 +62,7 @@ const iotSiteWiseClient = new IoTSiteWiseClient();
 function CustomApp() {
    return (
     <AssetPropertyExplorer 
-      requestFns={iotSiteWiseClient} 
+      iotSiteWiseClient={iotSiteWiseClient} 
       ...
     />
   );
@@ -94,12 +94,12 @@ const customIoTSiteWiseClient = {
   listAssetModelProperties: async (request, options) => {
     // implementation
   },
-} satisfies AssetPropertyExplorerProps['requestFns'];
+} satisfies AssetPropertyExplorerProps['iotSiteWiseClient'];
 
 function CustomApp() {
    return (
     <AssetPropertyExplorer 
-      requestFns={customIoTSiteWiseClient} 
+      iotSiteWiseClient={customIoTSiteWiseClient} 
       ...
     />
   );

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/internal-asset-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/internal-asset-explorer.tsx
@@ -32,7 +32,7 @@ import { useUserCustomization } from '../../helpers/use-user-customization';
 import { AssetHierarchyPath } from './asset-hierarchy-path';
 
 export function InternalAssetExplorer({
-  requestFns,
+  iotSiteWiseClient,
   parameters,
   shouldPersistUserCustomization = DEFAULT_SHOULD_PERSIST_USER_CUSTOMIZATION,
   defaultPageSize = DEFAULT_DEFAULT_PAGE_SIZE,
@@ -105,9 +105,10 @@ export function InternalAssetExplorer({
       : isSearched(userSearchStatement)
       ? [{ searchStatement: userSearchStatement }]
       : parameters,
-    listAssets: requestFns?.listAssets?.bind(requestFns),
-    listAssociatedAssets: requestFns?.listAssociatedAssets?.bind(requestFns),
-    executeQuery: requestFns?.executeQuery?.bind(requestFns),
+    listAssets: iotSiteWiseClient?.listAssets?.bind(iotSiteWiseClient),
+    listAssociatedAssets:
+      iotSiteWiseClient?.listAssociatedAssets?.bind(iotSiteWiseClient),
+    executeQuery: iotSiteWiseClient?.executeQuery?.bind(iotSiteWiseClient),
     pageSize: userCustomization.pageSize,
   });
 
@@ -137,12 +138,12 @@ export function InternalAssetExplorer({
           isFilterEnabled={isTableFilterEnabled}
           isUserSettingsEnabled={isUserSettingsEnabled}
           titleExtension={
-            requestFns?.listAssociatedAssets &&
+            iotSiteWiseClient?.listAssociatedAssets &&
             parameters === undefined && (
               <AssetHierarchyPath
                 parentAsset={parentAsset}
-                listAssociatedAssets={requestFns?.listAssociatedAssets?.bind(
-                  requestFns
+                listAssociatedAssets={iotSiteWiseClient?.listAssociatedAssets?.bind(
+                  iotSiteWiseClient
                 )}
                 onClickPathAsset={onClickAssetName}
               />

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-explorer/types.ts
@@ -15,7 +15,7 @@ import type { AssetResource } from '../../types/resources';
 export interface AssetExplorerProps
   extends CommonResourceExplorerProps<AssetResource> {
   parameters?: AssetResourcesRequestParameters;
-  requestFns?: {
+  iotSiteWiseClient?: {
     listAssets?: ListAssets;
     listAssociatedAssets?: ListAssociatedAssets;
     executeQuery?: ExecuteQuery;

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-model-explorer/internal-asset-model-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-model-explorer/internal-asset-model-explorer.tsx
@@ -28,7 +28,7 @@ import { DEFAULT_ASSET_MODEL_DROP_DOWN_DEFINITION } from '../../constants/drop-d
 import { useAssetModels } from './use-asset-models';
 
 export function InternalAssetModelExplorer({
-  requestFns,
+  iotSiteWiseClient,
   parameters = [{ assetModelTypes: ['ASSET_MODEL'] }],
   shouldPersistUserCustomization = DEFAULT_SHOULD_PERSIST_USER_CUSTOMIZATION,
   defaultPageSize = DEFAULT_DEFAULT_PAGE_SIZE,
@@ -62,7 +62,8 @@ export function InternalAssetModelExplorer({
     useAssetModels({
       parameters: parameters,
       pageSize: userCustomization.pageSize,
-      listAssetModels: requestFns?.listAssetModels?.bind(requestFns),
+      listAssetModels:
+        iotSiteWiseClient?.listAssetModels?.bind(iotSiteWiseClient),
     });
 
   return (

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-model-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-model-explorer/types.ts
@@ -15,7 +15,7 @@ export interface AssetModelExplorerProps
    * @defaultValue `[{ assetModelTypes: ['ASSET_MODEL'] }]` - All asset models of type ASSET_MODEL will be requested.
    */
   parameters?: readonly AssetModelParameters[];
-  requestFns?: {
+  iotSiteWiseClient?: {
     listAssetModels?: ListAssetModels;
   };
   onSelectAssetModel?: OnSelectResource<AssetModelResource>;

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/internal-asset-property-explorer.tsx
@@ -35,7 +35,7 @@ import { useUserCustomization } from '../../helpers/use-user-customization';
 import { TableResourceDefinition } from '../../types/table';
 
 export function InternalAssetPropertyExplorer({
-  requestFns,
+  iotSiteWiseClient,
   parameters = [],
   shouldPersistUserCustomization = DEFAULT_SHOULD_PERSIST_USER_CUSTOMIZATION,
   defaultPageSize = DEFAULT_DEFAULT_PAGE_SIZE,
@@ -63,7 +63,7 @@ export function InternalAssetPropertyExplorer({
 }: AssetPropertyExplorerProps) {
   const tableResourceDefinition =
     customTableResourceDefinition ??
-    requestFns?.batchGetAssetPropertyValue !== undefined
+    iotSiteWiseClient?.batchGetAssetPropertyValue !== undefined
       ? ([
           ...DEFAULT_ASSET_PROPERTY_TABLE_DEFINITION,
           ...createDefaultLatestValuesTableDefinition(
@@ -99,11 +99,12 @@ export function InternalAssetPropertyExplorer({
         ? [{ searchStatement: userSearchStatement }]
         : parameters,
       batchGetAssetPropertyValue:
-        requestFns?.batchGetAssetPropertyValue?.bind(requestFns),
-      executeQuery: requestFns?.executeQuery?.bind(requestFns),
-      listAssetProperties: requestFns?.listAssetProperties?.bind(requestFns),
+        iotSiteWiseClient?.batchGetAssetPropertyValue?.bind(iotSiteWiseClient),
+      executeQuery: iotSiteWiseClient?.executeQuery?.bind(iotSiteWiseClient),
+      listAssetProperties:
+        iotSiteWiseClient?.listAssetProperties?.bind(iotSiteWiseClient),
       listAssetModelProperties:
-        requestFns?.listAssetModelProperties?.bind(requestFns),
+        iotSiteWiseClient?.listAssetModelProperties?.bind(iotSiteWiseClient),
       pageSize: userCustomization.pageSize,
     });
 

--- a/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/asset-property-explorer/types.ts
@@ -16,7 +16,7 @@ import type { AssetPropertyResource } from '../../types/resources';
 export interface AssetPropertyExplorerProps
   extends CommonResourceExplorerProps<AssetPropertyResource> {
   parameters?: AssetPropertyResourcesRequestParameters;
-  requestFns?: {
+  iotSiteWiseClient?: {
     batchGetAssetPropertyValue?: BatchGetAssetPropertyValue;
     executeQuery?: ExecuteQuery;
     listAssetProperties?: ListAssetProperties;

--- a/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/internal-time-series-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/internal-time-series-explorer.tsx
@@ -34,7 +34,7 @@ import { DEFAULT_TIME_SERIES_DROP_DOWN_DEFINITION } from '../../constants/drop-d
 import { TableResourceDefinition } from '../../types/table';
 
 export function InternalTimeSeriesExplorer({
-  requestFns,
+  iotSiteWiseClient,
   parameters = [{}],
   resourceName = DEFAULT_TIME_SERIES_RESOURCE_NAME,
   pluralResourceName = DEFAULT_PLURAL_TIME_SERIES_RESOURCE_NAME,
@@ -60,7 +60,7 @@ export function InternalTimeSeriesExplorer({
 }: TimeSeriesExplorerProps) {
   const tableResourceDefinition =
     customTableResourceDefinition ??
-    requestFns?.batchGetAssetPropertyValue !== undefined
+    iotSiteWiseClient?.batchGetAssetPropertyValue !== undefined
       ? ([
           ...DEFAULT_TIME_SERIES_TABLE_DEFINITION,
           ...createDefaultLatestValuesTableDefinition(
@@ -86,8 +86,9 @@ export function InternalTimeSeriesExplorer({
       pageSize: userCustomization.pageSize,
       parameters,
       batchGetAssetPropertyValue:
-        requestFns?.batchGetAssetPropertyValue?.bind(requestFns),
-      listTimeSeries: requestFns?.listTimeSeries?.bind(requestFns),
+        iotSiteWiseClient?.batchGetAssetPropertyValue?.bind(iotSiteWiseClient),
+      listTimeSeries:
+        iotSiteWiseClient?.listTimeSeries?.bind(iotSiteWiseClient),
     }
   );
 

--- a/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/time-series-explorer/types.ts
@@ -13,7 +13,7 @@ import type {
 export interface TimeSeriesExplorerProps
   extends CommonResourceExplorerProps<TimeSeriesResource> {
   parameters?: readonly TimeSeriesRequestParameters[];
-  requestFns?: {
+  iotSiteWiseClient?: {
     batchGetAssetPropertyValue?: BatchGetAssetPropertyValue;
     listTimeSeries?: ListTimeSeries;
   };

--- a/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/asset-drop-down.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/asset-drop-down.spec.tsx
@@ -22,7 +22,7 @@ function SelectableAssetDropDown({
   return (
     <AssetExplorer
       variant='drop-down'
-      requestFns={{ listAssets }}
+      iotSiteWiseClient={{ listAssets }}
       selectionMode={selectionMode}
       selectedAssets={selectedAssets}
       onSelectAsset={setSelectedAssets}
@@ -62,7 +62,9 @@ describe('asset drop-down', () => {
         assetSummaries: [asset1, asset2, asset3],
       } = listAssetsResponse;
       const listAssets = jest.fn().mockResolvedValue(listAssetsResponse);
-      render(<AssetExplorer variant='drop-down' requestFns={{ listAssets }} />);
+      render(
+        <AssetExplorer variant='drop-down' iotSiteWiseClient={{ listAssets }} />
+      );
 
       expect(dropDown.queryOption(asset1.name)).not.toBeInTheDocument();
       expect(dropDown.queryOption(asset2.name)).not.toBeInTheDocument();
@@ -90,7 +92,9 @@ describe('asset drop-down', () => {
   describe('request handling', () => {
     it('requests a single page of assets correctly', async () => {
       const listAssets = jest.fn().mockResolvedValue(createListAssetsPage(3));
-      render(<AssetExplorer variant='drop-down' requestFns={{ listAssets }} />);
+      render(
+        <AssetExplorer variant='drop-down' iotSiteWiseClient={{ listAssets }} />
+      );
 
       // Page is requested without opening the drop-down
       expect(listAssets).toHaveBeenCalledOnce();
@@ -105,7 +109,9 @@ describe('asset drop-down', () => {
         .mockResolvedValueOnce(createListAssetsPage(1, 0, 'next-token-1'))
         .mockResolvedValueOnce(createListAssetsPage(1, 10, 'next-token-2'))
         .mockResolvedValueOnce(createListAssetsPage(1, 20));
-      render(<AssetExplorer variant='drop-down' requestFns={{ listAssets }} />);
+      render(
+        <AssetExplorer variant='drop-down' iotSiteWiseClient={{ listAssets }} />
+      );
 
       // First page is requested without opening the drop-down
       expect(listAssets).toHaveBeenCalledOnce();
@@ -128,7 +134,7 @@ describe('asset drop-down', () => {
       render(
         <AssetExplorer
           variant='drop-down'
-          requestFns={{ listAssets }}
+          iotSiteWiseClient={{ listAssets }}
           parameters={[
             { assetModelId: 'asset-model-id-1' },
             { assetModelId: 'asset-model-id-2' },
@@ -320,7 +326,7 @@ describe('asset drop-down', () => {
       render(
         <AssetExplorer
           variant='drop-down'
-          requestFns={{ listAssets }}
+          iotSiteWiseClient={{ listAssets }}
           dropDownSettings={{
             isFilterEnabled: true,
           }}

--- a/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/asset-model-drop-down.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/asset-model-drop-down.spec.tsx
@@ -24,7 +24,7 @@ function SelectableAssetModelDropDown({
   return (
     <AssetModelExplorer
       variant='drop-down'
-      requestFns={{ listAssetModels }}
+      iotSiteWiseClient={{ listAssetModels }}
       selectionMode={selectionMode}
       selectedAssetModels={selectedAssetModels}
       onSelectAssetModel={setSelectedAssetModels}
@@ -69,7 +69,7 @@ describe('asset model drop-down', () => {
       render(
         <AssetModelExplorer
           variant='drop-down'
-          requestFns={{ listAssetModels }}
+          iotSiteWiseClient={{ listAssetModels }}
         />
       );
 
@@ -104,7 +104,7 @@ describe('asset model drop-down', () => {
       render(
         <AssetModelExplorer
           variant='drop-down'
-          requestFns={{ listAssetModels }}
+          iotSiteWiseClient={{ listAssetModels }}
         />
       );
 
@@ -124,7 +124,7 @@ describe('asset model drop-down', () => {
       render(
         <AssetModelExplorer
           variant='drop-down'
-          requestFns={{ listAssetModels }}
+          iotSiteWiseClient={{ listAssetModels }}
         />
       );
 
@@ -150,7 +150,7 @@ describe('asset model drop-down', () => {
       render(
         <AssetModelExplorer
           variant='drop-down'
-          requestFns={{ listAssetModels }}
+          iotSiteWiseClient={{ listAssetModels }}
           parameters={[
             { assetModelTypes: ['ASSET_MODEL'] },
             { assetModelTypes: ['COMPONENT_MODEL'] },
@@ -355,7 +355,7 @@ describe('asset model drop-down', () => {
       render(
         <AssetModelExplorer
           variant='drop-down'
-          requestFns={{ listAssetModels }}
+          iotSiteWiseClient={{ listAssetModels }}
           dropDownSettings={{
             isFilterEnabled: true,
           }}

--- a/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/asset-property-drop-down.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/asset-property-drop-down.spec.tsx
@@ -32,7 +32,7 @@ function SelectableAssetPropertyDropDown({
   return (
     <AssetPropertyExplorer
       variant='drop-down'
-      requestFns={{ listAssetProperties, listAssetModelProperties }}
+      iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
       parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
       selectionMode={selectionMode}
       selectedAssetProperties={selectedAssetProperties}
@@ -89,7 +89,7 @@ describe('asset property drop-down', () => {
       render(
         <AssetPropertyExplorer
           variant='drop-down'
-          requestFns={{
+          iotSiteWiseClient={{
             listAssetProperties,
             listAssetModelProperties,
           }}
@@ -134,7 +134,7 @@ describe('asset property drop-down', () => {
       render(
         <AssetPropertyExplorer
           variant='drop-down'
-          requestFns={{ listAssetProperties, listAssetModelProperties }}
+          iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
           parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
         />
       );
@@ -162,7 +162,7 @@ describe('asset property drop-down', () => {
       render(
         <AssetPropertyExplorer
           variant='drop-down'
-          requestFns={{ listAssetProperties, listAssetModelProperties }}
+          iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
           parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
         />
       );
@@ -192,7 +192,7 @@ describe('asset property drop-down', () => {
       render(
         <AssetPropertyExplorer
           variant='drop-down'
-          requestFns={{ listAssetProperties, listAssetModelProperties }}
+          iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
           parameters={[
             { assetId: 'asset-id-1', assetModelId: 'asset-model-id-1' },
             { assetId: 'asset-id-2', assetModelId: 'asset-model-id-1' },
@@ -483,7 +483,7 @@ describe('asset property drop-down', () => {
       render(
         <AssetPropertyExplorer
           variant='drop-down'
-          requestFns={{ listAssetProperties, listAssetModelProperties }}
+          iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
           parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
           dropDownSettings={{
             isFilterEnabled: true,

--- a/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/time-series-drop-down.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/time-series-drop-down.spec.tsx
@@ -27,7 +27,7 @@ function SelectableTimeSeriesDropDown({
   return (
     <TimeSeriesExplorer
       variant='drop-down'
-      requestFns={{ listTimeSeries }}
+      iotSiteWiseClient={{ listTimeSeries }}
       selectionMode={selectionMode}
       selectedTimeSeries={selectedTimeSeries}
       onSelectTimeSeries={setSelectedTimeSeries}
@@ -79,7 +79,7 @@ describe('time series drop-down', () => {
       render(
         <TimeSeriesExplorer
           variant='drop-down'
-          requestFns={{ listTimeSeries }}
+          iotSiteWiseClient={{ listTimeSeries }}
           parameters={[{ assetId: 'asset-id' }]}
         />
       );
@@ -118,7 +118,7 @@ describe('time series drop-down', () => {
       render(
         <TimeSeriesExplorer
           variant='drop-down'
-          requestFns={{ listTimeSeries }}
+          iotSiteWiseClient={{ listTimeSeries }}
           parameters={[{ assetId: 'asset-id' }]}
         />
       );
@@ -139,7 +139,7 @@ describe('time series drop-down', () => {
       render(
         <TimeSeriesExplorer
           variant='drop-down'
-          requestFns={{ listTimeSeries }}
+          iotSiteWiseClient={{ listTimeSeries }}
           parameters={[{ assetId: 'asset-id' }]}
         />
       );
@@ -165,7 +165,7 @@ describe('time series drop-down', () => {
       render(
         <TimeSeriesExplorer
           variant='drop-down'
-          requestFns={{ listTimeSeries }}
+          iotSiteWiseClient={{ listTimeSeries }}
           parameters={[{ assetId: 'asset-id-1' }, { assetId: 'asset-id-2' }]}
         />
       );
@@ -389,7 +389,7 @@ describe('time series drop-down', () => {
       render(
         <TimeSeriesExplorer
           variant='drop-down'
-          requestFns={{ listTimeSeries }}
+          iotSiteWiseClient={{ listTimeSeries }}
           parameters={[{ assetId: 'asset-id' }]}
           dropDownSettings={{
             isFilterEnabled: true,

--- a/packages/react-components/src/components/resource-explorers/testing/table-variant/asset-model-table.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/table-variant/asset-model-table.spec.tsx
@@ -22,7 +22,7 @@ function SelectableAssetModelTable({
 
   return (
     <AssetModelExplorer
-      requestFns={{ listAssetModels }}
+      iotSiteWiseClient={{ listAssetModels }}
       selectionMode={selectionMode}
       selectedAssetModels={selectedAssetModels}
       onSelectAssetModel={setSelectedAssetModels}
@@ -93,7 +93,7 @@ describe('asset model table', () => {
       const listAssetModels = jest
         .fn()
         .mockResolvedValue(listAssetModelsResponse);
-      render(<AssetModelExplorer requestFns={{ listAssetModels }} />);
+      render(<AssetModelExplorer iotSiteWiseClient={{ listAssetModels }} />);
 
       await table.waitForLoadingToFinish();
 
@@ -120,7 +120,7 @@ describe('asset model table', () => {
       const listAssetModels = jest
         .fn()
         .mockResolvedValue(createListAssetModelsPage(3));
-      render(<AssetModelExplorer requestFns={{ listAssetModels }} />);
+      render(<AssetModelExplorer iotSiteWiseClient={{ listAssetModels }} />);
 
       await table.waitForLoadingToFinish();
 
@@ -140,7 +140,7 @@ describe('asset model table', () => {
       render(
         <AssetModelExplorer
           defaultPageSize={10}
-          requestFns={{ listAssetModels }}
+          iotSiteWiseClient={{ listAssetModels }}
         />
       );
 
@@ -184,7 +184,7 @@ describe('asset model table', () => {
       render(
         <AssetModelExplorer
           defaultPageSize={10}
-          requestFns={{ listAssetModels }}
+          iotSiteWiseClient={{ listAssetModels }}
           parameters={[
             { assetModelTypes: ['ASSET_MODEL'] },
             { assetModelTypes: ['COMPONENT_MODEL'] },
@@ -384,7 +384,7 @@ describe('asset model table', () => {
       render(
         <AssetModelExplorer
           tableSettings={{ isFilterEnabled: true }}
-          requestFns={{ listAssetModels }}
+          iotSiteWiseClient={{ listAssetModels }}
         />
       );
 
@@ -417,7 +417,7 @@ describe('asset model table', () => {
       render(
         <AssetModelExplorer
           tableSettings={{ isFilterEnabled: true }}
-          requestFns={{ listAssetModels }}
+          iotSiteWiseClient={{ listAssetModels }}
         />
       );
 

--- a/packages/react-components/src/components/resource-explorers/testing/table-variant/asset-property-table.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/table-variant/asset-property-table.spec.tsx
@@ -34,7 +34,7 @@ function SelectableAssetPropertyTable({
 
   return (
     <AssetPropertyExplorer
-      requestFns={{ listAssetProperties, listAssetModelProperties }}
+      iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
       parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
       selectionMode={selectionMode}
       selectedAssetProperties={selectedAssetProperties}
@@ -156,7 +156,7 @@ describe('asset property table', () => {
       });
       render(
         <AssetPropertyExplorer
-          requestFns={{ listAssetProperties, listAssetModelProperties }}
+          iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
           parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
         />
       );
@@ -191,7 +191,7 @@ describe('asset property table', () => {
     it('renders expected columns when displaying latest values', () => {
       render(
         <AssetPropertyExplorer
-          requestFns={{ batchGetAssetPropertyValue: jest.fn() }}
+          iotSiteWiseClient={{ batchGetAssetPropertyValue: jest.fn() }}
         />
       );
 
@@ -216,7 +216,7 @@ describe('asset property table', () => {
         .mockResolvedValue(createListAssetModelPropertiesPage(3));
       render(
         <AssetPropertyExplorer
-          requestFns={{ listAssetProperties, listAssetModelProperties }}
+          iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
           parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
         />
       );
@@ -245,7 +245,7 @@ describe('asset property table', () => {
       render(
         <AssetPropertyExplorer
           defaultPageSize={10}
-          requestFns={{ listAssetProperties, listAssetModelProperties }}
+          iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
           parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
         />
       );
@@ -300,7 +300,7 @@ describe('asset property table', () => {
       render(
         <AssetPropertyExplorer
           defaultPageSize={10}
-          requestFns={{ listAssetProperties, listAssetModelProperties }}
+          iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
           parameters={[
             { assetId: 'asset-id-1', assetModelId: 'asset-model-id-1' },
             { assetId: 'asset-id-2', assetModelId: 'asset-model-id-1' },
@@ -367,7 +367,7 @@ describe('asset property table', () => {
         >);
       render(
         <AssetPropertyExplorer
-          requestFns={{ executeQuery }}
+          iotSiteWiseClient={{ executeQuery }}
           tableSettings={{ isSearchEnabled: true }}
         />
       );
@@ -420,7 +420,7 @@ describe('asset property table', () => {
       } satisfies Awaited<ReturnType<ExecuteQuery>>);
       render(
         <AssetPropertyExplorer
-          requestFns={{ executeQuery }}
+          iotSiteWiseClient={{ executeQuery }}
           tableSettings={{ isSearchEnabled: true }}
         />
       );
@@ -514,7 +514,7 @@ describe('asset property table', () => {
       } satisfies Awaited<ReturnType<ExecuteQuery>>);
       render(
         <AssetPropertyExplorer
-          requestFns={{ executeQuery }}
+          iotSiteWiseClient={{ executeQuery }}
           parameters={[{ searchStatement: 'Asset Property' }]}
           tableSettings={{ isSearchEnabled: true }}
         />
@@ -582,7 +582,7 @@ describe('asset property table', () => {
         >);
       render(
         <AssetPropertyExplorer
-          requestFns={{ executeQuery }}
+          iotSiteWiseClient={{ executeQuery }}
           tableSettings={{ isSearchEnabled: true }}
         />
       );
@@ -656,7 +656,7 @@ describe('asset property table', () => {
       } satisfies Awaited<ReturnType<BatchGetAssetPropertyValue>>);
       render(
         <AssetPropertyExplorer
-          requestFns={{
+          iotSiteWiseClient={{
             batchGetAssetPropertyValue,
             listAssetProperties,
             listAssetModelProperties,
@@ -727,7 +727,7 @@ describe('asset property table', () => {
       } satisfies Awaited<ReturnType<BatchGetAssetPropertyValue>>);
       render(
         <AssetPropertyExplorer
-          requestFns={{
+          iotSiteWiseClient={{
             batchGetAssetPropertyValue,
             listAssetProperties,
             listAssetModelProperties,
@@ -916,7 +916,7 @@ describe('asset property table', () => {
       render(
         <AssetPropertyExplorer
           tableSettings={{ isFilterEnabled: true }}
-          requestFns={{ listAssetProperties, listAssetModelProperties }}
+          iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
           parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
         />
       );
@@ -963,7 +963,7 @@ describe('asset property table', () => {
       render(
         <AssetPropertyExplorer
           tableSettings={{ isFilterEnabled: true }}
-          requestFns={{ listAssetProperties, listAssetModelProperties }}
+          iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
           parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
         />
       );
@@ -1056,7 +1056,7 @@ describe('asset property table', () => {
       render(
         <AssetPropertyExplorer
           tableSettings={{ isUserSettingsEnabled: true }}
-          requestFns={{ batchGetAssetPropertyValue: jest.fn() }}
+          iotSiteWiseClient={{ batchGetAssetPropertyValue: jest.fn() }}
         />
       );
 

--- a/packages/react-components/src/components/resource-explorers/testing/table-variant/asset-table.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/table-variant/asset-table.spec.tsx
@@ -20,7 +20,7 @@ function SelectableAssetTable({
 
   return (
     <AssetExplorer
-      requestFns={{ listAssets }}
+      iotSiteWiseClient={{ listAssets }}
       selectionMode={selectionMode}
       selectedAssets={selectedAssets}
       onSelectAsset={setSelectedAssets}
@@ -98,7 +98,7 @@ describe('asset table', () => {
       const listAssets = jest.fn().mockResolvedValue({
         assetSummaries: [asset1WithHierarchy, asset2, asset3],
       });
-      render(<AssetExplorer requestFns={{ listAssets }} />);
+      render(<AssetExplorer iotSiteWiseClient={{ listAssets }} />);
 
       await table.waitForLoadingToFinish();
 
@@ -133,7 +133,7 @@ describe('asset table', () => {
   describe('requests', () => {
     it('requests a single page of assets correctly', async () => {
       const listAssets = jest.fn().mockResolvedValue(createListAssetsPage(3));
-      render(<AssetExplorer requestFns={{ listAssets }} />);
+      render(<AssetExplorer iotSiteWiseClient={{ listAssets }} />);
 
       await table.waitForLoadingToFinish();
 
@@ -151,7 +151,10 @@ describe('asset table', () => {
         .mockResolvedValueOnce(createListAssetsPage(10, 0, 'next-token'))
         .mockResolvedValueOnce(createListAssetsPage(10, 10));
       render(
-        <AssetExplorer defaultPageSize={10} requestFns={{ listAssets }} />
+        <AssetExplorer
+          defaultPageSize={10}
+          iotSiteWiseClient={{ listAssets }}
+        />
       );
 
       await table.waitForLoadingToFinish();
@@ -193,7 +196,7 @@ describe('asset table', () => {
       render(
         <AssetExplorer
           defaultPageSize={10}
-          requestFns={{ listAssociatedAssets }}
+          iotSiteWiseClient={{ listAssociatedAssets }}
           parameters={[{ assetId: 'asset-id-1' }, { assetId: 'asset-id-2' }]}
         />
       );
@@ -251,7 +254,7 @@ describe('asset table', () => {
         >);
       render(
         <AssetExplorer
-          requestFns={{ executeQuery }}
+          iotSiteWiseClient={{ executeQuery }}
           tableSettings={{ isSearchEnabled: true }}
         />
       );
@@ -300,7 +303,7 @@ describe('asset table', () => {
       } satisfies Awaited<ReturnType<ExecuteQuery>>);
       render(
         <AssetExplorer
-          requestFns={{ executeQuery }}
+          iotSiteWiseClient={{ executeQuery }}
           tableSettings={{ isSearchEnabled: true }}
         />
       );
@@ -369,7 +372,7 @@ describe('asset table', () => {
       } satisfies Awaited<ReturnType<ExecuteQuery>>);
       render(
         <AssetExplorer
-          requestFns={{ executeQuery }}
+          iotSiteWiseClient={{ executeQuery }}
           parameters={[{ searchStatement: 'Asset' }]}
           tableSettings={{ isSearchEnabled: true }}
         />
@@ -415,7 +418,7 @@ describe('asset table', () => {
         >);
       render(
         <AssetExplorer
-          requestFns={{ executeQuery }}
+          iotSiteWiseClient={{ executeQuery }}
           tableSettings={{ isSearchEnabled: true }}
         />
       );
@@ -563,7 +566,7 @@ describe('asset table', () => {
       render(
         <AssetExplorer
           tableSettings={{ isFilterEnabled: true }}
-          requestFns={{ listAssets }}
+          iotSiteWiseClient={{ listAssets }}
         />
       );
 
@@ -599,7 +602,7 @@ describe('asset table', () => {
       render(
         <AssetExplorer
           tableSettings={{ isFilterEnabled: true }}
-          requestFns={{ listAssets }}
+          iotSiteWiseClient={{ listAssets }}
         />
       );
 

--- a/packages/react-components/src/components/resource-explorers/testing/table-variant/time-series-table.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/table-variant/time-series-table.spec.tsx
@@ -24,7 +24,7 @@ function SelectableTimeSeriesTable({
 
   return (
     <TimeSeriesExplorer
-      requestFns={{ listTimeSeries }}
+      iotSiteWiseClient={{ listTimeSeries }}
       parameters={[{ assetId: 'asset-id' }]}
       selectionMode={selectionMode}
       selectedTimeSeries={selectedTimeSeries}
@@ -107,7 +107,7 @@ describe('time series table', () => {
       });
       render(
         <TimeSeriesExplorer
-          requestFns={{ listTimeSeries }}
+          iotSiteWiseClient={{ listTimeSeries }}
           parameters={[{ assetId: 'asset-id' }]}
         />
       );
@@ -139,7 +139,7 @@ describe('time series table', () => {
     it('renders expected columns when displaying latest values', () => {
       render(
         <TimeSeriesExplorer
-          requestFns={{ batchGetAssetPropertyValue: jest.fn() }}
+          iotSiteWiseClient={{ batchGetAssetPropertyValue: jest.fn() }}
         />
       );
 
@@ -161,7 +161,7 @@ describe('time series table', () => {
         .mockResolvedValue(createListTimeSeriesPage(3));
       render(
         <TimeSeriesExplorer
-          requestFns={{ listTimeSeries }}
+          iotSiteWiseClient={{ listTimeSeries }}
           parameters={[{ assetId: 'asset-id' }]}
         />
       );
@@ -184,7 +184,7 @@ describe('time series table', () => {
       render(
         <TimeSeriesExplorer
           defaultPageSize={10}
-          requestFns={{ listTimeSeries }}
+          iotSiteWiseClient={{ listTimeSeries }}
           parameters={[{ assetId: 'asset-id' }]}
         />
       );
@@ -228,7 +228,7 @@ describe('time series table', () => {
       render(
         <TimeSeriesExplorer
           defaultPageSize={10}
-          requestFns={{ listTimeSeries }}
+          iotSiteWiseClient={{ listTimeSeries }}
           parameters={[{ assetId: 'asset-id-1' }, { assetId: 'asset-id-2' }]}
         />
       );
@@ -331,7 +331,7 @@ describe('time series table', () => {
       } satisfies Awaited<ReturnType<BatchGetAssetPropertyValue>>);
       render(
         <TimeSeriesExplorer
-          requestFns={{
+          iotSiteWiseClient={{
             batchGetAssetPropertyValue,
             listTimeSeries,
           }}
@@ -398,7 +398,7 @@ describe('time series table', () => {
       } satisfies Awaited<ReturnType<BatchGetAssetPropertyValue>>);
       render(
         <TimeSeriesExplorer
-          requestFns={{
+          iotSiteWiseClient={{
             batchGetAssetPropertyValue,
             listTimeSeries,
           }}
@@ -566,7 +566,7 @@ describe('time series table', () => {
       render(
         <TimeSeriesExplorer
           tableSettings={{ isFilterEnabled: true }}
-          requestFns={{ listTimeSeries }}
+          iotSiteWiseClient={{ listTimeSeries }}
           parameters={[{ assetId: 'asset-id' }]}
         />
       );
@@ -605,7 +605,7 @@ describe('time series table', () => {
       render(
         <TimeSeriesExplorer
           tableSettings={{ isFilterEnabled: true }}
-          requestFns={{ listTimeSeries }}
+          iotSiteWiseClient={{ listTimeSeries }}
           parameters={[{ assetId: 'asset-id' }]}
         />
       );
@@ -694,7 +694,7 @@ describe('time series table', () => {
       render(
         <TimeSeriesExplorer
           tableSettings={{ isUserSettingsEnabled: true }}
-          requestFns={{ batchGetAssetPropertyValue: jest.fn() }}
+          iotSiteWiseClient={{ batchGetAssetPropertyValue: jest.fn() }}
         />
       );
 

--- a/packages/react-components/src/components/resource-explorers/types/resource-explorer.ts
+++ b/packages/react-components/src/components/resource-explorers/types/resource-explorer.ts
@@ -19,7 +19,7 @@ import {
 /** Props common to all resource explorers. */
 export type CommonResourceExplorerProps<Resource = unknown> = {
   /** TODO */
-  requestFns?: unknown;
+  iotSiteWiseClient?: unknown;
 
   /**
    * Specify the resource explorer variant to render.

--- a/packages/react-components/stories/resource-explorers/asset-explorer.stories.tsx
+++ b/packages/react-components/stories/resource-explorers/asset-explorer.stories.tsx
@@ -78,7 +78,7 @@ function storyArgsToProps(
 export const HierarchyNavigation: AssetExplorerStory = (controls, context) => {
   const props = storyArgsToProps(controls, context);
 
-  return <AssetExplorer {...props} requestFns={client} />;
+  return <AssetExplorer {...props} iotSiteWiseClient={client} />;
 };
 
 export const SearchOnly: AssetExplorerStory = (controls, context) => {
@@ -87,7 +87,7 @@ export const SearchOnly: AssetExplorerStory = (controls, context) => {
   return (
     <AssetExplorer
       {...props}
-      requestFns={{ executeQuery: client.executeQuery.bind(client) }}
+      iotSiteWiseClient={{ executeQuery: client.executeQuery.bind(client) }}
     />
   );
 };

--- a/packages/react-components/stories/resource-explorers/asset-model-explorer.stories.tsx
+++ b/packages/react-components/stories/resource-explorers/asset-model-explorer.stories.tsx
@@ -84,7 +84,7 @@ export const AssetAndComponentModels: AssetModelExplorerStory = (
 ) => {
   const props = storyArgsToProps(controls, context);
 
-  return <AssetModelExplorer {...props} requestFns={client} />;
+  return <AssetModelExplorer {...props} iotSiteWiseClient={client} />;
 };
 
 export const OnlyAssetModels: AssetModelExplorerStory = (controls, context) => {
@@ -93,7 +93,7 @@ export const OnlyAssetModels: AssetModelExplorerStory = (controls, context) => {
   return (
     <AssetModelExplorer
       {...props}
-      requestFns={client}
+      iotSiteWiseClient={client}
       parameters={[{ assetModelTypes: ['ASSET_MODEL'] }]}
     />
   );
@@ -108,7 +108,7 @@ export const OnlyComponentModels: AssetModelExplorerStory = (
   return (
     <AssetModelExplorer
       {...props}
-      requestFns={client}
+      iotSiteWiseClient={client}
       parameters={[{ assetModelTypes: ['COMPONENT_MODEL'] }]}
     />
   );

--- a/packages/react-components/stories/resource-explorers/asset-property-explorer.stories.tsx
+++ b/packages/react-components/stories/resource-explorers/asset-property-explorer.stories.tsx
@@ -85,7 +85,11 @@ export const WithLatestValues: AssetPropertyExplorerStory = (
   const props = storyArgsToProps(controls, context);
 
   return (
-    <AssetPropertyExplorer {...props} requestFns={client} parameters={[]} />
+    <AssetPropertyExplorer
+      {...props}
+      iotSiteWiseClient={client}
+      parameters={[]}
+    />
   );
 };
 
@@ -99,7 +103,7 @@ export const WithoutLatestValues: AssetPropertyExplorerStory = (
   return (
     <AssetPropertyExplorer
       {...props}
-      requestFns={{
+      iotSiteWiseClient={{
         executeQuery: client.executeQuery.bind(client),
         listAssetProperties: client.listAssetProperties.bind(client),
         listAssetModelProperties: client.listAssetModelProperties.bind(client),

--- a/packages/react-components/stories/resource-explorers/explorer-combinations.stories.tsx
+++ b/packages/react-components/stories/resource-explorers/explorer-combinations.stories.tsx
@@ -29,13 +29,16 @@ export function AssetExplorerPlusAssetPropertyExplorer() {
   return (
     <>
       <AssetExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         onSelectAsset={setSelectedAssets}
         selectedAssets={selectedAssets}
         selectionMode='multi'
       />
 
-      <AssetPropertyExplorer requestFns={client} parameters={selectedAssets} />
+      <AssetPropertyExplorer
+        iotSiteWiseClient={client}
+        parameters={selectedAssets}
+      />
     </>
   );
 }
@@ -48,7 +51,7 @@ export function AssetExplorerPlusTimeSeriesExplorer() {
   return (
     <>
       <AssetExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         onSelectAsset={setSelectedAssets}
         selectedAssets={selectedAssets}
         selectionMode='multi'
@@ -60,7 +63,7 @@ export function AssetExplorerPlusTimeSeriesExplorer() {
       />
 
       <TimeSeriesExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         parameters={selectedAssets}
         tableSettings={{ isFilterEnabled: true, isUserSettingsEnabled: true }}
       />
@@ -76,7 +79,7 @@ export function AssetExplorerPlusAssetExplorer() {
   return (
     <>
       <AssetExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         onSelectAsset={setSelectedAssets}
         selectedAssets={selectedAssets}
         selectionMode='multi'
@@ -88,7 +91,7 @@ export function AssetExplorerPlusAssetExplorer() {
       />
 
       <AssetExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         parameters={selectedAssets}
         tableSettings={{ isFilterEnabled: true, isUserSettingsEnabled: true }}
       />
@@ -104,7 +107,7 @@ export function AssetModelExplorerPlusAssetExplorer() {
   return (
     <>
       <AssetModelExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         onSelectAssetModel={setSelectedAssetModels}
         selectedAssetModels={selectedAssetModels}
         selectionMode='multi'
@@ -115,7 +118,7 @@ export function AssetModelExplorerPlusAssetExplorer() {
       />
 
       <AssetExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         parameters={selectedAssetModels}
         tableSettings={{ isFilterEnabled: true, isUserSettingsEnabled: true }}
       />
@@ -134,7 +137,7 @@ export function AssetModelExplorerPlusAssetExplorerPlusAssetPropertyExplorer() {
   return (
     <>
       <AssetModelExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         onSelectAssetModel={setSelectedAssetModels}
         selectedAssetModels={selectedAssetModels}
         selectionMode='multi'
@@ -145,7 +148,7 @@ export function AssetModelExplorerPlusAssetExplorerPlusAssetPropertyExplorer() {
       />
 
       <AssetExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         parameters={selectedAssetModels}
         onSelectAsset={setSelectedAssets}
         selectedAssets={selectedAssets}
@@ -157,7 +160,7 @@ export function AssetModelExplorerPlusAssetExplorerPlusAssetPropertyExplorer() {
       />
 
       <AssetPropertyExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         parameters={selectedAssets}
         tableSettings={{
           isFilterEnabled: true,
@@ -179,7 +182,7 @@ export function AssetModelExplorerPlusAssetExplorerPlusTimeSeriesExplorer() {
   return (
     <>
       <AssetModelExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         onSelectAssetModel={setSelectedAssetModels}
         selectedAssetModels={selectedAssetModels}
         selectionMode='multi'
@@ -190,7 +193,7 @@ export function AssetModelExplorerPlusAssetExplorerPlusTimeSeriesExplorer() {
       />
 
       <AssetExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         parameters={selectedAssetModels}
         onSelectAsset={setSelectedAssets}
         selectedAssets={selectedAssets}
@@ -202,7 +205,7 @@ export function AssetModelExplorerPlusAssetExplorerPlusTimeSeriesExplorer() {
       />
 
       <TimeSeriesExplorer
-        requestFns={client}
+        iotSiteWiseClient={client}
         parameters={selectedAssets}
         tableSettings={{
           isFilterEnabled: true,

--- a/packages/react-components/stories/resource-explorers/time-series-explorer.stories.tsx
+++ b/packages/react-components/stories/resource-explorers/time-series-explorer.stories.tsx
@@ -82,7 +82,7 @@ export const AllTimeSeriesWithLatestValues: TimeSeriesExplorerStory = (
 ) => {
   const props = storyArgsToProps(controls, context);
 
-  return <TimeSeriesExplorer {...props} requestFns={client} />;
+  return <TimeSeriesExplorer {...props} iotSiteWiseClient={client} />;
 };
 
 export const AllTimeSeriesWithoutLatestValues: TimeSeriesExplorerStory = (
@@ -94,7 +94,7 @@ export const AllTimeSeriesWithoutLatestValues: TimeSeriesExplorerStory = (
   return (
     <TimeSeriesExplorer
       {...props}
-      requestFns={{ listTimeSeries: client.listTimeSeries.bind(client) }}
+      iotSiteWiseClient={{ listTimeSeries: client.listTimeSeries.bind(client) }}
     />
   );
 };
@@ -108,7 +108,7 @@ export const AllAssociatedTimeSeries: TimeSeriesExplorerStory = (
   return (
     <TimeSeriesExplorer
       {...props}
-      requestFns={client}
+      iotSiteWiseClient={client}
       parameters={[{ timeSeriesType: 'ASSOCIATED' }]}
     />
   );
@@ -123,7 +123,7 @@ export const AllDisassociatedTimeSeries: TimeSeriesExplorerStory = (
   return (
     <TimeSeriesExplorer
       {...props}
-      requestFns={client}
+      iotSiteWiseClient={client}
       parameters={[{ timeSeriesType: 'DISASSOCIATED' }]}
     />
   );


### PR DESCRIPTION
## Overview
1) We decided to use the naming convention of iotSiteWise client for props that pass in the AWS IoTSiteWise client.
2) Replacing all requestFns prop names in the RE to be iotSiteWiseClient. The customer is unaware of what a requestFn is. They will be passing in a client, whether it be from the SDK or a custom one. The prop name, IotSiteWiseClient captures the intended usage of the RE components.


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
