### PR TITLE
feat: improve assistant dashboard prompt engineering

### DIFF
--- a/packages/react-components/src/common/assistantProps.ts
+++ b/packages/react-components/src/common/assistantProps.ts
@@ -24,3 +24,8 @@ export type AssistantActionType =
   | 'clear-selection';
 export type AssistantWidgetTypes = 'kpi' | 'gauge' | 'table' | 'chart';
 export type ComponentId = string;
+
+export type AlarmAssistantContext = {
+  assetId?: string;
+  alarmName?: string;
+};

--- a/packages/react-components/src/components/assistant-common/types.ts
+++ b/packages/react-components/src/components/assistant-common/types.ts
@@ -1,4 +1,0 @@
-export type AlarmAssistantContext = {
-  assetId?: string;
-  alarmName?: string;
-};

--- a/packages/react-components/src/components/chart/hooks/useNormalizedDataStreams.ts
+++ b/packages/react-components/src/components/chart/hooks/useNormalizedDataStreams.ts
@@ -6,7 +6,7 @@ import { useMemo } from 'react';
 import { bisector } from 'd3-array';
 import { uniqWith } from 'lodash';
 import { type AlarmContent } from '../../alarm-components/alarm-content/types';
-import { type AlarmAssistantContext } from '../../assistant-common/types';
+import type { AlarmAssistantContext } from '../../../common/assistantProps';
 
 const interpolateY = (
   point1: DataPointWithAlarm,

--- a/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
+++ b/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
@@ -6,8 +6,10 @@ import { type TrendCursorValues } from '../../../../echarts/extensions/trendCurs
 import { useDataStreamMaxMin } from '../../hooks/useDataStreamMaxMin';
 import { type MinMaxMap } from '../../store/dataStreamMinMaxStore';
 import type { TableProps } from '@cloudscape-design/components/table';
-import type { AssistantProperty } from '../../../../common/assistantProps';
-import { type AlarmAssistantContext } from '../../../assistant-common/types';
+import type {
+  AssistantProperty,
+  AlarmAssistantContext,
+} from '../../../../common/assistantProps';
 
 type LegendTableDataStream = Pick<
   DataStream,

--- a/packages/react-components/src/components/chart/legend/table/types.ts
+++ b/packages/react-components/src/components/chart/legend/table/types.ts
@@ -1,5 +1,5 @@
 import { type DataStream, type Primitive } from '@iot-app-kit/core';
-import { type AlarmAssistantContext } from '../../../assistant-common/types';
+import type { AlarmAssistantContext } from '../../../../common/assistantProps';
 
 export type TrendCursorValues = { [id in string]?: number };
 export type DataStreamInformation = Pick<

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -91,6 +91,7 @@ export type {
   AssistantActionType,
   AssistantProperty,
   AssistantWidgetTypes,
+  AlarmAssistantContext,
 } from './common/assistantProps';
 export { AssistantChatbot } from './components/assistant-chatbot';
 export {


### PR DESCRIPTION
## Overview
Given feedbacks from external and internal customers a couple of prompt engineering improvements were done to increase the probably of positive response from the Sitewise assistant API. 

Changes:
- When 1 property is selected the prompt provided to the assistant will be `generate a property summary`
- When 1 alarm is selected the prompt provided will be  `generate an alarm summary`
- When +1 properties are selected the prompt provided will be `generate property summaries and compare`
- When 1 alarm and (1 to 2) properties are selected the prompt provided will be `generate summaries and compare`
- When +1 alarm are selected the prompt provided will be `generate summaries and compare`
- When customer types a question direct in the chatbot field, the dashboard will gather data from all selected widgets and pass as context, to give additional context to the inputted question.

## Verifying Changes


https://github.com/user-attachments/assets/05b9dc14-c449-45fa-8229-5feeacaea0f1



### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
