### PR TITLE
fix: helpers package resolution

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "packages/core": "12.2.0",
+  "packages/helper": "12.2.0",
   "packages/dashboard": "12.2.0",
   "apps/doc-site": "12.2.0",
   "packages/core-util": "12.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36955,6 +36955,7 @@
     },
     "packages/helpers": {
       "name": "@iot-app-kit/helpers",
+      "version": "12.2.0",
       "dependencies": {
         "@iot-app-kit/ts-config": "*",
         "eslint-config-iot-app-kit": "*",
@@ -36976,7 +36977,7 @@
         "@iot-app-kit/charts-core": "^2.1.2",
         "@iot-app-kit/core": "12.2.0",
         "@iot-app-kit/core-util": "12.2.0",
-        "@iot-app-kit/helpers": "*",
+        "@iot-app-kit/helpers": "12.2.0",
         "@iot-app-kit/source-iottwinmaker": "12.2.0",
         "@tanstack/react-query": "^5.32.1",
         "autosize": "^6.0.1",
@@ -37230,7 +37231,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@iot-app-kit/core": "12.2.0",
-        "@iot-app-kit/helpers": "*",
+        "@iot-app-kit/helpers": "12.2.0",
         "@iot-app-kit/react-components": "12.2.0",
         "@iot-app-kit/source-iottwinmaker": "12.2.0",
         "@matterport/r3f": "0.2.7",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@iot-app-kit/helpers",
+  "version": "12.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -120,7 +120,7 @@
     "@iot-app-kit/charts-core": "^2.1.2",
     "@iot-app-kit/core": "12.2.0",
     "@iot-app-kit/core-util": "12.2.0",
-    "@iot-app-kit/helpers": "*",
+    "@iot-app-kit/helpers": "12.2.0",
     "@iot-app-kit/source-iottwinmaker": "12.2.0",
     "@tanstack/react-query": "^5.32.1",
     "autosize": "^6.0.1",

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -157,7 +157,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@iot-app-kit/core": "12.2.0",
-    "@iot-app-kit/helpers": "*",
+    "@iot-app-kit/helpers": "12.2.0",
     "@iot-app-kit/react-components": "12.2.0",
     "@iot-app-kit/source-iottwinmaker": "12.2.0",
     "@matterport/r3f": "0.2.7",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,9 @@
     "packages/core": {
       "component": "core"
     },
+    "packages/helpers": {
+      "component": "helpers"
+    },
     "packages/testing-util": {
       "component": "testing-util"
     },
@@ -53,6 +56,7 @@
       "components": [
         "root",
         "core",
+        "helpers",
         "dashboard",
         "doc-site",
         "react-components",


### PR DESCRIPTION
## Overview

To fix the helpers package resolution, example

```
% npm install @iot-app-kit/react-components
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@iot-app-kit%2fhelpers - Not found
npm error 404
npm error 404  '@iot-app-kit/helpers@*' is not in this registry.
```

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
