### PR TITLE
fix(dashboard): state fixes for dynamic assets tab

### DIFF
--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesExplorer.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetModelPropertiesExplorer/assetModelPropertiesExplorer.tsx
@@ -19,6 +19,7 @@ export interface AssetExplorerProps {
   selectedWidgets: DashboardWidget[];
   timeZone?: string;
   significantDigits?: number;
+  correctSelectionMode: 'single' | 'multi';
 }
 
 export const AssetModelPropertiesExplorer = ({
@@ -29,12 +30,13 @@ export const AssetModelPropertiesExplorer = ({
   selectedWidgets,
   timeZone,
   significantDigits,
+  correctSelectionMode,
 }: AssetExplorerProps) => {
   return (
     <AssetPropertyExplorer
       iotSiteWiseClient={iotSiteWiseClient}
       parameters={selectedAsset}
-      selectionMode='multi'
+      selectionMode={correctSelectionMode}
       onSelectAssetProperty={selectAssetModelProperties}
       selectedAssetProperties={selectedAssetModelProperties}
       tableSettings={{

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/createAssetModelQuery.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/createAssetModelQuery.ts
@@ -8,10 +8,12 @@ export const createAssetModelQuery = ({
   assetModelId: string;
   assetModelPropertyIds: string[];
   assetId?: string;
-}): SiteWiseAssetModelQuery['assetModels'] => [
-  {
-    assetModelId: assetModelId,
-    assetIds: assetId ? [assetId] : [],
-    properties: assetModelPropertyIds.map((propertyId) => ({ propertyId })),
-  },
-];
+}): SiteWiseAssetModelQuery['assetModels'] => {
+  return [
+    {
+      assetModelId: assetModelId,
+      assetIds: assetId ? [assetId] : [],
+      properties: assetModelPropertyIds.map((propertyId) => ({ propertyId })),
+    },
+  ];
+};

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/getAssetModelQueryInformation.ts
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/assetModelDataStreamExplorer/getAssetModelQueryInformation.ts
@@ -8,12 +8,16 @@ export const getAssetModelQueryInformation = (
 
   const assetModelId = firstAssetModel?.assetModelId;
   const assetId = firstAssetModel?.assetIds?.at(0);
-  const propertyIds = firstAssetModel?.properties.map(
+
+  const propertyIds: string[] | undefined = firstAssetModel?.properties.map(
     ({ propertyId }) => propertyId
   );
+  // dedupe any new property ids
+  const uniquePropertyIds = [...new Set(propertyIds)];
+
   return {
     assetModelId,
     assetId,
-    propertyIds,
+    propertyIds: uniquePropertyIds,
   };
 };

--- a/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/iotSiteWiseQueryEditor/iotSiteWiseQueryEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IoTSiteWise } from '@aws-sdk/client-iotsitewise';
+import { AssetSummary, IoTSiteWise } from '@aws-sdk/client-iotsitewise';
 import Tabs from '@cloudscape-design/components/tabs';
 import { useSelector } from 'react-redux';
 import type { DashboardState } from '~/store/state';
@@ -15,6 +15,7 @@ export interface IoTSiteWiseQueryEditorProps {
   selectedWidgets: DashboardWidget[];
   addButtonDisabled: boolean;
   correctSelectionMode: 'single' | 'multi';
+  currentSelectedAsset?: AssetSummary;
 }
 
 export function IoTSiteWiseQueryEditor({
@@ -23,6 +24,7 @@ export function IoTSiteWiseQueryEditor({
   selectedWidgets,
   addButtonDisabled,
   correctSelectionMode,
+  currentSelectedAsset,
 }: IoTSiteWiseQueryEditorProps) {
   const isEdgeModeEnabled = useSelector(
     (state: DashboardState) => state.isEdgeModeEnabled
@@ -76,6 +78,7 @@ export function IoTSiteWiseQueryEditor({
         selectedWidgets={selectedWidgets}
         timeZone={timeZone}
         significantDigits={significantDigits}
+        currentSelectedAsset={currentSelectedAsset}
       />
     ),
   };

--- a/packages/dashboard/src/components/queryEditor/queryEditor.tsx
+++ b/packages/dashboard/src/components/queryEditor/queryEditor.tsx
@@ -7,6 +7,8 @@ import { type IoTSiteWise } from '@aws-sdk/client-iotsitewise';
 import { type DashboardWidget } from '~/types';
 import { useIsAddButtonDisabled } from './helpers/useIsAddButtonDisabled';
 import { getCorrectSelectionMode } from './helpers/getCorrectSelectionMode';
+import { useAssetsForAssetModel } from './iotSiteWiseQueryEditor/assetModelDataStreamExplorer/assetsForAssetModelSelect/useAssetsForAssetModel/useAssetsForAssetModel';
+import { useModelBasedQuery } from './iotSiteWiseQueryEditor/assetModelDataStreamExplorer/modelBasedQuery/useModelBasedQuery';
 
 export function QueryEditor({
   iotSiteWiseClient,
@@ -18,6 +20,16 @@ export function QueryEditor({
   const [_query, setQuery] = useQuery();
   const addButtonDisabled = useIsAddButtonDisabled(selectedWidgets);
   const correctSelectionMode = getCorrectSelectionMode(selectedWidgets);
+  const { assetModelId, assetIds } = useModelBasedQuery();
+  const { assetSummaries } = useAssetsForAssetModel({
+    assetModelId,
+    iotSiteWiseClient,
+    fetchAll: true,
+  });
+
+  const currentSelectedAsset = assetSummaries.find(
+    ({ id }) => id === assetIds?.at(0)
+  );
 
   return (
     <QueryEditorErrorBoundary>
@@ -27,6 +39,7 @@ export function QueryEditor({
         selectedWidgets={selectedWidgets}
         addButtonDisabled={addButtonDisabled}
         correctSelectionMode={correctSelectionMode}
+        currentSelectedAsset={currentSelectedAsset}
       />
     </QueryEditorErrorBoundary>
   );

--- a/packages/react-components/src/utils/transformAlarmsToThreshold.ts
+++ b/packages/react-components/src/utils/transformAlarmsToThreshold.ts
@@ -30,7 +30,7 @@ const createThreshold = ({
 export const transformAlarmsToThreshold = (
   alarm: AlarmData
 ): Threshold | undefined => {
-  const { models, inputProperty, thresholds, status } = alarm;
+  const { models, inputProperty: inputProperties, thresholds, status } = alarm;
   const modelsFound = models && models.length !== 0;
   const thresholdsFound = thresholds && thresholds?.length !== 0;
 
@@ -43,15 +43,15 @@ export const transformAlarmsToThreshold = (
         threshold.value?.doubleValue ?? threshold.value?.integerValue;
       const comparisonOperator =
         model.alarmRule?.simpleRule?.comparisonOperator;
-      const property = inputProperty && inputProperty.at(0);
+      const inputProperty = inputProperties && inputProperties.at(0);
 
-      if (thresholdValue && comparisonOperator && property) {
+      if (thresholdValue && comparisonOperator && inputProperty) {
         const scComparisonOperator = IoTEventsToSynchroChartsComparisonOperator[
           comparisonOperator
         ] as COMPARISON_OPERATOR;
 
         return createThreshold({
-          labelText: `${property.name} ${COMPARATOR_MAP[scComparisonOperator]} ${thresholdValue}`,
+          labelText: `${inputProperty.property.name} ${COMPARATOR_MAP[scComparisonOperator]} ${thresholdValue}`,
           thresholdValue: thresholdValue,
           severity: model.severity,
           comparisonOperator: scComparisonOperator,


### PR DESCRIPTION
## Overview
Fix for screen jumping to top when selecting dashboard model properties. To fix, removed useState call and moved selectedAsset state up to parent QueryEditor component.

In doing so found the following bugs and fixed them as well.

- Asset Model RE keeps state of old selected asset properties after changing asset
   - fix: added clearing selected properties to useEffect of when asset changes
   
- Asset Properties table does not change selection mode based on widget type
   - fix: passed in missing 'correctSelectionMode' prop into table
  
- Asset Model Tab breaks if you add duplicate properties after edit/preview change
  - deduped properties in hook where we reduce properties to ids for later use

## Verifying Changes

https://github.com/user-attachments/assets/69206819-d696-496e-921a-ed3e73f28206


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
