### PR TITLE
feat(sitewise-alarms): alarm data status now single error and marked useAlarms as experimental

### DIFF
--- a/packages/react-components/src/hooks/useAlarms/types.ts
+++ b/packages/react-components/src/hooks/useAlarms/types.ts
@@ -19,7 +19,7 @@ export type AlarmDataStatus = {
   isRefetching: boolean; // will be true whenever subsequent api calls are being executed
   isSuccess: boolean;
   isError: boolean;
-  errors?: Error[];
+  error?: Error;
 };
 
 /**

--- a/packages/react-components/src/hooks/useAlarms/useAlarms.ts
+++ b/packages/react-components/src/hooks/useAlarms/useAlarms.ts
@@ -42,6 +42,10 @@ function useAlarms<T>(
  * useAlarms implementation which branches based on the 2 scenarios above.
  * If transform is defined, the output is T[], dictated by the second signature above.
  * If transform is undefined, the output is AlarmData[], dicatated by the first signature above.
+ *
+ * Given a list of AlarmRequests, fetch all available data for the alarms.
+ *
+ * @experimental Do not use in production
  */
 function useAlarms<T>(options?: UseAlarmsOptions<T>): (T | AlarmData)[] {
   const {
@@ -105,14 +109,18 @@ function useAlarms<T>(options?: UseAlarmsOptions<T>): (T | AlarmData)[] {
   );
 
   // Remove internal properties on AlarmDataInternal
-  const alarmData: AlarmData[] = inputPropertiesAlarmData.map(
-    ({
-      request: _unusedRequest,
-      properties: _unusedProperties,
-      ...alarmData
-    }) => ({
-      ...alarmData,
-    })
+  const alarmData: AlarmData[] = useMemo(
+    () =>
+      inputPropertiesAlarmData.map(
+        ({
+          request: _unusedRequest,
+          properties: _unusedProperties,
+          ...alarmData
+        }) => ({
+          ...alarmData,
+        })
+      ),
+    [inputPropertiesAlarmData]
   );
 
   /**


### PR DESCRIPTION
## Overview
Updated `AlarmData.status` `errors` to be a single `error`. We decided that it is not useful to provide multiple error objects for devs or other customers to parse. We still need to determine exactly what will be placed in this field, but for now we agree that a single error is more useful than an array of errors.

Also marked the `useAlarms` hook as experimental. We do not need to expose this in the public API yet either way.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
