### PR TITLE
fix(timeZone): wrap timezone setState in useEffect

### DIFF
--- a/packages/react-components/src/components/anomaly-chart/index.tsx
+++ b/packages/react-components/src/components/anomaly-chart/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { AnomalyChartOptions } from './types';
 import {
   AnomalyObjectDataSourceTransformer,
@@ -68,8 +68,10 @@ export const AnomalyChart = (options: AnomalyChartOptions) => {
     timeZone,
   });
 
-  // Set timezone for use in sub components
-  useDataStore.getState().setTimeZone(timeZone);
+  useEffect(() => {
+    // Set timezone for use in sub components
+    useDataStore.getState().setTimeZone(timeZone);
+  }, [timeZone]);
 
   return (
     <div

--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import type { MouseEvent } from 'react';
 import {
   colorBorderDividerSecondary,
@@ -64,8 +64,10 @@ const BaseChart = ({
   timeZone,
   ...options
 }: ChartOptions) => {
-  // Set timezone for use in sub components
-  useDataStore.getState().setTimeZone(timeZone);
+  useEffect(() => {
+    // Set timezone for use in sub components
+    useDataStore.getState().setTimeZone(timeZone);
+  }, [timeZone]);
 
   const {
     visible: dataQualityPreferencesVisible,


### PR DESCRIPTION
## Overview
* Fix for console error `Cannot update a component ('Timestamp') while rendering a different component ('BaseChart')
To locate the bad setState() call inside 'BaseChart', follow the stack trace`
* Wrap `setState` call for timezone in `useEffect`

## Verifying Changes
* Load a dashboard with data, confirm in console you don't see the above error

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
