### PR TITLE
feat(alarms): support alarms in resource explorer and in widget types

### DIFF
--- a/packages/dashboard/src/components/csvDownloadButton/index.tsx
+++ b/packages/dashboard/src/components/csvDownloadButton/index.tsx
@@ -78,11 +78,18 @@ export const CSVDownloadButton = ({
 
     // since fetchTimeSeriesData is async it'll wait for future viewports to be in cache
     // to avoid this, if viewport is in the future we dont request time series data
-    const mappedQuery = assetModelQueryToSiteWiseAssetQuery(queryConfig.query);
+    const { assetModels = [], assets = [] } = queryConfig.query ?? {};
+    const combinedAssets = assetModelQueryToSiteWiseAssetQuery({
+      assetModels,
+      assets,
+    });
     const dataStreams = isViewportInFuture
       ? []
       : await fetchTimeSeriesData({
-          query: mappedQuery,
+          query: {
+            ...queryConfig.query,
+            assets: combinedAssets,
+          },
           viewport: calculatedViewport,
           // since bar chart doesnt do raw data we need to pass a custom resolution mapping to handle auto select resolution mode
           settings:

--- a/packages/dashboard/src/components/dashboard/queryContext.ts
+++ b/packages/dashboard/src/components/dashboard/queryContext.ts
@@ -1,11 +1,41 @@
-import { DataStream, Primitive } from '@iot-app-kit/core';
 import { createContext, useContext } from 'react';
 import { useRefreshRate } from '~/customization/hooks/useRefreshRate';
+import { alarmModelQueryToSiteWiseAssetQuery } from '~/customization/widgets/utils/alarmModelQueryToAlarmQuery';
 import { assetModelQueryToSiteWiseAssetQuery } from '~/customization/widgets/utils/assetModelQueryToAssetQuery';
-import {
+
+import type {
+  DataStream,
+  Primitive,
+  TimeSeriesDataQuery,
+} from '@iot-app-kit/core';
+import type {
+  AlarmDataQuery,
+  SiteWiseDataStreamQuery,
+  SiteWiseQuery,
+  SiteWiseAlarmDataStreamQuery,
+} from '@iot-app-kit/source-iotsitewise';
+import type {
   DashboardIotSiteWiseQueries,
   IoTSiteWiseDataStreamQuery,
 } from '~/types';
+
+const createTimeSeriesDataQuery = (
+  iotSiteWiseQuery: SiteWiseQuery,
+  { assets = [], properties = [], requestSettings }: SiteWiseDataStreamQuery
+) => {
+  if (assets.length === 0 && properties.length === 0) return [];
+  return [
+    iotSiteWiseQuery.timeSeriesData({ assets, properties, requestSettings }),
+  ];
+};
+
+const createAlarmDataQuery = (
+  iotSiteWiseQuery: SiteWiseQuery,
+  { alarms = [], requestSettings }: SiteWiseAlarmDataStreamQuery
+) => {
+  if (alarms.length === 0) return [];
+  return [iotSiteWiseQuery.alarmData({ alarms, requestSettings })];
+};
 
 export const QueryContext = createContext<Partial<DashboardIotSiteWiseQueries>>(
   {}
@@ -16,30 +46,50 @@ export const useQueries = ({
   properties = [],
   assetModels = [],
   requestSettings = {},
-}: IoTSiteWiseDataStreamQuery = {}) => {
+  alarms = [],
+  alarmModels = [],
+}: IoTSiteWiseDataStreamQuery = {}): (
+  | AlarmDataQuery
+  | TimeSeriesDataQuery
+)[] => {
   const { iotSiteWiseQuery } = useContext(QueryContext);
   const [refreshRate] = useRefreshRate();
 
   if (
     iotSiteWiseQuery == null ||
-    (assets.length === 0 && properties.length === 0 && assetModels.length === 0)
+    (assets.length === 0 &&
+      properties.length === 0 &&
+      assetModels.length === 0 &&
+      alarms.length === 0)
   ) {
     return [];
   }
 
-  const mappedQuery = assetModelQueryToSiteWiseAssetQuery({
+  const combinedAssets = assetModelQueryToSiteWiseAssetQuery({
     assetModels,
     assets,
-    properties,
-    requestSettings: {
-      ...requestSettings,
-      refreshRate,
-    },
+  });
+  const combinedAlarms = alarmModelQueryToSiteWiseAssetQuery({
+    alarmModels,
+    alarms,
   });
 
-  const queries = [iotSiteWiseQuery.timeSeriesData(mappedQuery)] ?? [];
+  const requestSettingsWithRefreshRate = {
+    ...requestSettings,
+    refreshRate,
+  };
 
-  return queries;
+  return [
+    ...createTimeSeriesDataQuery(iotSiteWiseQuery, {
+      assets: combinedAssets,
+      properties,
+      requestSettings: requestSettingsWithRefreshRate,
+    }),
+    ...createAlarmDataQuery(iotSiteWiseQuery, {
+      alarms: combinedAlarms,
+      requestSettings: requestSettingsWithRefreshRate,
+    }),
+  ];
 };
 
 export const useFetchTimeSeriesData = () => {

--- a/packages/dashboard/src/components/queryEditor/helpers/alarmSelectionLabel.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/alarmSelectionLabel.ts
@@ -1,0 +1,20 @@
+import {
+  AlarmExplorerProps,
+  AlarmResource,
+} from '@iot-app-kit/react-components';
+
+export function alarmSelectionLabel(
+  selectedItems: AlarmExplorerProps['selectedAlarms'],
+  modeledDataStream: AlarmResource
+) {
+  const isPropertySelected = selectedItems?.find(
+    (item) =>
+      item.assetCompositeModelId === modeledDataStream.assetCompositeModelId
+  );
+
+  if (!isPropertySelected) {
+    return `Select alarm data stream ${modeledDataStream.name}`;
+  } else {
+    return `Deselect alarm data stream ${modeledDataStream.name}`;
+  }
+}

--- a/packages/dashboard/src/components/queryEditor/helpers/useIsAddButtonDisabled.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/useIsAddButtonDisabled.ts
@@ -11,7 +11,9 @@ export const useIsAddButtonDisabled = (selectedWidgets: DashboardWidget[]) => {
     if (
       query?.assetModels?.length ||
       query?.assets?.length ||
-      query?.properties?.length
+      query?.properties?.length ||
+      query?.alarms?.length ||
+      query?.alarmModels?.length
     )
       return true;
   }

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/createAlarmModelQuery.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/createAlarmModelQuery.ts
@@ -1,0 +1,20 @@
+import { AlarmExplorerProps } from '@iot-app-kit/react-components';
+import { SiteWiseAlarmAssetModelQuery } from '@iot-app-kit/source-iotsitewise';
+
+export const createAlarmModelQuery = ({
+  assetModelId,
+  assetId,
+  alarms,
+}: {
+  assetModelId: string;
+  alarms: NonNullable<AlarmExplorerProps['selectedAlarms']>;
+  assetId?: string;
+}): SiteWiseAlarmAssetModelQuery['alarmModels'] => [
+  {
+    assetModelId: assetModelId,
+    assetIds: assetId ? [assetId] : [],
+    alarmComponents: alarms.map(({ assetCompositeModelId }) => ({
+      assetCompositeModelId,
+    })),
+  },
+];

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/modelBasedQuery/findModelBasedQueryWidgets.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/modelBasedQuery/findModelBasedQueryWidgets.ts
@@ -12,7 +12,9 @@ export const findModelBasedQueryWidgets = (
   dashboardConfiguration.widgets
     .filter(isQueryWidget)
     .filter(
-      (w) => (w.properties.queryConfig.query?.assetModels ?? []).length > 0
+      (w) =>
+        (w.properties.queryConfig.query?.assetModels ?? []).length > 0 ||
+        (w.properties.queryConfig.query?.alarmModels ?? []).length > 0
     );
 
 export const hasModelBasedQuery = (

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/modelBasedQuery/useModelBasedQuery.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/modelBasedQuery/useModelBasedQuery.ts
@@ -52,6 +52,7 @@ export const useModelBasedQuery = () => {
             query: {
               ...properties.queryConfig.query,
               assetModels: [],
+              alarmModels: [],
             },
           },
         },
@@ -79,6 +80,12 @@ export const useModelBasedQuery = () => {
                   properties.queryConfig.query?.assetModels ?? []
                 ).map((assetModel) => ({
                   ...assetModel,
+                  assetIds: [id],
+                })),
+                alarmModels: (
+                  properties.queryConfig.query?.alarmModels ?? []
+                ).map((alarmModel) => ({
+                  ...alarmModel,
                   assetIds: [id],
                 })),
               },

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/components/expandableSectionHeading.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/components/expandableSectionHeading.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { fontSizeHeadingL } from '@cloudscape-design/design-tokens';
+
+export const ExpandableSectionHeading = ({
+  headerText,
+}: {
+  headerText: string;
+}) => <h3 style={{ margin: 0, fontSize: fontSizeHeadingL }}>{headerText}</h3>;

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/queryExtender/queryExtender.spec.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/queryExtender/queryExtender.spec.ts
@@ -1,4 +1,7 @@
-import { type TimeSeriesResource } from '@iot-app-kit/react-components/dist/es/components/resource-explorers/types/resources';
+import {
+  type AlarmResource,
+  type TimeSeriesResource,
+} from '@iot-app-kit/react-components';
 import { ModeledDataStream } from '../modeledDataStreamQueryEditor/modeledDataStreamExplorer/types';
 import { QueryExtender } from './queryExtender';
 
@@ -175,5 +178,121 @@ describe(QueryExtender.name, () => {
     const extendedQuery = queryExtender.extendPropertyAliasQueries([]);
 
     expect(extendedQuery).toEqual(currentQuery);
+  });
+
+  describe('extendAlarmQueries', () => {
+    it('should extend the current query with new alarm queries', () => {
+      const currentQuery = {
+        alarms: [
+          {
+            assetId: 'asset-1',
+            alarmComponents: [{ assetCompositeModelId: 'alarm-1' }],
+          },
+        ],
+        assets: [
+          {
+            assetId: 'asset-1',
+            properties: [{ propertyId: 'property-1' }],
+          },
+        ],
+        properties: [{ propertyAlias: 'property-1' }],
+      };
+      const queryExtender = new QueryExtender(currentQuery);
+      const modeledAlarmStreams = [
+        {
+          assetId: 'asset-2',
+          assetCompositeModelId: 'alarm-2',
+        },
+      ] as AlarmResource[];
+
+      const extendedQuery =
+        queryExtender.extendAlarmQueries(modeledAlarmStreams);
+
+      expect(extendedQuery).toEqual({
+        alarms: [
+          {
+            assetId: 'asset-1',
+            alarmComponents: [{ assetCompositeModelId: 'alarm-1' }],
+          },
+          {
+            assetId: 'asset-2',
+            alarmComponents: [{ assetCompositeModelId: 'alarm-2' }],
+          },
+        ],
+        assets: [
+          {
+            assetId: 'asset-1',
+            properties: [{ propertyId: 'property-1' }],
+          },
+        ],
+        properties: [{ propertyAlias: 'property-1' }],
+      });
+    });
+
+    it('should dedupe alarm queries with properties', () => {
+      const currentQuery = {
+        alarms: [
+          {
+            assetId: 'asset-1',
+            alarmComponents: [{ assetCompositeModelId: 'alarm-1' }],
+          },
+        ],
+      };
+      const queryExtender = new QueryExtender(currentQuery);
+      const modeledAlarmStreams = [
+        {
+          assetId: 'asset-1',
+          assetCompositeModelId: 'alarm-1',
+        },
+        {
+          assetId: 'asset-1',
+          assetCompositeModelId: 'alarm-2',
+        },
+      ] as AlarmResource[];
+
+      const extendedQuery =
+        queryExtender.extendAlarmQueries(modeledAlarmStreams);
+
+      expect(extendedQuery).toEqual({
+        alarms: [
+          {
+            assetId: 'asset-1',
+            alarmComponents: [
+              { assetCompositeModelId: 'alarm-1' },
+              { assetCompositeModelId: 'alarm-2' },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('should initialize with an empty query when no argument is passed', () => {
+      const queryExtender = new QueryExtender();
+      const extendedQuery = queryExtender.extendAlarmQueries([]);
+
+      expect(extendedQuery).toEqual({ alarms: [] });
+    });
+
+    it('should return the current query when an empty array is passed to extendAssetQueries', () => {
+      const currentQuery = {
+        alarms: [
+          {
+            assetId: 'asset-1',
+            alarmComponents: [{ assetCompositeModelId: 'alarm-1' }],
+          },
+        ],
+        assets: [
+          {
+            assetId: 'asset-1',
+            properties: [{ propertyId: 'property-1' }],
+          },
+        ],
+        properties: [{ propertyAlias: 'property-1' }],
+      };
+      const queryExtender = new QueryExtender(currentQuery);
+      const extendedQuery = queryExtender.extendAlarmQueries([]);
+
+      expect(extendedQuery).toEqual(currentQuery);
+    });
   });
 });

--- a/packages/dashboard/src/components/queryEditor/useQuery.ts
+++ b/packages/dashboard/src/components/queryEditor/useQuery.ts
@@ -22,6 +22,8 @@ export const styledQueryWidgetOnDrop = (
     assets: [],
     properties: [],
     assetModels: [],
+    alarms: [],
+    alarmModels: [],
     ...updatedQuery,
   };
 

--- a/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
+++ b/packages/dashboard/src/customization/widgets/lineScatterChart/component.tsx
@@ -165,10 +165,18 @@ const LineScatterChartWidgetComponent: React.FC<LineScatterChartWidget> = (
   } = widget.properties;
 
   const query = queryConfig.query;
+
   const queries = useQueries(query);
 
-  const mappedQuery = assetModelQueryToSiteWiseAssetQuery(query);
-  const styleSettings = useAdaptedStyleSettings({ line, symbol }, mappedQuery);
+  const { assetModels = [], assets = [] } = query ?? {};
+  const combinedAssets = assetModelQueryToSiteWiseAssetQuery({
+    assetModels,
+    assets,
+  });
+  const styleSettings = useAdaptedStyleSettings(
+    { line, symbol },
+    { ...query, assets: combinedAssets }
+  );
 
   const aggregation = getAggregation(widget);
 

--- a/packages/dashboard/src/customization/widgets/table/component.tsx
+++ b/packages/dashboard/src/customization/widgets/table/component.tsx
@@ -64,9 +64,16 @@ const TableWidgetComponent: React.FC<TableWidget> = (widget) => {
   const queries = useQueries(queryConfig.query);
   const key = createWidgetRenderKey(widget.id);
 
-  const mappedQuery = assetModelQueryToSiteWiseAssetQuery(queryConfig.query);
+  const { assets = [], assetModels = [] } = queryConfig.query ?? {};
+  const combinedAssets = assetModelQueryToSiteWiseAssetQuery({
+    assets,
+    assetModels,
+  });
   // if styleSettings is undefined, pass empty object so useTableItems does not pick name property
-  const items = useTableItems(mappedQuery, styleSettings ?? {});
+  const items = useTableItems(
+    { ...queryConfig.query, assets: combinedAssets },
+    styleSettings ?? {}
+  );
 
   const significantDigits =
     widgetSignificantDigits ?? dashboardSignificantDigits;

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -8,6 +8,8 @@ import type {
   SiteWiseAssetQuery,
   SiteWisePropertyAliasQuery,
   SiteWiseAssetModelQuery,
+  SiteWiseAlarmQuery,
+  SiteWiseAlarmAssetModelQuery,
 } from '@iot-app-kit/source-iotsitewise';
 import type { DashboardWidget } from '~/types';
 import type {
@@ -29,9 +31,11 @@ export type QueryConfig<S, T> = {
 
 export type SiteWiseQueryConfig = QueryConfig<
   'iotsitewise',
-  | (Partial<SiteWiseAssetQuery> &
+  | ((Partial<SiteWiseAssetQuery> &
       Partial<SiteWisePropertyAliasQuery> &
-      Partial<SiteWiseAssetModelQuery>)
+      Partial<SiteWiseAssetModelQuery>) &
+      Partial<SiteWiseAlarmQuery> &
+      Partial<SiteWiseAlarmAssetModelQuery>)
   | undefined
 >;
 
@@ -141,6 +145,15 @@ export type StyledAssetQuery = {
     assetModelId: SiteWiseAssetModelQuery['assetModels'][number]['assetModelId'];
     assetIds?: SiteWiseAssetModelQuery['assetModels'][number]['assetIds'];
     properties: StyledAssetPropertyQuery[];
+  }[];
+  alarms?: {
+    assetId: SiteWiseAlarmQuery['alarms'][number]['assetId'];
+    alarmComponents: SiteWiseAlarmQuery['alarms'][number]['alarmComponents'];
+  }[];
+  alarmModels?: {
+    assetModelId: SiteWiseAlarmAssetModelQuery['alarmModels'][number]['assetModelId'];
+    assetIds?: SiteWiseAlarmAssetModelQuery['alarmModels'][number]['assetIds'];
+    alarmComponents: SiteWiseAlarmQuery['alarms'][number]['alarmComponents'];
   }[];
 };
 

--- a/packages/dashboard/src/customization/widgets/utils/alarmModelQueryToAlarmQuery.ts
+++ b/packages/dashboard/src/customization/widgets/utils/alarmModelQueryToAlarmQuery.ts
@@ -1,0 +1,61 @@
+import {
+  AlarmAssetModelQuery,
+  SiteWiseAlarmQuery,
+} from '@iot-app-kit/source-iotsitewise';
+import uniq from 'lodash/uniq';
+import unionBy from 'lodash/unionBy';
+import { IoTSiteWiseDataStreamQuery } from '~/types';
+
+type AlarmModelQueryWithAssetId = Required<AlarmAssetModelQuery>;
+const alarmModelWithAssetId = (
+  alarmModelQuery: AlarmAssetModelQuery
+): alarmModelQuery is AlarmModelQueryWithAssetId =>
+  alarmModelQuery.assetIds != null && alarmModelQuery.assetIds.length > 0;
+
+const alarmModelQueryToAlarmQuery = (
+  alarmModelQuery: AlarmModelQueryWithAssetId
+) =>
+  alarmModelQuery.assetIds.map((assetId) => ({
+    assetId,
+    alarmComponents: alarmModelQuery.alarmComponents,
+  }));
+
+const combineAlarms = (
+  alarmsA: SiteWiseAlarmQuery['alarms'],
+  alarmsB: SiteWiseAlarmQuery['alarms']
+) => {
+  const assetIds = uniq([...alarmsA, ...alarmsB].map(({ assetId }) => assetId));
+  return assetIds.map((assetId) => {
+    const foundA = alarmsA.find((alarm) => alarm.assetId === assetId);
+    const foundB = alarmsB.find((alarm) => alarm.assetId === assetId);
+
+    if (foundA && foundB) {
+      return {
+        ...foundA,
+        alarmComponents: unionBy(
+          foundA.alarmComponents,
+          foundB.alarmComponents,
+          'assetCompositeModelId'
+        ),
+      };
+    }
+
+    // assetIds is the combined list of a and b, one must be defined;
+    return (foundA ?? foundB) as SiteWiseAlarmQuery['alarms'][number];
+  });
+};
+
+export const alarmModelQueryToSiteWiseAssetQuery = ({
+  alarmModels = [],
+  alarms = [],
+}: Pick<IoTSiteWiseDataStreamQuery, 'alarms' | 'alarmModels'>) => {
+  const alarmModelQueriesWithAssetId = alarmModels.filter(
+    alarmModelWithAssetId
+  );
+
+  const mappedAssetModelQuery = alarmModelQueriesWithAssetId.flatMap(
+    alarmModelQueryToAlarmQuery
+  );
+
+  return combineAlarms(alarms, mappedAssetModelQuery);
+};

--- a/packages/dashboard/src/customization/widgets/utils/assetModelQueryToAssetQuery.ts
+++ b/packages/dashboard/src/customization/widgets/utils/assetModelQueryToAssetQuery.ts
@@ -6,7 +6,7 @@ import {
 import unionBy from 'lodash/unionBy';
 import uniq from 'lodash/uniq';
 
-import { SiteWiseQueryConfig } from '../types';
+import { IoTSiteWiseDataStreamQuery } from '~/types';
 
 type AssetModelQueryWithAssetId = Required<AssetModelQuery>;
 const assetModelWithAssetId = (
@@ -42,10 +42,10 @@ const combineAssets = (
   });
 };
 
-export const assetModelQueryToSiteWiseAssetQuery = (
-  query: SiteWiseQueryConfig['query']
-) => {
-  const assetModels = query?.assetModels ?? [];
+export const assetModelQueryToSiteWiseAssetQuery = ({
+  assetModels = [],
+  assets = [],
+}: Pick<IoTSiteWiseDataStreamQuery, 'assetModels' | 'assets'>) => {
   const assetModelQueriesWithAssetId = assetModels.filter(
     assetModelWithAssetId
   );
@@ -54,10 +54,5 @@ export const assetModelQueryToSiteWiseAssetQuery = (
     assetModelQueryToAssetQuery
   );
 
-  const assetQuery = query?.assets ?? [];
-
-  return {
-    ...query,
-    assets: combineAssets(assetQuery, mappedAssetModelQuery),
-  };
+  return combineAssets(assets, mappedAssetModelQuery);
 };

--- a/packages/dashboard/src/customization/widgets/utils/assetQuery/applyAggregationToQuery.ts
+++ b/packages/dashboard/src/customization/widgets/utils/assetQuery/applyAggregationToQuery.ts
@@ -6,6 +6,8 @@ export const applyAggregationToQuery = (
     assets = [],
     properties = [],
     assetModels = [],
+    alarms = [],
+    alarmModels = [],
   }: IoTSiteWiseDataStreamQuery,
   aggregationType: AggregateType | undefined
 ) => ({
@@ -27,4 +29,6 @@ export const applyAggregationToQuery = (
       aggregationType,
     })),
   })),
+  alarms,
+  alarmModels,
 });

--- a/packages/dashboard/src/customization/widgets/utils/assetQuery/applyDefaultStylesToQuery.tsx
+++ b/packages/dashboard/src/customization/widgets/utils/assetQuery/applyDefaultStylesToQuery.tsx
@@ -5,6 +5,8 @@ export const applyDefaultStylesToQuery = ({
   assets = [],
   properties = [],
   assetModels = [],
+  alarms = [],
+  alarmModels = [],
 }: StyledAssetQuery) => {
   const assignDefaultColor = colorerFromStyledQuery({
     assets,
@@ -26,5 +28,7 @@ export const applyDefaultStylesToQuery = ({
         assignDefaultColor(propertyQuery)
       ),
     })),
+    alarms,
+    alarmModels,
   };
 };

--- a/packages/dashboard/src/customization/widgets/utils/assetQuery/applyResolutionToQuery.ts
+++ b/packages/dashboard/src/customization/widgets/utils/assetQuery/applyResolutionToQuery.ts
@@ -5,6 +5,8 @@ export const applyResolutionToQuery = (
     assets = [],
     properties = [],
     assetModels = [],
+    alarms = [],
+    alarmModels = [],
   }: IoTSiteWiseDataStreamQuery,
   resolution: string | undefined
 ) => ({
@@ -26,4 +28,6 @@ export const applyResolutionToQuery = (
       resolution,
     })),
   })),
+  alarms,
+  alarmModels,
 });

--- a/packages/dashboard/src/customization/widgets/utils/assetQuery/assignDefaultRefId.ts
+++ b/packages/dashboard/src/customization/widgets/utils/assetQuery/assignDefaultRefId.ts
@@ -7,6 +7,8 @@ export const assignDefaultRefId = (
     assets = [],
     properties = [],
     assetModels = [],
+    alarms = [],
+    alarmModels = [],
   }: IoTSiteWiseDataStreamQuery,
   getId: () => string = uuid
 ) => ({
@@ -28,4 +30,6 @@ export const assignDefaultRefId = (
       refId: propertyQuery.refId || getId(),
     })),
   })),
+  alarms,
+  alarmModels,
 });

--- a/packages/dashboard/src/customization/widgets/utils/assignDefaultStyleSettings.ts
+++ b/packages/dashboard/src/customization/widgets/utils/assignDefaultStyleSettings.ts
@@ -15,6 +15,7 @@ const assignDefaults = (
     assets = [],
     properties = [],
     assetModels = [],
+    alarms = [],
   }: IoTSiteWiseDataStreamQuery,
   resAndAggr: { aggregation?: AggregateType; resolution?: string },
   getId: () => string = uuid
@@ -43,6 +44,7 @@ const assignDefaults = (
       refId: propertyQuery.refId || getId(),
     })),
   })),
+  alarms,
 });
 
 const assignDefaultColors = (

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -7,10 +7,12 @@ import {
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
 import type { AwsCredentialIdentity, Provider } from '@aws-sdk/types';
 import {
+  SiteWiseAlarmQuery,
   SiteWiseAssetModelQuery,
   SiteWiseAssetQuery,
   SiteWisePropertyAliasQuery,
   SiteWiseQuery,
+  SiteWiseAlarmAssetModelQuery,
 } from '@iot-app-kit/source-iotsitewise';
 import { RefreshRate } from './components/refreshRate/types';
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
@@ -32,7 +34,11 @@ export type DashboardIotSiteWiseQueries = {
 };
 
 export type IoTSiteWiseDataStreamQuery = Partial<
-  SiteWiseAssetQuery & SiteWisePropertyAliasQuery & SiteWiseAssetModelQuery
+  SiteWiseAssetQuery &
+    SiteWisePropertyAliasQuery &
+    SiteWiseAssetModelQuery &
+    SiteWiseAlarmQuery &
+    SiteWiseAlarmAssetModelQuery
 >;
 
 export type DashboardClientConfiguration =

--- a/packages/react-components/src/common/chartTypes.ts
+++ b/packages/react-components/src/common/chartTypes.ts
@@ -1,3 +1,6 @@
+import { TimeSeriesDataQuery } from '@iot-app-kit/core';
+import { AlarmDataQuery } from '@iot-app-kit/source-iotsitewise';
+
 export type AxisSettings = {
   showX?: boolean;
   showY?: boolean;
@@ -8,3 +11,5 @@ export type ChartSize = {
   width: number;
   height: number;
 };
+
+export type ComponentQuery = AlarmDataQuery | TimeSeriesDataQuery;

--- a/packages/react-components/src/components/bar-chart/barChart.tsx
+++ b/packages/react-components/src/components/bar-chart/barChart.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   StyleSettingsMap,
   Threshold,
-  TimeSeriesDataQuery,
   Viewport,
   ThresholdSettings,
 } from '@iot-app-kit/core';
@@ -18,13 +17,18 @@ import {
   DEFAULT_VIEWPORT,
   ECHARTS_GESTURE,
 } from '../../common/constants';
-import { AxisSettings, ChartSize } from '../../common/chartTypes';
+import type {
+  AxisSettings,
+  ChartSize,
+  ComponentQuery,
+} from '../../common/chartTypes';
+import { getTimeSeriesQueries } from '../../utils/queries';
 
 const HOUR_IN_MS = 1000 * 60 * 60;
 const DAY_IN_MS = HOUR_IN_MS * 24;
 const FIFTEEN_MIN_IN_MS = 15 * 60 * 1000;
 export interface BarChartProps {
-  queries: TimeSeriesDataQuery[];
+  queries: ComponentQuery[];
   thresholdSettings?: ThresholdSettings;
   chartSize?: ChartSize;
   axis?: AxisSettings;
@@ -54,7 +58,7 @@ export const BarChart = (props: BarChartProps) => {
 
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
-    queries,
+    queries: getTimeSeriesQueries(queries),
     settings: {
       fetchFromStartToEnd: true,
       fetchMostRecentBeforeStart: true,

--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -36,6 +36,7 @@ import { PreferencesModalToggle } from './preferences/toggle';
 import { useDataQuality } from './hooks/useDataQuality';
 import { Timestamp } from '../timestampBar';
 import useDataStore from '../../store';
+import { getTimeSeriesQueries } from '../../utils/queries';
 
 /**
  * Developer Notes:
@@ -106,7 +107,7 @@ const BaseChart = ({
     thresholds,
     utilizedViewport,
     visibleData,
-  } = useVisualizedDataStreams(queries, viewport);
+  } = useVisualizedDataStreams(getTimeSeriesQueries(queries), viewport);
 
   //handle dataZoom updates, which are dependent on user events and viewportInMS changes
   useDataZoom(chartRef, utilizedViewport);

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -3,10 +3,10 @@ import {
   Primitive,
   StyledThreshold,
   ThresholdSettings,
-  TimeSeriesDataQuery,
   Viewport,
 } from '@iot-app-kit/core';
 import { OptionId } from 'echarts/types/src/util/types';
+import type { ComponentQuery } from '../../common/chartTypes';
 
 export type YAxisOptions = {
   yLabel?: string;
@@ -95,7 +95,7 @@ export type ChartDataQuality = {
 };
 
 export type ChartOptions = {
-  queries: TimeSeriesDataQuery[];
+  queries: ComponentQuery[];
   defaultVisualizationType?: Visualization;
   size?: SizeConfig;
   styleSettings?: ChartStyleSettings;

--- a/packages/react-components/src/components/dial/dial.tsx
+++ b/packages/react-components/src/components/dial/dial.tsx
@@ -4,16 +4,11 @@ import { DEFAULT_VIEWPORT, ECHARTS_GESTURE } from '../../common/constants';
 import { useTimeSeriesData } from '../../hooks/useTimeSeriesData';
 import { widgetPropertiesFromInputs } from '../../common/widgetPropertiesFromInputs';
 import { useViewport } from '../../hooks/useViewport';
-import type {
-  TimeQuery,
-  Threshold,
-  TimeSeriesData,
-  TimeSeriesDataRequest,
-  StyleSettingsMap,
-  Viewport,
-} from '@iot-app-kit/core';
+import type { Threshold, StyleSettingsMap, Viewport } from '@iot-app-kit/core';
 import type { DialSettings } from './types';
 import { DEFAULT_DIAL_SETTINGS } from './constants';
+import type { ComponentQuery } from '../../common/chartTypes';
+import { getTimeSeriesQueries } from '../../utils/queries';
 
 export const Dial = ({
   query,
@@ -22,7 +17,7 @@ export const Dial = ({
   styles,
   settings,
 }: {
-  query: TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>;
+  query: ComponentQuery;
   viewport?: Viewport;
   thresholds?: Threshold[];
   styles?: StyleSettingsMap;
@@ -30,7 +25,7 @@ export const Dial = ({
 }) => {
   const { dataStreams } = useTimeSeriesData({
     viewport: passedInViewport,
-    queries: [query],
+    queries: getTimeSeriesQueries([query]),
     // Currently set to only fetch raw data.
     // TODO: Support all resolutions and aggregation types
     settings: { fetchMostRecentBeforeEnd: true, resolution: '0' },

--- a/packages/react-components/src/components/gauge/gauge.tsx
+++ b/packages/react-components/src/components/gauge/gauge.tsx
@@ -12,6 +12,7 @@ import {
   DEFAULT_GAUGE_PROGRESS_COLOR,
   DEFAULT_GAUGE_STYLES,
 } from './constants';
+import { getTimeSeriesQueries } from '../../utils/queries';
 
 export const Gauge = ({
   size,
@@ -25,7 +26,7 @@ export const Gauge = ({
 }: GaugeProps) => {
   const { dataStreams } = useTimeSeriesData({
     viewport: passedInViewport,
-    queries: [query],
+    queries: getTimeSeriesQueries([query]),
     settings: { fetchMostRecentBeforeEnd: true },
     styles,
   });

--- a/packages/react-components/src/components/gauge/types.ts
+++ b/packages/react-components/src/components/gauge/types.ts
@@ -1,17 +1,15 @@
 import {
   StyleSettingsMap,
   Threshold,
-  TimeQuery,
-  TimeSeriesData,
-  TimeSeriesDataRequest,
   Viewport,
   Primitive,
 } from '@iot-app-kit/core';
 import type { WidgetSettings } from '../../common/dataTypes';
+import type { ComponentQuery } from '../../common/chartTypes';
 
 export type GaugeProps = {
   size?: { width: number; height: number };
-  query: TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>;
+  query: ComponentQuery;
   viewport?: Viewport;
   thresholds?: Threshold[];
   styles?: StyleSettingsMap;

--- a/packages/react-components/src/components/kpi/kpi.tsx
+++ b/packages/react-components/src/components/kpi/kpi.tsx
@@ -6,11 +6,12 @@ import { DEFAULT_VIEWPORT } from '../../common/constants';
 import type {
   StyleSettingsMap,
   Viewport,
-  TimeSeriesDataQuery,
   StyledThreshold,
 } from '@iot-app-kit/core';
 import type { KPISettings } from './types';
 import { KpiBase } from './kpiBase';
+import type { ComponentQuery } from '../../common/chartTypes';
+import { getTimeSeriesQueries } from '../../utils/queries';
 
 export const KPI = ({
   query,
@@ -21,7 +22,7 @@ export const KPI = ({
   significantDigits,
   timeZone,
 }: {
-  query: TimeSeriesDataQuery;
+  query: ComponentQuery;
   viewport?: Viewport;
   thresholds?: StyledThreshold[];
   styles?: StyleSettingsMap;
@@ -32,7 +33,7 @@ export const KPI = ({
 }) => {
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
-    queries: [query],
+    queries: getTimeSeriesQueries([query]),
     settings: {
       fetchMostRecentBeforeEnd: true,
     },

--- a/packages/react-components/src/components/resource-explorers/index.ts
+++ b/packages/react-components/src/components/resource-explorers/index.ts
@@ -15,6 +15,7 @@ export { DEFAULT_STRING_FILTER_OPERATORS } from './constants/defaults';
 export { DEFAULT_TIME_SERIES_WITH_LATEST_VALUES_TABLE_DEFINITION } from './constants/table-resource-definitions';
 export { resourceExplorerQueryClient } from './requests';
 export {
+  type AlarmResource,
   type AssetPropertyResource,
   type AssetResource,
   type TimeSeriesResource,

--- a/packages/react-components/src/components/status-timeline/statusTimeline.tsx
+++ b/packages/react-components/src/components/status-timeline/statusTimeline.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_VIEWPORT,
   ECHARTS_GESTURE,
 } from '../../common/constants';
+import type { ComponentQuery } from '../../common/chartTypes';
 
 // TODO: Remove this type assertion - iot-app-kit/charts has the wrong type for StatusTimeline
 const StatusTimelineBase: typeof LineChart =
@@ -35,7 +36,7 @@ export const StatusTimeline = ({
   styles,
   ...rest
 }: {
-  queries: TimeSeriesDataQuery[];
+  queries: ComponentQuery[];
   axis?: StatusTimelineAxisSettings;
   thresholds?: Threshold[];
   viewport?: Viewport;
@@ -46,7 +47,7 @@ export const StatusTimeline = ({
 }) => {
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
-    queries,
+    queries: queries.filter((q) => 'build' in q) as TimeSeriesDataQuery[],
     settings: {
       fetchFromStartToEnd: true,
       fetchMostRecentBeforeStart: true,

--- a/packages/react-components/src/components/status/status.tsx
+++ b/packages/react-components/src/components/status/status.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
-import type {
-  Threshold,
-  TimeQuery,
-  TimeSeriesData,
-  TimeSeriesDataRequest,
-  StyleSettingsMap,
-  Viewport,
-} from '@iot-app-kit/core';
-import type { StatusSettings } from './types';
 import { KPI } from '../kpi/kpi';
+import type { Threshold, StyleSettingsMap, Viewport } from '@iot-app-kit/core';
+import type { StatusSettings } from './types';
+import type { ComponentQuery } from '../../common/chartTypes';
 
 export const Status = ({
   query,
@@ -19,7 +13,7 @@ export const Status = ({
   settings,
   significantDigits,
 }: {
-  query: TimeQuery<TimeSeriesData[], TimeSeriesDataRequest>;
+  query: ComponentQuery;
   viewport?: Viewport;
   aggregationType?: string;
   thresholds?: Threshold[];

--- a/packages/react-components/src/components/table/table.tsx
+++ b/packages/react-components/src/components/table/table.tsx
@@ -2,17 +2,14 @@ import React from 'react';
 import { TableBase } from './tableBase';
 import { useTimeSeriesData } from '../../hooks/useTimeSeriesData';
 import { useViewport } from '../../hooks/useViewport';
-import type {
-  StyleSettingsMap,
-  Threshold,
-  TimeSeriesDataQuery,
-  Viewport,
-} from '@iot-app-kit/core';
+import type { StyleSettingsMap, Threshold, Viewport } from '@iot-app-kit/core';
 import { UseCollectionOptions } from '@cloudscape-design/collection-hooks';
 import { TableColumnDefinition, TableItem, TableItemHydrated } from './types';
 import { createTableItems } from './createTableItems';
 import { DEFAULT_TABLE_MESSAGES } from './messages';
 import { TableProps as TableBaseProps } from '@cloudscape-design/components';
+import type { ComponentQuery } from '../../common/chartTypes';
+import { getTimeSeriesQueries } from '../../utils/queries';
 
 const DEFAULT_VIEWPORT: Viewport = { duration: '10m' };
 
@@ -31,7 +28,7 @@ export const Table = ({
   ...props
 }: {
   columnDefinitions: TableColumnDefinition[];
-  queries: TimeSeriesDataQuery[];
+  queries: ComponentQuery[];
   items: TableItem[];
   thresholds?: Threshold[];
   sorting?: UseCollectionOptions<TableItemHydrated>['sorting'];
@@ -51,7 +48,7 @@ export const Table = ({
 >) => {
   const { dataStreams, thresholds: queryThresholds } = useTimeSeriesData({
     viewport: passedInViewport,
-    queries,
+    queries: getTimeSeriesQueries(queries),
     // Currently set to only fetch raw data.
     // TODO: Support all resolutions and aggregation types
     settings: { fetchMostRecentBeforeEnd: true, resolution: '0' },

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -52,14 +52,17 @@ export type {
 export { formatDate } from './utils/time';
 
 export {
+  AlarmExplorer,
   AssetModelExplorer,
   AssetExplorer,
   AssetPropertyExplorer,
   TimeSeriesExplorer,
+  type AlarmExplorerProps,
   type AssetModelExplorerProps,
   type AssetExplorerProps,
   type AssetPropertyExplorerProps,
   type TimeSeriesExplorerProps,
+  type AlarmResource,
   type AssetPropertyResource,
   type AssetResource,
   type TimeSeriesResource,

--- a/packages/react-components/src/store/config.ts
+++ b/packages/react-components/src/store/config.ts
@@ -1,6 +1,6 @@
 import { StateCreator } from 'zustand/esm';
 
-export type Flags = 'useModelBasedQuery';
+export type Flags = 'useModelBasedQuery' | 'useAlarms';
 export interface ConfigState {
   config: Record<Flags, boolean>;
   timeZone?: string;
@@ -8,5 +8,6 @@ export interface ConfigState {
 export const createConfigSlice: StateCreator<ConfigState> = () => ({
   config: {
     useModelBasedQuery: !!localStorage?.getItem('USE_MODEL_BASED_QUERY'),
+    useAlarms: !!localStorage?.getItem('USE_ALARMS'),
   },
 });

--- a/packages/react-components/src/utils/queries.ts
+++ b/packages/react-components/src/utils/queries.ts
@@ -1,0 +1,21 @@
+import type { TimeSeriesDataQuery } from '@iot-app-kit/core';
+import type { ComponentQuery } from '../common/chartTypes';
+import type { AlarmDataQuery } from '@iot-app-kit/source-iotsitewise';
+
+export const getTimeSeriesQueries = (
+  queries: ComponentQuery[]
+): TimeSeriesDataQuery[] => {
+  return queries.filter(
+    (query): query is TimeSeriesDataQuery =>
+      (query as TimeSeriesDataQuery).build !== undefined
+  );
+};
+
+export const getAlarmQueries = (
+  queries: ComponentQuery[]
+): AlarmDataQuery[] => {
+  return queries.filter(
+    (query): query is AlarmDataQuery =>
+      (query as AlarmDataQuery).query !== undefined
+  );
+};

--- a/packages/source-iotsitewise/src/index.ts
+++ b/packages/source-iotsitewise/src/index.ts
@@ -14,10 +14,14 @@ export type { SiteWiseAssetTreeNode } from './asset-modules/sitewise-asset-tree/
 export type { HierarchyGroup } from './asset-modules';
 export type {
   SiteWiseDataStreamQuery,
+  SiteWiseAlarmDataStreamQuery,
   SiteWiseAssetQuery,
   SiteWisePropertyAliasQuery,
   SiteWiseAssetModelQuery,
+  SiteWiseAlarmQuery,
+  SiteWiseAlarmAssetModelQuery,
   AssetModelQuery,
+  AlarmAssetModelQuery,
   AssetPropertyQuery,
   PropertyAliasQuery,
   AssetQuery,

--- a/packages/source-iotsitewise/src/time-series-data/types.ts
+++ b/packages/source-iotsitewise/src/time-series-data/types.ts
@@ -63,6 +63,12 @@ export type AssetModelQuery = {
   properties: AssetModelPropertyQuery[];
 };
 
+export type AlarmAssetModelQuery = {
+  assetModelId: AssetModelId;
+  assetIds?: AssetId[]; // can map multiple assets
+  alarmComponents: AlarmComponentQuery[];
+};
+
 export type AlarmComponentQuery = {
   /**
    * Asset composite model id for alarm.
@@ -98,6 +104,11 @@ export type SiteWisePropertyAliasQuery = DataStreamQuery & {
 
 export type SiteWiseAssetModelQuery = DataStreamQuery & {
   assetModels: AssetModelQuery[];
+  requestSettings?: RequestSettings;
+};
+
+export type SiteWiseAlarmAssetModelQuery = {
+  alarmModels: AlarmAssetModelQuery[];
   requestSettings?: RequestSettings;
 };
 


### PR DESCRIPTION
## Overview
- useQueries in dashboard now returns both timeSeriesData and alarm queries
    - due to above change, all react-component APIs had to be updated to accept timeseries OR alarm queries
    - also needed to filter queries passed into useTimeSeriesData until UX is ready
- updated resource explorer to display alarm data (gated behind USE_ALARMS)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
