### PR TITLE
fix: assistant failed to fetch

### DIFF
--- a/packages/dashboard/src/components/assistant/chatbot.tsx
+++ b/packages/dashboard/src/components/assistant/chatbot.tsx
@@ -28,7 +28,7 @@ export const Chatbot: FC<AssistantChatbotProps> = (
 ) => {
   const dispatch = useDispatch();
   const assistant = useSelector((state: DashboardState) => state.assistant);
-  const { iotSiteWisePrivateClient } = useClients();
+  const { iotSiteWise } = useClients();
   const { getContextByComponent } = useAssistantContext();
   const initialMessages: Array<IMessage> = [
     {
@@ -42,7 +42,7 @@ export const Chatbot: FC<AssistantChatbotProps> = (
 
   const client = new IoTSitewiseAssistantClient({
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    iotSiteWiseClient: iotSiteWisePrivateClient!,
+    iotSiteWiseClient: iotSiteWise!,
   });
 
   const { messages, setMessages, invokeAssistant, generateSummary, clearAll } =

--- a/packages/dashboard/src/components/dashboard/getClients.ts
+++ b/packages/dashboard/src/components/dashboard/getClients.ts
@@ -1,17 +1,12 @@
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
-import {
-  IoTSiteWiseClient,
-  IoTSiteWise,
-  IoTSiteWise as InternalIoTSiteWise,
-} from '@aws-sdk/client-iotsitewise';
+import { IoTSiteWiseClient, IoTSiteWise } from '@aws-sdk/client-iotsitewise';
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
 import { type DashboardClientConfiguration } from '~/types';
 import { type DashboardClientContext } from './clientContext';
 import { isCredentials } from '~/hooks/useAWSRegion';
 
 export const getClients = (
-  dashboardClientConfiguration: DashboardClientConfiguration,
-  region: string
+  dashboardClientConfiguration: DashboardClientConfiguration
 ): DashboardClientContext => {
   if (!isCredentials(dashboardClientConfiguration)) {
     return {
@@ -41,23 +36,10 @@ export const getClients = (
     region: dashboardClientConfiguration.awsRegion,
   });
 
-  // This is required to set endpoint for Pen Test
-  const assistantEndpointMetadata = document.querySelector(
-    'meta[name="assistantEndpoint"]'
-  ) as HTMLMetaElement;
-  const iotSiteWisePrivateClient = new InternalIoTSiteWise({
-    credentials: dashboardClientConfiguration.awsCredentials,
-    region: dashboardClientConfiguration.awsRegion,
-    endpoint:
-      assistantEndpointMetadata?.content ??
-      `https://data.iotsitewise.${region}.amazonaws.com`,
-  });
-
   return {
     iotEventsClient,
     iotSiteWiseClient,
     iotTwinMakerClient,
     iotSiteWise,
-    iotSiteWisePrivateClient,
   };
 };

--- a/packages/dashboard/src/components/dashboard/getQueries.ts
+++ b/packages/dashboard/src/components/dashboard/getQueries.ts
@@ -8,12 +8,10 @@ import { type EdgeMode } from '@iot-app-kit/core';
 
 export const getQueries = (
   dashboardClientConfiguration: DashboardClientConfiguration,
-  region: string,
   edgeMode?: EdgeMode
 ): DashboardIotSiteWiseQueries => {
   const { iotEventsClient, iotSiteWiseClient } = getClients(
-    dashboardClientConfiguration,
-    region
+    dashboardClientConfiguration
   );
 
   if (!iotEventsClient || !iotSiteWiseClient) {

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -31,7 +31,6 @@ import { debounce } from 'lodash';
 import { FpsView } from 'react-fps';
 import { PropertiesPanel } from '~/customization/propertiesSections';
 import { queryClient } from '~/data/query-client';
-import { useAWSRegion } from '~/hooks/useAWSRegion';
 import '../../styles/variables.css';
 
 export type DashboardProperties = {
@@ -92,14 +91,13 @@ const Dashboard: React.FC<DashboardProperties> = ({
     assistantConfiguration?.state,
   ]);
 
-  const { region } = useAWSRegion(clientConfiguration);
   const clients = useMemo(
-    () => getClients(clientConfiguration, region),
-    [clientConfiguration, region]
+    () => getClients(clientConfiguration),
+    [clientConfiguration]
   );
   const queries = useMemo(
-    () => getQueries(clientConfiguration, region, edgeMode),
-    [clientConfiguration, edgeMode, region]
+    () => getQueries(clientConfiguration, edgeMode),
+    [clientConfiguration, edgeMode]
   );
 
   return (

--- a/packages/dashboard/src/components/dashboard/view.tsx
+++ b/packages/dashboard/src/components/dashboard/view.tsx
@@ -25,7 +25,6 @@ import { getQueries } from './getQueries';
 import { QueryContext } from './queryContext';
 
 import '@cloudscape-design/global-styles/index.css';
-import { useAWSRegion } from '~/hooks/useAWSRegion';
 import '../../styles/variables.css';
 
 export type DashboardViewProperties = {
@@ -58,10 +57,9 @@ const DashboardView: React.FC<DashboardViewProperties> = ({
     ? debounce(onViewportChange, 100)
     : undefined;
 
-  const { region } = useAWSRegion(clientConfiguration);
   const clients = useMemo(
-    () => getClients(clientConfiguration, region),
-    [clientConfiguration, region]
+    () => getClients(clientConfiguration),
+    [clientConfiguration]
   );
 
   return (
@@ -74,7 +72,7 @@ const DashboardView: React.FC<DashboardViewProperties> = ({
     >
       <ClientContext.Provider value={clients}>
         <QueryContext.Provider
-          value={getQueries(clientConfiguration, region, edgeMode)}
+          value={getQueries(clientConfiguration, edgeMode)}
         >
           <QueryClientProvider client={queryClient}>
             <Provider

--- a/packages/dashboard/src/hooks/useAssistantConfiguration.ts
+++ b/packages/dashboard/src/hooks/useAssistantConfiguration.ts
@@ -17,15 +17,15 @@ export const useAssistantConfiguration = (widgetId: string) => {
   const dispatch = useDispatch();
   const readOnly = useSelector((state: DashboardState) => state.readOnly);
   const assistant = useSelector((state: DashboardState) => state.assistant);
-  const { iotSiteWisePrivateClient } = useClients();
+  const { iotSiteWise } = useClients();
 
   const assistantClient = useMemo(
     () =>
       new IoTSitewiseAssistantClient({
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        iotSiteWiseClient: iotSiteWisePrivateClient!,
+        iotSiteWiseClient: iotSiteWise!,
       }),
-    [iotSiteWisePrivateClient]
+    [iotSiteWise]
   );
 
   let assistantConfiguration: AssistantProperty | undefined;

--- a/packages/dashboard/src/messages.ts
+++ b/packages/dashboard/src/messages.ts
@@ -311,7 +311,7 @@ export const DefaultDashboardMessages: DashboardMessages = {
   assistant: {
     floatingMenu: {
       propertySelection:
-        'Select the checkboxes from the widgets below to include them in the AI generate summary action.',
+        'Select the checkboxes in the widgets below and click on Generate summary to see the AI generated summaries.',
       error: {
         ariaLabel: 'error',
         propertyLimitHeader: 'Property limit reached',

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -1,5 +1,4 @@
 import {
-  type IoTSiteWise as InternalIoTSiteWise,
   type DescribeDashboardRequest,
   type DescribeDashboardResponse,
   type IoTSiteWise,
@@ -30,7 +29,6 @@ export type DashboardIotSiteWiseClients = {
   iotEventsClient: IoTEventsClient;
   iotTwinMakerClient: IoTTwinMakerClient;
   iotSiteWise: IoTSiteWise;
-  iotSiteWisePrivateClient?: InternalIoTSiteWise;
 };
 
 export type DashboardIotSiteWiseQueries = {


### PR DESCRIPTION
## Overview
- Fix issue to call assistant API.
- Remove private iot sitewise client
- Adjust copy for assistant dashboard copy based on customer feedback. 

## Verifying Changes

- Manual tests
<img width="1733" alt="Screenshot 2024-11-21 at 10 45 25 AM" src="https://github.com/user-attachments/assets/c6d87094-3d3c-431b-8407-9d0d628ede57">


### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
