### PR TITLE
fix(dashboard): remove promise client from public API and internally generate it

### DIFF
--- a/packages/dashboard/src/components/dashboard/clientContext.ts
+++ b/packages/dashboard/src/components/dashboard/clientContext.ts
@@ -1,8 +1,11 @@
+import { IoTSiteWise } from '@aws-sdk/client-iotsitewise';
 import { createContext, useContext } from 'react';
 import { DashboardIotSiteWiseClients } from '~/types';
 
-export const ClientContext = createContext<
-  Partial<DashboardIotSiteWiseClients>
->({});
+export interface DashboardClientContext extends DashboardIotSiteWiseClients {
+  iotSiteWise: IoTSiteWise;
+}
+
+export const ClientContext = createContext<Partial<DashboardClientContext>>({});
 
 export const useClients = () => useContext(ClientContext);

--- a/packages/dashboard/src/components/dashboard/getClients.ts
+++ b/packages/dashboard/src/components/dashboard/getClients.ts
@@ -3,9 +3,9 @@ import { IoTSiteWise, IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import {
   DashboardClientConfiguration,
-  DashboardIotSiteWiseClients,
   DashboardClientCredentials,
 } from '~/types';
+import { DashboardClientContext } from './clientContext';
 
 export const isCredentials = (
   dashboardClientConfiguration: DashboardClientConfiguration
@@ -15,9 +15,17 @@ export const isCredentials = (
 
 export const getClients = (
   dashboardClientConfiguration: DashboardClientConfiguration
-): DashboardIotSiteWiseClients => {
-  if (!isCredentials(dashboardClientConfiguration))
-    return dashboardClientConfiguration;
+): DashboardClientContext => {
+  if (!isCredentials(dashboardClientConfiguration)) {
+    return {
+      ...dashboardClientConfiguration,
+      iotSiteWise: new IoTSiteWise({
+        credentials:
+          dashboardClientConfiguration.iotSiteWiseClient.config.credentials,
+        region: dashboardClientConfiguration.iotSiteWiseClient.config.region,
+      }),
+    };
+  }
 
   const iotEventsClient = new IoTEventsClient({
     credentials: dashboardClientConfiguration.awsCredentials,

--- a/packages/dashboard/src/components/dashboard/index.test.tsx
+++ b/packages/dashboard/src/components/dashboard/index.test.tsx
@@ -7,11 +7,17 @@ import {
 import { DashboardWrapper as Dashboard } from './wrapper';
 import React from 'react';
 import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
-import {
-  IoTSiteWise,
-  type IoTSiteWiseClient,
-} from '@aws-sdk/client-iotsitewise';
+import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { RefreshRate } from '../refreshRate/types';
+
+const config = {
+  credentials: {
+    accessKeyId: '',
+    secretAccessKey: '',
+    sessionToken: '',
+  },
+  region: 'test-region',
+};
 
 it('renders', function () {
   const { queryByText, queryByTestId } = render(
@@ -27,12 +33,13 @@ it('renders', function () {
       }}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
-        iotSiteWiseClient:
-          createMockSiteWiseSDK() as unknown as IoTSiteWiseClient,
+        iotSiteWiseClient: {
+          ...createMockSiteWiseSDK(),
+          config,
+        } as unknown as IoTSiteWiseClient,
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
-        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );
@@ -56,12 +63,13 @@ it('renders in readonly initially', function () {
       }}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
-        iotSiteWiseClient:
-          createMockSiteWiseSDK() as unknown as IoTSiteWiseClient,
+        iotSiteWiseClient: {
+          ...createMockSiteWiseSDK(),
+          config,
+        } as unknown as IoTSiteWiseClient,
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
-        iotSiteWise: new IoTSiteWise(),
       }}
       initialViewMode='preview'
     />
@@ -93,12 +101,13 @@ it('renders in edit initially', function () {
       }}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
-        iotSiteWiseClient:
-          createMockSiteWiseSDK() as unknown as IoTSiteWiseClient,
+        iotSiteWiseClient: {
+          ...createMockSiteWiseSDK(),
+          config,
+        } as unknown as IoTSiteWiseClient,
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
-        iotSiteWise: new IoTSiteWise(),
       }}
       initialViewMode='edit'
     />
@@ -134,12 +143,13 @@ it('passes the correct viewMode to onSave', function () {
       dashboardConfiguration={savedConfig}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
-        iotSiteWiseClient:
-          createMockSiteWiseSDK() as unknown as IoTSiteWiseClient,
+        iotSiteWiseClient: {
+          ...createMockSiteWiseSDK(),
+          config,
+        } as unknown as IoTSiteWiseClient,
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
-        iotSiteWise: new IoTSiteWise(),
       }}
       initialViewMode='edit'
     />
@@ -171,11 +181,13 @@ it('renders dashboard name', function () {
       name='Test dashboard'
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
-        iotSiteWiseClient: createMockSiteWiseSDK() as IoTSiteWiseClient,
+        iotSiteWiseClient: {
+          ...createMockSiteWiseSDK(),
+          config,
+        } as unknown as IoTSiteWiseClient,
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
-        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );
@@ -197,11 +209,13 @@ it('renders without dashboard name', function () {
       }}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
-        iotSiteWiseClient: createMockSiteWiseSDK() as IoTSiteWiseClient,
+        iotSiteWiseClient: {
+          ...createMockSiteWiseSDK(),
+          config,
+        } as unknown as IoTSiteWiseClient,
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
-        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );

--- a/packages/dashboard/src/components/dashboard/view.test.tsx
+++ b/packages/dashboard/src/components/dashboard/view.test.tsx
@@ -4,13 +4,19 @@ import {
   createMockSiteWiseSDK,
 } from '@iot-app-kit/testing-util';
 import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
-import {
-  IoTSiteWise,
-  type IoTSiteWiseClient,
-} from '@aws-sdk/client-iotsitewise';
+import { type IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 
 import DashboardView from './view';
 import React from 'react';
+
+const config = {
+  credentials: {
+    accessKeyId: '',
+    secretAccessKey: '',
+    sessionToken: '',
+  },
+  region: 'test-region',
+};
 
 it('renders', function () {
   const { queryByText, queryByTestId } = render(
@@ -25,12 +31,13 @@ it('renders', function () {
       }}
       clientConfiguration={{
         iotEventsClient: createMockIoTEventsSDK(),
-        iotSiteWiseClient:
-          createMockSiteWiseSDK() as unknown as IoTSiteWiseClient,
+        iotSiteWiseClient: {
+          ...createMockSiteWiseSDK(),
+          config,
+        } as unknown as IoTSiteWiseClient,
         iotTwinMakerClient: {
           send: jest.fn(),
         } as unknown as IoTTwinMakerClient,
-        iotSiteWise: new IoTSiteWise(),
       }}
     />
   );

--- a/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
+++ b/packages/dashboard/src/customization/propertiesSections/propertiesPanel/panel.spec.tsx
@@ -1,4 +1,4 @@
-import { IoTSiteWise, IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { type IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import React from 'react';
 import {
@@ -105,7 +105,6 @@ const renderTestComponentAsync = async (
     }) as unknown as IoTSiteWiseClient,
     iotEventsClient: createMockIoTEventsSDK(),
     iotTwinMakerClient: { send: jest.fn() } as unknown as IoTTwinMakerClient,
-    iotSiteWise: new IoTSiteWise(),
   };
 
   await act(async () => {

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -3,7 +3,6 @@ import {
   IoTSiteWiseClient,
   DescribeDashboardRequest,
   DescribeDashboardResponse,
-  IoTSiteWise,
 } from '@aws-sdk/client-iotsitewise';
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
 import type { AwsCredentialIdentity, Provider } from '@aws-sdk/types';
@@ -26,7 +25,6 @@ export type DashboardIotSiteWiseClients = {
   iotSiteWiseClient: IoTSiteWiseClient;
   iotEventsClient: IoTEventsClient;
   iotTwinMakerClient: IoTTwinMakerClient;
-  iotSiteWise: IoTSiteWise;
 };
 
 export type DashboardIotSiteWiseQueries = {

--- a/packages/dashboard/stories/dashboard/edge-dashboard.stories.tsx
+++ b/packages/dashboard/stories/dashboard/edge-dashboard.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { IoTSiteWiseClient, IoTSiteWise } from '@aws-sdk/client-iotsitewise';
+import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import { registerPlugin } from '@iot-app-kit/core';
@@ -27,7 +27,6 @@ const clientConfig = {
 const iotSiteWiseClient = new IoTSiteWiseClient(clientConfig);
 const iotEventsClient = new IoTEventsClient(clientConfig);
 const iotTwinMakerClient = new IoTTwinMakerClient(clientConfig);
-const iotSiteWise = new IoTSiteWise(clientConfig);
 
 const DEFAULT_DASHBOARD_CONFIG = {
   displaySettings: {
@@ -42,7 +41,6 @@ const CLIENT_CONFIGURATION: DashboardClientConfiguration = {
   iotSiteWiseClient,
   iotEventsClient,
   iotTwinMakerClient,
-  iotSiteWise,
 };
 
 registerPlugin('metricsRecorder', {


### PR DESCRIPTION
## Overview
A public API change when upgrading the dashboard got released that breaks the dashboard experience. Removing the api change before release. To do so separated the type that was being used by both the dashboard and the client context, so only the client context has the promise based client. The client is now always generated internally from passed in credentials.

## Verifying Changes



## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
