### PR TITLE
fix: helpers package resolution

### DIFF
--- a/apps/dev-env/playwright.config.ts
+++ b/apps/dev-env/playwright.config.ts
@@ -1,8 +1,7 @@
-import {
-  MINUTE_IN_MS,
-  SECOND_IN_MS,
-} from '@iot-app-kit/helpers/constants/time';
 import { defineConfig, devices } from '@playwright/test';
+
+const SECOND_IN_MS = 1000;
+const MINUTE_IN_MS = 60_000;
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36955,6 +36955,7 @@
     },
     "packages/helpers": {
       "name": "@iot-app-kit/helpers",
+      "version": "12.2.0",
       "dependencies": {
         "@iot-app-kit/ts-config": "*",
         "eslint-config-iot-app-kit": "*",
@@ -36976,7 +36977,6 @@
         "@iot-app-kit/charts-core": "^2.1.2",
         "@iot-app-kit/core": "12.2.0",
         "@iot-app-kit/core-util": "12.2.0",
-        "@iot-app-kit/helpers": "*",
         "@iot-app-kit/source-iottwinmaker": "12.2.0",
         "@tanstack/react-query": "^5.32.1",
         "autosize": "^6.0.1",
@@ -37230,7 +37230,6 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@iot-app-kit/core": "12.2.0",
-        "@iot-app-kit/helpers": "*",
         "@iot-app-kit/react-components": "12.2.0",
         "@iot-app-kit/source-iottwinmaker": "12.2.0",
         "@matterport/r3f": "0.2.7",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@iot-app-kit/helpers",
+  "version": "12.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -120,7 +120,6 @@
     "@iot-app-kit/charts-core": "^2.1.2",
     "@iot-app-kit/core": "12.2.0",
     "@iot-app-kit/core-util": "12.2.0",
-    "@iot-app-kit/helpers": "*",
     "@iot-app-kit/source-iottwinmaker": "12.2.0",
     "@tanstack/react-query": "^5.32.1",
     "autosize": "^6.0.1",

--- a/packages/react-components/playwright.config.ts
+++ b/packages/react-components/playwright.config.ts
@@ -1,8 +1,7 @@
-import {
-  MINUTE_IN_MS,
-  SECOND_IN_MS,
-} from '@iot-app-kit/helpers/constants/time';
 import { defineConfig, devices } from '@playwright/test';
+
+const SECOND_IN_MS = 1000;
+const MINUTE_IN_MS = 60_000;
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -157,7 +157,6 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@iot-app-kit/core": "12.2.0",
-    "@iot-app-kit/helpers": "*",
     "@iot-app-kit/react-components": "12.2.0",
     "@iot-app-kit/source-iottwinmaker": "12.2.0",
     "@matterport/r3f": "0.2.7",

--- a/packages/scene-composer/playwright.config.ts
+++ b/packages/scene-composer/playwright.config.ts
@@ -1,5 +1,7 @@
-import { MINUTE_IN_MS, SECOND_IN_MS } from '@iot-app-kit/helpers/constants/time';
 import { defineConfig, devices } from '@playwright/test';
+
+const SECOND_IN_MS = 1000;
+const MINUTE_IN_MS = 60_000;
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,9 @@
     "packages/core": {
       "component": "core"
     },
+    "packages/helpers": {
+      "component": "helpers"
+    },
     "packages/testing-util": {
       "component": "testing-util"
     },
@@ -53,6 +56,7 @@
       "components": [
         "root",
         "core",
+        "helpers",
         "dashboard",
         "doc-site",
         "react-components",


### PR DESCRIPTION
## Overview

Removed dependency of to fix the helpers package resolution problem, example error:

```
% npm install @iot-app-kit/react-components
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@iot-app-kit%2fhelpers - Not found
npm error 404
npm error 404  '@iot-app-kit/helpers@*' is not in this registry.
```

## Verifying Changes

Verified removed references of `"@iot-app-kit/helpers"`

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
