### PR TITLE
chore: add build system tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -114,7 +114,7 @@ jobs:
             ${{ runner.os }}-test-lint-${{ matrix.package}}-
 
       - name: Validate
-        run: npx turbo build lint test --filter=@iot-app-kit/${{ matrix.package }}
+        run: npx turbo build lint test pack --filter=@iot-app-kit/${{ matrix.package }}
 
   playwright:
     needs: repo

--- a/apps/dev-env/package.json
+++ b/apps/dev-env/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "start": "npm run dev",
-    "clean": "npx rimraf storybook-static .turbo .cache test-results playwright-report",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "clean": "npx rimraf storybook-static .cache test-results playwright-report",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "dev": "NODE_OPTIONS='--import tsx/esm' storybook dev -p 6006",
     "lint": "eslint . --max-warnings=0 --cache --cache-location .cache/eslint/ & tsc --noEmit",
     "fix": "eslint --fix . --cache --cache-location ./cache/eslint/",

--- a/apps/doc-site/package.json
+++ b/apps/doc-site/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "clean": "npx rimraf storybook-static .turbo",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "clean": "npx rimraf storybook-static",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "start": "storybook dev -p 6006",
     "dev": "npm start",
     "build": "storybook build",

--- a/configuration/vite-config/package.json
+++ b/configuration/vite-config/package.json
@@ -7,12 +7,14 @@
     "./definePackageConfig": "./src/definePackageConfig.ts"
   },
   "bin": {
+    "iot-postbuild": "./src/scripts/postbuild.ts",
     "iot-prepack": "./src/scripts/prepack.ts",
     "iot-postpack": "./src/scripts/postpack.ts"
   },
   "scripts": {
-    "clean": "npx rimraf .cache .turbo",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "clean": "npx rimraf .cache",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "lint": "eslint . --max-warnings=0 --cache --cache-location .cache/eslint/ & tsc --noEmit",
     "fix": "eslint --fix . --cache --cache-location ./cache/eslint/",
     "test:typescript": "tsc --noEmit"
@@ -22,7 +24,9 @@
     "@iot-app-kit/ts-config": "*",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^18.16.18",
-    "rimraf": "^5.0.1"
+    "@types/tar-fs": "^2.0.4",
+    "rimraf": "^5.0.1",
+    "tar-fs": "^3.0.6"
   },
   "dependencies": {
     "fs-extra": "^11.2.0",

--- a/configuration/vite-config/src/scripts/postbuild.ts
+++ b/configuration/vite-config/src/scripts/postbuild.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S npx tsx
+import { validateBuildArtifacts } from '../validation/validateBuildArtifacts';
+
+postbuild();
+
+function postbuild(): void | never {
+  console.info('*** Starting postbuild. ***');
+  validateBuildArtifacts();
+  console.info('*** Ending postbuild. ***');
+}

--- a/configuration/vite-config/src/scripts/postpack.ts
+++ b/configuration/vite-config/src/scripts/postpack.ts
@@ -1,9 +1,20 @@
 #!/usr/bin/env -S npx tsx
 import fse from 'fs-extra';
+import fs from 'fs';
 import { listRegisteredPackages } from '../packageRegistry';
+import { type LocalPackageJson, readPackageJson } from '../packageJson';
+import { listInstalledPackages } from '../installedPackages';
+import { extract } from 'tar-fs';
+import { getShortName, type PackageName } from '../package';
+import zlib from 'zlib';
 
-function postpack() {
+await postpack();
+
+async function postpack() {
+  console.info('*** Starting postpack. ***');
   revertReferencesToCopiedProtectedPackages();
+  await validatePostpack();
+  console.info('*** Ending postpack. ***');
 }
 
 function revertReferencesToCopiedProtectedPackages() {
@@ -22,4 +33,138 @@ function revertReferencesToCopiedProtectedPackages() {
   fse.writeJSONSync(packageJsonPath, packageJson, { spaces: 2 });
 }
 
-postpack();
+async function validatePostpack() {
+  console.info(`*** Validating package.json. ***`);
+
+  const packageJson = readPackageJson('./package.json');
+
+  listInstalledPackages(packageJson, {
+    filter: { scope: 'protected', dependencyType: 'dependencies' },
+  }).forEach((p) => {
+    if (packageJson.dependencies?.[p.name] !== '*') {
+      console.error(
+        '*** Failure: Local dependency has incorrect version setting. ***'
+      );
+      throw new Error(
+        `[iot-app-kit] Expected local dependency version to be '*'. Found: ${
+          packageJson.dependencies?.[p.name] ?? 'No version found'
+        }.`
+      );
+    }
+  });
+
+  try {
+    console.info(`*** Validating package tarball contents. ***`);
+
+    const tarballContentsDest = './package-tarball-contents';
+    const packageContents = `${tarballContentsDest}/package`;
+
+    await extractPackageTarball(packageJson, tarballContentsDest);
+
+    const packedPackageJson = readPackageJson(
+      `./${packageContents}/package.json`
+    );
+
+    listInstalledPackages(packedPackageJson, {
+      filter: { scope: 'protected', dependencyType: 'dependencies' },
+    }).forEach((p) => {
+      if (
+        packedPackageJson.dependencies?.[p.name] !==
+        `file:./dist/${getShortName(p.name as PackageName)}`
+      ) {
+        console.error(
+          '*** Failure: Packed local dependency has incorrect version setting. ***'
+        );
+        throw new Error(
+          `[iot-app-kit] Expected packed local dependency version to use file reference. Found: ${
+            packedPackageJson.dependencies?.[p.name] ?? 'No version found'
+          }.`
+        );
+      }
+    });
+
+    fse.readFileSync(`./${packageContents}/README.md`);
+    fse.readFileSync(`./${packageContents}/LICENSE`);
+    fse.readFileSync(`./${packageContents}/NOTICE`);
+    fse.readFileSync(`./${packageContents}/dist/cjs/index.cjs.js`);
+    fse.readFileSync(`./${packageContents}/dist/cjs/index.cjs.js.map`);
+    fse.readFileSync(`./${packageContents}/dist/cjs/index.d.ts`);
+    fse.readFileSync(`./${packageContents}/dist/cjs/index.d.ts.map`);
+    fse.readFileSync(`./${packageContents}/dist/esm/index.js`);
+    fse.readFileSync(`./${packageContents}/dist/esm/index.js.map`);
+    fse.readFileSync(`./${packageContents}/dist/esm/index.d.ts`);
+    fse.readFileSync(`./${packageContents}/dist/esm/index.d.ts.map`);
+
+    listInstalledPackages(packedPackageJson, {
+      filter: { scope: 'protected', dependencyType: 'dependencies' },
+    })
+      .map(({ name, ...protectedPackage }) => ({
+        shortName: getShortName(name),
+        name,
+        ...protectedPackage,
+      }))
+      .forEach(({ name, shortName }) => {
+        console.info(
+          `*** Validating tarball contents for runtime dependency on protected package ${name}. ***`
+        );
+        fse.readFileSync(`./${packageContents}/dist/${shortName}/package.json`);
+        fse.readFileSync(
+          `./${packageContents}/dist/${shortName}/dist/cjs/index.cjs.js`
+        );
+        fse.readFileSync(
+          `./${packageContents}/dist/${shortName}/dist/cjs/index.cjs.js.map`
+        );
+        fse.readFileSync(
+          `./${packageContents}/dist/${shortName}/dist/cjs/index.d.ts`
+        );
+        fse.readFileSync(
+          `./${packageContents}/dist/${shortName}/dist/cjs/index.d.ts.map`
+        );
+        fse.readFileSync(
+          `./${packageContents}/dist/${shortName}/dist/esm/index.js`
+        );
+        fse.readFileSync(
+          `./${packageContents}/dist/${shortName}/dist/esm/index.js.map`
+        );
+        fse.readFileSync(
+          `./${packageContents}/dist/${shortName}/dist/esm/index.d.ts`
+        );
+        fse.readFileSync(
+          `./${packageContents}/dist/${shortName}/dist/esm/index.d.ts.map`
+        );
+      });
+
+    // clean up extracted tarball
+    fse.removeSync(tarballContentsDest);
+
+    console.info('*** Success: Package tarball contents are valid. ***');
+  } catch (error) {
+    console.error(
+      'Failure: Validation of package tarball contents failed. Package tarball is invalid.'
+    );
+    throw error;
+  }
+}
+
+async function extractPackageTarball(
+  packageJson: LocalPackageJson,
+  dest: string
+) {
+  return new Promise((resolve, reject) => {
+    fs.createReadStream(
+      `./iot-app-kit-${getShortName(packageJson.name as PackageName)}-${
+        packageJson.version
+      }.tgz`
+    )
+      .pipe(zlib.createGunzip())
+      .pipe(
+        extract(dest)
+          .on('error', (error) => {
+            reject(error);
+          })
+          .on('finish', () => {
+            resolve(undefined);
+          })
+      );
+  });
+}

--- a/configuration/vite-config/src/validation/validateBuildArtifacts.ts
+++ b/configuration/vite-config/src/validation/validateBuildArtifacts.ts
@@ -1,0 +1,67 @@
+import fse from 'fs-extra';
+import { listInstalledPackages } from '../installedPackages';
+import { readPackageJson } from '../packageJson';
+import { getShortName } from '../package';
+
+export function validateBuildArtifacts(): void | never {
+  console.info(`*** Validating build artifacts. ***`);
+
+  try {
+    const packageJson = readPackageJson('./package.json');
+
+    console.info(`*** Validating CJS build artifacts. ***`);
+    fse.readFileSync('./dist/cjs/index.cjs.js');
+    fse.readFileSync('./dist/cjs/index.cjs.js.map');
+    fse.readFileSync('./dist/cjs/index.d.ts');
+    fse.readFileSync('./dist/cjs/index.d.ts.map');
+
+    console.info(`*** Validating ESM build artifacts. ***`);
+    fse.readFileSync('./dist/esm/index.js');
+    fse.readFileSync('./dist/esm/index.js.map');
+    fse.readFileSync('./dist/esm/index.d.ts');
+    fse.readFileSync('./dist/esm/index.d.ts.map');
+
+    console.info(`*** Validating dependencies on protected packages. ***`);
+
+    const protectedPackagesInstalledAsRuntimeDependencies =
+      listInstalledPackages(packageJson, {
+        filter: { scope: 'protected', dependencyType: 'dependencies' },
+      });
+
+    if (protectedPackagesInstalledAsRuntimeDependencies.length > 0) {
+      console.info(
+        '*** Runtime dependencies on protected package detected. ***'
+      );
+
+      protectedPackagesInstalledAsRuntimeDependencies
+        .map(({ name, ...protectedPackage }) => ({
+          shortName: getShortName(name),
+          name,
+          ...protectedPackage,
+        }))
+        .forEach(({ name, shortName }) => {
+          console.info(`*** Validating build artifacts for ${name}. ***`);
+          fse.readFileSync(`./dist/${shortName}/package.json`);
+
+          console.info(`*** Validating CJS build artifacts for ${name}. ***`);
+          fse.readFileSync(`./dist/${shortName}/dist/cjs/index.cjs.js`);
+          fse.readFileSync(`./dist/${shortName}/dist/cjs/index.cjs.js.map`);
+          fse.readFileSync(`./dist/${shortName}/dist/cjs/index.d.ts`);
+          fse.readFileSync(`./dist/${shortName}/dist/cjs/index.d.ts.map`);
+
+          console.info(`*** Validating ESM build artifacts for ${name}. ***`);
+          fse.readFileSync(`./dist/${shortName}/dist/esm/index.js`);
+          fse.readFileSync(`./dist/${shortName}/dist/esm/index.js.map`);
+          fse.readFileSync(`./dist/${shortName}/dist/esm/index.d.ts`);
+          fse.readFileSync(`./dist/${shortName}/dist/esm/index.d.ts.map`);
+        });
+    }
+
+    console.info('*** Success: Build artifacts are valid. ***');
+  } catch (error) {
+    console.error(
+      '*** Failure: Validation of build artifacts failed. Build artifacts are invalid. ***'
+    );
+    throw error;
+  }
+}

--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -22,8 +22,9 @@
     "start": "vite",
     "build": "vite build",
     "serve": "vite preview",
-    "clean": "npx rimraf dist .turbo",
-    "clean:nuke": "npx rimraf dist .turbo node_modules"
+    "clean": "npx rimraf dist",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules"
   },
   "eslintConfig": {
     "extends": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,6 +146,7 @@
         "vite-plugin-dts": "^4.3.0"
       },
       "bin": {
+        "iot-postbuild": "src/scripts/postbuild.ts",
         "iot-postpack": "src/scripts/postpack.ts",
         "iot-prepack": "src/scripts/prepack.ts"
       },
@@ -154,7 +155,36 @@
         "@iot-app-kit/ts-config": "*",
         "@types/fs-extra": "^11.0.4",
         "@types/node": "^18.16.18",
-        "rimraf": "^5.0.1"
+        "@types/tar-fs": "^2.0.4",
+        "rimraf": "^5.0.1",
+        "tar-fs": "^3.0.6"
+      }
+    },
+    "configuration/vite-config/node_modules/tar-fs": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
+      }
+    },
+    "configuration/vite-config/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "configuration/vite-config/node_modules/type-fest": {
@@ -17341,6 +17371,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/tar-fs": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/tar-fs/-/tar-fs-2.0.4.tgz",
+      "integrity": "sha512-ipPec0CjTmVDWE+QKr9cTmIIoTl7dFG/yARCM5MqK8i6CNLIG1P8x4kwDsOQY1ChZOZjH0wO9nvfgBvWl4R3kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tar-stream": "*"
+      }
+    },
+    "node_modules/@types/tar-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-3.1.3.tgz",
+      "integrity": "sha512-Zbnx4wpkWBMBSu5CytMbrT5ZpMiF55qgM+EpHzR4yIDu7mv52cej8hTkOc6K+LzpkOAbxwn/m7j3iO+/l42YkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/three": {
       "version": "0.149.0",
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.149.0.tgz",
@@ -18890,6 +18941,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/babel-plugin-formatjs": {
       "version": "10.5.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-formatjs/-/babel-plugin-formatjs-10.5.3.tgz",
@@ -19091,6 +19149,57 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.0.tgz",
+      "integrity": "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.5.tgz",
+      "integrity": "sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-path": "^2.0.0",
+        "bare-stream": "^2.0.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.4.tgz",
+      "integrity": "sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-path": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
+      "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^2.1.0"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.4.2.tgz",
+      "integrity": "sha512-XZ4ln/KV4KT+PXdIWTKjsLY+quqCaEtqqtgGJVPw9AoM73By03ij64YjepK0aQvHSWDb6AfAZwqKaFu68qkrdA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.20.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -23198,6 +23307,13 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -29852,6 +29968,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ramda": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
@@ -32395,6 +32518,21 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.0.tgz",
+      "integrity": "sha512-Qz6MsDZXJ6ur9u+b+4xCG18TluU7PGlRfXVAAjNiGsFrBUt/ioyLkxbFaKJygoPs+/kW4VyBj0bSj89Qu0IGyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
@@ -33856,6 +33994,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.2.tgz",
+      "integrity": "sha512-/MDslo7ZyWTA2vnk1j7XoDVfXsGk3tp+zFEJHJGm0UjIlQifonVFwlVbQDFh8KJzTBnT8ie115TYqir6bclddA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-extensions": {

--- a/packages/core-util/package.json
+++ b/packages/core-util/package.json
@@ -6,7 +6,8 @@
     "access": "public"
   },
   "files": [
-    "dist"
+    "dist",
+    "NOTICE"
   ],
   "type": "module",
   "main": "dist/cjs/index.cjs.js",
@@ -25,8 +26,10 @@
   },
   "scripts": {
     "build": "NODE_OPTIONS='--import tsx/esm' vite build",
-    "clean": "npx rimraf dist coverage .turbo .cache *.tgz",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "postbuild": "iot-postbuild",
+    "clean": "npx rimraf dist coverage .cache *.tgz",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "lint": "eslint . --max-warnings=0 --cache --cache-location .cache/eslint/",
     "fix": "eslint --fix . --cache --cache-location .cache/eslint/",
     "test": "NODE_OPTIONS='--import tsx/esm' TZ=UTC vitest run",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,8 @@
     "access": "public"
   },
   "files": [
-    "dist"
+    "dist",
+    "NOTICE"
   ],
   "type": "module",
   "main": "./dist/cjs/index.cjs.js",
@@ -26,8 +27,10 @@
   },
   "scripts": {
     "build": "NODE_OPTIONS='--import tsx/esm' vite build",
-    "clean": "npx rimraf dist coverage .turbo .cache *.tgz LICENSE NOTICE",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "postbuild": "iot-postbuild",
+    "clean": "npx rimraf dist coverage .cache *.tgz LICENSE NOTICE",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "lint": "eslint . --max-warnings=2 --cache --cache-location .cache/eslint/",
     "fix": "eslint --fix . --cache --cache-location .cache/eslint/",
     "test": "NODE_OPTIONS='--import tsx/esm' TZ=UTC vitest run",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -9,8 +9,7 @@
   "license": "Apache-2.0",
   "files": [
     "dist",
-    "CHANGELOG.md",
-    "*NOTICE"
+    "NOTICE"
   ],
   "repository": {
     "type": "git",
@@ -36,8 +35,10 @@
   },
   "scripts": {
     "build": "NODE_OPTIONS='--import tsx/esm' vite build && npm run copy-assets:es && npm run copy-assets:cjs",
-    "clean": "npx rimraf dist .turbo .cache *.tgz LICENSE NOTICE",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "postbuild": "iot-postbuild",
+    "clean": "npx rimraf dist .cache *.tgz LICENSE NOTICE",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "copy-assets:es": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" -u 1 dist/esm/",
     "copy-assets:cjs": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" -u 1 dist/cjs/",
     "test": "NODE_OPTIONS='--import tsx/esm' vitest run",

--- a/packages/data-mocked/package.json
+++ b/packages/data-mocked/package.json
@@ -10,8 +10,9 @@
     "./handers": "./src/handlers.ts"
   },
   "scripts": {
-    "clean": "npx rimraf .turbo .cache",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "clean": "npx rimraf .cache",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "lint": "eslint . --max-warnings=0 --cache --cache-location .cache/eslint/ & npm run test:typescript",
     "fix": "eslint --fix . --cache --cache-location ./cache/eslint/",
     "test:typescript": "tsc --noEmit"

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -19,8 +19,10 @@
   },
   "scripts": {
     "build": "NODE_OPTIONS='--import tsx/esm' vite build",
-    "clean": "npx rimraf .turbo .cache dist",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "postbuild": "iot-postbuild",
+    "clean": "npx rimraf .cache dist",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "lint": "eslint . --max-warnings=0 --cache --cache-location .cache/eslint/",
     "fix": "eslint --fix . --cache --cache-location ./cache/eslint/",
     "test:typescript": "tsc --noEmit"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -6,7 +6,8 @@
     "access": "public"
   },
   "files": [
-    "dist"
+    "dist",
+    "NOTICE"
   ],
   "type": "module",
   "main": "./dist/cjs/index.cjs.js",
@@ -26,8 +27,10 @@
   "scripts": {
     "start": "npm run dev",
     "build": "NODE_OPTIONS='--import tsx/esm' vite build && npm run copy-assets:es && npm run copy-assets:cjs",
-    "clean": "npx rimraf dist storybook-static test-results playwright-report coverage .turbo .cache *.tgz LICENSE NOTICE",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "postbuild": "iot-postbuild",
+    "clean": "npx rimraf dist storybook-static test-results playwright-report coverage .cache *.tgz LICENSE NOTICE",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "copy-assets:es": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" -u 1 dist/esm/",
     "copy-assets:cjs": "copyfiles -e \"**/*.tsx\" -e \"**/*.ts\" -e \"**/*.snap\" -e \"**/*.js\" -e \"**/*.jsx\" -e \"**/*.json\" \"src/**/*\" -u 1 dist/cjs/",
     "dev": "NODE_OPTIONS='--import tsx/esm' storybook dev -p 6007",

--- a/packages/scene-composer/package.json
+++ b/packages/scene-composer/package.json
@@ -8,7 +8,8 @@
   "description": "AWS IoT TwinMaker Scene Composer Library",
   "homepage": "https://github.com/awslabs/iot-app-kit#readme",
   "files": [
-    "dist"
+    "dist",
+    "NOTICE"
   ],
   "type": "module",
   "main": "./dist/cjs/index.cjs.js",
@@ -31,9 +32,11 @@
   },
   "scripts": {
     "build": "run-s svglint extract-msgs convert-svg build:ts copy-assets:es copy-assets:cjs",
+    "postbuild": "iot-postbuild",
     "build:ts": "NODE_OPTIONS='--import tsx/esm' vite build",
-    "clean": "npx rimraf dist coverage playwright-report test-results .turbo .cache *.tgz LICENSE NOTICE",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "clean": "npx rimraf dist coverage playwright-report test-results .cache *.tgz LICENSE NOTICE",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "pre:compile": "run-s svglint extract-msgs convert-svg",
     "convert-svg": "npx @svgr/cli --out-dir src/assets/auto-gen/icons/ --typescript --jsx-runtime automatic --index-template tools/index-template.cjs -- src/assets/icons/",
     "release": "run-s build copy-assets:es copy-assets:cjs",

--- a/packages/source-iotsitewise/package.json
+++ b/packages/source-iotsitewise/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/awslabs/iot-app-kit#readme",
   "license": "Apache-2.0",
   "files": [
-    "dist"
+    "dist",
+    "NOTICE"
   ],
   "type": "module",
   "main": "./dist/cjs/index.cjs.js",
@@ -32,8 +33,10 @@
   },
   "scripts": {
     "build": "NODE_OPTIONS='--import tsx/esm' vite build",
-    "clean": "npx rimraf dist coverage .turbo .cache *.tgz LICENSE NOTICE",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "postbuild": "iot-postbuild",
+    "clean": "npx rimraf dist coverage .cache *.tgz LICENSE NOTICE",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "lint": "eslint . --max-warnings=0 --cache --cache-location .cache/eslint/",
     "fix": "eslint --fix . --cache --cache-location .cache/eslint/",
     "test": "NODE_OPTIONS='--import tsx/esm' TZ=UTC vitest run --silent",

--- a/packages/source-iottwinmaker/package.json
+++ b/packages/source-iottwinmaker/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/awslabs/iot-app-kit#readme",
   "license": "Apache-2.0",
   "files": [
-    "dist"
+    "dist",
+    "NOTICE"
   ],
   "type": "module",
   "main": "./dist/cjs/index.cjs.js",
@@ -31,8 +32,10 @@
   },
   "scripts": {
     "build": "NODE_OPTIONS='--import tsx/esm' vite build",
-    "clean": "npx rimraf dist coverage .turbo .cache *.tgz LICENSE NOTICE",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "postbuild": "iot-postbuild",
+    "clean": "npx rimraf dist coverage .cache *.tgz LICENSE NOTICE",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "lint": "eslint . --max-warnings=0 --cache --cache-location .cache/eslint/",
     "fix": "eslint --fix . --cache --cache-location .cache/eslint/",
     "test": "NODE_OPTIONS='--import tsx/esm' TZ=UTC vitest run",

--- a/packages/testing-util/package.json
+++ b/packages/testing-util/package.json
@@ -13,8 +13,9 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "clean": "npx rimraf .turbo .cache",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "clean": "npx rimraf .cache",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "lint": "eslint . --max-warnings=1 --cache --cache-location .cache/eslint/",
     "lint-fix": "eslint --fix . --cache --cache-location .cache/eslint/"
   },

--- a/packages/tools-iottwinmaker/package.json
+++ b/packages/tools-iottwinmaker/package.json
@@ -8,6 +8,10 @@
     "node": ">=16",
     "npm": ">=8"
   },
+  "files": [
+    "dist",
+    "NOTICE"
+  ],
   "type": "module",
   "main": "./dist/cjs/index.cjs.js",
   "module": "./dist/esm/index.js",
@@ -31,9 +35,11 @@
   },
   "scripts": {
     "build": "NODE_OPTIONS='--import tsx/esm' vite build && npm run package",
+    "postbuild": "iot-postbuild",
     "build-global": "npm run clean && npm run build && npm run package && npm install -g",
-    "clean": "npx rimraf dist coverage tmdt_local .turbo .cache *.tgz LICENSE NOTICE && npm uninstall -g tmdt || true",
-    "clean:nuke": "npm run clean && npx rimraf node_modules",
+    "clean": "npx rimraf dist coverage tmdt_local .cache *.tgz LICENSE NOTICE && npm uninstall -g tmdt || true",
+    "clean:turbo": "npx rimraf .turbo",
+    "clean:nuke": "npm run clean && npm run clean:turbo && npx rimraf node_modules",
     "lint": "eslint . --max-warnings=0 --cache --cache-location .cache/eslint/",
     "fix": "eslint --fix . --cache --cache-location .cache/eslint/",
     "test": "NODE_OPTIONS='--import tsx/esm' TZ=UTC vitest run -c vite.config.ts --silent",

--- a/turbo.json
+++ b/turbo.json
@@ -34,7 +34,7 @@
       "outputLogs": "full"
     },
     "pack": {
-      "dependsOn": ["^clean", "clean", "build"],
+      "dependsOn": ["^clean", "clean", "//#clean", "build"],
       "cache": false,
       "outputLogs": "new-only"
     },


### PR DESCRIPTION
## Overview
This change improves the stability of the build by adding validation steps to the build and release processes. 

After a package is built, newly added validations run, inspecting the contents of the package's dist to ensure they are correct. Validations also occur before and after `npm pack` is run on a package, ensuring the package in the correct condition to pack, then extracting and validating the tarball contents.

Additionally, the GH actions now run `turbo pack`, which runs the packaging steps for each package, including their validation steps.

These new tests ensure the stability of our build and packaging steps preventing mistakes impacting these steps from being merged.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
