### PR TITLE
fix(alarms): gauge and kpi alarm thresholds

### DIFF
--- a/packages/react-components/src/components/gauge/gauge.tsx
+++ b/packages/react-components/src/components/gauge/gauge.tsx
@@ -1,5 +1,5 @@
-// eslint-disable-next-line import/default
-import React from 'react';
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useMemo } from 'react';
 
 import { GaugeBase } from './gaugeBase';
 import { GaugeProps } from './types';
@@ -84,9 +84,11 @@ export const Gauge = ({
   const color =
     styles && refId ? styles[refId]?.color : DEFAULT_GAUGE_PROGRESS_COLOR;
 
-  const allThresholds = transformedAlarm?.threshold
-    ? [...thresholds, transformedAlarm?.threshold]
-    : thresholds;
+  const allThresholds = useMemo(() => {
+    return transformedAlarm?.threshold
+      ? [...thresholds, transformedAlarm?.threshold]
+      : thresholds;
+  }, [JSON.stringify(thresholds), JSON.stringify(transformedAlarm?.threshold)]);
 
   return (
     <GaugeBase

--- a/packages/react-components/src/components/kpi/kpi.tsx
+++ b/packages/react-components/src/components/kpi/kpi.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useMemo } from 'react';
 import { useTimeSeriesData } from '../../hooks/useTimeSeriesData';
 import { useViewport } from '../../hooks/useViewport';
 import { widgetPropertiesFromInputs } from '../../common/widgetPropertiesFromInputs';
@@ -51,6 +52,7 @@ export const KPI = ({
     viewport: utilizedViewport,
     settings: {
       fetchThresholds: true,
+      fetchOnlyLatest: true,
       refreshRate: alarmQueries.at(0)?.query.requestSettings?.refreshRate,
     },
     transform: buildTransformAlarmForSingleQueryWidgets({
@@ -72,6 +74,17 @@ export const KPI = ({
     styles,
   });
 
+  const allThresholds = useMemo(() => {
+    const allThresholds = [...queryThresholds, ...thresholds];
+    transformedAlarm?.threshold &&
+      allThresholds.push(transformedAlarm?.threshold);
+    return allThresholds;
+  }, [
+    JSON.stringify(queryThresholds),
+    JSON.stringify(thresholds),
+    JSON.stringify(transformedAlarm?.threshold),
+  ]);
+
   const {
     propertyPoint,
     propertyThreshold,
@@ -79,7 +92,7 @@ export const KPI = ({
     propertyResolution,
   } = widgetPropertiesFromInputs({
     dataStreams,
-    thresholds: [...queryThresholds, ...thresholds],
+    thresholds: allThresholds,
     viewport: utilizedViewport,
   });
 


### PR DESCRIPTION
## Overview
properly memo thresholds for KPI and gauge

### KPI + Gauge with inactive and active alarms
<img width="1070" alt="Screenshot 2024-09-30 at 13 11 39" src="https://github.com/user-attachments/assets/39f3c6c6-e58e-46bd-8574-18c807dae427">


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
