### PR TITLE
fix(resource-explorer): only use alias to query if present

### DIFF
--- a/packages/react-components/src/components/resource-explorers/requests/use-latest-values/create-request-entry-batches.ts
+++ b/packages/react-components/src/components/resource-explorers/requests/use-latest-values/create-request-entry-batches.ts
@@ -22,11 +22,18 @@ function createEntries<DataStream extends DataStreamResource>(
   const entries = dataStreams.map((dataStream) => {
     const entryId = createEntryId(dataStream);
 
-    return {
+    const baseEntry = {
       dataStream,
       entryId,
+    };
+
+    if (dataStream.alias) {
+      return { ...baseEntry, propertyAlias: dataStream.alias };
+    }
+
+    return {
+      ...baseEntry,
       assetId: dataStream.assetId,
-      propertyAlias: dataStream.alias,
       propertyId: dataStream.propertyId,
     };
   });


### PR DESCRIPTION
## Overview
Fix bug which prevents loading all properties if a single property has an alias 
before:
https://github.com/user-attachments/assets/8cb98696-4266-46f3-a31a-31a04fc8ec43

after:
https://github.com/user-attachments/assets/fe5c2a6e-b04b-4146-adb0-63c9c0dc34ef


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
