### PR TITLE
feat(alarms): add alarm resource explorer

### DIFF
--- a/packages/react-components/src/components/resource-explorers/constants/defaults.ts
+++ b/packages/react-components/src/components/resource-explorers/constants/defaults.ts
@@ -39,6 +39,8 @@ export const DEFAULT_PLURAL_ASSET_PROPERTY_RESOURCE_NAME: PluralResourceName =
 export const DEFAULT_TIME_SERIES_RESOURCE_NAME: ResourceName = 'Time series';
 export const DEFAULT_PLURAL_TIME_SERIES_RESOURCE_NAME: PluralResourceName =
   'Time series';
+export const DEFAULT_ALARM_RESOURCE_NAME: ResourceName = 'Alarm';
+export const DEFAULT_PLURAL_ALARM_RESOURCE_NAME: PluralResourceName = 'Alarms';
 
 export const DEFAULT_IS_RESOURCE_DISABLED: IsResourceDisabled<unknown> = () =>
   false;

--- a/packages/react-components/src/components/resource-explorers/constants/drop-down-resource-definitions.ts
+++ b/packages/react-components/src/components/resource-explorers/constants/drop-down-resource-definitions.ts
@@ -1,5 +1,6 @@
 import type { DropDownResourceDefinition } from '../types/drop-down';
 import type {
+  AlarmResource,
   AssetModelResource,
   AssetPropertyResource,
   AssetResource,
@@ -23,6 +24,12 @@ export const DEFAULT_ASSET_DROP_DOWN_DEFINITION: DropDownResourceDefinition<Asse
 export const DEFAULT_ASSET_PROPERTY_DROP_DOWN_DEFINITION: DropDownResourceDefinition<AssetPropertyResource> =
   {
     selectResourceId: ({ propertyId }) => propertyId,
+    renderResourceName: ({ name }) => name,
+  };
+
+export const DEFAULT_ALARM_DROP_DOWN_DEFINITION: DropDownResourceDefinition<AlarmResource> =
+  {
+    selectResourceId: ({ assetCompositeModelId }) => assetCompositeModelId,
     renderResourceName: ({ name }) => name,
   };
 

--- a/packages/react-components/src/components/resource-explorers/constants/table-resource-definitions.ts
+++ b/packages/react-components/src/components/resource-explorers/constants/table-resource-definitions.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_STRING_FILTER_OPERATORS } from './defaults';
 import type {
+  AlarmResource,
   AssetModelResource,
   AssetPropertyResource,
   AssetPropertyResourceWithLatestValue,
@@ -118,6 +119,61 @@ export const DEFAULT_ASSET_PROPERTY_TABLE_DEFINITION: TableResourceDefinition<As
       name: 'Alias',
       pluralName: 'Aliases',
       render: ({ alias }) => alias,
+      defaultIsVisible: false,
+      filterOperators: DEFAULT_STRING_FILTER_OPERATORS,
+    },
+  ];
+
+export const ALARM_TABLE_ASSET_ID_DEFINITION: TableResourceDefinition<AlarmResource> =
+  [
+    {
+      id: 'asset',
+      name: 'Asset ID',
+      pluralName: 'Asset IDs',
+      render: ({ assetId }) => assetId,
+      defaultIsVisible: false,
+      filterOperators: DEFAULT_STRING_FILTER_OPERATORS,
+    },
+  ];
+
+export const DEFAULT_ALARM_TABLE_DEFINITION: TableResourceDefinition<AlarmResource> =
+  [
+    {
+      id: 'name',
+      name: 'Name',
+      pluralName: 'Names',
+      render: ({ name }) => name,
+      filterOperators: DEFAULT_STRING_FILTER_OPERATORS,
+    },
+    {
+      id: 'id',
+      name: 'ID',
+      pluralName: 'IDs',
+      render: ({ assetCompositeModelId }) => assetCompositeModelId,
+      defaultIsVisible: false,
+      filterOperators: DEFAULT_STRING_FILTER_OPERATORS,
+    },
+    {
+      id: 'input-property-name',
+      name: 'Input Property Name',
+      pluralName: 'Input Property Names',
+      render: ({ inputPropertyName }) => inputPropertyName,
+      defaultIsVisible: false,
+      filterOperators: DEFAULT_STRING_FILTER_OPERATORS,
+    },
+    {
+      id: 'input-property-id',
+      name: 'Input Property ID',
+      pluralName: 'Input Property IDs',
+      render: ({ inputPropertyId }) => inputPropertyId,
+      defaultIsVisible: false,
+      filterOperators: DEFAULT_STRING_FILTER_OPERATORS,
+    },
+    {
+      id: 'asset-model',
+      name: 'Asset Model ID',
+      pluralName: 'Asset Model IDs',
+      render: ({ assetModelId }) => assetModelId,
       defaultIsVisible: false,
       filterOperators: DEFAULT_STRING_FILTER_OPERATORS,
     },

--- a/packages/react-components/src/components/resource-explorers/explorers/alarm-explorer/alarm-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/alarm-explorer/alarm-explorer.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { I18nProvider } from '@cloudscape-design/components/i18n';
+import messages from '@cloudscape-design/components/i18n/messages/all.all';
+
+import { InternalAlarmExplorer } from './internal-alarm-explorer';
+import type { AlarmExplorerProps } from './types';
+
+/**
+ * Explore and select IoT SiteWise alarm resources.
+ * This explorer will be able to handle displaying
+ * alarm resources by assetModel paramater or by
+ * assetId parameters
+ *
+ * @experimental Do not use in production.
+ */
+export function AlarmExplorer(alarmExplorerProps: AlarmExplorerProps) {
+  return (
+    <I18nProvider locale='en' messages={[messages]}>
+      <InternalAlarmExplorer {...alarmExplorerProps} />
+    </I18nProvider>
+  );
+}

--- a/packages/react-components/src/components/resource-explorers/explorers/alarm-explorer/index.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/alarm-explorer/index.ts
@@ -1,0 +1,2 @@
+export { AlarmExplorer } from './alarm-explorer';
+export type { AlarmExplorerProps } from './types';

--- a/packages/react-components/src/components/resource-explorers/explorers/alarm-explorer/internal-alarm-explorer.tsx
+++ b/packages/react-components/src/components/resource-explorers/explorers/alarm-explorer/internal-alarm-explorer.tsx
@@ -1,0 +1,202 @@
+import React, { useMemo } from 'react';
+import { noop } from 'lodash';
+
+import type {
+  AlarmByAssetRequestParameters,
+  AlarmExplorerProps,
+  AlarmResourcesRequestParameters,
+} from './types';
+import {
+  ResourceDropDown,
+  ResourceTable,
+  ResourceExplorerVariant,
+} from '../../variants';
+import {
+  DEFAULT_DEFAULT_PAGE_SIZE,
+  DEFAULT_IS_RESOURCE_DISABLED,
+  DEFAULT_IS_TABLE_FILTER_ENABLED,
+  DEFAULT_IS_TABLE_SEARCH_ENABLED,
+  DEFAULT_IS_TABLE_ENABLED,
+  DEFAULT_IS_TABLE_USER_SETTINGS_ENABLED,
+  DEFAULT_ON_SELECT_RESOURCE,
+  DEFAULT_RESOURCE_EXPLORER_VARIANT,
+  DEFAULT_SELECTED_RESOURCES,
+  DEFAULT_SELECTION_MODE,
+  DEFAULT_SHOULD_PERSIST_USER_CUSTOMIZATION,
+  createDefaultTableUserSettings,
+  DEFAULT_ALARM_RESOURCE_NAME,
+  DEFAULT_PLURAL_ALARM_RESOURCE_NAME,
+  latestValueTimeCellRenderer,
+  latestValueCellRenderer,
+} from '../../constants/defaults';
+import { AlarmResourceWithLatestValue } from '../../types/resources';
+import {
+  ALARM_TABLE_ASSET_ID_DEFINITION,
+  DEFAULT_ALARM_TABLE_DEFINITION,
+  createDefaultLatestValuesTableDefinition,
+} from '../../constants/table-resource-definitions';
+import { DEFAULT_ALARM_DROP_DOWN_DEFINITION } from '../../constants/drop-down-resource-definitions';
+import { useUserCustomization } from '../../helpers/use-user-customization';
+import { TableResourceDefinition } from '../../types/table';
+import { useAlarms } from '../../../../hooks/useAlarms';
+import { isAlarmResource, transformAlarmData } from './transformAlarmData';
+
+export function InternalAlarmExplorer({
+  iotSiteWiseClient,
+  iotEventsClient,
+  parameters = [],
+  shouldPersistUserCustomization = DEFAULT_SHOULD_PERSIST_USER_CUSTOMIZATION,
+  defaultPageSize = DEFAULT_DEFAULT_PAGE_SIZE,
+  variant = DEFAULT_RESOURCE_EXPLORER_VARIANT,
+  resourceName = DEFAULT_ALARM_RESOURCE_NAME,
+  pluralResourceName = DEFAULT_PLURAL_ALARM_RESOURCE_NAME,
+  isAlarmDisabled = DEFAULT_IS_RESOURCE_DISABLED,
+  selectedAlarms = DEFAULT_SELECTED_RESOURCES,
+  onSelectAlarm = DEFAULT_ON_SELECT_RESOURCE,
+  selectionMode = DEFAULT_SELECTION_MODE,
+  tableResourceDefinition: customTableResourceDefinition,
+  defaultTableUserSettings: customDefaultTableUserSettings,
+  tableSettings: {
+    isTitleEnabled = DEFAULT_IS_TABLE_ENABLED,
+    isSearchEnabled = DEFAULT_IS_TABLE_SEARCH_ENABLED,
+    isFilterEnabled: isTableFilterEnabled = DEFAULT_IS_TABLE_FILTER_ENABLED,
+    isUserSettingsEnabled = DEFAULT_IS_TABLE_USER_SETTINGS_ENABLED,
+  } = {},
+  dropDownResourceDefinition = DEFAULT_ALARM_DROP_DOWN_DEFINITION,
+  dropDownSettings: { isFilterEnabled: isDropDownFilterEnabled = false } = {},
+  ariaLabels,
+  description = '',
+  timeZone,
+  significantDigits,
+}: AlarmExplorerProps) {
+  const requests = useMemo(
+    () =>
+      isAlarmByAssetRequestParameters(parameters)
+        ? parameters.map((p) => ({ assetId: p.assetId }))
+        : parameters.map((p) => ({ assetModelId: p.assetModelId })),
+    [parameters]
+  );
+
+  const alarms = useAlarms({
+    iotEventsClient,
+    iotSiteWiseClient,
+    requests,
+    transform: transformAlarmData,
+    settings: {
+      fetchOnlyLatest: true,
+      refreshRate: 5000,
+    },
+  });
+
+  const alarmResources = useMemo(
+    () => alarms.map(({ resource }) => resource).filter(isAlarmResource),
+    [alarms]
+  );
+
+  const isLoading = useMemo(
+    () => alarms.some(({ status }) => status.isLoading),
+    [alarms]
+  );
+
+  const error = useMemo(() => {
+    const isError = alarms.some(({ status }) => status.isError);
+
+    if (!isError) return null;
+
+    // TODO: Will use error from hook once api is finalized
+    return new Error('Error loading SiteWise alarms.');
+  }, [alarms]);
+
+  const alarmAssetRequestTableDefinition = isAlarmByAssetRequestParameters(
+    parameters
+  )
+    ? [
+        ...ALARM_TABLE_ASSET_ID_DEFINITION,
+        ...createDefaultLatestValuesTableDefinition(
+          latestValueTimeCellRenderer(timeZone),
+          latestValueCellRenderer(significantDigits)
+        ),
+      ]
+    : [];
+
+  const tableResourceDefinition =
+    customTableResourceDefinition ??
+    ([
+      ...DEFAULT_ALARM_TABLE_DEFINITION,
+      ...alarmAssetRequestTableDefinition,
+    ] as TableResourceDefinition<AlarmResourceWithLatestValue>);
+
+  const defaultTableUserSettings =
+    customDefaultTableUserSettings ??
+    createDefaultTableUserSettings(tableResourceDefinition);
+
+  const [userCustomization, setUserCutomization] = useUserCustomization({
+    resourceName,
+    defaultPageSize,
+    defaultTableUserSettings,
+    shouldPersistUserCustomization,
+  });
+
+  return (
+    <ResourceExplorerVariant
+      variant={variant}
+      table={
+        <ResourceTable
+          resourceName={resourceName}
+          pluralResourceName={pluralResourceName}
+          resourceDefinition={tableResourceDefinition}
+          resources={alarmResources}
+          createResourceKey={createResourceKey}
+          isResourceDisabled={isAlarmDisabled}
+          isLoading={isLoading}
+          error={error}
+          selectionMode={selectionMode}
+          selectedResources={selectedAlarms}
+          onSelectResource={onSelectAlarm}
+          onClickNextPage={noop}
+          userCustomization={userCustomization}
+          onUpdateUserCustomization={setUserCutomization}
+          isTitleEnabled={isTitleEnabled}
+          isSearchEnabled={isSearchEnabled}
+          isFilterEnabled={isTableFilterEnabled}
+          isUserSettingsEnabled={isUserSettingsEnabled}
+          ariaLabels={ariaLabels}
+          description={description}
+        />
+      }
+      dropDown={
+        <ResourceDropDown
+          resourceName={resourceName}
+          pluralResourceName={pluralResourceName}
+          resourceDefinition={dropDownResourceDefinition}
+          resources={alarmResources}
+          isResourceDisabled={isAlarmDisabled}
+          isLoading={isLoading}
+          error={error}
+          selectionMode={selectionMode}
+          selectedResources={selectedAlarms}
+          onSelectResource={onSelectAlarm}
+          hasNextPage={false}
+          onScrollNextPage={noop}
+          isFilterEnabled={isDropDownFilterEnabled}
+        />
+      }
+    />
+  );
+}
+
+function createResourceKey({
+  assetId,
+  assetCompositeModelId,
+}: AlarmResourceWithLatestValue): string {
+  return `${assetId}-${assetCompositeModelId}`;
+}
+
+function isAlarmByAssetRequestParameters(
+  parameters: AlarmResourcesRequestParameters
+): parameters is readonly AlarmByAssetRequestParameters[] {
+  return (
+    parameters[0] !== undefined &&
+    Boolean((parameters[0] as AlarmByAssetRequestParameters).assetId)
+  );
+}

--- a/packages/react-components/src/components/resource-explorers/explorers/alarm-explorer/transformAlarmData.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/alarm-explorer/transformAlarmData.ts
@@ -1,0 +1,46 @@
+import { AlarmData, AlarmDataStatus } from '../../../../hooks/useAlarms';
+import { parseAlarmStateAssetProperty } from '../../../../hooks/useAlarms/transformers';
+import {
+  AlarmResource,
+  AlarmResourceWithLatestValue,
+} from '../../types/resources';
+
+export const transformAlarmData = ({
+  assetId,
+  assetModelId,
+  compositeModelId,
+  compositeModelName,
+  state,
+  status,
+  inputProperty,
+}: AlarmData): {
+  resource: Partial<AlarmResourceWithLatestValue>;
+  status: AlarmDataStatus;
+} => {
+  const latestState = parseAlarmStateAssetProperty(state?.data?.at(-1));
+
+  return {
+    resource: {
+      name: compositeModelName,
+      assetCompositeModelId: compositeModelId,
+      assetId,
+      assetModelId,
+      inputPropertyId: inputProperty?.at(0)?.id,
+      inputPropertyName: inputProperty?.at(0)?.name,
+      latestValue: latestState?.value.state,
+      // default latest value timestamp renderer uses seconds as unit
+      latestValueTimestamp: (latestState?.timestamp ?? 0) / 1000,
+    },
+    status,
+  };
+};
+
+export const isAlarmResource = (
+  alarmResourcePartial: Partial<AlarmResourceWithLatestValue>
+): alarmResourcePartial is AlarmResource => {
+  return (
+    alarmResourcePartial.assetModelId != null &&
+    alarmResourcePartial.assetCompositeModelId != null &&
+    alarmResourcePartial.name != null
+  );
+};

--- a/packages/react-components/src/components/resource-explorers/explorers/alarm-explorer/types.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/alarm-explorer/types.ts
@@ -1,0 +1,39 @@
+import { TableProps } from '@cloudscape-design/components';
+import { IoTSiteWise, IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { IoTEvents, IoTEventsClient } from '@aws-sdk/client-iot-events';
+import type {
+  IsResourceDisabled,
+  OnSelectResource,
+  SelectedResources,
+} from '../../types/common';
+import type { CommonResourceExplorerProps } from '../../types/resource-explorer';
+import type {
+  AlarmResource,
+  AlarmResourceWithLatestValue,
+} from '../../types/resources';
+
+export interface AlarmExplorerProps
+  extends CommonResourceExplorerProps<AlarmResourceWithLatestValue> {
+  iotSiteWiseClient?: IoTSiteWiseClient | IoTSiteWise;
+  iotEventsClient?: IoTEventsClient | IoTEvents;
+  parameters?: AlarmResourcesRequestParameters;
+  onSelectAlarm?: OnSelectResource<AlarmResource>;
+  selectedAlarms?: SelectedResources<AlarmResource>;
+  isAlarmDisabled?: IsResourceDisabled<AlarmResource>;
+  ariaLabels?: TableProps.AriaLabels<AlarmResource>;
+  description?: string;
+  timeZone?: string;
+  significantDigits?: number;
+}
+
+export type AlarmResourcesRequestParameters =
+  | readonly AlarmByAssetRequestParameters[]
+  | readonly AlarmByAssetModelRequestParameters[];
+
+export type AlarmByAssetRequestParameters = {
+  assetId: string;
+};
+
+export type AlarmByAssetModelRequestParameters = {
+  assetModelId: string;
+};

--- a/packages/react-components/src/components/resource-explorers/explorers/index.ts
+++ b/packages/react-components/src/components/resource-explorers/explorers/index.ts
@@ -14,3 +14,5 @@ export {
   TimeSeriesExplorer,
   type TimeSeriesExplorerProps,
 } from './time-series-explorer';
+
+export { AlarmExplorer, type AlarmExplorerProps } from './alarm-explorer';

--- a/packages/react-components/src/components/resource-explorers/index.ts
+++ b/packages/react-components/src/components/resource-explorers/index.ts
@@ -3,10 +3,12 @@ export {
   AssetExplorer,
   AssetPropertyExplorer,
   TimeSeriesExplorer,
+  AlarmExplorer,
   type AssetModelExplorerProps,
   type AssetExplorerProps,
   type AssetPropertyExplorerProps,
   type TimeSeriesExplorerProps,
+  type AlarmExplorerProps,
 } from './explorers';
 
 export { DEFAULT_STRING_FILTER_OPERATORS } from './constants/defaults';

--- a/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/alarm-drop-down.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/drop-down-variant/alarm-drop-down.spec.tsx
@@ -1,0 +1,448 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import * as dropDown from '../helpers/drop-down';
+import { AlarmExplorer } from '../../explorers';
+import { resourceExplorerQueryClient } from '../../requests/resource-explorer-query-client';
+import { queryClient } from '../../../../queries';
+
+describe('asset property drop-down', () => {
+  beforeEach(() => {
+    resourceExplorerQueryClient.clear();
+    queryClient.clear();
+    jest.resetAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders a drop-down without configuration', async () => {
+      render(<AlarmExplorer variant='drop-down' />);
+
+      expect(screen.getByText('Select alarm')).toBeVisible();
+
+      await dropDown.open();
+
+      expect(screen.getByText('No alarms.')).toBeVisible();
+    });
+
+    it('renders a multi-select drop-down without configuration', async () => {
+      render(<AlarmExplorer variant='drop-down' selectionMode='multi' />);
+
+      expect(screen.getByText('Select alarms')).toBeVisible();
+
+      await dropDown.open();
+
+      expect(screen.getByText('No alarms.')).toBeVisible();
+    });
+  });
+
+  /**
+   * TODO: Uncomment when loading is fixed
+   */
+
+  // describe('request handling', () => {
+  //   it('requests a single page of asset properties correctly', async () => {
+  //     const listAssetProperties = jest
+  //       .fn()
+  //       .mockResolvedValue(createListAssetPropertiesPage(3));
+  //     const listAssetModelProperties = jest
+  //       .fn()
+  //       .mockResolvedValue(createListAssetModelPropertiesPage(3));
+  //     render(
+  //       <AssetPropertyExplorer
+  //         variant='drop-down'
+  //         iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
+  //         parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
+  //       />
+  //     );
+
+  //     await dropDown.open();
+  //     await dropDown.waitForLoadingToFinish();
+
+  //     expect(listAssetProperties).toHaveBeenCalledOnce();
+  //     expect(listAssetModelProperties).toHaveBeenCalledOnce();
+  //   });
+
+  //   it('requests multiple pages of asset properties correctly', async () => {
+  //     const listAssetProperties = jest
+  //       .fn()
+  //       .mockResolvedValueOnce(
+  //         createListAssetPropertiesPage(1, 0, 'next-token-1')
+  //       )
+  //       .mockResolvedValueOnce(
+  //         createListAssetPropertiesPage(1, 1, 'next-token-2')
+  //       )
+  //       .mockResolvedValueOnce(createListAssetPropertiesPage(1, 2));
+  //     const listAssetModelProperties = jest
+  //       .fn()
+  //       .mockResolvedValue(createListAssetModelPropertiesPage(3));
+  //     render(
+  //       <AssetPropertyExplorer
+  //         variant='drop-down'
+  //         iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
+  //         parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
+  //       />
+  //     );
+
+  //     await dropDown.open();
+  //     await dropDown.waitForLoadingToFinish();
+
+  //     expect(listAssetProperties).toHaveBeenCalledTimes(3);
+  //     expect(listAssetModelProperties).toHaveBeenCalledOnce();
+  //   });
+
+  //   it('requests multiple lists of pages of asset properties correctly', async () => {
+  //     const listAssetProperties = jest
+  //       .fn()
+  //       .mockResolvedValueOnce(
+  //         createListAssetPropertiesPage(1, 0, 'next-token-1')
+  //       )
+  //       .mockResolvedValueOnce(createListAssetPropertiesPage(1, 1))
+  //       .mockResolvedValueOnce(
+  //         createListAssetPropertiesPage(1, 2, 'next-token-2')
+  //       )
+  //       .mockResolvedValueOnce(createListAssetPropertiesPage(1, 3));
+  //     const listAssetModelProperties = jest
+  //       .fn()
+  //       .mockResolvedValue(createListAssetModelPropertiesPage(4, 0));
+
+  //     render(
+  //       <AssetPropertyExplorer
+  //         variant='drop-down'
+  //         iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
+  //         parameters={[
+  //           { assetId: 'asset-id-1', assetModelId: 'asset-model-id-1' },
+  //           { assetId: 'asset-id-2', assetModelId: 'asset-model-id-1' },
+  //         ]}
+  //       />
+  //     );
+
+  //     await dropDown.open();
+  //     await dropDown.waitForLoadingToFinish();
+
+  //     await waitFor(() => expect(listAssetProperties).toHaveBeenCalledTimes(4));
+  //     await waitFor(() =>
+  //       expect(listAssetModelProperties).toHaveBeenCalledOnce()
+  //     );
+  //   });
+  // });
+
+  // describe('selection', () => {
+  //   it('does not allow selecting asset properties if selectionMode is undefined', async () => {
+  //     const listAssetPropertiesResponse = createListAssetPropertiesPage(3);
+  //     const listAssetModelPropertiesResponse =
+  //       createListAssetModelPropertiesPage(3);
+  //     const {
+  //       assetModelPropertySummaries: [
+  //         assetModelProperty1,
+  //         assetModelProperty2,
+  //         assetModelProperty3,
+  //       ],
+  //     } = listAssetModelPropertiesResponse;
+  //     const listAssetProperties = jest
+  //       .fn()
+  //       .mockResolvedValue(listAssetPropertiesResponse);
+  //     const listAssetModelProperties = jest
+  //       .fn()
+  //       .mockResolvedValue(listAssetModelPropertiesResponse);
+  //     const user = userEvent.setup();
+  //     render(
+  //       <SelectableAssetPropertyDropDown
+  //         listAssetProperties={listAssetProperties}
+  //         listAssetModelProperties={listAssetModelProperties}
+  //       />
+  //     );
+
+  //     await dropDown.open();
+  //     await dropDown.waitForLoadingToFinish();
+  //     await user.click(dropDown.getOption(assetModelProperty1.name));
+
+  //     expect(
+  //       screen.queryByText(assetModelProperty1.name)
+  //     ).not.toBeInTheDocument();
+  //     expect(
+  //       dropDown.queryOption(assetModelProperty1.name)
+  //     ).not.toBeInTheDocument();
+  //     expect(
+  //       dropDown.queryOption(assetModelProperty2.name)
+  //     ).not.toBeInTheDocument();
+  //     expect(
+  //       dropDown.queryOption(assetModelProperty3.name)
+  //     ).not.toBeInTheDocument();
+  //   });
+
+  //   describe('single-select', () => {
+  //     it('allows selecting a single asset property', async () => {
+  //       const listAssetPropertiesResponse = createListAssetPropertiesPage(3);
+  //       const listAssetModelPropertiesResponse =
+  //         createListAssetModelPropertiesPage(3);
+  //       const {
+  //         assetModelPropertySummaries: [
+  //           assetModelProperty1,
+  //           assetModelProperty2,
+  //           assetModelProperty3,
+  //         ],
+  //       } = listAssetModelPropertiesResponse;
+  //       const listAssetProperties = jest
+  //         .fn()
+  //         .mockResolvedValue(listAssetPropertiesResponse);
+  //       const listAssetModelProperties = jest
+  //         .fn()
+  //         .mockResolvedValue(listAssetModelPropertiesResponse);
+  //       const user = userEvent.setup();
+  //       render(
+  //         <SelectableAssetPropertyDropDown
+  //           selectionMode='single'
+  //           listAssetProperties={listAssetProperties}
+  //           listAssetModelProperties={listAssetModelProperties}
+  //         />
+  //       );
+
+  //       await dropDown.open();
+  //       await dropDown.waitForLoadingToFinish();
+  //       await user.click(dropDown.getOption(assetModelProperty1.name));
+
+  //       expect(screen.getByText(assetModelProperty1.name)).toBeVisible();
+  //       expect(
+  //         dropDown.queryOption(assetModelProperty1.name)
+  //       ).not.toBeInTheDocument();
+  //       expect(
+  //         dropDown.queryOption(assetModelProperty2.name)
+  //       ).not.toBeInTheDocument();
+  //       expect(
+  //         dropDown.queryOption(assetModelProperty3.name)
+  //       ).not.toBeInTheDocument();
+  //     });
+
+  //     it('replaces the selection when a new selection is made', async () => {
+  //       const listAssetPropertiesResponse = createListAssetPropertiesPage(3);
+  //       const listAssetModelPropertiesResponse =
+  //         createListAssetModelPropertiesPage(3);
+  //       const {
+  //         assetModelPropertySummaries: [
+  //           assetModelProperty1,
+  //           assetModelProperty2,
+  //         ],
+  //       } = listAssetModelPropertiesResponse;
+  //       const listAssetProperties = jest
+  //         .fn()
+  //         .mockResolvedValue(listAssetPropertiesResponse);
+  //       const listAssetModelProperties = jest
+  //         .fn()
+  //         .mockResolvedValue(listAssetModelPropertiesResponse);
+  //       const user = userEvent.setup();
+  //       render(
+  //         <SelectableAssetPropertyDropDown
+  //           selectionMode='single'
+  //           listAssetProperties={listAssetProperties}
+  //           listAssetModelProperties={listAssetModelProperties}
+  //         />
+  //       );
+
+  //       await dropDown.open();
+  //       await dropDown.waitForLoadingToFinish();
+  //       await user.click(dropDown.getOption(assetModelProperty1.name));
+
+  //       expect(screen.getByText(assetModelProperty1.name)).toBeVisible();
+
+  //       await user.click(screen.getByText(assetModelProperty1.name));
+  //       await user.click(dropDown.getOption(assetModelProperty2.name));
+
+  //       expect(screen.getByText(assetModelProperty2.name)).toBeVisible();
+  //       expect(
+  //         screen.queryByText(assetModelProperty1.name)
+  //       ).not.toBeInTheDocument();
+  //     });
+  //   });
+
+  //   describe('multi-select', () => {
+  //     it('allows selecting multiple asset properties', async () => {
+  //       const listAssetPropertiesResponse = createListAssetPropertiesPage(3);
+  //       const listAssetModelPropertiesResponse =
+  //         createListAssetModelPropertiesPage(3);
+  //       const {
+  //         assetModelPropertySummaries: [
+  //           assetModelProperty1,
+  //           assetModelProperty2,
+  //           assetModelProperty3,
+  //         ],
+  //       } = listAssetModelPropertiesResponse;
+  //       const listAssetProperties = jest
+  //         .fn()
+  //         .mockResolvedValue(listAssetPropertiesResponse);
+  //       const listAssetModelProperties = jest
+  //         .fn()
+  //         .mockResolvedValue(listAssetModelPropertiesResponse);
+  //       const user = userEvent.setup();
+  //       render(
+  //         <SelectableAssetPropertyDropDown
+  //           selectionMode='multi'
+  //           listAssetProperties={listAssetProperties}
+  //           listAssetModelProperties={listAssetModelProperties}
+  //         />
+  //       );
+
+  //       await dropDown.open();
+  //       await dropDown.waitForLoadingToFinish();
+  //       await user.click(dropDown.getOption(assetModelProperty1.name));
+  //       await user.click(dropDown.getOption(assetModelProperty2.name));
+  //       await dropDown.close();
+
+  //       expect(screen.getByText(assetModelProperty1.name)).toBeVisible();
+  //       expect(screen.getByText(assetModelProperty2.name)).toBeVisible();
+  //       expect(
+  //         dropDown.queryOption(assetModelProperty1.name)
+  //       ).not.toBeInTheDocument();
+  //       expect(
+  //         dropDown.queryOption(assetModelProperty2.name)
+  //       ).not.toBeInTheDocument();
+  //       expect(
+  //         dropDown.queryOption(assetModelProperty3.name)
+  //       ).not.toBeInTheDocument();
+  //     });
+
+  //     it('allows for de-selecting asset properties', async () => {
+  //       const listAssetPropertiesResponse = createListAssetPropertiesPage(2);
+  //       const listAssetModelPropertiesResponse =
+  //         createListAssetModelPropertiesPage(2);
+  //       const {
+  //         assetModelPropertySummaries: [
+  //           assetModelProperty1,
+  //           assetModelProperty2,
+  //         ],
+  //       } = listAssetModelPropertiesResponse;
+  //       const listAssetProperties = jest
+  //         .fn()
+  //         .mockResolvedValue(listAssetPropertiesResponse);
+  //       const listAssetModelProperties = jest
+  //         .fn()
+  //         .mockResolvedValue(listAssetModelPropertiesResponse);
+  //       const user = userEvent.setup();
+  //       render(
+  //         <SelectableAssetPropertyDropDown
+  //           selectionMode='multi'
+  //           listAssetProperties={listAssetProperties}
+  //           listAssetModelProperties={listAssetModelProperties}
+  //         />
+  //       );
+
+  //       await dropDown.open();
+  //       await dropDown.waitForLoadingToFinish();
+  //       await user.click(dropDown.getOption(assetModelProperty1.name));
+  //       await user.click(dropDown.getOption(assetModelProperty2.name));
+  //       await dropDown.close();
+
+  //       expect(screen.getByText(assetModelProperty1.name)).toBeVisible();
+  //       expect(screen.getByText(assetModelProperty2.name)).toBeVisible();
+
+  //       await user.click(
+  //         screen.getByRole('button', {
+  //           name: `Remove ${assetModelProperty2.name}`,
+  //         })
+  //       );
+
+  //       expect(screen.getByText(assetModelProperty1.name)).toBeVisible();
+  //       expect(
+  //         screen.queryByText(assetModelProperty2.name)
+  //       ).not.toBeInTheDocument();
+
+  //       await user.click(
+  //         screen.getByRole('button', {
+  //           name: `Remove ${assetModelProperty1.name}`,
+  //         })
+  //       );
+
+  //       expect(
+  //         screen.queryByText(assetModelProperty1.name)
+  //       ).not.toBeInTheDocument();
+  //     });
+  //   });
+  // });
+
+  // describe('filtering', () => {
+  //   it('filters asset properties', async () => {
+  //     const assetProperty1 = {
+  //       id: 'asset-property-1',
+  //     };
+  //     const assetModelProperty1 = {
+  //       ...assetProperty1,
+  //       name: 'Similar Name 1',
+  //     };
+  //     const assetProperty2 = {
+  //       id: 'asset-property-2',
+  //     };
+  //     const assetModelProperty2 = {
+  //       ...assetProperty2,
+  //       name: 'Similar Name 2',
+  //     };
+  //     const assetProperty3 = {
+  //       id: 'asset-property-3',
+  //     };
+  //     const assetModelProperty3 = {
+  //       ...assetProperty3,
+  //       name: 'Different Name 3',
+  //     };
+  //     const listAssetProperties = jest.fn().mockResolvedValue({
+  //       assetPropertySummaries: [
+  //         assetProperty1,
+  //         assetProperty2,
+  //         assetProperty3,
+  //       ],
+  //     });
+  //     const listAssetModelProperties = jest.fn().mockResolvedValue({
+  //       assetModelPropertySummaries: [
+  //         assetModelProperty1,
+  //         assetModelProperty2,
+  //         assetModelProperty3,
+  //       ],
+  //     });
+  //     const user = userEvent.setup();
+  //     render(
+  //       <AssetPropertyExplorer
+  //         variant='drop-down'
+  //         iotSiteWiseClient={{ listAssetProperties, listAssetModelProperties }}
+  //         parameters={[{ assetId: 'asset-id', assetModelId: 'asset-model-id' }]}
+  //         dropDownSettings={{
+  //           isFilterEnabled: true,
+  //         }}
+  //       />
+  //     );
+
+  //     await dropDown.open();
+  //     await dropDown.waitForLoadingToFinish();
+
+  //     expect(
+  //       screen.getByPlaceholderText('Filter asset properties')
+  //     ).toBeVisible();
+
+  //     expect(dropDown.getOption(assetModelProperty1.name)).toBeVisible();
+  //     expect(dropDown.getOption(assetModelProperty2.name)).toBeVisible();
+  //     expect(dropDown.getOption(assetModelProperty3.name)).toBeVisible();
+
+  //     await user.keyboard('Similar Name');
+
+  //     expect(dropDown.getOption(assetModelProperty1.name)).toBeVisible();
+  //     expect(dropDown.getOption(assetModelProperty2.name)).toBeVisible();
+  //     expect(
+  //       dropDown.queryOption(assetModelProperty3.name)
+  //     ).not.toBeInTheDocument();
+  //     expect(screen.getByText('(2/3) asset properties matched')).toBeVisible();
+
+  //     await dropDown.clearFilter();
+
+  //     expect(dropDown.getOption(assetModelProperty1.name)).toBeVisible();
+  //     expect(dropDown.getOption(assetModelProperty2.name)).toBeVisible();
+  //     expect(dropDown.getOption(assetModelProperty3.name)).toBeVisible();
+
+  //     await user.keyboard('Different Name');
+
+  //     expect(
+  //       dropDown.queryOption(assetModelProperty1.name)
+  //     ).not.toBeInTheDocument();
+  //     expect(
+  //       dropDown.queryOption(assetModelProperty2.name)
+  //     ).not.toBeInTheDocument();
+  //     expect(dropDown.getOption(assetModelProperty3.name)).toBeVisible();
+  //     expect(screen.getByText('(1/3) asset properties matched')).toBeVisible();
+  //   });
+  // });
+});

--- a/packages/react-components/src/components/resource-explorers/testing/table-variant/alarm-table.spec.tsx
+++ b/packages/react-components/src/components/resource-explorers/testing/table-variant/alarm-table.spec.tsx
@@ -1,0 +1,537 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { AlarmExplorer } from '../../explorers';
+import { resourceExplorerQueryClient } from '../../requests';
+import * as table from '../helpers/table';
+import { queryClient } from '../../../../queries';
+
+describe('alarm table', () => {
+  beforeEach(() => {
+    resourceExplorerQueryClient.clear();
+    queryClient.clear();
+    jest.resetAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders a table without configuration', async () => {
+      render(<AlarmExplorer />);
+
+      expect(screen.getByRole('table')).toBeVisible();
+      expect(screen.getByText(`No alarms.`));
+
+      // Title
+      expect(screen.getByText('Alarms'));
+      expect(screen.getByText('(0)')).toBeVisible();
+
+      // Search
+      expect(table.querySearchField()).not.toBeInTheDocument();
+
+      // Filter
+      expect(screen.queryByLabelText('Filter')).not.toBeInTheDocument();
+
+      // User settings
+      expect(
+        screen.queryByRole('button', { name: 'Preferences' })
+      ).not.toBeInTheDocument();
+
+      // Pagination
+      expect(table.getPreviousPageButton()).toBeVisible();
+      expect(table.getPreviousPageButton()).toBeDisabled();
+      expect(table.getNextPageButton()).toBeVisible();
+      expect(table.getNextPageButton()).toBeDisabled();
+    });
+
+    it('renders without title disabled', () => {
+      render(<AlarmExplorer tableSettings={{ isTitleEnabled: false }} />);
+
+      expect(screen.queryByText('Alarms')).not.toBeInTheDocument();
+      expect(screen.queryByText('(0)')).not.toBeInTheDocument();
+    });
+
+    it('renders with search enabled', () => {
+      render(<AlarmExplorer tableSettings={{ isSearchEnabled: true }} />);
+
+      expect(table.getSearchField()).toBeVisible();
+    });
+
+    it('renders with filter enabled', () => {
+      render(<AlarmExplorer tableSettings={{ isFilterEnabled: true }} />);
+
+      expect(screen.getByLabelText('Filter')).toBeVisible();
+    });
+
+    it('renders with user settings enabled', () => {
+      render(<AlarmExplorer tableSettings={{ isUserSettingsEnabled: true }} />);
+
+      expect(screen.getByRole('button', { name: 'Preferences' })).toBeVisible();
+    });
+
+    it('renders expected columns', () => {
+      render(<AlarmExplorer />);
+
+      expect(screen.getByText('Name')).toBeVisible();
+      expect(screen.queryByText('ID')).not.toBeInTheDocument();
+      expect(screen.queryByText('Latest value')).not.toBeInTheDocument();
+      expect(screen.queryByText('Latest value time')).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * TODO: Uncomment when loading is fixed
+   */
+  // describe('requests', () => {
+  //   it('requests a alarms correctly', async () => {
+  //     mockUseAlarms();
+
+  //     render(
+  //       <AlarmExplorer
+  //         iotSiteWiseClient={iotSiteWiseClientMock}
+  //         parameters={[{ assetId: MOCK_ASSET_ID }]}
+  //       />
+  //     );
+
+  //     await table.waitForLoadingToFinish();
+
+  //     expect(describeAssetMock).toHaveBeenCalledOnce();
+  //     expect(screen.getByText('(2)')).toBeInTheDocument();
+  //     expect(table.getPreviousPageButton()).toBeVisible();
+  //     expect(table.getPreviousPageButton()).toBeDisabled();
+  //     expect(table.getNextPageButton()).toBeVisible();
+  //     expect(table.getNextPageButton()).toBeDisabled();
+  //   });
+  // });
+
+  /**
+   * TODO: Uncomment the following tests when loading is fixed
+   * in the useAlarms hooks
+   */
+
+  // Latest values not implemented in the useAlarms hook yet.
+  // describe.skip('latest values', () => {
+  //   it('supports displaying the latest values of asset properties', async () => {
+  //     mockUseAlarms();
+
+  //     render(
+  //       <AlarmExplorer
+  //         iotSiteWiseClient={iotSiteWiseClientMock}
+  //         parameters={[{ assetId: MOCK_ASSET_ID }]}
+  //       />
+  //     );
+
+  //     await table.waitForLoadingToFinish();
+
+  //     // expect(batchGetAssetPropertyValue).toHaveBeenCalledOnce();
+  //     expect(screen.getByText(MOCK_COMPOSITE_MODEL_NAME)).toBeVisible();
+  //     expect(screen.getByText(MOCK_COMPOSITE_MODEL_NAME_2)).toBeVisible();
+  //     // expect(
+  //     //   screen.getByText(
+  //     //     assetProperty1SuccessEntry.assetPropertyValue.value.stringValue
+  //     //   )
+  //     // ).toBeVisible();
+  //     // expect(
+  //     //   screen.getByText(
+  //     //     assetProperty2SuccessEntry.assetPropertyValue.value.integerValue
+  //     //   )
+  //     // ).toBeVisible();
+  //     // expect(
+  //     //   screen.getByText(
+  //     //     assetProperty3SuccessEntry.assetPropertyValue.value.doubleValue
+  //     //   )
+  //     // ).toBeVisible();
+  //     // expect(
+  //     //   screen.getByText(
+  //     //     formatDate(
+  //     //       assetProperty1SuccessEntry.assetPropertyValue.timestamp
+  //     //         .timeInSeconds * 1000
+  //     //     )
+  //     //   )
+  //     // ).toBeVisible();
+  //     // expect(
+  //     //   screen.getByText(
+  //     //     formatDate(
+  //     //       assetProperty2SuccessEntry.assetPropertyValue.timestamp
+  //     //         .timeInSeconds * 1000
+  //     //     )
+  //     //   )
+  //     // ).toBeVisible();
+  //     // expect(
+  //     //   screen.getByText(
+  //     //     formatDate(
+  //     //       assetProperty3SuccessEntry.assetPropertyValue.timestamp
+  //     //         .timeInSeconds * 1000
+  //     //     )
+  //     //   )
+  //     // ).toBeVisible();
+  //   });
+
+  //   it('regularly requests latest values', async () => {
+  //     jest.useFakeTimers();
+
+  //     const batchGetAssetPropertyValue = jest.fn().mockResolvedValue({
+  //       successEntries: [],
+  //       skippedEntries: [],
+  //       errorEntries: [],
+  //     } satisfies Awaited<ReturnType<BatchGetAssetPropertyValue>>);
+  //     render(
+  //       <AlarmExplorer
+  //         iotSiteWiseClient={iotSiteWiseClientMock}
+  //         parameters={[{ assetId: MOCK_ASSET_ID }]}
+  //       />
+  //     );
+
+  //     await table.waitForLoadingToFinish();
+
+  //     expect(batchGetAssetPropertyValue).toHaveBeenCalledOnce();
+
+  //     jest.advanceTimersByTime(DEFAULT_LATEST_VALUE_REQUEST_INTERVAL);
+  //     expect(batchGetAssetPropertyValue).toHaveBeenCalledTimes(2);
+
+  //     // Remove mocking
+  //     jest.useRealTimers();
+  //   });
+  // });
+
+  // describe('selection', () => {
+  //   it('does not allow selecting asset properties if selectionMode is undefined', async () => {
+  //     const mockDescribeAssetResponse = {
+  //       assetModelId: MOCK_ASSET_MODEL_ID,
+  //       assetId: MOCK_ASSET_ID,
+  //       assetArn: 'assetArn',
+  //       assetName: 'assetName',
+  //       assetProperties: [],
+  //       assetHierarchies: [],
+  //       assetCreationDate: new Date(),
+  //       assetLastUpdateDate: new Date(),
+  //       assetStatus: {
+  //         state: 'ACTIVE',
+  //       },
+  //       assetCompositeModels: [mockAlarmCompositeModel, mockAlarmCompositeModel2],
+  //     }
+
+  //     describeAssetMock.mockResolvedValue(
+  //       mockDescribeAssetResponse
+  //     );
+
+  //     render(
+  //       <SelectableAlarmTable />
+  //     );
+
+  //     await table.waitForLoadingToFinish();
+
+  //     expect(screen.queryAllByRole('radio')).toHaveLength(0);
+  //     expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+  //   });
+
+  //   describe('single-select', () => {
+  //     it('allows selecting a single asset property', async () => {
+  //       const mockDescribeAssetResponse = {
+  //         assetModelId: MOCK_ASSET_MODEL_ID,
+  //         assetId: MOCK_ASSET_ID,
+  //         assetArn: 'assetArn',
+  //         assetName: 'assetName',
+  //         assetProperties: [],
+  //         assetHierarchies: [],
+  //         assetCreationDate: new Date(),
+  //         assetLastUpdateDate: new Date(),
+  //         assetStatus: {
+  //           state: 'ACTIVE',
+  //         },
+  //         assetCompositeModels: [mockAlarmCompositeModel, mockAlarmCompositeModel2],
+  //       }
+
+  //       describeAssetMock.mockResolvedValue(
+  //         mockDescribeAssetResponse
+  //       );
+
+  //       const user = userEvent.setup();
+  //       render(
+  //         <SelectableAlarmTable
+  //           selectionMode='single'
+  //         />
+  //       );
+
+  //       await table.waitForLoadingToFinish();
+
+  //       expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+  //       const radios = screen.queryAllByRole('radio');
+  //       expect(radios).toHaveLength(2);
+  //       const [assetPropertyRadio1, assetPropertyRadio2, assetPropertyRadio3] =
+  //         radios;
+
+  //       expect(assetPropertyRadio1).not.toBeChecked();
+  //       expect(assetPropertyRadio2).not.toBeChecked();
+  //       expect(assetPropertyRadio3).not.toBeChecked();
+
+  //       await user.click(assetPropertyRadio1);
+
+  //       expect(assetPropertyRadio1).toBeChecked();
+  //       expect(assetPropertyRadio2).not.toBeChecked();
+  //       expect(assetPropertyRadio3).not.toBeChecked();
+
+  //       await user.click(assetPropertyRadio2);
+
+  //       expect(assetPropertyRadio1).not.toBeChecked();
+  //       expect(assetPropertyRadio2).toBeChecked();
+  //       expect(assetPropertyRadio3).not.toBeChecked();
+
+  //       await user.click(assetPropertyRadio3);
+
+  //       expect(assetPropertyRadio1).not.toBeChecked();
+  //       expect(assetPropertyRadio2).not.toBeChecked();
+  //       expect(assetPropertyRadio3).toBeChecked();
+  //     });
+  //   });
+
+  //   describe('multi-select', () => {
+  //     it('allows selecting multiple asset properties', async () => {
+  //       const mockDescribeAssetResponse = {
+  //         assetModelId: MOCK_ASSET_MODEL_ID,
+  //         assetId: MOCK_ASSET_ID,
+  //         assetArn: 'assetArn',
+  //         assetName: 'assetName',
+  //         assetProperties: [],
+  //         assetHierarchies: [],
+  //         assetCreationDate: new Date(),
+  //         assetLastUpdateDate: new Date(),
+  //         assetStatus: {
+  //           state: 'ACTIVE',
+  //         },
+  //         assetCompositeModels: [mockAlarmCompositeModel, mockAlarmCompositeModel2],
+  //       }
+
+  //       describeAssetMock.mockResolvedValue(
+  //         mockDescribeAssetResponse
+  //       );
+
+  //       const user = userEvent.setup();
+  //       render(
+  //         <SelectableAlarmTable
+  //           selectionMode='multi'
+  //         />
+  //       );
+
+  //       await table.waitForLoadingToFinish();
+
+  //       expect(screen.queryAllByRole('radio')).toHaveLength(0);
+  //       const checkboxes = screen.queryAllByRole('checkbox');
+  //       expect(checkboxes).toHaveLength(4);
+  //       const [
+  //         allAssetPropertiesCheckbox,
+  //         assetPropertyCheckbox1,
+  //         assetPropertyCheckbox2,
+  //         assetPropertyCheckbox3,
+  //       ] = checkboxes;
+
+  //       expect(allAssetPropertiesCheckbox).not.toBeChecked();
+  //       expect(allAssetPropertiesCheckbox).not.toBePartiallyChecked();
+  //       expect(assetPropertyCheckbox1).not.toBeChecked();
+  //       expect(assetPropertyCheckbox2).not.toBeChecked();
+  //       expect(assetPropertyCheckbox3).not.toBeChecked();
+
+  //       await user.click(assetPropertyCheckbox1);
+
+  //       expect(allAssetPropertiesCheckbox).not.toBeChecked();
+  //       expect(allAssetPropertiesCheckbox).toBePartiallyChecked();
+  //       expect(assetPropertyCheckbox1).toBeChecked();
+  //       expect(assetPropertyCheckbox2).not.toBeChecked();
+  //       expect(assetPropertyCheckbox3).not.toBeChecked();
+
+  //       await user.click(assetPropertyCheckbox2);
+
+  //       expect(allAssetPropertiesCheckbox).not.toBeChecked();
+  //       expect(allAssetPropertiesCheckbox).toBePartiallyChecked();
+  //       expect(assetPropertyCheckbox1).toBeChecked();
+  //       expect(assetPropertyCheckbox2).toBeChecked();
+  //       expect(assetPropertyCheckbox3).not.toBeChecked();
+
+  //       await user.click(assetPropertyCheckbox3);
+
+  //       expect(allAssetPropertiesCheckbox).toBeChecked();
+  //       expect(allAssetPropertiesCheckbox).not.toBePartiallyChecked();
+  //       expect(assetPropertyCheckbox1).toBeChecked();
+  //       expect(assetPropertyCheckbox2).toBeChecked();
+  //       expect(assetPropertyCheckbox3).toBeChecked();
+
+  //       await user.click(assetPropertyCheckbox1);
+
+  //       expect(allAssetPropertiesCheckbox).not.toBeChecked();
+  //       expect(allAssetPropertiesCheckbox).toBePartiallyChecked();
+  //       expect(assetPropertyCheckbox1).not.toBeChecked();
+  //       expect(assetPropertyCheckbox2).toBeChecked();
+  //       expect(assetPropertyCheckbox3).toBeChecked();
+
+  //       await user.click(assetPropertyCheckbox2);
+
+  //       expect(allAssetPropertiesCheckbox).not.toBeChecked();
+  //       expect(allAssetPropertiesCheckbox).toBePartiallyChecked();
+  //       expect(assetPropertyCheckbox1).not.toBeChecked();
+  //       expect(assetPropertyCheckbox2).not.toBeChecked();
+  //       expect(assetPropertyCheckbox3).toBeChecked();
+
+  //       await user.click(assetPropertyCheckbox3);
+
+  //       expect(allAssetPropertiesCheckbox).not.toBeChecked();
+  //       expect(allAssetPropertiesCheckbox).not.toBePartiallyChecked();
+  //       expect(assetPropertyCheckbox1).not.toBeChecked();
+  //       expect(assetPropertyCheckbox2).not.toBeChecked();
+  //       expect(assetPropertyCheckbox3).not.toBeChecked();
+  //     });
+  //   });
+  // });
+
+  // describe('filtering', () => {
+  //   it('supports filtering by property', async () => {
+  //     mockUseAlarms();
+
+  //     render(
+  //       <AlarmExplorer
+  //         tableSettings={{ isFilterEnabled: true }}
+  //         iotSiteWiseClient={iotSiteWiseClientMock}
+  //         parameters={[{ assetId: MOCK_ASSET_ID }]}
+  //       />
+  //     );
+
+  //     await table.waitForLoadingToFinish();
+  //     await table.openFilterControls();
+
+  //     expect(screen.getByRole('option', { name: 'Name' })).toBeVisible();
+  //     expect(screen.getByRole('option', { name: 'ID' })).toBeVisible();
+  //   });
+
+  //   it('supports filtering by text', async () => {
+  //     mockUseAlarms();
+
+  //     const user = userEvent.setup();
+  //     render(
+  //       <AlarmExplorer
+  //         tableSettings={{ isFilterEnabled: true }}
+  //         iotSiteWiseClient={iotSiteWiseClientMock}
+  //         parameters={[{ assetId: MOCK_ASSET_ID }]}
+  //       />
+  //     );
+
+  //     await table.waitForLoadingToFinish();
+
+  //     expect(screen.getByText(MOCK_COMPOSITE_MODEL_NAME)).toBeVisible();
+  //     expect(screen.getByText(MOCK_COMPOSITE_MODEL_NAME_2)).toBeVisible();
+
+  //     await table.openFilterControls();
+  //     await user.keyboard('2');
+  //     await user.click(screen.getByText('Use: "2"'));
+
+  //     expect(screen.getByText(MOCK_COMPOSITE_MODEL_NAME_2)).toBeVisible();
+  //     expect(
+  //       screen.queryByText(MOCK_COMPOSITE_MODEL_NAME)
+  //     ).not.toBeInTheDocument();
+
+  //     await user.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+  //     expect(screen.getByText(MOCK_COMPOSITE_MODEL_NAME)).toBeVisible();
+  //     expect(screen.getByText(MOCK_COMPOSITE_MODEL_NAME_2)).toBeVisible();
+  //   });
+  // });
+
+  // describe('user settings', () => {
+  //   it('renders user settings as expected', async () => {
+  //     const user = userEvent.setup();
+  //     render(
+  //       <AlarmExplorer
+  //         tableSettings={{ isUserSettingsEnabled: true }}
+  //       />
+  //     );
+
+  //     expect(screen.queryByText('Preferences')).not.toBeInTheDocument();
+
+  //     await user.click(screen.getByRole('button', { name: 'Preferences' }));
+
+  //     expect(screen.getByText('Preferences')).toBeVisible();
+  //     expect(screen.getByText('Page size')).toBeVisible();
+  //     expect(screen.getByText('Wrap lines')).toBeVisible();
+  //     expect(screen.getByText('Striped rows')).toBeVisible();
+  //     expect(screen.getByText('Compact mode')).toBeVisible();
+  //     expect(screen.getByText('Sticky first columns')).toBeVisible();
+  //     expect(screen.getByText('Sticky last columns')).toBeVisible();
+  //     expect(screen.getByText('Column preferences')).toBeVisible();
+  //   });
+
+  //   it('renders expect column preferences', async () => {
+  //     render(
+  //       <AlarmExplorer
+  //         tableSettings={{ isUserSettingsEnabled: true }}
+  //       />
+  //     );
+
+  //     await table.openUserSettings();
+
+  //     expect(table.getColumnDisplayCheckbox('Name')).toBeVisible();
+  //     expect(table.getColumnDisplayCheckbox('Name')).toBeChecked();
+  //     expect(table.getColumnDisplayCheckbox('Name')).toBeEnabled();
+  //     expect(table.getColumnDisplayCheckbox('ID')).toBeVisible();
+  //     expect(table.getColumnDisplayCheckbox('ID')).not.toBeChecked();
+  //     expect(table.getColumnDisplayCheckbox('ID')).toBeEnabled();
+  //     expect(
+  //       table.queryColumnDisplayCheckbox('Latest value')
+  //     ).toBeInTheDocument();
+  //     expect(
+  //       table.queryColumnDisplayCheckbox('Latest value time')
+  //     ).toBeInTheDocument();
+  //   });
+
+  //   it('renders expect column preferences with latest values enabled', async () => {
+  //     render(
+  //       <AlarmExplorer
+  //         tableSettings={{ isUserSettingsEnabled: true }}
+  //       />
+  //     );
+
+  //     await table.openUserSettings();
+
+  //     expect(table.getColumnDisplayCheckbox('Latest value')).toBeVisible();
+  //     expect(table.getColumnDisplayCheckbox('Latest value')).toBeChecked();
+  //     expect(table.getColumnDisplayCheckbox('Latest value')).toBeEnabled();
+  //     expect(table.getColumnDisplayCheckbox('Latest value time')).toBeVisible();
+  //     expect(table.getColumnDisplayCheckbox('Latest value time')).toBeChecked();
+  //     expect(table.getColumnDisplayCheckbox('Latest value time')).toBeEnabled();
+  //   });
+
+  //   it('supports users changing settings', async () => {
+  //     const user = userEvent.setup();
+  //     render(
+  //       <AlarmExplorer
+  //         tableSettings={{ isUserSettingsEnabled: true }}
+  //       />
+  //     );
+
+  //     expect(screen.getByText('Name')).toBeVisible();
+
+  //     await table.openUserSettings();
+  //     await user.click(table.getColumnDisplayCheckbox('Name'));
+  //     await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+  //     expect(screen.queryByText('Name')).not.toBeInTheDocument();
+  //   });
+
+  //   it('supports users cancelling changing settings', async () => {
+  //     const user = userEvent.setup();
+  //     render(
+  //       <AlarmExplorer
+  //         tableSettings={{ isUserSettingsEnabled: true }}
+  //       />
+  //     );
+
+  //     expect(screen.getByText('Name')).toBeVisible();
+
+  //     await table.openUserSettings();
+  //     await user.click(table.getColumnDisplayCheckbox('Name'));
+  //     await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+  //     expect(screen.getByText('Name')).toBeVisible();
+
+  //     await table.openUserSettings();
+  //     await user.click(table.getColumnDisplayCheckbox('Name'));
+  //     await user.click(screen.getByRole('button', { name: 'Close modal' }));
+
+  //     expect(screen.getByText('Name')).toBeVisible();
+  //   });
+  // });
+});

--- a/packages/react-components/src/components/resource-explorers/types/resources.ts
+++ b/packages/react-components/src/components/resource-explorers/types/resources.ts
@@ -24,6 +24,24 @@ export interface AssetPropertyResource {
   unit?: string;
 }
 
+export interface AlarmResource {
+  name: string;
+  assetId: string;
+  assetModelId: string;
+  assetCompositeModelId: string;
+  inputPropertyId?: string;
+  inputPropertyName?: string;
+}
+
+export interface AlarmModelResource {
+  assetModelId: string;
+  assetCompositeModelId: string;
+  name: string;
+}
+
+export type AlarmResourceWithLatestValue =
+  DataStreamResourceWithLatestValue<AlarmResource>;
+
 export type AssetPropertyResourceWithLatestValue =
   DataStreamResourceWithLatestValue<AssetPropertyResource>;
 

--- a/packages/react-components/src/hooks/requestFunctions/useIoTEventsClient.spec.ts
+++ b/packages/react-components/src/hooks/requestFunctions/useIoTEventsClient.spec.ts
@@ -58,4 +58,12 @@ describe('useIoTEventsClient tests', () => {
       iotEventsClient.describeAlarmModel as DescribeAlarmModel
     ).toBeDefined();
   });
+
+  it('useIoTEventsClient handles an undefined IoTEventsClient', async () => {
+    const { result } = renderHook(() =>
+      useIoTEventsClient({ iotEventsClient: undefined })
+    );
+
+    expect(result.current).toStrictEqual({});
+  });
 });

--- a/packages/react-components/src/hooks/requestFunctions/useIoTEventsClient.ts
+++ b/packages/react-components/src/hooks/requestFunctions/useIoTEventsClient.ts
@@ -26,7 +26,7 @@ export function useIoTEventsClient({
       } as IoTEvents;
     }
 
-    return iotEventsClient;
+    return iotEventsClient ?? {};
   }, [iotEventsClient]);
 
   return iotEvents as IoTEvents;

--- a/packages/react-components/src/hooks/requestFunctions/useIoTSiteWiseClient.spec.ts
+++ b/packages/react-components/src/hooks/requestFunctions/useIoTSiteWiseClient.spec.ts
@@ -108,4 +108,12 @@ describe('useIoTSiteWiseClient tests', () => {
       iotSiteWiseClient.describeAssetModel as DescribeAssetModel
     ).toBeDefined();
   });
+
+  it('useIoTSiteWiseClient handles an undefined SiteWise client', async () => {
+    const { result } = renderHook(() =>
+      useIoTSiteWiseClient({ iotSiteWiseClient: undefined })
+    );
+
+    expect(result.current).toStrictEqual({});
+  });
 });

--- a/packages/react-components/src/hooks/requestFunctions/useIoTSiteWiseClient.ts
+++ b/packages/react-components/src/hooks/requestFunctions/useIoTSiteWiseClient.ts
@@ -56,7 +56,7 @@ export function useIoTSiteWiseClient({
       } as IoTSiteWise;
     }
 
-    return iotSiteWiseClient;
+    return iotSiteWiseClient ?? ({} as IoTSiteWise);
   }, [iotSiteWiseClient]);
 
   return iotSiteWise as IoTSiteWise;

--- a/packages/react-components/src/hooks/useAlarms/constants.ts
+++ b/packages/react-components/src/hooks/useAlarms/constants.ts
@@ -4,3 +4,12 @@ export const ALARM_TYPE_PROPERTY_NAME = 'AWS/ALARM_TYPE';
 export const ALARM_SOURCE_PROPERTY_NAME = 'AWS/ALARM_SOURCE';
 
 export const SITE_WISE_BACKED_PROPERTY_PREFIX = '$sitewise';
+
+export const ALARM_STATUS = {
+  ACTIVE: 'Active',
+  NORMAL: 'Normal',
+  LATCHED: 'Latched',
+  DISABLED: 'Disabled',
+  ACKNOWLEDGED: 'Acknowledged',
+  SNOOZE_DISABLED: 'SnoozeDisabled',
+} as const;

--- a/packages/react-components/src/hooks/useAlarms/transformers/index.ts
+++ b/packages/react-components/src/hooks/useAlarms/transformers/index.ts
@@ -1,0 +1,1 @@
+export * from './parseAlarmStateProperty';

--- a/packages/react-components/src/hooks/useAlarms/transformers/parseAlarmStateProperty.ts
+++ b/packages/react-components/src/hooks/useAlarms/transformers/parseAlarmStateProperty.ts
@@ -1,0 +1,44 @@
+import { AssetPropertyValue } from '@aws-sdk/client-iotsitewise';
+import { ALARM_STATUS } from '../constants';
+import { toTimestamp } from '../../../utils/time';
+
+export type UpperCaseStateName = keyof typeof ALARM_STATUS;
+export type PascalCaseStateName = (typeof ALARM_STATUS)[UpperCaseStateName];
+
+export const parseAlarmStateAssetProperty = (
+  assetPropertyValue?: AssetPropertyValue
+) => {
+  if (assetPropertyValue == null) {
+    return undefined;
+  }
+
+  const { timestamp, quality, value } = assetPropertyValue;
+
+  const alarmStateJSON = value?.stringValue;
+
+  if (alarmStateJSON == null) {
+    return undefined;
+  }
+
+  try {
+    const { stateName } = JSON.parse(alarmStateJSON);
+
+    let normalizedStateName: PascalCaseStateName;
+
+    if (ALARM_STATUS[stateName as UpperCaseStateName] != null) {
+      normalizedStateName = ALARM_STATUS[stateName as UpperCaseStateName];
+    } else {
+      normalizedStateName = stateName;
+    }
+
+    return {
+      quality,
+      timestamp: toTimestamp(timestamp),
+      value: {
+        state: normalizedStateName,
+      },
+    };
+  } catch (err) {
+    throw new Error(`Could not parse alarm data: ${err}`);
+  }
+};

--- a/packages/react-components/src/queries/useAssetPropertyValues/utils/toDataPoint.ts
+++ b/packages/react-components/src/queries/useAssetPropertyValues/utils/toDataPoint.ts
@@ -9,7 +9,7 @@ import type {
 } from '@aws-sdk/client-iotsitewise';
 
 /** converts the TimeInNanos to milliseconds */
-const toTimestamp = (time: TimeInNanos | undefined): number =>
+export const toTimestamp = (time: TimeInNanos | undefined): number =>
   (time &&
     Math.floor(
       (time.timeInSeconds || 0) * SECOND_IN_MS +

--- a/packages/react-components/stories/resource-explorers/alarm-explorer.stories.tsx
+++ b/packages/react-components/stories/resource-explorers/alarm-explorer.stories.tsx
@@ -1,0 +1,91 @@
+import { type Meta } from '@storybook/react';
+import React from 'react';
+import {
+  CommonResourceExplorerControls,
+  SHARED_RESOURCE_EXPLORER_STORY_ARG_TYPES,
+} from './controls';
+import { client } from './data-source';
+import {
+  AlarmExplorer,
+  type AlarmExplorerProps,
+} from '../../src/components/resource-explorers';
+import { StoryFnReactReturnType } from '@storybook/react/dist/ts3.9/client/preview/types';
+import {
+  StoryWithClearedResourceCache,
+  StoryWithSelectableResource,
+  StoryWithTanstackDevTools,
+} from './decorators';
+
+export default {
+  title: 'Resource Explorers/Alarm Explorer',
+  component: AlarmExplorer,
+  parameters: {
+    controls: {
+      expanded: true,
+    },
+  },
+  decorators: [
+    StoryWithTanstackDevTools,
+    StoryWithClearedResourceCache,
+    StoryWithSelectableResource,
+  ],
+  argTypes: {
+    ...SHARED_RESOURCE_EXPLORER_STORY_ARG_TYPES,
+  },
+} satisfies Meta<typeof AlarmExplorer>;
+
+type AlarmExplorerStory = (
+  controls: AlarmExplorerStoryControls,
+  context: AlarmExplorerStoryContext
+) => StoryFnReactReturnType;
+
+type AlarmExplorerStoryControls = CommonResourceExplorerControls;
+
+interface AlarmExplorerStoryContext {
+  selectedResources: NonNullable<AlarmExplorerProps['selectedAlarms']>;
+  onSelectResource: NonNullable<AlarmExplorerProps['onSelectAlarm']>;
+}
+
+function storyArgsToProps(
+  {
+    isTableTitleEnabled,
+    isTableSearchEnabled,
+    isTableFilterEnabled,
+    isTableUserSettingsEnabled,
+    isDropDownFilterEnabled,
+    ...controls
+  }: AlarmExplorerStoryControls,
+  { selectedResources, onSelectResource }: AlarmExplorerStoryContext
+): AlarmExplorerProps {
+  return {
+    selectedAlarms: selectedResources,
+    onSelectAlarm: onSelectResource,
+    tableSettings: {
+      isTitleEnabled: isTableTitleEnabled,
+      isSearchEnabled: isTableSearchEnabled,
+      isFilterEnabled: isTableFilterEnabled,
+      isUserSettingsEnabled: isTableUserSettingsEnabled,
+    },
+    dropDownSettings: {
+      isFilterEnabled: isDropDownFilterEnabled,
+    },
+    ...controls,
+  };
+}
+
+// Requires setting parameters manually (or using search)
+export const WithLatestValues: AlarmExplorerStory = (controls, context) => {
+  const props = storyArgsToProps(controls, context);
+
+  return (
+    <AlarmExplorer {...props} iotSiteWiseClient={client} parameters={[]} />
+  );
+};
+
+export const ZeroConfigurationTable: AlarmExplorerStory = () => {
+  return <AlarmExplorer />;
+};
+
+export const ZeroConfigurationDropDown: AlarmExplorerStory = () => {
+  return <AlarmExplorer variant='drop-down' />;
+};

--- a/packages/react-components/stories/resource-explorers/explorer-combinations.stories.tsx
+++ b/packages/react-components/stories/resource-explorers/explorer-combinations.stories.tsx
@@ -13,6 +13,7 @@ import {
   TimeSeriesExplorer,
   type AssetModelExplorerProps,
   type AssetExplorerProps,
+  AlarmExplorer,
 } from '../../src/components/resource-explorers';
 
 export default {
@@ -211,6 +212,56 @@ export function AssetModelExplorerPlusAssetExplorerPlusTimeSeriesExplorer() {
           isFilterEnabled: true,
           isUserSettingsEnabled: true,
         }}
+      />
+    </>
+  );
+}
+
+export function AssetExplorerPlusAlarmExplorer() {
+  const [selectedAssets, setSelectedAssets] = useState<
+    NonNullable<AssetExplorerProps['selectedAssets']>
+  >([]);
+
+  console.log(selectedAssets);
+
+  return (
+    <>
+      <AssetExplorer
+        iotSiteWiseClient={client}
+        onSelectAsset={setSelectedAssets}
+        selectedAssets={selectedAssets}
+        selectionMode='multi'
+      />
+
+      <AlarmExplorer
+        iotSiteWiseClient={client}
+        parameters={selectedAssets}
+        tableSettings={{
+          isUserSettingsEnabled: true,
+        }}
+      />
+    </>
+  );
+}
+
+export function AssetModelExplorerPlusAlarmExplorer() {
+  const [selectedAssetModels, setSelectedAssetModels] = useState<
+    NonNullable<AssetModelExplorerProps['selectedAssetModels']>
+  >([]);
+
+  return (
+    <>
+      <AssetModelExplorer
+        iotSiteWiseClient={client}
+        onSelectAssetModel={setSelectedAssetModels}
+        selectedAssetModels={selectedAssetModels}
+        selectionMode='multi'
+      />
+
+      <AlarmExplorer
+        iotSiteWiseClient={client}
+        parameters={selectedAssetModels}
+        tableSettings={{ isFilterEnabled: true, isUserSettingsEnabled: true }}
       />
     </>
   );


### PR DESCRIPTION
## Overview
Adds an Alarm resource explorer which uses the useAlarms hook to display a table of alarms from either asset or asset model parameters.

Note: Some of the tests for the explorers are commented out. They will be revisited in a following PR once the asset property values hooks part useAlarms are completed and stable.

<img width="585" alt="image" src="https://github.com/user-attachments/assets/0b7ae655-9a08-4fc2-b59b-7512a8abc09e">

<img width="576" alt="image" src="https://github.com/user-attachments/assets/4172ba1a-b97e-4582-8cde-e0ee7e5e6ae4">

<img width="843" alt="image" src="https://github.com/user-attachments/assets/18db26fa-288d-49a9-a416-b2ae741b8049">

<img width="840" alt="image" src="https://github.com/user-attachments/assets/e70837f1-a4c0-4930-a230-9f0d7d970de8">

<img width="832" alt="image" src="https://github.com/user-attachments/assets/266ce1d8-d31f-472c-ac9e-ad55785a187c">

<img width="841" alt="image" src="https://github.com/user-attachments/assets/a2f4ddf1-7850-4ed8-8828-2251d3b52a5d">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
