### PR TITLE
fix(dashboard: testing): filter by asset model type in MSW to fix flaky test

### DIFF
--- a/packages/dashboard/src/msw/iot-sitewise/handlers/listAssetModels/listAssetModels.ts
+++ b/packages/dashboard/src/msw/iot-sitewise/handlers/listAssetModels/listAssetModels.ts
@@ -7,7 +7,12 @@ import { summarizeAssetModel } from '../../resources/assetModels/summarizeAssetM
 
 export function listAssetModelsHandler() {
   return rest.get(LIST_ASSET_MODELS_URL, (_req, res, ctx) => {
-    const assetModelSummaries = ASSET_MODELS.getAll().map(summarizeAssetModel);
+    let assetModelSummaries = ASSET_MODELS.getAll().map(summarizeAssetModel);
+    if (_req.url.search.includes('assetModelTypes=ASSET_MODEL')) {
+      assetModelSummaries = assetModelSummaries?.filter(
+        (summmary) => summmary.assetModelType !== 'COMPONENT_MODEL'
+      );
+    }
     const response: ListAssetModelsResponse = { assetModelSummaries };
 
     return res(ctx.delay(), ctx.status(200), ctx.json(response));


### PR DESCRIPTION
## Overview
[Flaky test](https://github.com/awslabs/iot-app-kit/blob/f371eae2fa80e3ae4399dfd8f4194b971a55b4b7/packages/dashboard/e2e/tests/resourceExplorer/resourceExplorer.spec.ts#L304) was passing before bc the API call to listAssetModels would not always be quick enough to render the composite model property. It should have failed everytime because MSW was returning all assetModels regardless of filter.

Added filter based on query parameters to MSW listAssetModels call to reflect filtering of models of COMPONENT_MODEL type in dynamic assets tab.

## Verifying Changes

All tests pass, including flaky [one](https://github.com/awslabs/iot-app-kit/blob/f371eae2fa80e3ae4399dfd8f4194b971a55b4b7/packages/dashboard/e2e/tests/resourceExplorer/resourceExplorer.spec.ts#L304)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
