### PR TITLE
fix(draco): modifying check to ensure globalSettings are ready for ev…

### DIFF
--- a/packages/scene-composer/src/components/three-fiber/ModelRefComponent/__tests__/GLTFLoader.spec.ts
+++ b/packages/scene-composer/src/components/three-fiber/ModelRefComponent/__tests__/GLTFLoader.spec.ts
@@ -94,8 +94,7 @@ describe('GLTFLoader', () => {
     it('should execute without draco decoder enabled', async () => {
       const getGlobalSettingsMock = getGlobalSettings as jest.Mock;
       const dracoDecoder: DracoDecoderConfig = {
-        enable: true,
-        path: 'draco/path',
+        enable: false,
       };
       const basisuDecoder: BasisuDecoderConfig = {
         enable: false,
@@ -109,8 +108,7 @@ describe('GLTFLoader', () => {
       extensionsCb(mockLoader);
 
       expect(extendLoader).toBeCalledTimes(1);
-      expect(setDecoderPathSpy).toBeCalledWith('draco/path');
-      expect(mockLoader.setDRACOLoader).toBeCalledTimes(1);
+      expect(mockLoader.setDRACOLoader).toBeCalledTimes(0);
     });
   });
 

--- a/packages/scene-composer/src/three/loaderUtilsHelpers.spec.ts
+++ b/packages/scene-composer/src/three/loaderUtilsHelpers.spec.ts
@@ -18,6 +18,7 @@ describe('dracoSupport', () => {
 
     getGlobalSettingsMock.mockReturnValue({
       dracoDecoder,
+      getSceneObjectFunction: jest.fn(),
     });
 
     const loader = {
@@ -41,6 +42,7 @@ describe('dracoSupport', () => {
 
       getGlobalSettingsMock.mockReturnValue({
         dracoDecoder,
+        getSceneObjectFunction: jest.fn(),
       });
 
       const loader = {
@@ -73,6 +75,7 @@ describe('setupBasisu', () => {
     };
     getGlobalSettingsMock.mockReturnValue({
       basisuDecoder,
+      getSceneObjectFunction: jest.fn(),
     });
 
     const loader = {
@@ -94,6 +97,7 @@ describe('setupBasisu', () => {
       };
       getGlobalSettingsMock.mockReturnValue({
         basisuDecoder,
+        getSceneObjectFunction: jest.fn(),
       });
       const loader = {
         setKTX2Loader: jest.fn(),

--- a/packages/scene-composer/src/three/loaderUtilsHelpers.ts
+++ b/packages/scene-composer/src/three/loaderUtilsHelpers.ts
@@ -10,8 +10,9 @@ import { TwinMakerTextureLoader } from './TwinMakerTextureLoader';
 import { GLTFLoader, GLTFLoader as TwinMakerGLTFLoader } from './GLTFLoader';
 
 export const setupDracoSupport = (loader: GLTFLoader, dracoLoader: DRACOLoader = new DRACOLoader()): void => {
-  const { dracoDecoder } = getGlobalSettings();
-  if (dracoDecoder.enable) {
+  const { dracoDecoder, getSceneObjectFunction } = getGlobalSettings();
+  // getSceneObjectFunction is needed for the check to ensure that globalSettings are ready to be evaluated against
+  if (dracoDecoder.enable && getSceneObjectFunction) {
     const dracoDecoderPath = dracoDecoder.path ?? `${THREE_PATH}/examples/jsm/libs/draco/gltf/`;
     // TODO: with CSP issues, Chrome/Edge and some other unknown browsers may fail to load WASM, so we enforce to
     // only JS DRACO decoder for now. Please fix once we found a better solution
@@ -26,10 +27,10 @@ export const setupBasisuSupport = (
   renderer: WebGLRenderer,
   ktx2Loader: KTX2Loader = new KTX2Loader(),
 ): void => {
-  const { basisuDecoder } = getGlobalSettings();
-  if (basisuDecoder.enable) {
+  const { basisuDecoder, getSceneObjectFunction } = getGlobalSettings();
+  // getSceneObjectFunction is needed for the check to ensure that globalSettings are ready to be evaluated against
+  if (basisuDecoder.enable && getSceneObjectFunction) {
     const ktx2DecoderPath = basisuDecoder.path ?? `${THREE_PATH}/examples/jsm/libs/basis/`;
-
     ktx2Loader.setTranscoderPath(ktx2DecoderPath).detectSupport(renderer);
 
     (loader as TwinMakerGLTFLoader).setKTX2Loader(ktx2Loader);


### PR DESCRIPTION
…aluation

## Overview
Due to how `globalSettings` are setup, we need to add a check for `getSceneObjectFuncion` to the transcoder logic to ensure that they are not executed prior to to receiving the config overrides. 
- includes fix for test

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
