### PR TITLE
fix(alarms): fix data mapping from input property values

### DIFF
--- a/packages/react-components/src/hooks/useAlarms/hookHelpers/useInputPropertyTimeSeriesData/useInputPropertyTimeSeriesData.ts
+++ b/packages/react-components/src/hooks/useAlarms/hookHelpers/useInputPropertyTimeSeriesData/useInputPropertyTimeSeriesData.ts
@@ -58,7 +58,7 @@ export const useInputPropertyTimeSeriesData = ({
   });
 
   return useMemo(() => {
-    return alarmsInternal.map((alarm) => {
+    return alarms.map((alarm) => {
       const datastreamsForAlarm = filterDataStreamsForAlarm(alarm, dataStreams);
 
       updateAlarmStatusForDatastreams(alarm, datastreamsForAlarm);
@@ -67,5 +67,5 @@ export const useInputPropertyTimeSeriesData = ({
 
       return alarm;
     });
-  }, [alarmsInternal, dataStreams]);
+  }, [alarms, dataStreams]);
 };


### PR DESCRIPTION
## Overview
Bugfix for useAlarms AlarmData mapping. The internal alarms data in useInputPropertyTimeSeriesData is only being modified when the property changes. This ensures we don't call time series data every time any irrelevant property changes in the alarms model, but it also means the internal model may not be up to date. To fix this, we only call useTimeSeriesData with the internal model, so that it is not overly reactive, but map the output with the up to date models.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
