### PR TITLE
fix(draco): updating global settings

### DIFF
--- a/packages/scene-composer/src/components/StateManager.tsx
+++ b/packages/scene-composer/src/components/StateManager.tsx
@@ -13,6 +13,7 @@ import { GetSceneCommandOutput } from '@aws-sdk/client-iottwinmaker';
 
 import {
   getMatterportSdk,
+  setBasisuDecoder,
   setDracoDecoder,
   setFeatureConfig,
   setGetSceneObjectFunction,
@@ -181,6 +182,12 @@ const StateManager: React.FC<SceneComposerInternalProps> = ({
       setActiveCameraSettings(getCameraSettings(object3D, cameraComponent));
     }
   }, [selectedSceneNodeRef]);
+
+  useEffect(() => {
+    if (config.basisuDecoder) {
+      setBasisuDecoder(config.basisuDecoder);
+    }
+  }, [config.basisuDecoder]);
 
   useEffect(() => {
     if (config.dracoDecoder) {


### PR DESCRIPTION
## Overview
Adding `useEffect` to update store with decoder path override. 

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
