### PR TITLE
fix: remove lint and tests from publish-packages command

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:git": "git diff --exit-code",
     "release": "npm run build",
     "pack": "turbo run pack",
-    "publish-packages": "npm run install-ws && turbo run build lint test",
+    "publish-packages": "npm run install-ws && turbo run build",
     "versionup:patch": "turbo run version --no-git-tag-version patch",
     "versionup:minor": "turbo run version --no-git-tag-version minor",
     "versionup:major": "turbo run version --no-git-tag-version major",


### PR DESCRIPTION
## Overview
Fix: Remove lint and tests from publish-packages command, to fix npm publish action

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
