### PR TITLE
fix(dashboard): memo dashboard props to app changes resulting in dashboard reverting state

### DIFF
--- a/packages/tools-iottwinmaker/src/commands/deploy.spec.ts
+++ b/packages/tools-iottwinmaker/src/commands/deploy.spec.ts
@@ -179,10 +179,10 @@ it('creates new workspace when given workspace that does not exist and user prom
   expect(await handler(argv2)).toBe(0);
   expect(s3Mock.commandCalls(CreateBucketCommand).length).toBe(2);
   expect(s3Mock.commandCalls(PutBucketVersioningCommand).length).toBe(2);
-  expect(s3Mock.commandCalls(PutBucketPolicyCommand).length).toBe(2);
+  expect(s3Mock.commandCalls(PutBucketPolicyCommand).length).toBe(3);
   expect(s3Mock.commandCalls(PutPublicAccessBlockCommand).length).toBe(2);
   expect(s3Mock.commandCalls(PutBucketEncryptionCommand).length).toBe(2);
-  expect(s3Mock.commandCalls(PutBucketAclCommand).length).toBe(1);
+  expect(s3Mock.commandCalls(PutBucketAclCommand).length).toBe(0);
   expect(s3Mock.commandCalls(PutBucketCorsCommand).length).toBe(1);
   expect(twinmakerMock.commandCalls(GetWorkspaceCommand).length).toBe(4);
   expect(twinmakerMock.commandCalls(CreateWorkspaceCommand).length).toBe(1);


### PR DESCRIPTION
When the wrapping application changes layout it triggers a rerender of the dashboard and the un-memoized function parameters get called resulting in the initial dashboard state being applied even though the dashboard props haven't changed. This results in the unsaved changes being discarded and the user losing progress.

## Overview
All called functions used to set dashboard props are run through useMemo first to make them stable.

## Verifying Changes
While running dashboard inside a wrapping app layout, change the page layout by closing a tab, side navigation panel, notification bar, etc. 

The dashboard should keep any edits made even if not saved.  It should not swap between preview and edit modes.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
