### PR TITLE
fix(dashboard): remove absolute positioning for RE footer

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/footer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/footer.tsx
@@ -10,7 +10,6 @@ import {
   spaceStaticXxxs,
 } from '@cloudscape-design/design-tokens';
 import './index.css';
-import { STICKY_BUTTON_WIDTH_FACTOR } from '../constants';
 
 export type ResourceExplorerFooterOptions = {
   addDisabled?: boolean;
@@ -29,7 +28,7 @@ export const ResourceExplorerFooter = ({
   const stickyFooter = {
     backgroundColor: colorBackgroundContainerContent,
     bottom: spaceStaticXxxs,
-    width: width + STICKY_BUTTON_WIDTH_FACTOR,
+    width: width,
     borderTop: `${spaceStaticXxxs} solid ${colorBorderDividerDefault}`,
   };
 

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/index.css
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/footer/index.css
@@ -1,5 +1,4 @@
 .queryeditor-button-sticky {
   position: fixed;
   z-index: 999;
-  left: 0;
 }


### PR DESCRIPTION
## Overview
Having the left: 0 was causing issues in Juicebox RE footer due to there being a sidenav. This places it at the bottom of the screen instead.
![Screenshot 2024-09-24 at 1 54 11 PM](https://github.com/user-attachments/assets/93ed38cb-ba53-40cc-98c3-2db46dc4fe45)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
