### PR TITLE
fix(dashboard-dynamic-asset): asset name should be shown on refresh in dropdown

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelDataStreamExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelDataStreamExplorer.tsx
@@ -81,7 +81,6 @@ export const AssetModelDataStreamExplorer = ({
           } as AssetResource,
         ]
       : createInitialAssetResource(assetIds?.at(0))
-    // createInitialAssetResource(assetIds?.at(0))
   );
 
   const [selectedAssetModelProperties, selectAssetModelProperties] =
@@ -96,6 +95,16 @@ export const AssetModelDataStreamExplorer = ({
   useEffect(() => {
     updateSelectedAsset(selectedAsset[0]);
   }, [updateSelectedAsset, selectedAsset]);
+
+  useEffect(() => {
+    if (currentSelectedAsset)
+      selectAsset([
+        {
+          ...currentSelectedAsset,
+          assetId: currentSelectedAsset?.id,
+        } as AssetResource,
+      ]);
+  }, [currentSelectedAsset, selectAsset]);
 
   const onReset = () => {
     selectAssetModel([]);


### PR DESCRIPTION
## Overview
When a page is refreshed, the asset selection dropdown would show the asset id instead of the name. To get the name, we are currently filtering based on ID after calling a describe asset model call. Initially, the call returns undefined. 

Added a useEffect call to update selected asset once API call provides data. 

## Verifying Changes


https://github.com/user-attachments/assets/2572a051-8b63-44d2-aa4b-9dea8864ace9





## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
