### PR TITLE
fix(alarm thresholds): only filter threshold values past the viewport end date

### DIFF
--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/useAlarmThreshold.spec.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/useAlarmThreshold.spec.ts
@@ -226,7 +226,7 @@ describe('useAlarmThreshold', () => {
 
     expect(batchGetAssetPropertyValueMock).not.toHaveBeenCalled();
 
-    expect(batchGetAssetPropertyValueHistoryMock).toHaveBeenCalledOnce();
+    expect(batchGetAssetPropertyValueHistoryMock).toHaveBeenCalledTimes(2);
     expect(result.current[0].thresholds).toEqual(
       mockAssetProperty1Data.reverse()
     );
@@ -248,14 +248,10 @@ describe('useAlarmThreshold', () => {
       expect(result.current[1].status.isSuccess).toBe(true);
     });
 
-    expect(batchGetAssetPropertyValueHistoryMock).toHaveBeenCalledTimes(2);
+    expect(batchGetAssetPropertyValueHistoryMock).toHaveBeenCalledTimes(4);
 
-    expect(result.current[0].thresholds).toEqual(
-      mockAssetProperty1Data.slice(2)
-    );
-    expect(result.current[1].thresholds).toEqual(
-      mockAssetProperty2Data.slice(2)
-    );
+    expect(result.current[0].thresholds).toEqual(mockAssetProperty1Data);
+    expect(result.current[1].thresholds).toEqual(mockAssetProperty2Data);
   });
 
   it('fetches the historical threshold asset properties within a live viewport.', async () => {
@@ -322,7 +318,7 @@ describe('useAlarmThreshold', () => {
 
     expect(batchGetAssetPropertyValueMock).not.toHaveBeenCalled();
 
-    expect(batchGetAssetPropertyValueHistoryMock).toHaveBeenCalledOnce();
+    expect(batchGetAssetPropertyValueHistoryMock).toHaveBeenCalledTimes(2);
     expect(result.current[0].thresholds).toEqual(
       mockAssetProperty1Data.reverse()
     );
@@ -353,7 +349,7 @@ describe('useAlarmThreshold', () => {
       jest.advanceTimersByTime(TEST_ADVANCE_TIMERS_PAST_REFRESH_RATE);
     });
 
-    expect(batchGetAssetPropertyValueHistoryMock).toHaveBeenCalledTimes(2);
+    expect(batchGetAssetPropertyValueHistoryMock).toHaveBeenCalledTimes(4);
 
     jest.useRealTimers();
   });

--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/useAlarmThreshold.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/useAlarmThreshold.ts
@@ -1,5 +1,8 @@
 import { useMemo } from 'react';
-import { IoTSiteWiseClient } from '@aws-sdk/client-iotsitewise';
+import {
+  AssetPropertyValue,
+  IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
 import { Viewport } from '@iot-app-kit/core';
 import { AlarmData } from '../types';
 import {
@@ -82,7 +85,7 @@ export const useAlarmThreshold = ({
    * Useful if there is no threshold data within the viewport.
    */
   const mostRecentBeforeEndValueQueries = useHistoricalAssetPropertyValues({
-    enabled: enabled && queryMode === 'LATEST_IN_VIEWPORT',
+    enabled: enabled && queryMode !== 'LATEST',
     iotSiteWiseClient,
     requests,
     viewport,
@@ -123,12 +126,13 @@ export const useAlarmThreshold = ({
             ? getStaticThresholdAsAssetPropertyValue(alarm.models[0])
             : undefined;
 
-        let thresholdData = staticThresholdValue
+        const staticThresholdData = staticThresholdValue
           ? [staticThresholdValue]
-          : undefined;
+          : [];
+        let thresholdData: AssetPropertyValue[] = [];
 
         // If there is no static value then the query may have data for the threshold
-        if (!thresholdData) {
+        if (!staticThresholdData.length) {
           updateAlarmStatusForQueries(alarm, [
             latestValueQuery,
             mostRecentBeforeEndValueQuery,
@@ -144,7 +148,11 @@ export const useAlarmThreshold = ({
           ];
         }
 
-        updateAlarmThresholdData(alarm, { data: thresholdData, viewport });
+        updateAlarmThresholdData(alarm, {
+          data: thresholdData,
+          viewport,
+          staticData: staticThresholdData,
+        });
 
         return alarm;
       }) ?? []

--- a/packages/react-components/src/hooks/useAlarms/utils/alarmThresholdValueFilterer.ts
+++ b/packages/react-components/src/hooks/useAlarms/utils/alarmThresholdValueFilterer.ts
@@ -1,0 +1,27 @@
+import { Bisector } from 'd3-array';
+import { Interval } from '../../../queries';
+
+export const alarmThresholdValueFilterer =
+  <Point>(
+    bisector: Bisector<Point, Date>,
+    extractTime: (point: Point) => number
+  ) =>
+  (points: Point[], { end }: Interval, includeBoundaryPoints = true) => {
+    if (points.length === 0) {
+      return [];
+    }
+
+    // If all data is after the view port
+    if (end.getTime() < extractTime(points[0])) {
+      return [];
+    }
+
+    // Otherwise return all the data before the end of the viewport
+    const startIndex = Math.max(0);
+    const endIndex = Math.min(
+      bisector.right(points, end) - (includeBoundaryPoints ? 0 : 1),
+      points.length - 1
+    );
+
+    return points.slice(startIndex, endIndex + 1);
+  };


### PR DESCRIPTION
## Overview
Static alarm thresholds were being filtered when a viewport was provided. This change updates the logic to always prioritze static alarm threshold values. Thresholds were being filtered to use anything within viewport.

Changes: 
1. prioritize static thresholds
2. always create `mostRecentBeforeEndValueQueries` as long as queryMode !== latest
3. filter all thresholdData that is after the viewport end


### test cases + outcomes

| Alarm(s) | Viewport | Outcome |
| -------- | ------- | ------- |
| custom alarm property with a static threshold | last 10 minutes | static threshold is used |
| custom alarm property with a static threshold | none | static threshold is used |
| demo alarm with ingested threshold | last 10 minutes | will fetch and use last threshold before end of viewport |
| demo alarm with ingested threshold | none | will fetch and use last threshold before end of viewport |
| custom alarm property with a static threshold value + demo alarm with ingested threshold | last 10 minutes | will use static value for custom alarm and use last threshold before end of viewport |
| custom alarm property with a static threshold value + demo alarm with ingested threshold | none | will use static value for custom alarm and use last threshold before end of viewport |

example: fetching custom alarm with defined viewport
```
"thresholds": [
      {
        "value": {
          "doubleValue": 10
        },
        "timestamp": {
          "timeInSeconds": 1727122118
        }
      }
    ]
```

example: fetching demo data alarm with defined viewport
```
"thresholds": [
      {
        "quality": "GOOD",
        "timestamp": {
          "offsetInNanos": 0,
          "timeInSeconds": 1727121673
        },
        "value": {
          "doubleValue": 30
        }
      }
    ]
```


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
