### PR TITLE
feat(bar chart alarms): add alarms to bar chart

### DIFF
--- a/packages/react-components/src/queries/utils/convertAlarmQueryToAlarmRequest.ts
+++ b/packages/react-components/src/queries/utils/convertAlarmQueryToAlarmRequest.ts
@@ -1,0 +1,18 @@
+import { AlarmDataQuery } from '@iot-app-kit/source-iotsitewise';
+import { AlarmCompositeModelRequest } from '../../hooks/useAlarms';
+
+export const convertAlarmQueryToAlarmRequest = (
+  alarmQuery: AlarmDataQuery
+): AlarmCompositeModelRequest[] => {
+  return (
+    alarmQuery.query.alarms?.reduce((results, alarm) => {
+      alarm.alarmComponents.map((component) => {
+        results.push({
+          assetId: alarm.assetId,
+          assetCompositeModelId: component.assetCompositeModelId,
+        });
+      });
+      return results;
+    }, [] as AlarmCompositeModelRequest[]) ?? []
+  );
+};

--- a/packages/react-components/src/utils/transformAlarmsToThreshold.ts
+++ b/packages/react-components/src/utils/transformAlarmsToThreshold.ts
@@ -1,0 +1,62 @@
+import { Threshold } from '@iot-app-kit/core';
+import { AlarmData } from '../hooks/useAlarms';
+import { IoTEventsToSynchroChartsComparisonOperator } from '@iot-app-kit/source-iotsitewise';
+import { COMPARATOR_MAP, COMPARISON_OPERATOR } from '../common/constants';
+
+const createThreshold = ({
+  thresholdValue,
+  severity,
+  labelText,
+  comparisonOperator,
+}: {
+  thresholdValue: number;
+  severity: number | undefined;
+  labelText: string;
+  comparisonOperator: COMPARISON_OPERATOR;
+}): Threshold => {
+  return {
+    color: 'red',
+    value: thresholdValue,
+    severity: severity,
+    showValue: false,
+    label: {
+      text: labelText,
+      show: true,
+    },
+    comparisonOperator: comparisonOperator,
+  };
+};
+
+export const transformAlarmsToThreshold = (
+  alarm: AlarmData
+): Threshold | undefined => {
+  const { models, inputProperty, thresholds, status } = alarm;
+  const modelsFound = models && models.length !== 0;
+  const thresholdsFound = thresholds && thresholds?.length !== 0;
+
+  if (status.isSuccess) {
+    if (modelsFound && thresholdsFound) {
+      const model = models[0];
+      const threshold = thresholds[thresholds.length - 1];
+
+      const thresholdValue =
+        threshold.value?.doubleValue ?? threshold.value?.integerValue;
+      const comparisonOperator =
+        model.alarmRule?.simpleRule?.comparisonOperator;
+      const property = inputProperty && inputProperty.at(0);
+
+      if (thresholdValue && comparisonOperator && property) {
+        const scComparisonOperator = IoTEventsToSynchroChartsComparisonOperator[
+          comparisonOperator
+        ] as COMPARISON_OPERATOR;
+
+        return createThreshold({
+          labelText: `${property.name} ${COMPARATOR_MAP[scComparisonOperator]} ${thresholdValue}`,
+          thresholdValue: thresholdValue,
+          severity: model.severity,
+          comparisonOperator: scComparisonOperator,
+        });
+      }
+    }
+  }
+};

--- a/packages/source-iotsitewise/src/alarms/iotevents/index.ts
+++ b/packages/source-iotsitewise/src/alarms/iotevents/index.ts
@@ -2,4 +2,7 @@ export * from './types';
 export * from './siteWiseAlarmModule';
 export { parseAlarmData } from './util/parseAlarmData';
 export { constructAlarmThresholds } from './util/constructAlarmThresholds';
-export { SOURCE } from './constants';
+export {
+  SOURCE,
+  IoTEventsToSynchroChartsComparisonOperator,
+} from './constants';

--- a/packages/source-iotsitewise/src/index.ts
+++ b/packages/source-iotsitewise/src/index.ts
@@ -4,6 +4,7 @@ export * from './__mocks__';
 export { initialize } from './initialize';
 export { BranchReference } from './asset-modules/sitewise-asset-tree/types';
 export { toId, fromId } from './time-series-data/util/dataStreamId';
+export { IoTEventsToSynchroChartsComparisonOperator } from './alarms/iotevents';
 export type {
   SiteWiseDataSourceInitInputs,
   SiteWiseQuery,


### PR DESCRIPTION
## Overview

Add alarms to the bar chart by using the synchr-charts threshold props 

https://github.com/user-attachments/assets/1b5b97d4-3a16-4550-9f61-630cd78c0347

custom alarm only:
<img width="697" alt="Screenshot 2024-09-25 at 14 11 15" src="https://github.com/user-attachments/assets/aa3de83c-2d59-4f7b-b854-a1074045b436">

demo alarm only:
<img width="697" alt="Screenshot 2024-09-25 at 14 11 01" src="https://github.com/user-attachments/assets/fced119c-6689-44f9-8fd5-edd88cc8cd3e">

zoomed in so label isnt hidden: 
<img width="729" alt="image" src="https://github.com/user-attachments/assets/6b76f49c-e409-4001-8b88-2c672ef52d94">


Tests:

| Test    | Outcome |
| -------- | ------- |
| Custom alarm  | Alarm renders properly |
| Demo alarm | Alarm renders properly     |
| Custom and Demo Alarm    | Both alarms render properly    |





## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
