### PR TITLE
fix(dashboard): remove gap at bottom of chart in juicebox

### DIFF
--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -45,6 +45,7 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ widget, title, children }) => {
   // the title back into the react-components
   const widgetsWithTitle = ['gauge', 'xy-plot', 'bar-chart', 'status-timeline'];
 
+  // {children} is wrapped with <></> to remove wrapper node added by React -  https://react.dev/reference/react/Fragment
   return (
     <div
       aria-description='widget tile'
@@ -56,7 +57,9 @@ const WidgetTile: React.FC<WidgetTileProps> = ({ widget, title, children }) => {
       }}
     >
       {widgetsWithTitle.includes(widget.type) && titleComponentWithBorder}
-      <div className='widget-tile-body'>{children}</div>
+      <div className='widget-tile-body'>
+        <>{children}</>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Overview
We were seeing this gap at the bottom of the line chart in juicebox. ![image](https://github.com/user-attachments/assets/b228b550-82b9-423f-ba59-bd251950b85b)

Issue is due to react-adding wrapper div around base-chart element in juicebox. 
![image](https://github.com/user-attachments/assets/16624e77-e2f6-41eb-bc47-8b04f35b8041)

This is automatically done by React when there is no react fragment wrapping around passed in divs (which is occurring in the table component due to the chart + legend).  https://react.dev/reference/react/Fragment 

## Verifying Changes

This fix was tarballed and tested that it removed the gap in Juicebox.
![image](https://github.com/user-attachments/assets/380b8f91-09f6-4ff8-a848-7283606d3968)


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
