### PR TITLE
fix(example): fix HDR loader in react example

### DIFF
--- a/examples/react-app/vite.config.ts
+++ b/examples/react-app/vite.config.ts
@@ -26,5 +26,12 @@ export default defineConfig(() => {
     preview: {
       port: 4000,
     },
+    optimizeDeps: {
+      esbuildOptions: {
+        loader: {
+          '.hdr': 'dataurl',
+        },
+      },
+    }
   };
 });


### PR DESCRIPTION
## Overview
Attempting to use the react example app as a stand alone app base can result in the HDR files form scene composer not loading and breaking at run time under vite.

To make using the example be a better starting point for new appliation development adding stand alone vite support for HDR files to the default vite.config.ts settings.

## Verifying Changes
Runs when built inside iot-app-kit.  
If examples/react-app is copied to it's own folder and npm install and npm run start are run on it as a stand alone application the vite server should not through any errors about not having a loader for hdr files.

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
