### PR TITLE
fix: fix time series data hook reactivity

### DIFF
--- a/packages/core/src/data-module/TimeSeriesDataModule.ts
+++ b/packages/core/src/data-module/TimeSeriesDataModule.ts
@@ -187,7 +187,9 @@ export class TimeSeriesDataModule<Query extends DataStreamQuery> {
      */
 
     const unsubscribe = () => {
-      this.unsubscribe(subscriptionId);
+      if (this.subscriptions.getSubscription(subscriptionId)) {
+        this.unsubscribe(subscriptionId);
+      }
     };
 
     const update = (subscriptionUpdate: SubscriptionUpdate<Query>) =>

--- a/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.ts
+++ b/packages/react-components/src/hooks/useTimeSeriesData/useTimeSeriesData.ts
@@ -108,6 +108,15 @@ export const useTimeSeriesData = ({
   const queriesString = JSON.stringify(scrubbedQueries);
 
   useEffect(() => {
+    /**
+     * Reset datastreams whenever the query changes so that
+     * old datastreams are cleared away. This is important if
+     * the new query does not end up calling next for some
+     * reason. In that case, the datastreams state would still
+     * represent the previous queries data.
+     */
+    setDataStreams([]);
+
     const id = uuid();
     providerIdRef.current = id;
     const provider = ProviderStore.set(


### PR DESCRIPTION
## Overview
2 bugfixes:
1. There is a bug in the handling of time series data module session subscriptions where it is possible for a callback to try to unsubscribe to a session that is already unregistered. This is in the handler which unsubscribes if the client session expires. The fix checks that the subscription is still valid and unsubscribes only if it hasn't been already handled. The likely scenario for this happening is if a user leaves there dashboard open over night and re-focuses the tab so that the polling starts again.
2. There is a bug where, in the dashboard, if you add multiple datastreams to a chart with an alarm, removing the datastreams before removing the alarm will result in the last datastream to be removed staying in the chart. This is a reactivity bug in use-time-series-data. To fix this, we clear the datastreams state whenever the queries provided to use time series data changes.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
