### PR TITLE
fix(alarms): complete skipped queries

### DIFF
--- a/packages/react-components/src/queries/useHistoricalAssetPropertyValues/requestExecution/batchResponseProcessor.ts
+++ b/packages/react-components/src/queries/useHistoricalAssetPropertyValues/requestExecution/batchResponseProcessor.ts
@@ -30,6 +30,16 @@ export class BatchResponseProcessor {
   ) {
     if (this.isComplete) return;
 
+    const skippedForEntry = (response.skippedEntries ?? []).filter(
+      ({ entryId }) => entryId === this.entry.entryId
+    );
+
+    if (skippedForEntry.length > 0) {
+      // Ensure that isComplete is false
+      this.valuesTargetNumber = -1;
+      return;
+    }
+
     const sucessesForEntry = (response.successEntries ?? []).filter(
       ({ entryId }) => entryId === this.entry.entryId
     );


### PR DESCRIPTION
## Overview
Bugfix for historical requests which fully paginate without finding any single datapoint. When a query fully paginates it will be added to the skipped queries response. This adds a check for that to set the is completed flag if there are no further pages to look at.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
