### PR TITLE
fix(dashboard-RE-improvements): add timezone + sig digits to dynamic tab

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelDataStreamExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelDataStreamExplorer.tsx
@@ -34,6 +34,8 @@ export interface AssetModelDataStreamExplorerProps {
   selectedWidgets: DashboardWidget[];
   addButtonDisabled: boolean;
   correctSelectionMode: 'single' | 'multi';
+  timeZone?: string;
+  significantDigits?: number;
 }
 
 export const AssetModelDataStreamExplorer = ({
@@ -41,6 +43,8 @@ export const AssetModelDataStreamExplorer = ({
   selectedWidgets,
   addButtonDisabled,
   correctSelectionMode,
+  timeZone,
+  significantDigits,
 }: AssetModelDataStreamExplorerProps) => {
   const metricsRecorder = getPlugin('metricsRecorder');
   const {
@@ -128,6 +132,8 @@ export const AssetModelDataStreamExplorer = ({
     selectedAssetModelProperties,
     correctSelectionMode,
     selectedWidgets,
+    timeZone,
+    significantDigits,
   };
 
   return (

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesExplorer.tsx
@@ -17,6 +17,8 @@ export interface AssetExplorerProps {
   selectedAsset: SelectedAsset;
   selectAssetModelProperties: UpdateSelectedAssetModelProperties;
   selectedWidgets: DashboardWidget[];
+  timeZone?: string;
+  significantDigits?: number;
 }
 
 export const AssetModelPropertiesExplorer = ({
@@ -25,6 +27,8 @@ export const AssetModelPropertiesExplorer = ({
   selectedAssetModelProperties,
   selectAssetModelProperties,
   selectedWidgets,
+  timeZone,
+  significantDigits,
 }: AssetExplorerProps) => {
   return (
     <AssetPropertyExplorer
@@ -49,6 +53,8 @@ export const AssetModelPropertiesExplorer = ({
             selectedWidgets
           ),
       }}
+      timeZone={timeZone}
+      significantDigits={significantDigits}
     />
   );
 };

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
@@ -74,6 +74,8 @@ export function IoTSiteWiseQueryEditor({
         correctSelectionMode={correctSelectionMode}
         addButtonDisabled={addButtonDisabled}
         selectedWidgets={selectedWidgets}
+        timeZone={timeZone}
+        significantDigits={significantDigits}
       />
     ),
   };


### PR DESCRIPTION
## Overview
Pass in timezone + significant digits props into the asset property table in Dynamic Assets tab to support that functionality.

## Verifying Changes

https://github.com/user-attachments/assets/384a2230-c832-45b9-8d25-1409545bd90d

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
