### PR TITLE
fix(react-components): allow vertical legend reszing when title present on widget

### DIFF
--- a/packages/react-components/src/components/chart/baseChart.tsx
+++ b/packages/react-components/src/components/chart/baseChart.tsx
@@ -345,7 +345,7 @@ const BaseChart = ({
       >
         <div className='base-chart-container-element'>
           <Resizable
-            height={adjustedChartHeight}
+            height={chartHeight}
             width={chartWidth}
             onResize={onResize}
             axis={`${isBottomAligned ? 'y' : 'x'}`}


### PR DESCRIPTION
## Overview
When there was a title present, legend resizing vertically would automatically set the height of the legend to the maximum size and allow no user interaction. This was because we were setting the height to be the adjustedChartHeight value, that considers the title being present. However, in the hook where we get the chartHeight/Width the chart height is already factored in. This was making the chart default to something too large, hence always being stuck at the max-constraint.

Simple fix: just use the chartHeight given by our useResizableEChart hook.

## Verifying Changes

https://github.com/user-attachments/assets/7f0f0f6d-bc4f-46f1-95f2-945a43702a52

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
