### PR TITLE
fix(alarms): return blank alarm data when queries are loading

### DIFF
--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/useAlarmAssets.spec.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/useAlarmAssets.spec.ts
@@ -87,6 +87,38 @@ describe('useAlarmAssets', () => {
     queryClient.clear();
   });
 
+  it('should have the correct status', async () => {
+    describeAssetMock.mockResolvedValue(
+      mockDescribeAssetResponse({ compositeModels: [mockAlarmCompositeModel] })
+    );
+
+    const alarmAssetRequest = {
+      assetId: MOCK_ASSET_ID,
+    };
+
+    const alarmCompositeModelRequest = {
+      assetId: MOCK_ASSET_ID,
+      assetCompositeModelId: MOCK_COMPOSITE_MODEL_ID,
+    };
+
+    const { result: alarmDataResults } = renderHook(() =>
+      useAlarmAssets({
+        iotSiteWiseClient: iotSiteWiseClientMock,
+        requests: [alarmAssetRequest, alarmCompositeModelRequest],
+      })
+    );
+
+    await waitFor(() => {
+      expect(alarmDataResults.current[0].status.isLoading).toBe(true);
+      expect(alarmDataResults.current[1].status.isLoading).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(alarmDataResults.current[0].status.isSuccess).toBe(true);
+      expect(alarmDataResults.current[1].status.isSuccess).toBe(true);
+    });
+  });
+
   it('should return AlarmData with content for one alarm in an alarm composite model request', async () => {
     describeAssetMock.mockResolvedValue(
       mockDescribeAssetResponse({ compositeModels: [mockAlarmCompositeModel] })

--- a/packages/react-components/src/hooks/useAlarms/utils/alarmDataUtils.ts
+++ b/packages/react-components/src/hooks/useAlarms/utils/alarmDataUtils.ts
@@ -27,10 +27,18 @@ export const buildFromAssetResponse = ({
   status: AlarmDataStatus;
   assetResponse?: DescribeAssetResponse;
 }): AlarmData[] => {
-  const { assetId, assetCompositeModelId, inputPropertyId } = request;
+  const { assetId, assetCompositeModelId, inputPropertyId, assetModelId } =
+    request;
 
   if (!assetResponse || !assetId) {
-    return [];
+    return [
+      {
+        assetModelId,
+        assetId,
+        compositeModelId: assetCompositeModelId,
+        status,
+      },
+    ];
   }
 
   if (assetResponse && assetId && assetResponse?.assetId !== assetId) {
@@ -113,7 +121,12 @@ export const buildFromAssetModelResponse = ({
   const { assetModelId } = request;
 
   if (!assetModelResponse || !assetModelId) {
-    return [];
+    return [
+      {
+        assetModelId,
+        status,
+      },
+    ];
   }
 
   if (assetModelId && assetModelResponse?.assetModelId !== assetModelId) {


### PR DESCRIPTION
## Overview
Bugfix for `useAlarmAssets`. If the `useDescribeAssets / useDescribeAssetModels` queries were loading for the first time, their response will be undefined. In that case, we were not returning any AlarmData objects. This means that we could not correctly access the `isLoading` flags. The hook will now return an empty AlarmData object with the query status if the `useDescribeAssets / useDescribeAssetModels` queries responses are undefined. 

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
