### PR TITLE
fix(alarms): asset model alarms

### DIFF
--- a/packages/dashboard/src/components/dashboard/queryContext.ts
+++ b/packages/dashboard/src/components/dashboard/queryContext.ts
@@ -60,7 +60,8 @@ export const useQueries = ({
     (assets.length === 0 &&
       properties.length === 0 &&
       assetModels.length === 0 &&
-      alarms.length === 0)
+      alarms.length === 0 &&
+      alarmModels.length === 0)
   ) {
     return [];
   }


### PR DESCRIPTION
## Overview
Bugfix for adding alarm by asset model. Ensure that we don't return an empty query when only asset model alarms are configured.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
