### PR TITLE
fix: optional property check for error metadata

### DIFF
--- a/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.ts
@@ -163,7 +163,7 @@ const sendRequest = ({
       Object.entries(callbackCache).forEach(([entryId, { onError }]) => {
         onError({
           entryId,
-          errorCode: e.$metadata.httpStatusCode,
+          errorCode: e?.$metadata.httpStatusCode,
           errorMessage: e.message,
         });
       });


### PR DESCRIPTION
## Overview

Adding optional check before accessing `$metadata` (`e?.$metadata.httpStatusCode`)

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
