### PR TITLE
fix: update hover states and alarm colors

### DIFF
--- a/packages/dashboard/src/components/widgets/tile/tile.tsx
+++ b/packages/dashboard/src/components/widgets/tile/tile.tsx
@@ -92,7 +92,6 @@ const WidgetTile: React.FC<WidgetTileProps> = ({
       aria-description='widget tile'
       className='widget-tile'
       style={{
-        height: isSelected ? 'calc(100% + 10px)' : 'inherit',
         borderRadius: borderRadiusBadge,
         backgroundColor: colorBackgroundContainerContent,
         border: isSelected ? `2px solid ${colorBackgroundControlChecked}` : '',

--- a/packages/dashboard/src/components/widgets/widgetActions.css
+++ b/packages/dashboard/src/components/widgets/widgetActions.css
@@ -1,7 +1,14 @@
+@import url("../../styles/variables.css");
+
 .widget-actions-container {
   display: flex;
   align-items: center;
   position: absolute;
   top: -18px;
   z-index: 999; /* Widget actions toolbox should be above the widget container */
+  border: var(--selection-border-width) solid var(--colors-grey-button-border)
+}
+
+.widget-actions-container:hover {
+  border: var(--selection-border-width) solid var(--selection-color);
 }

--- a/packages/dashboard/src/components/widgets/widgetActions.tsx
+++ b/packages/dashboard/src/components/widgets/widgetActions.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, type ButtonProps } from '@cloudscape-design/components';
 import {
   colorBackgroundButtonNormalDefault,
-  colorBackgroundButtonPrimaryDefault,
   spaceStaticL,
   spaceStaticXl,
   spaceStaticXs,
@@ -110,7 +109,6 @@ const WidgetActions = ({ widget }: { widget: DashboardWidget }) => {
         height: `${spaceStaticXl}`,
         right: `${spaceStaticL}`,
         borderRadius: `${spaceStaticXs}`,
-        border: `2px solid ${colorBackgroundButtonPrimaryDefault}`,
         backgroundColor: `${colorBackgroundButtonNormalDefault}`,
         pointerEvents: 'auto',
       }}

--- a/packages/dashboard/src/styles/variables.css
+++ b/packages/dashboard/src/styles/variables.css
@@ -43,4 +43,6 @@
   --colors-background-button: #f90;
   --colors-button-hover: #ec7211;
   --colors-grey-border: #e9ebed;
+  --colors-grey-button-border: #c6c6cd;
+  --colors-blue-button-border: #006ce0;
 }

--- a/packages/react-components/src/components/status-timeline/alarmTransforms.ts
+++ b/packages/react-components/src/components/status-timeline/alarmTransforms.ts
@@ -42,32 +42,32 @@ export const transformAlarmStateToDataStream = (
 
 export const ALARM_STATE_THRESHOLDS = [
   {
-    color: '#D91515',
+    color: '#D13112',
     value: 'Active',
     comparisonOperator: COMPARISON_OPERATOR.EQ,
   },
   {
-    color: '#037F0C',
+    color: '#1E8102',
     value: 'Normal',
     comparisonOperator: COMPARISON_OPERATOR.EQ,
   },
   {
-    color: '#8D6605',
+    color: '#F89256',
     value: 'Latched',
     comparisonOperator: COMPARISON_OPERATOR.EQ,
   },
   {
-    color: '#656871',
+    color: '#697078',
     value: 'Disabled',
     comparisonOperator: COMPARISON_OPERATOR.EQ,
   },
   {
-    color: '#656871',
+    color: '#3184C2',
     value: 'Acknowledged',
     comparisonOperator: COMPARISON_OPERATOR.EQ,
   },
   {
-    color: '#656871',
+    color: '#879596',
     value: 'SnoozeDisabled',
     comparisonOperator: COMPARISON_OPERATOR.EQ,
   },


### PR DESCRIPTION
## Overview

### before hover updates: 
### (close button always has blue border, bottom border on widget is hidden)
![beforeUpdate](https://github.com/user-attachments/assets/70f11314-1cc4-46fc-b27c-b2015db8c20f)

### after hover updates: 
![afterUpdates](https://github.com/user-attachments/assets/8979fe9f-16d1-4c28-ac8b-813503c016a0)

---

### before alarm color updates:
<img width="642" alt="Screenshot 2025-01-09 at 09 11 51" src="https://github.com/user-attachments/assets/9d3d0387-8bab-4897-8e82-1a1ba2e446f5" />

### after alarm color updates:
<img width="649" alt="Screenshot 2025-01-09 at 09 11 29" src="https://github.com/user-attachments/assets/537b0c82-7c89-4058-9cad-e15f2f03efbb" />


## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
