### PR TITLE
fix: scene-composer type export

### DIFF
--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -10,10 +10,10 @@
   "type": "module",
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
-  "types": "./dist/src/index.d.ts",
+  "types": "./dist/esm/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
+      "types": "./dist/esm/src/index.d.ts",
       "require": "./dist/cjs/src/index.js",
       "import": "./dist/esm/src/index.js",
       "default": "./dist/esm/src/index.js"

--- a/packages/tools-iottwinmaker/package.json
+++ b/packages/tools-iottwinmaker/package.json
@@ -14,10 +14,10 @@
   "types": "./dist/esm/build.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
+      "types": "./dist/esm/build.d.ts",
+      "require": "./dist/cjs/build.js",
+      "import": "./dist/esm/build.js",
+      "default": "./dist/esm/build.js"
     }
   },
   "bin": {


### PR DESCRIPTION
## Overview
This change fixes a mistake in the scene-composer package type export definition. Without this change, types will not be declared correctly for consumers of the package.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
