### PR TITLE
feat(sitewise-alarms): add useAlarmModels hook to fetch iot events alarm models in useAlarms

### DIFF
--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/index.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/index.ts
@@ -1,2 +1,3 @@
 export * from './useAlarmAssets';
 export * from './useLatestAlarmPropertyValue';
+export * from './useAlarmModels';

--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/predicates.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/predicates.ts
@@ -1,3 +1,4 @@
+import { AssetPropertyValue } from '@aws-sdk/client-iotsitewise';
 import {
   AlarmAssetModelRequest,
   AlarmAssetRequest,
@@ -21,3 +22,7 @@ export const isAssetRequest = (
 export const isAlarmProperty = (
   property?: AlarmProperty
 ): property is AlarmProperty => !!property?.property;
+
+export const isAssetPropertyValue = (
+  assetPropertyValue?: AssetPropertyValue
+): assetPropertyValue is AssetPropertyValue => Boolean(assetPropertyValue);

--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/useAlarmModels.spec.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/useAlarmModels.spec.ts
@@ -1,0 +1,115 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { queryClient } from '../../../queries';
+import {
+  describeAlarmModelMock,
+  iotEventsClientMock,
+  mockAlarmDataDescribeAsset,
+  mockAlarmDataGetAssetPropertyValue,
+  mockAlarmDataGetAssetPropertyValue2,
+  mockAlarmModel,
+  mockAlarmModel2,
+} from '../../../testing/alarms';
+import { AlarmData } from '../types';
+import { useAlarmModels } from './useAlarmModels';
+
+describe('useAlarmModels', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    queryClient.clear();
+  });
+
+  it('should inject alarm model into AlarmData for one alarm', async () => {
+    describeAlarmModelMock.mockResolvedValue(mockAlarmModel);
+
+    const expectedAlarmData: AlarmData = {
+      ...mockAlarmDataGetAssetPropertyValue,
+      models: [mockAlarmModel],
+    };
+
+    const { result: alarmDataResults } = renderHook(() =>
+      useAlarmModels({
+        iotEventsClient: iotEventsClientMock,
+        alarmDataList: [mockAlarmDataGetAssetPropertyValue],
+      })
+    );
+
+    await waitFor(() => {
+      expect(alarmDataResults.current.length).toBe(1);
+      expect(alarmDataResults.current[0]).toMatchObject(expectedAlarmData);
+    });
+
+    expect(describeAlarmModelMock).toBeCalledTimes(1);
+  });
+
+  it('should not change AlarmData for external alarm without a source property', async () => {
+    const externalAlarmData: AlarmData = {
+      ...mockAlarmDataGetAssetPropertyValue,
+      source: undefined,
+    };
+
+    const { result: alarmDataResults } = renderHook(() =>
+      useAlarmModels({
+        iotEventsClient: iotEventsClientMock,
+        alarmDataList: [externalAlarmData],
+      })
+    );
+
+    await waitFor(() => {
+      expect(alarmDataResults.current.length).toBe(1);
+      expect(alarmDataResults.current[0]).toMatchObject(externalAlarmData);
+    });
+
+    expect(describeAlarmModelMock).toBeCalledTimes(0);
+  });
+
+  it('should not change AlarmData when alarm source property has no data', async () => {
+    const { result: alarmDataResults } = renderHook(() =>
+      useAlarmModels({
+        iotEventsClient: iotEventsClientMock,
+        alarmDataList: [mockAlarmDataDescribeAsset],
+      })
+    );
+
+    await waitFor(() => {
+      expect(alarmDataResults.current.length).toBe(1);
+      expect(alarmDataResults.current[0]).toMatchObject(
+        mockAlarmDataDescribeAsset
+      );
+    });
+
+    expect(describeAlarmModelMock).toBeCalledTimes(0);
+  });
+
+  it('should inject alarm model into AlarmData for multiple alarms', async () => {
+    describeAlarmModelMock.mockResolvedValueOnce(mockAlarmModel);
+    describeAlarmModelMock.mockResolvedValueOnce(mockAlarmModel2);
+
+    const expectedAlarmData1: AlarmData = {
+      ...mockAlarmDataGetAssetPropertyValue,
+      models: [mockAlarmModel],
+    };
+
+    const expectedAlarmData2: AlarmData = {
+      ...mockAlarmDataGetAssetPropertyValue2,
+      models: [mockAlarmModel2],
+    };
+
+    const { result: alarmDataResults } = renderHook(() =>
+      useAlarmModels({
+        iotEventsClient: iotEventsClientMock,
+        alarmDataList: [
+          mockAlarmDataGetAssetPropertyValue,
+          mockAlarmDataGetAssetPropertyValue2,
+        ],
+      })
+    );
+
+    await waitFor(() => {
+      expect(alarmDataResults.current.length).toBe(2);
+      expect(alarmDataResults.current[0]).toMatchObject(expectedAlarmData1);
+      expect(alarmDataResults.current[1]).toMatchObject(expectedAlarmData2);
+    });
+
+    expect(describeAlarmModelMock).toBeCalledTimes(2);
+  });
+});

--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/useAlarmModels.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/useAlarmModels.ts
@@ -1,0 +1,85 @@
+import { useMemo } from 'react';
+import { IoTEventsClient } from '@aws-sdk/client-iot-events';
+import { getAlarmModelNameFromAlarmSourceProperty } from '../utils/alarmModelUtils';
+import { AlarmData, AlarmProperty } from '../types';
+import { useDescribeAlarmModels } from '../../../queries';
+import { getStatusForQuery } from '../utils/queryUtils';
+
+export interface UseAlarmModelsOptions {
+  iotEventsClient?: IoTEventsClient;
+  alarmDataList?: AlarmData[];
+}
+
+/**
+ * useAlarmModels is a hook used to describe the IoT Events alarm model
+ * of a SiteWise alarm
+ *
+ * @param iotEventsClient is an AWS SDK IoT SiteWise client
+ * @param alarmDataList is a list of AlarmData
+ * @returns a list of AlarmData with the associated IoT Events alarm models
+ */
+export function useAlarmModels({
+  iotEventsClient,
+  alarmDataList = [],
+}: UseAlarmModelsOptions): AlarmData[] {
+  // Filter AlarmData with a source property and data
+  const alarmModelRequests = alarmDataList
+    .filter(
+      (alarmData) =>
+        alarmData.source &&
+        alarmData.source.data &&
+        alarmData.source.data.length > 0
+    )
+    .map((alarmData) => ({
+      alarmModelName: getAlarmModelNameFromAlarmSourceProperty(
+        alarmData.source
+      ),
+    }));
+
+  const alarmModelQueries = useDescribeAlarmModels({
+    iotEventsClient,
+    requests: alarmModelRequests,
+  });
+
+  return useMemo(() => {
+    /**
+     * Walk through the alarmDataList to inject the alarm models for a matching request.
+     *
+     * filteredIndex tracks progress through the filtered request list and associated query responses.
+     *
+     * Both lists have the same order, where the alarmDataList may have more elements than the filtered list.
+     */
+    let filteredIndex = 0;
+    return (
+      alarmDataList?.map((alarmData) => {
+        // Try to access AlarmData alarm source property
+        const sourceProperty: AlarmProperty | undefined = alarmData.source;
+        if (
+          sourceProperty &&
+          sourceProperty.data &&
+          filteredIndex < alarmModelRequests.length &&
+          // Look up if AlarmData alarm source matches the alarm model request
+          alarmModelRequests[filteredIndex].alarmModelName ===
+            getAlarmModelNameFromAlarmSourceProperty(sourceProperty)
+        ) {
+          const alarmModel = alarmModelQueries[filteredIndex].data;
+          const status = getStatusForQuery(
+            alarmModelQueries[filteredIndex],
+            alarmData.status
+          );
+          filteredIndex++;
+
+          // Inject alarm asset property data into the AlarmData
+          return {
+            ...alarmData,
+            // Right now only support the latest version of the alarm model
+            models: alarmModel ? [alarmModel] : undefined,
+            status,
+          };
+        } else {
+          return alarmData;
+        }
+      }) ?? []
+    );
+  }, [alarmDataList, alarmModelRequests, alarmModelQueries]);
+}

--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/useLatestAlarmPropertyValue.spec.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/useLatestAlarmPropertyValue.spec.ts
@@ -11,10 +11,10 @@ import {
   iotSiteWiseClientMock,
   mockAlarmDataDescribeAsset,
   mockAlarmDataDescribeAsset2,
-  mockDefaultAlarmSource,
-  mockDefaultAlarmState,
-  mockDefaultAlarmType,
-  mockStringAssetPropertyValue,
+  mockSourceAssetPropertyValue,
+  mockStateAssetPropertyValue,
+  mockStateAssetPropertyValue2,
+  mockTypeAssetPropertyValue,
 } from '../../../testing/alarms';
 import { AlarmData } from '../types';
 import { useLatestAlarmPropertyValue } from './useLatestAlarmPropertyValue';
@@ -31,15 +31,6 @@ const mockBatchGetAssetPropertyValue = ({
   skippedEntries: [],
 });
 
-const expectedStateAssetProperty = mockStringAssetPropertyValue(
-  mockDefaultAlarmState
-);
-const expectedTypeAssetProperty =
-  mockStringAssetPropertyValue(mockDefaultAlarmType);
-const expectedSourceAssetProperty = mockStringAssetPropertyValue(
-  mockDefaultAlarmSource
-);
-
 describe('useLatestAlarmPropertyValue', () => {
   beforeEach(() => {
     jest.resetAllMocks();
@@ -53,7 +44,7 @@ describe('useLatestAlarmPropertyValue', () => {
           successEntries: [
             {
               entryId: request.entries![0].entryId,
-              assetPropertyValue: expectedStateAssetProperty,
+              assetPropertyValue: mockStateAssetPropertyValue,
             },
           ],
         });
@@ -64,7 +55,7 @@ describe('useLatestAlarmPropertyValue', () => {
       ...mockAlarmDataDescribeAsset,
       state: {
         ...mockAlarmDataDescribeAsset.state!,
-        data: [expectedStateAssetProperty],
+        data: [mockStateAssetPropertyValue],
       },
     };
 
@@ -91,7 +82,7 @@ describe('useLatestAlarmPropertyValue', () => {
           successEntries: [
             {
               entryId: request.entries![0].entryId,
-              assetPropertyValue: expectedTypeAssetProperty,
+              assetPropertyValue: mockTypeAssetPropertyValue,
             },
           ],
         });
@@ -102,7 +93,7 @@ describe('useLatestAlarmPropertyValue', () => {
       ...mockAlarmDataDescribeAsset,
       type: {
         ...mockAlarmDataDescribeAsset.type!,
-        data: [expectedTypeAssetProperty],
+        data: [mockTypeAssetPropertyValue],
       },
     };
 
@@ -129,7 +120,7 @@ describe('useLatestAlarmPropertyValue', () => {
           successEntries: [
             {
               entryId: request.entries![0].entryId,
-              assetPropertyValue: expectedSourceAssetProperty,
+              assetPropertyValue: mockSourceAssetPropertyValue,
             },
           ],
         });
@@ -140,7 +131,7 @@ describe('useLatestAlarmPropertyValue', () => {
       ...mockAlarmDataDescribeAsset,
       source: {
         ...mockAlarmDataDescribeAsset.source!,
-        data: [expectedSourceAssetProperty],
+        data: [mockSourceAssetPropertyValue],
       },
     };
 
@@ -202,19 +193,17 @@ describe('useLatestAlarmPropertyValue', () => {
   });
 
   it('should return AlarmData with latest state property value for multiple alarms', async () => {
-    const expectedStateAssetProperty2 = mockStringAssetPropertyValue('ACTIVE');
-
     batchGetAssetPropertyValueMock.mockImplementation(
       (request: BatchGetAssetPropertyValueRequest) => {
         return mockBatchGetAssetPropertyValue({
           successEntries: [
             {
               entryId: request.entries![0].entryId,
-              assetPropertyValue: expectedStateAssetProperty,
+              assetPropertyValue: mockStateAssetPropertyValue,
             },
             {
               entryId: request.entries![1].entryId,
-              assetPropertyValue: expectedStateAssetProperty2,
+              assetPropertyValue: mockStateAssetPropertyValue2,
             },
           ],
         });
@@ -225,7 +214,7 @@ describe('useLatestAlarmPropertyValue', () => {
       ...mockAlarmDataDescribeAsset,
       state: {
         ...mockAlarmDataDescribeAsset.state!,
-        data: [expectedStateAssetProperty],
+        data: [mockStateAssetPropertyValue],
       },
     };
 
@@ -233,7 +222,7 @@ describe('useLatestAlarmPropertyValue', () => {
       ...mockAlarmDataDescribeAsset2,
       state: {
         ...mockAlarmDataDescribeAsset2.state!,
-        data: [expectedStateAssetProperty2],
+        data: [mockStateAssetPropertyValue2],
       },
     };
 
@@ -256,6 +245,4 @@ describe('useLatestAlarmPropertyValue', () => {
 
     expect(batchGetAssetPropertyValueMock).toBeCalledTimes(1);
   });
-
-  it('should overwrite the status of AlarmData when queries fail', async () => {});
 });

--- a/packages/react-components/src/hooks/useAlarms/useAlarms.spec.ts
+++ b/packages/react-components/src/hooks/useAlarms/useAlarms.spec.ts
@@ -2,24 +2,31 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { useAlarms } from './useAlarms';
 import { AlarmData, AlarmProperty } from './types';
 import {
+  MOCK_ALARM_INPUT_PROPERTY_ID,
   MOCK_ASSET_ID,
   MOCK_COMPOSITE_MODEL_ID,
   iotSiteWiseClientMock,
+  mockAlarmDataDescribeAlarmModel,
+  mockAlarmDataDescribeAlarmModel2,
   mockAlarmDataDescribeAsset,
   mockAlarmDataGetAssetPropertyValue,
+  mockInputProperty,
   mockStateAssetPropertyValue,
 } from '../../testing/alarms';
 import * as alarmAssetHook from './hookHelpers/useAlarmAssets';
 import * as alarmCompositeProp from './hookHelpers/useLatestAlarmPropertyValue';
+import * as alarmModelHook from './hookHelpers/useAlarmModels';
 
 jest.mock('./hookHelpers/useAlarmAssets');
 jest.mock('./hookHelpers/useLatestAlarmPropertyValue');
+jest.mock('./hookHelpers/useAlarmModels');
 
 const useAlarmAssetsMock = jest.spyOn(alarmAssetHook, 'useAlarmAssets');
 const useLatestAlarmPropertyValueMock = jest.spyOn(
   alarmCompositeProp,
   'useLatestAlarmPropertyValue'
 );
+const useAlarmModelsMock = jest.spyOn(alarmModelHook, 'useAlarmModels');
 
 describe('useAlarms', () => {
   beforeEach(() => {
@@ -31,6 +38,7 @@ describe('useAlarms', () => {
     useLatestAlarmPropertyValueMock.mockReturnValue([
       mockAlarmDataGetAssetPropertyValue,
     ]);
+    useAlarmModelsMock.mockReturnValue([mockAlarmDataDescribeAlarmModel]);
 
     const { result: alarmResults } = renderHook(() =>
       useAlarms({
@@ -46,12 +54,13 @@ describe('useAlarms', () => {
 
     await waitFor(() =>
       expect(alarmResults.current).toMatchObject([
-        mockAlarmDataGetAssetPropertyValue,
+        mockAlarmDataDescribeAlarmModel,
       ])
     );
 
-    expect(useAlarmAssetsMock).toBeCalled();
+    expect(useAlarmAssetsMock).toBeCalledTimes(1);
     expect(useLatestAlarmPropertyValueMock).toBeCalledTimes(3);
+    expect(useAlarmModelsMock).toBeCalledTimes(1);
   });
 
   it('should transform AlarmData according to supplied transform function', async () => {
@@ -59,6 +68,7 @@ describe('useAlarms', () => {
     useLatestAlarmPropertyValueMock.mockReturnValue([
       mockAlarmDataGetAssetPropertyValue,
     ]);
+    useAlarmModelsMock.mockReturnValue([mockAlarmDataDescribeAlarmModel]);
 
     const transform = (alarmData: AlarmData): AlarmProperty | undefined =>
       alarmData.state;
@@ -85,7 +95,51 @@ describe('useAlarms', () => {
       expect(alarmResults.current).toMatchObject([expectedStateProperty])
     );
 
-    expect(useAlarmAssetsMock).toBeCalled();
+    expect(useAlarmAssetsMock).toBeCalledTimes(1);
     expect(useLatestAlarmPropertyValueMock).toBeCalledTimes(3);
+    expect(useAlarmModelsMock).toBeCalledTimes(1);
+  });
+
+  it('should return AlarmData with associated inputProperty', async () => {
+    // Case where multiple alarms from the same asset have different alarm models
+    const mockAlarmDataInputProperty: AlarmData = {
+      ...mockAlarmDataDescribeAlarmModel,
+      inputProperty: [mockInputProperty],
+    };
+
+    const mockAlarmDataInputProperty2: AlarmData = {
+      ...mockAlarmDataDescribeAlarmModel,
+      models: mockAlarmDataDescribeAlarmModel2.models,
+      inputProperty: [mockInputProperty],
+    };
+
+    useAlarmAssetsMock.mockReturnValue([mockAlarmDataDescribeAsset]);
+    useLatestAlarmPropertyValueMock.mockReturnValue([
+      mockAlarmDataGetAssetPropertyValue,
+    ]);
+    useAlarmModelsMock.mockReturnValue([
+      mockAlarmDataInputProperty,
+      mockAlarmDataInputProperty2,
+    ]);
+
+    const { result: alarmResults } = renderHook(() =>
+      useAlarms({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        requests: [
+          {
+            assetId: MOCK_ASSET_ID,
+            inputPropertyId: MOCK_ALARM_INPUT_PROPERTY_ID,
+          },
+        ],
+      })
+    );
+
+    await waitFor(() =>
+      expect(alarmResults.current).toMatchObject([mockAlarmDataInputProperty])
+    );
+
+    expect(useAlarmAssetsMock).toBeCalledTimes(1);
+    expect(useLatestAlarmPropertyValueMock).toBeCalledTimes(3);
+    expect(useAlarmModelsMock).toBeCalledTimes(1);
   });
 });

--- a/packages/react-components/src/hooks/useAlarms/useAlarms.ts
+++ b/packages/react-components/src/hooks/useAlarms/useAlarms.ts
@@ -5,8 +5,12 @@ import {
   UseAlarmsOptions,
   UseAlarmOptionsWithoutTransform,
 } from './types';
-import { useAlarmAssets } from './hookHelpers';
-import { useLatestAlarmPropertyValue } from './hookHelpers/useLatestAlarmPropertyValue';
+import {
+  useAlarmAssets,
+  useAlarmModels,
+  useLatestAlarmPropertyValue,
+} from './hookHelpers';
+import { filterAlarmsMatchingInputProperties } from './utils/alarmModelUtils';
 
 /**
  * Identify function that returns the input AlarmData.
@@ -38,37 +42,76 @@ function useAlarms<T>(
  * If transform is undefined, the output is AlarmData[], dicatated by the first signature above.
  */
 function useAlarms<T>(options?: UseAlarmsOptions<T>): (T | AlarmData)[] {
-  const { iotSiteWiseClient, requests, transform } = options ?? {};
-
+  const { iotSiteWiseClient, iotEventsClient, requests, transform } =
+    options ?? {};
+  /**
+   * Fetch alarm summaries based on the request
+   * (e.g. all alarms for an asset or assetModel)
+   */
   const assetAlarmData = useAlarmAssets({
     iotSiteWiseClient,
     requests,
   });
 
+  /**
+   * Fetch latest asset property values for alarms with a state property.
+   * Data should be available for all alarms fetched for an asset.
+   */
   const statePropertyAlarmData = useLatestAlarmPropertyValue({
     iotSiteWiseClient,
     alarmDataList: assetAlarmData,
     alarmPropertyFieldName: 'state',
   });
 
+  /**
+   * Fetch latest asset property values for alarms with a type property.
+   * Data should be available for all alarms fetched for an asset.
+   */
   const typePropertyAlarmData = useLatestAlarmPropertyValue({
     iotSiteWiseClient,
     alarmDataList: statePropertyAlarmData,
     alarmPropertyFieldName: 'type',
   });
 
+  /**
+   * Fetch latest asset property values for alarms with a source property.
+   * Data should be available for all alarms fetched for an asset, where
+   * the alarm type is "IOT_EVENTS".
+   */
   const sourcePropertyAlarmData = useLatestAlarmPropertyValue({
     iotSiteWiseClient,
     alarmDataList: typePropertyAlarmData,
     alarmPropertyFieldName: 'source',
   });
 
+  /**
+   * Fetch IoT Events alarm models for each alarm
+   * Only supported for alarms with type "IOT_EVENTS"
+   * and data available for the source asset property.
+   */
+  const alarmModelAlarmData = useAlarmModels({
+    iotEventsClient,
+    alarmDataList: sourcePropertyAlarmData,
+  });
+
+  /**
+   * If an inputProperty is in an AlarmRequest then all alarms for
+   * the property's asset is fetched. After the IoT Events alarm models
+   * are fetched for each alarm we can verify which alarm on the asset
+   * is actually associated with an inputProperty.
+   */
+  const filterAlarmInputProperties = useMemo(
+    () => filterAlarmsMatchingInputProperties(alarmModelAlarmData),
+    [alarmModelAlarmData]
+  );
+
+  // Apply the transform callback if it exists, otherwise return the AlarmData
   return useMemo(
     () =>
       transform
-        ? sourcePropertyAlarmData?.map(transform)
-        : sourcePropertyAlarmData?.map(alarmDataIdentity),
-    [transform, sourcePropertyAlarmData]
+        ? filterAlarmInputProperties?.map(transform)
+        : filterAlarmInputProperties?.map(alarmDataIdentity),
+    [transform, filterAlarmInputProperties]
   );
 }
 

--- a/packages/react-components/src/hooks/useAlarms/utils/alarmModelUtils.ts
+++ b/packages/react-components/src/hooks/useAlarms/utils/alarmModelUtils.ts
@@ -1,0 +1,95 @@
+import { DescribeAlarmModelResponse } from '@aws-sdk/client-iot-events';
+import { SITE_WISE_BACKED_PROPERTY_PREFIX } from '../constants';
+import { AlarmData, AlarmProperty } from '../types';
+
+/**
+ * Expecting the alarm model name to be at the end of the ARN after the last '/'
+ *
+ * @param alarmModelArn is the alarm model ARN of the format:
+ *    arn:<partition>:iotevents:<region>:<accountId>:alarmModel/<alarmModelName>
+ * @returns the alarm model name or undefined if the ARN is malformed
+ */
+const nameFromAlarmModelArn = (alarmModelArn: string): string | undefined => {
+  const arnSplit = alarmModelArn.split('/');
+  if (arnSplit.length === 2 && arnSplit[1] !== '') {
+    return arnSplit[1];
+  }
+};
+
+/**
+ * Function extracts an IoT Events alarm model name from an IoT SiteWise alarm source property.
+ * An alarm source property stores an associated IoT Events alarm model ARN as a property value.
+ * This is only supported for "IOT_EVENTS" alarm types.
+ *
+ * @param alarmSourceProperty is an AlarmProperty as defined on an AlarmData object
+ * @returns the IoT Events alarm model name if available
+ */
+export const getAlarmModelNameFromAlarmSourceProperty = (
+  alarmSourceProperty?: AlarmProperty
+): string | undefined => {
+  let alarmModelArn: string | undefined;
+  if (alarmSourceProperty?.data && alarmSourceProperty?.data.length > 0) {
+    const dataLength = alarmSourceProperty?.data.length;
+    // Get latest property value
+    alarmModelArn = alarmSourceProperty.data[dataLength - 1].value?.stringValue;
+  }
+  return alarmModelArn && nameFromAlarmModelArn(alarmModelArn);
+};
+
+const isBackedBySiteWiseAssetProperty = (inputProperty: string): boolean =>
+  inputProperty.startsWith(SITE_WISE_BACKED_PROPERTY_PREFIX);
+
+const removeBackticks = (value: string) => {
+  return value.replace(/^`|`$/g, '');
+};
+
+/**
+ * Expecting the propertyId to be the 3rd string after $sitewise prefix.
+ *
+ * @param inputProperty - an expression with the propertyId e.g.
+ *    $sitewise.assetModel.`f6dca270-d4b9-4de0-9722-d57d3f260cb8`.`00b36ed5-7640-4635-b9d3-60c2db229568`.propertyValue.value
+ *    here the propertyId is 00b36ed5-7640-4635-b9d3-60c2db229568
+ * @returns the propertyId or undefined if we are not provided with a model propertyId that is backed by SiteWise
+ */
+const extractAssetPropertyId = (
+  inputProperty: string | undefined
+): string | undefined => {
+  if (inputProperty && isBackedBySiteWiseAssetProperty(inputProperty)) {
+    const splitInputProperty = inputProperty.split('.');
+    return removeBackticks(splitInputProperty[3]);
+  }
+};
+
+/**
+ * Function filters out AlarmData where the inputProperty field does not match
+ * any of its IoT Events alarm models.
+ *
+ * useAlarms fills in the inputProperty field if the original AlarmRequest has
+ * an inputPropertyId specified. Need to fetch all alarms from an asset and
+ * check them against all IoT Events alarm models to find which alarms have
+ * the inputPropertyId.
+ *
+ * @param alarmDataList is the list of AlarmData with fetched assets and alarm models
+ * @returns a filtered list of AlarmData where inputPropertyId matches the inputProperty
+ * from the alarm model
+ */
+export const filterAlarmsMatchingInputProperties = (
+  alarmDataList: AlarmData[]
+) => {
+  return alarmDataList.filter((alarmData) => {
+    if (alarmData.inputProperty) {
+      let matchingAlarmModel: DescribeAlarmModelResponse | undefined;
+      for (const property of alarmData.inputProperty) {
+        matchingAlarmModel = alarmData.models?.find((alarmModel) => {
+          const inputPropertyId = extractAssetPropertyId(
+            alarmModel.alarmRule?.simpleRule?.inputProperty
+          );
+          return inputPropertyId === property.id;
+        });
+      }
+      return matchingAlarmModel ? true : false;
+    } else {
+      return true;
+    }
+  });
+};

--- a/packages/react-components/src/queries/common/types.ts
+++ b/packages/react-components/src/queries/common/types.ts
@@ -1,0 +1,3 @@
+import { UseQueryOptions } from '@tanstack/react-query';
+
+export type QueryOptionsGlobal = Pick<UseQueryOptions, 'retry'>;

--- a/packages/react-components/src/queries/index.ts
+++ b/packages/react-components/src/queries/index.ts
@@ -7,3 +7,4 @@ export * from './useTimeSeriesData';
 export * from './useDescribeAssets';
 export * from './useDescribeAssetModels';
 export * from './useLatestAssetPropertyValues';
+export * from './useDescribeAlarmModels';

--- a/packages/react-components/src/queries/predicates/index.ts
+++ b/packages/react-components/src/queries/predicates/index.ts
@@ -5,6 +5,9 @@ import {
   RequestResponse,
 } from '@iot-app-kit/core';
 
+export const isAlarmModelId = (alarmModelId?: string): alarmModelId is string =>
+  Boolean(alarmModelId);
+
 export const isAssetId = (assetId?: string): assetId is string =>
   Boolean(assetId);
 

--- a/packages/react-components/src/queries/useDescribeAlarmModels/describeAlarmModelQueryKeyFactory.ts
+++ b/packages/react-components/src/queries/useDescribeAlarmModels/describeAlarmModelQueryKeyFactory.ts
@@ -1,0 +1,27 @@
+export class DescribeAlarmModelCacheKeyFactory {
+  #alarmModelName?: string;
+  #alarmModelVersion?: string;
+
+  constructor({
+    alarmModelName,
+    alarmModelVersion,
+  }: {
+    alarmModelName?: string;
+    alarmModelVersion?: string;
+  }) {
+    this.#alarmModelName = alarmModelName;
+    this.#alarmModelVersion = alarmModelVersion;
+  }
+
+  create() {
+    const cacheKey = [
+      {
+        resource: 'describe alarm model',
+        alarmModelName: this.#alarmModelName,
+        alarmModelVersion: this.#alarmModelVersion,
+      },
+    ] as const;
+
+    return cacheKey;
+  }
+}

--- a/packages/react-components/src/queries/useDescribeAlarmModels/index.ts
+++ b/packages/react-components/src/queries/useDescribeAlarmModels/index.ts
@@ -1,0 +1,1 @@
+export * from './useDescribeAlarmModels';

--- a/packages/react-components/src/queries/useDescribeAlarmModels/useDescribeAlarmModels.spec.ts
+++ b/packages/react-components/src/queries/useDescribeAlarmModels/useDescribeAlarmModels.spec.ts
@@ -1,0 +1,83 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useDescribeAlarmModels } from './useDescribeAlarmModels';
+import { queryClient } from '../queryClient';
+import {
+  MOCK_ALARM_MODEL_NAME,
+  MOCK_ALARM_MODEL_NAME_2,
+  describeAlarmModelMock,
+  iotEventsClientMock,
+} from '../../testing/alarms';
+
+describe('useDescribeAlarmModels', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    queryClient.clear();
+  });
+
+  it('should call DescribeAlarmModel in successful queries when calling useDescribeAlarmModels', async () => {
+    describeAlarmModelMock.mockResolvedValue({});
+    const { result: queriesResult } = renderHook(() =>
+      useDescribeAlarmModels({
+        iotEventsClient: iotEventsClientMock,
+        requests: [{ alarmModelName: MOCK_ALARM_MODEL_NAME }],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isSuccess).toBe(true));
+
+    expect(describeAlarmModelMock).toBeCalled();
+  });
+
+  it('should not call DescribeAlarmModel when no alarmModelNames passed into useDescribeAlarmModels', async () => {
+    describeAlarmModelMock.mockResolvedValue({});
+    const { result: queriesResult } = renderHook(() =>
+      useDescribeAlarmModels({
+        iotEventsClient: iotEventsClientMock,
+        requests: [],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current.length).toBe(0));
+
+    expect(describeAlarmModelMock).not.toBeCalled();
+  });
+
+  it('should disable query when undefined alarmModelName passed into useDescribeAlarmModels', async () => {
+    describeAlarmModelMock.mockResolvedValue({});
+    const { result: queriesResult } = renderHook(() =>
+      useDescribeAlarmModels({
+        iotEventsClient: iotEventsClientMock,
+        requests: [
+          { alarmModelName: MOCK_ALARM_MODEL_NAME },
+          undefined,
+          { alarmModelName: MOCK_ALARM_MODEL_NAME_2 },
+        ],
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isSuccess).toBe(true));
+    await waitFor(() => {
+      expect(queriesResult.current[1].fetchStatus).toBe('idle');
+      expect(queriesResult.current[1].isPending).toBe(true);
+      expect(queriesResult.current[1].isLoading).toBe(false);
+    });
+    await waitFor(() => expect(queriesResult.current[2].isSuccess).toBe(true));
+
+    expect(describeAlarmModelMock).toBeCalledTimes(2);
+  });
+
+  it('should handle DescribeAlarmModel failure', async () => {
+    describeAlarmModelMock.mockRejectedValue(
+      new Error('DescribeAlarmModel failed')
+    );
+    const { result: queriesResult } = renderHook(() =>
+      useDescribeAlarmModels({
+        iotEventsClient: iotEventsClientMock,
+        requests: [{ alarmModelName: MOCK_ALARM_MODEL_NAME }],
+        retry: false,
+      })
+    );
+
+    await waitFor(() => expect(queriesResult.current[0].isError).toBe(true));
+  });
+});

--- a/packages/react-components/src/queries/useDescribeAlarmModels/useDescribeAlarmModels.ts
+++ b/packages/react-components/src/queries/useDescribeAlarmModels/useDescribeAlarmModels.ts
@@ -1,0 +1,110 @@
+import { useMemo } from 'react';
+import {
+  DescribeAlarmModelRequest,
+  IoTEvents,
+  IoTEventsClient,
+} from '@aws-sdk/client-iot-events';
+import { DescribeAlarmModel } from '@iot-app-kit/core';
+import { QueryFunctionContext, useQueries } from '@tanstack/react-query';
+import invariant from 'tiny-invariant';
+import { queryClient } from '../queryClient';
+import { DescribeAlarmModelCacheKeyFactory } from './describeAlarmModelQueryKeyFactory';
+import { hasRequestFunction, isAlarmModelId } from '../predicates';
+import { useIoTEventsClient } from '../../hooks/requestFunctions/useIoTEventsClient';
+import { QueryOptionsGlobal } from '../common/types';
+
+export type UseDescribeAlarmModelsOptions = {
+  iotEventsClient?: IoTEventsClient | IoTEvents;
+  requests?: (DescribeAlarmModelRequest | undefined)[];
+} & QueryOptionsGlobal;
+
+/**
+ * useDescribeAlarmModels is a hook to call IoT Events DescribeAlarmModel on a list of alarmModelNames
+ * to retrieve the last version of the alarmModels
+ * AlarmModelNames may not be defined in the list, which will disable its query
+ *
+ * @param iotEventsClient is an AWS SDK IoT Events client
+ * @param alarmModelNames is a list of alarmModelNames where IoT Events DescribeAlarmModel API is called on each
+ * @returns list of tanstack query results with a DescribeAlarmModelResponse
+ */
+export function useDescribeAlarmModels({
+  iotEventsClient,
+  requests = [],
+  retry,
+}: UseDescribeAlarmModelsOptions) {
+  const { describeAlarmModel } = useIoTEventsClient({
+    iotEventsClient,
+  });
+
+  // Memoize the queries to ensure they don't rerun if the same alarmModelNames are used on a rerender
+  const queries = useMemo(
+    () =>
+      requests.map((describeAlarmModelRequest) => {
+        const cacheKeyFactory = new DescribeAlarmModelCacheKeyFactory({
+          ...describeAlarmModelRequest,
+        });
+        return {
+          enabled: isEnabled({
+            alarmModelName: describeAlarmModelRequest?.alarmModelName,
+            describeAlarmModel,
+          }),
+          queryKey: cacheKeyFactory.create(),
+          queryFn: createQueryFn(describeAlarmModel),
+          retry,
+        };
+      }),
+    [requests, describeAlarmModel, retry]
+  );
+
+  return useQueries({ queries }, queryClient);
+}
+
+// Query is enabled if both an alarmModelName and describeAlarmModel request function is available
+const isEnabled = ({
+  alarmModelName,
+  describeAlarmModel,
+}: {
+  alarmModelName?: string;
+  describeAlarmModel?: DescribeAlarmModel;
+}) =>
+  isAlarmModelId(alarmModelName) &&
+  hasRequestFunction<DescribeAlarmModel>(describeAlarmModel);
+
+// Query function calls describeAlarmModel with the given assetModelName and request function
+const createQueryFn = (describeAlarmModel?: DescribeAlarmModel) => {
+  return async ({
+    queryKey: [{ alarmModelName, alarmModelVersion }],
+    signal,
+  }: QueryFunctionContext<
+    ReturnType<DescribeAlarmModelCacheKeyFactory['create']>
+  >) => {
+    invariant(
+      hasRequestFunction<DescribeAlarmModel>(describeAlarmModel),
+      'Expected client with DescribeAlarmModel to be defined as required by the enabled flag.'
+    );
+
+    invariant(
+      isAlarmModelId(alarmModelName),
+      'Expected alarmModelName to be defined as required by the enabled flag.'
+    );
+    try {
+      return await describeAlarmModel(
+        { alarmModelName, alarmModelVersion },
+        { abortSignal: signal }
+      );
+    } catch (error) {
+      handleError({ alarmModelName, alarmModelVersion }, error);
+    }
+  };
+};
+
+const handleError = (
+  request: DescribeAlarmModelRequest,
+  error: unknown
+): never => {
+  console.error(`Failed to describe alarm model. Error: ${error}`);
+  console.info('Request input:');
+  console.table(request);
+
+  throw error;
+};

--- a/packages/react-components/src/queries/useDescribeAssetModels/useDescribeAssetModels.ts
+++ b/packages/react-components/src/queries/useDescribeAssetModels/useDescribeAssetModels.ts
@@ -11,7 +11,7 @@ import { queryClient } from '../queryClient';
 import { DescribeAssetModelCacheKeyFactory } from './describeAssetModelQueryKeyFactory';
 import { hasRequestFunction, isAssetModelId } from '../predicates';
 import { useIoTSiteWiseClient } from '../../hooks/requestFunctions/useIoTSiteWiseClient';
-import { QueryOptionsGlobal } from '../useLatestAssetPropertyValues';
+import { QueryOptionsGlobal } from '../common/types';
 
 export type UseDescribeAssetModelsOptions = {
   iotSiteWiseClient?: IoTSiteWiseClient | IoTSiteWise;

--- a/packages/react-components/src/queries/useDescribeAssets/useDescribeAssets.ts
+++ b/packages/react-components/src/queries/useDescribeAssets/useDescribeAssets.ts
@@ -11,7 +11,7 @@ import { DescribeAssetCacheKeyFactory } from '../useDescribeAsset/describeAssetQ
 import { queryClient } from '../queryClient';
 import { hasRequestFunction, isAssetId } from '../predicates';
 import { useIoTSiteWiseClient } from '../../hooks/requestFunctions/useIoTSiteWiseClient';
-import { QueryOptionsGlobal } from '../useLatestAssetPropertyValues';
+import { QueryOptionsGlobal } from '../common/types';
 
 export type UseDescribeAssetsOptions = {
   iotSiteWiseClient?: IoTSiteWiseClient | IoTSiteWise;

--- a/packages/react-components/src/queries/useHistoricalAssetPropertyValues/types.ts
+++ b/packages/react-components/src/queries/useHistoricalAssetPropertyValues/types.ts
@@ -6,7 +6,7 @@ import {
   Viewport,
 } from '@iot-app-kit/core';
 import { UseIoTSiteWiseClientOptions } from '../../hooks/requestFunctions/useIoTSiteWiseClient';
-import { UseQueryOptions } from '@tanstack/react-query';
+import { QueryOptionsGlobal } from '../common/types';
 
 export type QueryFnClient = {
   getAssetPropertyValueHistory?: GetAssetPropertyValueHistory;
@@ -20,8 +20,6 @@ export type HistoricalAssetPropertyValueRequest = Omit<
 
 export type HistoricalAssetPropertyValueResponse =
   RequestResponse<GetAssetPropertyValueHistory>;
-
-export type QueryOptionsGlobal = Pick<UseQueryOptions, 'retry'>;
 
 export type UseHistoricalAssetPropertyValuesOptions =
   UseIoTSiteWiseClientOptions & {

--- a/packages/react-components/src/queries/useLatestAssetPropertyValues/types.ts
+++ b/packages/react-components/src/queries/useLatestAssetPropertyValues/types.ts
@@ -5,7 +5,7 @@ import {
   RequestResponse,
 } from '@iot-app-kit/core';
 import { UseIoTSiteWiseClientOptions } from '../../hooks/requestFunctions/useIoTSiteWiseClient';
-import { UseQueryOptions } from '@tanstack/react-query';
+import { QueryOptionsGlobal } from '../common/types';
 
 export type QueryFnClient = {
   getAssetPropertyValue?: GetAssetPropertyValue;
@@ -16,8 +16,6 @@ export type LatestAssetPropertyValueRequest =
   RequestParameters<GetAssetPropertyValue>;
 export type LatestAssetPropertyValueResponse =
   RequestResponse<GetAssetPropertyValue>;
-
-export type QueryOptionsGlobal = Pick<UseQueryOptions, 'retry'>;
 
 export type UseLatestAssetPropertyValuesOptions =
   UseIoTSiteWiseClientOptions & {

--- a/packages/react-components/src/testing/alarms/index.ts
+++ b/packages/react-components/src/testing/alarms/index.ts
@@ -3,3 +3,5 @@ export * from './mockCompositeModels';
 export * from './mockIds';
 export * from './mockProperties';
 export * from './mockSiteWiseClient';
+export * from './mockEventsClient';
+export * from './mockAlarmModel';

--- a/packages/react-components/src/testing/alarms/mockAlarmData.ts
+++ b/packages/react-components/src/testing/alarms/mockAlarmData.ts
@@ -1,5 +1,10 @@
 import { AlarmData } from '../../hooks/useAlarms';
 import {
+  mockAlarmModel,
+  mockAlarmModel2,
+  mockAlarmModelArn,
+} from './mockAlarmModel';
+import {
   MOCK_ASSET_ID,
   MOCK_ASSET_MODEL_ID,
   MOCK_COMPOSITE_MODEL_ID,
@@ -8,17 +13,18 @@ import {
   MOCK_COMPOSITE_MODEL_NAME_2,
 } from './mockIds';
 import {
-  mockDefaultAlarmSource,
   mockDefaultAlarmState,
   mockDefaultAlarmType,
   mockSourceAssetModelProperty,
   mockSourceAssetProperty,
   mockSourceAssetProperty2,
   mockSourceAssetPropertyValue,
+  mockSourceAssetPropertyValue2,
   mockStateAssetModelProperty,
   mockStateAssetProperty,
   mockStateAssetProperty2,
   mockStateAssetPropertyValue,
+  mockStateAssetPropertyValue2,
   mockTypeAssetModelProperty,
   mockTypeAssetProperty,
   mockTypeAssetProperty2,
@@ -100,7 +106,7 @@ export const mockAlarmDataDescribeAssetModel: AlarmData = {
     data: [
       {
         value: {
-          stringValue: mockDefaultAlarmSource,
+          stringValue: mockAlarmModelArn,
         },
         timestamp: undefined,
       },
@@ -128,4 +134,29 @@ export const mockAlarmDataGetAssetPropertyValue: AlarmData = {
     property: mockSourceAssetProperty,
     data: [mockSourceAssetPropertyValue],
   },
+};
+
+export const mockAlarmDataGetAssetPropertyValue2: AlarmData = {
+  ...mockAlarmDataDescribeAsset2,
+  state: {
+    property: mockStateAssetProperty2,
+    data: [mockStateAssetPropertyValue2],
+  },
+  type: {
+    property: mockTypeAssetProperty2,
+    data: [mockTypeAssetPropertyValue],
+  },
+  source: {
+    property: mockSourceAssetProperty2,
+    data: [mockSourceAssetPropertyValue2],
+  },
+};
+
+export const mockAlarmDataDescribeAlarmModel: AlarmData = {
+  ...mockAlarmDataGetAssetPropertyValue,
+  models: [mockAlarmModel],
+};
+export const mockAlarmDataDescribeAlarmModel2: AlarmData = {
+  ...mockAlarmDataGetAssetPropertyValue2,
+  models: [mockAlarmModel2],
 };

--- a/packages/react-components/src/testing/alarms/mockAlarmModel.ts
+++ b/packages/react-components/src/testing/alarms/mockAlarmModel.ts
@@ -1,0 +1,45 @@
+import { DescribeAlarmModelResponse } from '@aws-sdk/client-iot-events';
+import {
+  MOCK_ALARM_INPUT_PROPERTY_ID,
+  MOCK_ALARM_INPUT_PROPERTY_ID_2,
+} from './mockIds';
+
+export const MOCK_ALARM_MODEL_NAME = 'alarmModelName';
+export const MOCK_ALARM_MODEL_NAME_2 = 'alarmModelName2';
+
+export const mockAlarmModelArn = `arn:aws:iotevents:us-east-1:123456789012:alarmModel/${MOCK_ALARM_MODEL_NAME}`;
+export const mockAlarmModelArn2 = `arn:aws:iotevents:us-east-1:123456789012:alarmModel/${MOCK_ALARM_MODEL_NAME_2}`;
+
+export const mockAlarmModel: DescribeAlarmModelResponse = {
+  alarmModelArn: mockAlarmModelArn,
+  alarmModelVersion: '1',
+  creationTime: new Date(),
+  lastUpdateTime: new Date(),
+  status: 'ACTIVE',
+  alarmModelName: MOCK_ALARM_MODEL_NAME,
+  severity: 1,
+  alarmRule: {
+    simpleRule: {
+      inputProperty: `$sitewise.assetModel.\`f6dca270-d4b9-4de0-9722-d57d3f260cb8\`.\`${MOCK_ALARM_INPUT_PROPERTY_ID}\`.propertyValue.value`,
+      comparisonOperator: 'GREATER',
+      threshold: '30',
+    },
+  },
+};
+
+export const mockAlarmModel2: DescribeAlarmModelResponse = {
+  alarmModelArn: mockAlarmModelArn2,
+  alarmModelVersion: '1',
+  creationTime: new Date(),
+  lastUpdateTime: new Date(),
+  status: 'ACTIVE',
+  alarmModelName: MOCK_ALARM_MODEL_NAME_2,
+  severity: 1,
+  alarmRule: {
+    simpleRule: {
+      inputProperty: `$sitewise.assetModel.\`f6dca270-d4b9-4de0-9722-d57d3f260cb8\`.\`${MOCK_ALARM_INPUT_PROPERTY_ID_2}\`.propertyValue.value`,
+      comparisonOperator: 'GREATER',
+      threshold: '30',
+    },
+  },
+};

--- a/packages/react-components/src/testing/alarms/mockEventsClient.ts
+++ b/packages/react-components/src/testing/alarms/mockEventsClient.ts
@@ -1,0 +1,6 @@
+import { IoTEvents } from '@aws-sdk/client-iot-events';
+
+export const describeAlarmModelMock = jest.fn();
+export const iotEventsClientMock = {
+  describeAlarmModel: describeAlarmModelMock,
+} as unknown as IoTEvents;

--- a/packages/react-components/src/testing/alarms/mockIds.ts
+++ b/packages/react-components/src/testing/alarms/mockIds.ts
@@ -10,4 +10,7 @@ export const MOCK_COMPOSITE_MODEL_ID_2 = 'assetCompositeModelId2';
 export const MOCK_COMPOSITE_MODEL_NAME = 'assetCompositeModelName';
 export const MOCK_COMPOSITE_MODEL_NAME_2 = 'assetCompositeModelName2';
 
-export const MOCK_ALARM_INPUT_PROPERTY_ID = 'inputPropertyId';
+export const MOCK_ALARM_INPUT_PROPERTY_ID =
+  '00b36ed5-7640-4635-b9d3-60c2db229568';
+export const MOCK_ALARM_INPUT_PROPERTY_ID_2 =
+  'e5c9a4f6-4c3c-4d5c-bceb-cb7a1ed1d042';

--- a/packages/react-components/src/testing/alarms/mockProperties.ts
+++ b/packages/react-components/src/testing/alarms/mockProperties.ts
@@ -8,7 +8,11 @@ import {
   ALARM_STATE_PROPERTY_NAME,
   ALARM_TYPE_PROPERTY_NAME,
 } from '../../hooks/useAlarms/constants';
-import { MOCK_ALARM_INPUT_PROPERTY_ID } from './mockIds';
+import {
+  MOCK_ALARM_INPUT_PROPERTY_ID,
+  MOCK_ALARM_INPUT_PROPERTY_ID_2,
+} from './mockIds';
+import { mockAlarmModelArn, mockAlarmModelArn2 } from './mockAlarmModel';
 
 export const mockStateAssetProperty: AssetProperty = {
   id: 'stateId',
@@ -47,6 +51,7 @@ export const mockSourceAssetProperty2: AssetProperty = {
 };
 
 export const mockDefaultAlarmState = 'NORMAL';
+export const mockDefaultAlarmState2 = 'ACTIVE';
 export const mockStateAssetModelProperty: AssetModelProperty = {
   ...mockStateAssetProperty,
   type: {
@@ -66,12 +71,11 @@ export const mockTypeAssetModelProperty: AssetModelProperty = {
   },
 };
 
-export const mockDefaultAlarmSource = 'alarmModelArn';
 export const mockSourceAssetModelProperty: AssetModelProperty = {
   ...mockSourceAssetProperty,
   type: {
     attribute: {
-      defaultValue: mockDefaultAlarmSource,
+      defaultValue: mockAlarmModelArn,
     },
   },
 };
@@ -79,6 +83,12 @@ export const mockSourceAssetModelProperty: AssetModelProperty = {
 export const mockInputProperty: AssetProperty = {
   id: MOCK_ALARM_INPUT_PROPERTY_ID,
   name: 'inputPropertyName',
+  dataType: 'STRING',
+};
+
+export const mockInputProperty2: AssetProperty = {
+  id: MOCK_ALARM_INPUT_PROPERTY_ID_2,
+  name: 'inputPropertyName2',
   dataType: 'STRING',
 };
 
@@ -100,4 +110,9 @@ export const mockStateAssetPropertyValue: AssetPropertyValue =
 export const mockTypeAssetPropertyValue: AssetPropertyValue =
   mockStringAssetPropertyValue(mockDefaultAlarmType);
 export const mockSourceAssetPropertyValue: AssetPropertyValue =
-  mockStringAssetPropertyValue(mockDefaultAlarmSource);
+  mockStringAssetPropertyValue(mockAlarmModelArn);
+
+export const mockStateAssetPropertyValue2: AssetPropertyValue =
+  mockStringAssetPropertyValue(mockDefaultAlarmState2);
+export const mockSourceAssetPropertyValue2: AssetPropertyValue =
+  mockStringAssetPropertyValue(mockAlarmModelArn2);

--- a/packages/react-components/stories/queries/queriesBase.stories.tsx
+++ b/packages/react-components/stories/queries/queriesBase.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import type { FC } from 'react';
-import { getSiteWiseClient } from '@iot-app-kit/core-util';
+import { getIotEventsClient, getSiteWiseClient } from '@iot-app-kit/core-util';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import {
   queryClient,
@@ -38,6 +38,11 @@ const client = getSiteWiseClient({
   awsRegion: getRegion(),
 });
 
+const iotEventsClient = getIotEventsClient({
+  awsCredentials: getEnvCredentials(),
+  awsRegion: getRegion(),
+});
+
 const RenderQueries = ({ json }: { json: unknown }) => {
   return (
     <div>
@@ -66,6 +71,7 @@ export default {
 export const UseAlarms: ComponentStory<FC> = () => {
   const alarmDataList = useAlarms({
     iotSiteWiseClient: client,
+    iotEventsClient,
     requests: [
       {
         assetId: ASSET_ID,


### PR DESCRIPTION
## Overview
Add useAlarmModels hook as an abstraction over useDescribeAlarmModels to fetch the latest IoT Events alarm model for an `IOT_EVENTS` alarm type. Hook injects the `DescribeAlarmModelResponse` into the running AlarmData list.

`useAlarms` calls this hook after the asset, assetModel, and latest alarm asset property values are fetched. The IoT Events alarm model ARN is found in the alarm source asset property. 

After the alarm models are fetched we need to handle the use case where the `AlarmRequest` has an `assetId` and `inputPropertyId` ("find all alarms associated with an inputProperty on an asset)
* `useAlarmAssets` will fetch alarms for requests assets and assetModels. If there is an `inputPropertyId` in the request the `AlarmData.inputProperty` field is filled in with the AssetProperty or AssetModelProperty for that inputProperty. All alarms for an asset/model are returned from the hook since we can't find which alarm is associated with the inputProperty until we get the IoT Events alarm model
* After we fetch the alarm models we can filter out the AlarmData where the inputProperty field does not match with the alarm model inputProperty

## Verifying Changes

Added unit tests and ran in storybook to see alarm output successfully in all AlarmRequest use cases.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
