### PR TITLE
feat(react-components): add useLatestAlarmPropertyValue hook to fetch alarm prop vals in useAlarms

### DIFF
--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/index.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/index.ts
@@ -1,1 +1,2 @@
 export * from './useAlarmAssets';
+export * from './useLatestAlarmPropertyValue';

--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/predicates.spec.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/predicates.spec.ts
@@ -1,0 +1,64 @@
+import {
+  MOCK_ALARM_INPUT_PROPERTY_ID,
+  MOCK_ASSET_ID,
+  MOCK_ASSET_MODEL_ID,
+  MOCK_COMPOSITE_MODEL_ID,
+  mockStateAssetProperty,
+} from '../../../testing/alarms';
+import { AlarmProperty, AlarmRequest } from '../types';
+import {
+  isAlarmProperty,
+  isAssetModelRequest,
+  isAssetRequest,
+} from './predicates';
+
+const alarmAssetModelRequest: AlarmRequest = {
+  assetModelId: MOCK_ASSET_MODEL_ID,
+};
+
+const alarmAssetRequest: AlarmRequest = {
+  assetId: MOCK_ASSET_ID,
+};
+const alarmAssetCompositeModelRequest: AlarmRequest = {
+  assetId: MOCK_ASSET_ID,
+  assetCompositeModelId: MOCK_COMPOSITE_MODEL_ID,
+};
+const alarmInputPropertyRequest: AlarmRequest = {
+  assetId: MOCK_ASSET_ID,
+  inputPropertyId: MOCK_ALARM_INPUT_PROPERTY_ID,
+};
+
+describe('alarm request predicates', () => {
+  test('isAssetModelRequest should return true when request has an assetModelId', () => {
+    expect(isAssetModelRequest(alarmAssetModelRequest)).toBe(true);
+  });
+
+  test('isAssetRequest should return true when request has an assetId', () => {
+    expect(isAssetRequest(alarmAssetRequest)).toBe(true);
+    expect(isAssetRequest(alarmAssetCompositeModelRequest)).toBe(true);
+    expect(isAssetRequest(alarmInputPropertyRequest)).toBe(true);
+  });
+
+  test('isAssetModelRequest should return false when request has an assetId', () => {
+    expect(isAssetModelRequest(alarmAssetRequest)).toBe(false);
+    expect(isAssetModelRequest(alarmAssetCompositeModelRequest)).toBe(false);
+    expect(isAssetModelRequest(alarmInputPropertyRequest)).toBe(false);
+  });
+
+  test('isAssetRequest should return false when request has an assetModelId', () => {
+    expect(isAssetRequest(alarmAssetModelRequest)).toBe(false);
+  });
+
+  test('isAlarmProperty should return true when provided an AlarmProperty', () => {
+    const mockAlarmProperty: AlarmProperty = {
+      property: mockStateAssetProperty,
+    };
+    expect(isAlarmProperty(mockAlarmProperty)).toBe(true);
+  });
+
+  test('isAlarmProperty should return false when other AlarmData property', () => {
+    const mockIncorrectAlarmProperty: AlarmProperty =
+      'assetId' as unknown as AlarmProperty;
+    expect(isAlarmProperty(mockIncorrectAlarmProperty)).toBe(false);
+  });
+});

--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/predicates.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/predicates.ts
@@ -3,16 +3,21 @@ import {
   AlarmAssetRequest,
   AlarmCompositeModelRequest,
   AlarmInputPropertyRequest,
+  AlarmProperty,
   AlarmRequest,
 } from '../types';
 
 export const isAssetModelRequest = (
   alarmRequest: AlarmRequest
-): alarmRequest is AlarmAssetModelRequest => Boolean(alarmRequest);
+): alarmRequest is AlarmAssetModelRequest => alarmRequest.assetId === undefined;
 
 export const isAssetRequest = (
   alarmRequest: AlarmRequest
 ): alarmRequest is
   | AlarmCompositeModelRequest
   | AlarmInputPropertyRequest
-  | AlarmAssetRequest => Boolean(alarmRequest);
+  | AlarmAssetRequest => alarmRequest.assetModelId === undefined;
+
+export const isAlarmProperty = (
+  property?: AlarmProperty
+): property is AlarmProperty => !!property?.property;

--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/useLatestAlarmPropertyValue.spec.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/useLatestAlarmPropertyValue.spec.ts
@@ -1,0 +1,261 @@
+import {
+  BatchGetAssetPropertyValueErrorEntry,
+  BatchGetAssetPropertyValueRequest,
+  BatchGetAssetPropertyValueResponse,
+  BatchGetAssetPropertyValueSuccessEntry,
+} from '@aws-sdk/client-iotsitewise';
+import { renderHook, waitFor } from '@testing-library/react';
+import { queryClient } from '../../../queries';
+import {
+  batchGetAssetPropertyValueMock,
+  iotSiteWiseClientMock,
+  mockAlarmDataDescribeAsset,
+  mockAlarmDataDescribeAsset2,
+  mockDefaultAlarmSource,
+  mockDefaultAlarmState,
+  mockDefaultAlarmType,
+  mockStringAssetPropertyValue,
+} from '../../../testing/alarms';
+import { AlarmData } from '../types';
+import { useLatestAlarmPropertyValue } from './useLatestAlarmPropertyValue';
+
+const mockBatchGetAssetPropertyValue = ({
+  errorEntries = [],
+  successEntries = [],
+}: {
+  errorEntries?: BatchGetAssetPropertyValueErrorEntry[];
+  successEntries?: BatchGetAssetPropertyValueSuccessEntry[];
+}): BatchGetAssetPropertyValueResponse => ({
+  errorEntries,
+  successEntries,
+  skippedEntries: [],
+});
+
+const expectedStateAssetProperty = mockStringAssetPropertyValue(
+  mockDefaultAlarmState
+);
+const expectedTypeAssetProperty =
+  mockStringAssetPropertyValue(mockDefaultAlarmType);
+const expectedSourceAssetProperty = mockStringAssetPropertyValue(
+  mockDefaultAlarmSource
+);
+
+describe('useLatestAlarmPropertyValue', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    queryClient.clear();
+  });
+
+  it('should return AlarmData with latest state property value for one alarm', async () => {
+    batchGetAssetPropertyValueMock.mockImplementation(
+      (request: BatchGetAssetPropertyValueRequest) => {
+        return mockBatchGetAssetPropertyValue({
+          successEntries: [
+            {
+              entryId: request.entries![0].entryId,
+              assetPropertyValue: expectedStateAssetProperty,
+            },
+          ],
+        });
+      }
+    );
+
+    const expectedAlarmData = {
+      ...mockAlarmDataDescribeAsset,
+      state: {
+        ...mockAlarmDataDescribeAsset.state!,
+        data: [expectedStateAssetProperty],
+      },
+    };
+
+    const { result: alarmDataResults } = renderHook(() =>
+      useLatestAlarmPropertyValue({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        alarmDataList: [mockAlarmDataDescribeAsset],
+        alarmPropertyFieldName: 'state',
+      })
+    );
+
+    await waitFor(() => {
+      expect(alarmDataResults.current.length).toBe(1);
+      expect(alarmDataResults.current[0]).toMatchObject(expectedAlarmData);
+    });
+
+    expect(batchGetAssetPropertyValueMock).toBeCalledTimes(1);
+  });
+
+  it('should return AlarmData with latest type property value for one alarm', async () => {
+    batchGetAssetPropertyValueMock.mockImplementation(
+      (request: BatchGetAssetPropertyValueRequest) => {
+        return mockBatchGetAssetPropertyValue({
+          successEntries: [
+            {
+              entryId: request.entries![0].entryId,
+              assetPropertyValue: expectedTypeAssetProperty,
+            },
+          ],
+        });
+      }
+    );
+
+    const expectedAlarmData = {
+      ...mockAlarmDataDescribeAsset,
+      type: {
+        ...mockAlarmDataDescribeAsset.type!,
+        data: [expectedTypeAssetProperty],
+      },
+    };
+
+    const { result: alarmDataResults } = renderHook(() =>
+      useLatestAlarmPropertyValue({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        alarmDataList: [mockAlarmDataDescribeAsset],
+        alarmPropertyFieldName: 'type',
+      })
+    );
+
+    await waitFor(() => {
+      expect(alarmDataResults.current.length).toBe(1);
+      expect(alarmDataResults.current[0]).toMatchObject(expectedAlarmData);
+    });
+
+    expect(batchGetAssetPropertyValueMock).toBeCalledTimes(1);
+  });
+
+  it('should return AlarmData with latest source property value for one alarm', async () => {
+    batchGetAssetPropertyValueMock.mockImplementation(
+      (request: BatchGetAssetPropertyValueRequest) => {
+        return mockBatchGetAssetPropertyValue({
+          successEntries: [
+            {
+              entryId: request.entries![0].entryId,
+              assetPropertyValue: expectedSourceAssetProperty,
+            },
+          ],
+        });
+      }
+    );
+
+    const expectedAlarmData = {
+      ...mockAlarmDataDescribeAsset,
+      source: {
+        ...mockAlarmDataDescribeAsset.source!,
+        data: [expectedSourceAssetProperty],
+      },
+    };
+
+    const { result: alarmDataResults } = renderHook(() =>
+      useLatestAlarmPropertyValue({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        alarmDataList: [mockAlarmDataDescribeAsset],
+        alarmPropertyFieldName: 'source',
+      })
+    );
+
+    await waitFor(() => {
+      expect(alarmDataResults.current.length).toBe(1);
+      expect(alarmDataResults.current[0]).toMatchObject(expectedAlarmData);
+    });
+
+    expect(batchGetAssetPropertyValueMock).toBeCalledTimes(1);
+  });
+
+  it('should return same AlarmData for external alarm without a source property', async () => {
+    const externalAlarmData: AlarmData = {
+      ...mockAlarmDataDescribeAsset,
+      source: undefined,
+    };
+
+    const { result: alarmDataResults } = renderHook(() =>
+      useLatestAlarmPropertyValue({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        alarmDataList: [externalAlarmData],
+        alarmPropertyFieldName: 'source',
+      })
+    );
+
+    await waitFor(() => {
+      expect(alarmDataResults.current.length).toBe(1);
+      expect(alarmDataResults.current[0]).toMatchObject(externalAlarmData);
+    });
+
+    expect(batchGetAssetPropertyValueMock).toBeCalledTimes(0);
+  });
+
+  it('should return same AlarmData when alarm field is not an AlarmProperty', async () => {
+    const { result: alarmDataResults } = renderHook(() =>
+      useLatestAlarmPropertyValue({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        alarmDataList: [mockAlarmDataDescribeAsset],
+        alarmPropertyFieldName: 'assetId',
+      })
+    );
+
+    await waitFor(() => {
+      expect(alarmDataResults.current.length).toBe(1);
+      expect(alarmDataResults.current[0]).toMatchObject(
+        mockAlarmDataDescribeAsset
+      );
+    });
+
+    expect(batchGetAssetPropertyValueMock).toBeCalledTimes(0);
+  });
+
+  it('should return AlarmData with latest state property value for multiple alarms', async () => {
+    const expectedStateAssetProperty2 = mockStringAssetPropertyValue('ACTIVE');
+
+    batchGetAssetPropertyValueMock.mockImplementation(
+      (request: BatchGetAssetPropertyValueRequest) => {
+        return mockBatchGetAssetPropertyValue({
+          successEntries: [
+            {
+              entryId: request.entries![0].entryId,
+              assetPropertyValue: expectedStateAssetProperty,
+            },
+            {
+              entryId: request.entries![1].entryId,
+              assetPropertyValue: expectedStateAssetProperty2,
+            },
+          ],
+        });
+      }
+    );
+
+    const expectedAlarmData = {
+      ...mockAlarmDataDescribeAsset,
+      state: {
+        ...mockAlarmDataDescribeAsset.state!,
+        data: [expectedStateAssetProperty],
+      },
+    };
+
+    const expectedAlarmData2 = {
+      ...mockAlarmDataDescribeAsset2,
+      state: {
+        ...mockAlarmDataDescribeAsset2.state!,
+        data: [expectedStateAssetProperty2],
+      },
+    };
+
+    const { result: alarmDataResults } = renderHook(() =>
+      useLatestAlarmPropertyValue({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        alarmDataList: [
+          mockAlarmDataDescribeAsset,
+          mockAlarmDataDescribeAsset2,
+        ],
+        alarmPropertyFieldName: 'state',
+      })
+    );
+
+    await waitFor(() => {
+      expect(alarmDataResults.current.length).toBe(2);
+      expect(alarmDataResults.current[0]).toMatchObject(expectedAlarmData);
+      expect(alarmDataResults.current[1]).toMatchObject(expectedAlarmData2);
+    });
+
+    expect(batchGetAssetPropertyValueMock).toBeCalledTimes(1);
+  });
+
+  it('should overwrite the status of AlarmData when queries fail', async () => {});
+});

--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/useLatestAlarmPropertyValue.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/useLatestAlarmPropertyValue.ts
@@ -1,0 +1,97 @@
+import { useMemo } from 'react';
+import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { AlarmData, AlarmProperty } from '../types';
+import { useLatestAssetPropertyValues } from '../../../queries';
+import { getStatusForQuery } from '../utils/queryUtils';
+import { isAlarmProperty } from './predicates';
+import { constructAlarmAssetModelProperty } from '../utils/compositeModelUtils';
+
+export interface UseAlarmCompositePropertyOptions {
+  alarmPropertyFieldName: keyof AlarmData;
+  iotSiteWiseClient?: IoTSiteWiseClient;
+  alarmDataList?: AlarmData[];
+}
+
+/**
+ * useLatestAlarmPropertyValue is a hook used to fetch the latest
+ * asset property value for a SiteWise alarm composite property
+ *
+ * @param alarmPropertyFieldName is the name of an alarm property field
+ * 'state' | 'type' | 'source'
+ * @param iotSiteWiseClient is an AWS SDK IoT SiteWise client
+ * @param alarmDataList is a list of AlarmData
+ * @returns a list of AlarmData with the latest property value injected
+ * into the associated property field
+ */
+export function useLatestAlarmPropertyValue({
+  alarmPropertyFieldName,
+  iotSiteWiseClient,
+  alarmDataList = [],
+}: UseAlarmCompositePropertyOptions): AlarmData[] {
+  // Filter AlarmData with an existing property for alarmPropertyFieldName
+  const alarmPropertyRequests = alarmDataList
+    .filter((alarmData) =>
+      isAlarmProperty(alarmData[alarmPropertyFieldName] as AlarmProperty)
+    )
+    .map((alarmData) => ({
+      assetId: alarmData.assetId,
+      propertyId: (alarmData[alarmPropertyFieldName] as AlarmProperty).property
+        .id,
+    }));
+
+  // Fetch latest asset property value for requested properties from the alarmDataList
+  const alarmPropertyQueries = useLatestAssetPropertyValues({
+    iotSiteWiseClient,
+    requests: alarmPropertyRequests,
+  });
+
+  return useMemo(() => {
+    /**
+     * Walk through the alarmDataList to inject the asset property value for a matching request.
+     *
+     * filteredIndex tracks progress through the filtered request list and associated query responses.
+     *
+     * Both lists have the same order, where the alarmDataList may have more elements than the filtered list.
+     */
+    let filteredIndex = 0;
+    return (
+      alarmDataList?.map((alarmData) => {
+        // Try to access AlarmData alarm property
+        const alarmProperty: AlarmProperty | undefined = alarmData[
+          alarmPropertyFieldName
+        ] as AlarmProperty;
+        if (
+          alarmProperty !== undefined &&
+          filteredIndex < alarmPropertyRequests.length &&
+          alarmPropertyRequests[filteredIndex].assetId === alarmData.assetId &&
+          alarmPropertyRequests[filteredIndex].propertyId ===
+            alarmProperty.property.id
+        ) {
+          const status = getStatusForQuery(
+            alarmPropertyQueries[filteredIndex],
+            alarmData.status
+          );
+          const newAlarmProperty = constructAlarmAssetModelProperty(
+            alarmProperty.property,
+            alarmPropertyQueries[filteredIndex].data?.propertyValue
+          );
+          filteredIndex++;
+
+          // Inject alarm asset property data into the AlarmData
+          return {
+            ...alarmData,
+            [alarmPropertyFieldName]: newAlarmProperty,
+            status,
+          };
+        } else {
+          return alarmData;
+        }
+      }) ?? []
+    );
+  }, [
+    alarmDataList,
+    alarmPropertyFieldName,
+    alarmPropertyRequests,
+    alarmPropertyQueries,
+  ]);
+}

--- a/packages/react-components/src/hooks/useAlarms/utils/queryUtils.ts
+++ b/packages/react-components/src/hooks/useAlarms/utils/queryUtils.ts
@@ -2,6 +2,28 @@ import { UseQueryResult } from '@tanstack/react-query';
 import { AlarmDataStatus } from '../types';
 
 /**
+ * Combine two query statuses
+ *
+ * If any one status isLoading/Refetching/Error is true then the running status is also true
+ * If any one status isSuccess is false then running status is also false
+ * Combine all errors into a running list
+ */
+// Combine two query statuses
+const combineStatuses = ({
+  oldStatus,
+  newStatus,
+}: {
+  oldStatus: AlarmDataStatus;
+  newStatus: AlarmDataStatus;
+}): AlarmDataStatus => ({
+  isLoading: oldStatus.isLoading || newStatus.isLoading,
+  isRefetching: oldStatus.isRefetching || newStatus.isRefetching,
+  isSuccess: oldStatus.isSuccess && newStatus.isSuccess,
+  isError: oldStatus.isError || newStatus.isError,
+  errors: [...(oldStatus.errors ?? []), ...(newStatus.errors ?? [])],
+});
+
+/**
  * getStatusForQuery builds the AlarmDataStatus for a tanstack query result.
  * Since AlarmData is built on multiple queries the status can be combined with a previous query.
  *
@@ -13,7 +35,7 @@ export const getStatusForQuery = (
   query: UseQueryResult,
   oldStatus?: AlarmDataStatus
 ): AlarmDataStatus => {
-  let errors: Error[] | undefined =
+  const errors: Error[] | undefined =
     query.error !== null ? [query.error] : undefined;
   let status: AlarmDataStatus = {
     isLoading: query.isLoading,
@@ -23,16 +45,41 @@ export const getStatusForQuery = (
     errors,
   };
   if (oldStatus) {
-    if (oldStatus.errors) {
-      errors = errors ? [...oldStatus.errors, ...errors] : oldStatus.errors;
+    status = combineStatuses({ oldStatus, newStatus: status });
+  }
+
+  return status;
+};
+
+/**
+ * combineStatusForQueries resolves a single status between multiple queries and
+ * the status of a previous query
+ *
+ * @param queries are the tanstack query results each with their own status
+ * @param oldStatus is the status from a previous query, which is combined with the given queries
+ * @returns one AlarmDataStatus
+ */
+export const combineStatusForQueries = (
+  queries: UseQueryResult[],
+  oldStatus?: AlarmDataStatus
+) => {
+  const errors: Error[] = [];
+  queries.forEach(({ error }) => {
+    if (error !== null) {
+      errors.push(error);
     }
-    status = {
-      isLoading: status.isLoading || oldStatus.isLoading,
-      isRefetching: status.isRefetching || oldStatus.isRefetching,
-      isSuccess: status.isSuccess && oldStatus.isSuccess,
-      isError: status.isError || oldStatus.isError,
-      errors,
-    };
+  });
+
+  let status: AlarmDataStatus = {
+    isLoading: queries.some(({ isLoading }) => isLoading),
+    isRefetching: queries.some(({ isRefetching }) => isRefetching),
+    isSuccess: queries.every(({ isSuccess }) => isSuccess),
+    isError: queries.some(({ isError }) => isError),
+    errors,
+  };
+
+  if (oldStatus) {
+    status = combineStatuses({ oldStatus, newStatus: status });
   }
 
   return status;

--- a/packages/react-components/src/queries/useDescribeAssetModels/useDescribeAssetModels.spec.ts
+++ b/packages/react-components/src/queries/useDescribeAssetModels/useDescribeAssetModels.spec.ts
@@ -19,7 +19,7 @@ describe('useDescribeAssetModels', () => {
     const { result: queriesResult } = renderHook(() =>
       useDescribeAssetModels({
         iotSiteWiseClient: iotSiteWiseClientMock,
-        describeAssetModelRequests: [{ assetModelId: MOCK_ASSET_MODEL_ID }],
+        requests: [{ assetModelId: MOCK_ASSET_MODEL_ID }],
       })
     );
 
@@ -33,7 +33,7 @@ describe('useDescribeAssetModels', () => {
     const { result: queriesResult } = renderHook(() =>
       useDescribeAssetModels({
         iotSiteWiseClient: iotSiteWiseClientMock,
-        describeAssetModelRequests: [],
+        requests: [],
       })
     );
 
@@ -47,7 +47,7 @@ describe('useDescribeAssetModels', () => {
     const { result: queriesResult } = renderHook(() =>
       useDescribeAssetModels({
         iotSiteWiseClient: iotSiteWiseClientMock,
-        describeAssetModelRequests: [
+        requests: [
           { assetModelId: MOCK_ASSET_MODEL_ID },
           undefined,
           { assetModelId: MOCK_ASSET_MODEL_ID_2 },
@@ -73,7 +73,7 @@ describe('useDescribeAssetModels', () => {
     const { result: queriesResult } = renderHook(() =>
       useDescribeAssetModels({
         iotSiteWiseClient: iotSiteWiseClientMock,
-        describeAssetModelRequests: [{ assetModelId: MOCK_ASSET_MODEL_ID }],
+        requests: [{ assetModelId: MOCK_ASSET_MODEL_ID }],
         retry: false,
       })
     );

--- a/packages/react-components/src/queries/useDescribeAssetModels/useDescribeAssetModels.ts
+++ b/packages/react-components/src/queries/useDescribeAssetModels/useDescribeAssetModels.ts
@@ -15,7 +15,7 @@ import { QueryOptionsGlobal } from '../useLatestAssetPropertyValues';
 
 export type UseDescribeAssetModelsOptions = {
   iotSiteWiseClient?: IoTSiteWiseClient | IoTSiteWise;
-  describeAssetModelRequests?: (DescribeAssetModelRequest | undefined)[];
+  requests?: (DescribeAssetModelRequest | undefined)[];
 } & QueryOptionsGlobal;
 
 /**
@@ -23,12 +23,12 @@ export type UseDescribeAssetModelsOptions = {
  * AssetModelIds may not be defined in the list, which will disable its query
  *
  * @param iotSiteWiseClient is an AWS SDK IoT SiteWise client
- * @param describeAssetModelRequests is a list of DescribeAssetModel requests
+ * @param requests is a list of DescribeAssetModel requests
  * @returns list of tanstack query results with a DescribeAssetModelResponse
  */
 export function useDescribeAssetModels({
   iotSiteWiseClient,
-  describeAssetModelRequests = [],
+  requests = [],
   retry,
 }: UseDescribeAssetModelsOptions) {
   const { describeAssetModel } = useIoTSiteWiseClient({ iotSiteWiseClient });
@@ -36,7 +36,7 @@ export function useDescribeAssetModels({
   // Memoize the queries to ensure they don't rerun if the same assetModelIds are used on a rerender
   const queries = useMemo(
     () =>
-      describeAssetModelRequests.map((describeAssetModelRequest) => {
+      requests.map((describeAssetModelRequest) => {
         const cacheKeyFactory = new DescribeAssetModelCacheKeyFactory({
           ...describeAssetModelRequest,
         });
@@ -50,7 +50,7 @@ export function useDescribeAssetModels({
           retry,
         };
       }),
-    [describeAssetModelRequests, describeAssetModel, retry]
+    [requests, describeAssetModel, retry]
   );
 
   return useQueries({ queries }, queryClient);

--- a/packages/react-components/src/queries/useDescribeAssets/useDescribeAssets.spec.tsx
+++ b/packages/react-components/src/queries/useDescribeAssets/useDescribeAssets.spec.tsx
@@ -19,7 +19,7 @@ describe('useDescribeAssets', () => {
     const { result: queriesResult } = renderHook(() =>
       useDescribeAssets({
         iotSiteWiseClient: iotSiteWiseClientMock,
-        describeAssetRequests: [{ assetId: MOCK_ASSET_ID }],
+        requests: [{ assetId: MOCK_ASSET_ID }],
       })
     );
 
@@ -33,7 +33,7 @@ describe('useDescribeAssets', () => {
     const { result: queriesResult } = renderHook(() =>
       useDescribeAssets({
         iotSiteWiseClient: iotSiteWiseClientMock,
-        describeAssetRequests: [],
+        requests: [],
       })
     );
 
@@ -47,7 +47,7 @@ describe('useDescribeAssets', () => {
     const { result: queriesResult } = renderHook(() =>
       useDescribeAssets({
         iotSiteWiseClient: iotSiteWiseClientMock,
-        describeAssetRequests: [
+        requests: [
           { assetId: MOCK_ASSET_ID },
           undefined,
           { assetId: MOCK_ASSET_ID_2 },
@@ -71,7 +71,7 @@ describe('useDescribeAssets', () => {
     const { result: queriesResult } = renderHook(() =>
       useDescribeAssets({
         iotSiteWiseClient: iotSiteWiseClientMock,
-        describeAssetRequests: [{ assetId: MOCK_ASSET_ID }],
+        requests: [{ assetId: MOCK_ASSET_ID }],
         retry: false,
       })
     );

--- a/packages/react-components/src/queries/useDescribeAssets/useDescribeAssets.ts
+++ b/packages/react-components/src/queries/useDescribeAssets/useDescribeAssets.ts
@@ -15,7 +15,7 @@ import { QueryOptionsGlobal } from '../useLatestAssetPropertyValues';
 
 export type UseDescribeAssetsOptions = {
   iotSiteWiseClient?: IoTSiteWiseClient | IoTSiteWise;
-  describeAssetRequests?: (DescribeAssetRequest | undefined)[];
+  requests?: (DescribeAssetRequest | undefined)[];
 } & QueryOptionsGlobal;
 
 /**
@@ -23,12 +23,12 @@ export type UseDescribeAssetsOptions = {
  * AssetIds may not be defined in the list, which will disable its query
  *
  * @param iotSiteWiseClient is an AWS SDK IoT SiteWise client
- * @param describeAssetRequests is a list of DescribeAsset requests
+ * @param requests is a list of DescribeAsset requests
  * @returns list of tanstack query results with a DescribeAssetResponse
  */
 export function useDescribeAssets({
   iotSiteWiseClient,
-  describeAssetRequests = [],
+  requests = [],
   retry,
 }: UseDescribeAssetsOptions) {
   const { describeAsset } = useIoTSiteWiseClient({ iotSiteWiseClient });
@@ -36,7 +36,7 @@ export function useDescribeAssets({
   // Memoize the queries to ensure they don't rerun if the same assetIds are used on a rerender
   const queries = useMemo(
     () =>
-      describeAssetRequests.map((describeAssetRequest) => {
+      requests.map((describeAssetRequest) => {
         const cacheKeyFactory = new DescribeAssetCacheKeyFactory({
           ...describeAssetRequest,
         });
@@ -50,7 +50,7 @@ export function useDescribeAssets({
           retry,
         };
       }),
-    [describeAssetRequests, describeAsset, retry]
+    [requests, describeAsset, retry]
   );
 
   return useQueries({ queries }, queryClient);

--- a/packages/react-components/src/testing/alarms/mockAlarmData.ts
+++ b/packages/react-components/src/testing/alarms/mockAlarmData.ts
@@ -14,12 +14,15 @@ import {
   mockSourceAssetModelProperty,
   mockSourceAssetProperty,
   mockSourceAssetProperty2,
+  mockSourceAssetPropertyValue,
   mockStateAssetModelProperty,
   mockStateAssetProperty,
   mockStateAssetProperty2,
+  mockStateAssetPropertyValue,
   mockTypeAssetModelProperty,
   mockTypeAssetProperty,
   mockTypeAssetProperty2,
+  mockTypeAssetPropertyValue,
 } from './mockProperties';
 
 export const mockAlarmDataDescribeAsset: AlarmData = {
@@ -108,5 +111,21 @@ export const mockAlarmDataDescribeAssetModel: AlarmData = {
     isError: false,
     isRefetching: false,
     isSuccess: true,
+  },
+};
+
+export const mockAlarmDataGetAssetPropertyValue: AlarmData = {
+  ...mockAlarmDataDescribeAsset,
+  state: {
+    property: mockStateAssetProperty,
+    data: [mockStateAssetPropertyValue],
+  },
+  type: {
+    property: mockTypeAssetProperty,
+    data: [mockTypeAssetPropertyValue],
+  },
+  source: {
+    property: mockSourceAssetProperty,
+    data: [mockSourceAssetPropertyValue],
   },
 };

--- a/packages/react-components/src/testing/alarms/mockSiteWiseClient.ts
+++ b/packages/react-components/src/testing/alarms/mockSiteWiseClient.ts
@@ -2,7 +2,9 @@ import { IoTSiteWise } from '@aws-sdk/client-iotsitewise';
 
 export const describeAssetMock = jest.fn();
 export const describeAssetModelMock = jest.fn();
+export const batchGetAssetPropertyValueMock = jest.fn();
 export const iotSiteWiseClientMock = {
   describeAsset: describeAssetMock,
   describeAssetModel: describeAssetModelMock,
+  batchGetAssetPropertyValue: batchGetAssetPropertyValueMock,
 } as unknown as IoTSiteWise;


### PR DESCRIPTION
## Overview
Add `useLatestAlarmPropertyValue` hook as an abstraction over `useLatestAssetPropertyValues` to fetch the latest alarm property value for "state", "type", or "source" properties. Hook injects the property data into the running AlarmData list.

Decided to make `useLatestAlarmPropertyValue` generic with a field for the `alarmPropertyFieldName` (`'state' | 'type' | 'source'`). There is a predicate to check which AlarmData of the running list has that property field, and fetches the latest data for each. The hook is self-contained and will only cause a re-render if that property field changes.

`useAlarms` builds AlarmData by passing the output of one hook into the other.

* Minor: renamed the input for `useDescribeAssets` and `useDescribeAssetModels` to be `requests` to standardize across all hooks

## Verifying Changes

Added unit tests and ran in storybook to see alarm output successfully.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
