### PR TITLE
fix(draco): improving the logic check for path override

### DIFF
--- a/packages/scene-composer/src/three/loaderUtilsHelpers.ts
+++ b/packages/scene-composer/src/three/loaderUtilsHelpers.ts
@@ -12,7 +12,8 @@ import { GLTFLoader, GLTFLoader as TwinMakerGLTFLoader } from './GLTFLoader';
 export const setupDracoSupport = (loader: GLTFLoader, dracoLoader: DRACOLoader = new DRACOLoader()): void => {
   const { dracoDecoder } = getGlobalSettings();
   if (dracoDecoder.enable) {
-    const dracoDecoderPath = dracoDecoder.path ?? `${THREE_PATH}/examples/jsm/libs/draco/gltf/`;
+    const dracoDecoderPath =
+      dracoDecoder.path !== undefined ? dracoDecoder.path : `${THREE_PATH}/examples/jsm/libs/draco/gltf/`;
     // TODO: with CSP issues, Chrome/Edge and some other unknown browsers may fail to load WASM, so we enforce to
     // only JS DRACO decoder for now. Please fix once we found a better solution
     dracoLoader.setDecoderConfig({ type: 'js' }).setDecoderPath(dracoDecoderPath);
@@ -28,7 +29,8 @@ export const setupBasisuSupport = (
 ): void => {
   const { basisuDecoder } = getGlobalSettings();
   if (basisuDecoder.enable) {
-    const ktx2DecoderPath = basisuDecoder.path ?? `${THREE_PATH}/examples/jsm/libs/basis/`;
+    const ktx2DecoderPath =
+      basisuDecoder.path !== undefined ? basisuDecoder.path : `${THREE_PATH}/examples/jsm/libs/basis/`;
 
     ktx2Loader.setTranscoderPath(ktx2DecoderPath).detectSupport(renderer);
 


### PR DESCRIPTION
## Overview
Correcting a flaw in the logic around the decoder override paths. Instead of doing a nullish (`??`) check, we're now ensuring that the value is not `undefined`.

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
