### PR TITLE
feat: add support for null / nan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36705,6 +36705,7 @@
       "devDependencies": {
         "@aws-sdk/types": "^3.696.0",
         "@iot-app-kit/eslint-config": "*",
+        "@iot-app-kit/helpers": "*",
         "@iot-app-kit/ts-config": "*",
         "@iot-app-kit/vite-config": "*",
         "@types/lodash-es": "^4.17.12",
@@ -36770,6 +36771,7 @@
         "@iot-app-kit/atoms": "*",
         "@iot-app-kit/core": "*",
         "@iot-app-kit/core-util": "*",
+        "@iot-app-kit/helpers": "*",
         "@iot-app-kit/react-components": "*",
         "@iot-app-kit/source-iotsitewise": "*",
         "@popperjs/core": "^2.11.8",
@@ -37025,6 +37027,9 @@
         "tsx": "^4.19.2",
         "typescript": "^5.5.4",
         "vite": "^5.4.11"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-iotsitewise": "^3.696.0"
       }
     },
     "packages/react-components": {

--- a/packages/core-util/package.json
+++ b/packages/core-util/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@iot-app-kit/core": "*",
+    "@iot-app-kit/helpers": "*",
     "lodash-es": "^4.17.21",
     "pako": "^2.1.0",
     "parse-duration": "^1.0.3",

--- a/packages/core-util/src/sdks/number.ts
+++ b/packages/core-util/src/sdks/number.ts
@@ -1,4 +1,4 @@
-import type { Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 
 /**
  * Rounds a number to a given precision

--- a/packages/core/src/common/dataFilters.ts
+++ b/packages/core/src/common/dataFilters.ts
@@ -1,9 +1,11 @@
 import { bisector } from 'd3-array';
 
+import type { Primitive } from '@iot-app-kit/helpers';
+
 import { isHistoricalViewport } from './predicates';
 import { parseDuration } from './time';
 import type { Viewport } from '../data-module/data-cache/requestTypes';
-import type { DataPoint, Primitive } from '../data-module/types';
+import type { DataPoint } from '../data-module/types';
 
 // By doing the mapping to a date within the bisector
 // we eliminate the need to iterate over the entire data.

--- a/packages/core/src/common/number.ts
+++ b/packages/core/src/common/number.ts
@@ -1,4 +1,4 @@
-import type { Primitive } from '../data-module/types';
+import type { Primitive } from '@iot-app-kit/helpers';
 
 const MAX_PRECISION = 4;
 

--- a/packages/core/src/data-module/data-cache/caching/caching.ts
+++ b/packages/core/src/data-module/data-cache/caching/caching.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from '@iot-app-kit/helpers';
 import {
   MINUTE_IN_MS,
   SECOND_IN_MS,
@@ -14,7 +15,6 @@ import { getExpiredCacheIntervals } from './expiredCacheIntervals';
 import { pointBisector } from '../../../common/dataFilters';
 import type {
   DataPoint,
-  Primitive,
   RequestInformation,
   RequestInformationAndRange,
 } from '../../types';

--- a/packages/core/src/data-module/types.ts
+++ b/packages/core/src/data-module/types.ts
@@ -1,3 +1,7 @@
+import type { Primitive } from '@iot-app-kit/helpers';
+
+export type { Primitive } from '@iot-app-kit/helpers';
+
 import { type AggregateType, type Quality } from '@aws-sdk/client-iotsitewise';
 import type {
   TimeSeriesDataRequest,
@@ -26,8 +30,6 @@ export interface DataPoint<T extends Primitive = Primitive>
 }
 
 export type Resolution = number;
-
-export type Primitive = string | number | boolean;
 
 export type DataStreamId = string;
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -94,6 +94,7 @@
     "@iot-app-kit/atoms": "*",
     "@iot-app-kit/core": "*",
     "@iot-app-kit/core-util": "*",
+    "@iot-app-kit/helpers": "*",
     "@iot-app-kit/react-components": "*",
     "@iot-app-kit/source-iotsitewise": "*",
     "@popperjs/core": "^2.11.8",

--- a/packages/dashboard/src/components/csvDownloadButton/types.ts
+++ b/packages/dashboard/src/components/csvDownloadButton/types.ts
@@ -1,4 +1,4 @@
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 import { type Quality } from '@aws-sdk/client-iotsitewise';
 
 export type CSVDownloadObject = {

--- a/packages/dashboard/src/components/dashboard/queryContext.ts
+++ b/packages/dashboard/src/components/dashboard/queryContext.ts
@@ -3,11 +3,9 @@ import { useRefreshRate } from '../../customization/hooks/useRefreshRate';
 import { alarmModelQueryToSiteWiseAssetQuery } from '../../customization/widgets/utils/alarmModelQueryToAlarmQuery';
 import { assetModelQueryToSiteWiseAssetQuery } from '../../customization/widgets/utils/assetModelQueryToAssetQuery';
 
-import type {
-  DataStream,
-  Primitive,
-  TimeSeriesDataQuery,
-} from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
+
+import type { DataStream, TimeSeriesDataQuery } from '@iot-app-kit/core';
 import type {
   AlarmDataQuery,
   SiteWiseAlarmDataStreamQuery,

--- a/packages/data-mocked/src/iot-sitewise/handlers/batchGetAssetPropertyValue/batchGetAssetPropertyValueHandler.ts
+++ b/packages/data-mocked/src/iot-sitewise/handlers/batchGetAssetPropertyValue/batchGetAssetPropertyValueHandler.ts
@@ -67,8 +67,9 @@ export class AssetPropertyValueFactory {
       ...this.#createDefaults(),
       ...partialAssetPropertyValue,
       value: {
+        // nullValue: { valueType: 'I' },
         integerValue: faker.number.int({ min: 0, max: 100 }),
-      },
+      } as any,
     };
 
     return assetPropertyValue;
@@ -81,8 +82,9 @@ export class AssetPropertyValueFactory {
       ...this.#createDefaults(),
       ...partialAssetPropertyValue,
       value: {
+        // nullValue: { valueType: 'D' },
         doubleValue: faker.number.float({ min: 0, max: 100, precision: 0.001 }),
-      },
+      } as any,
     };
 
     return assetPropertyValue;
@@ -95,8 +97,9 @@ export class AssetPropertyValueFactory {
       ...this.#createDefaults(),
       ...partialAssetPropertyValue,
       value: {
+        // nullValue: { valueType: 'B' },
         booleanValue: faker.datatype.boolean(),
-      },
+      } as any,
     };
 
     return assetPropertyValue;
@@ -109,8 +112,9 @@ export class AssetPropertyValueFactory {
       ...this.#createDefaults(),
       ...partialAssetPropertyValue,
       value: {
+        // nullValue: { valueType: 'S' },
         stringValue: faker.helpers.arrayElement(['ON', 'OFF']),
-      },
+      } as any,
     };
 
     return assetPropertyValue;
@@ -206,6 +210,7 @@ export function batchGetAssetPropertyValueHistoryHandler() {
     };
 
     await delay();
+
     return HttpResponse.json(response, { status: 200 });
   });
 }

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -36,6 +36,9 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.11"
   },
+  "peerDependencies": {
+    "@aws-sdk/client-iotsitewise": "^3.696.0"
+  },
   "iotAppKit": {
     "scope": "protected"
   }

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -5,3 +5,7 @@ export {
   NANO_SECOND_IN_MS,
   SECOND_IN_MS,
 } from './constants/time';
+
+export { toValue } from './utils/toValue';
+
+export type { Primitive } from './types';

--- a/packages/helpers/src/types.ts
+++ b/packages/helpers/src/types.ts
@@ -1,0 +1,1 @@
+export type Primitive = string | number | boolean | null;

--- a/packages/helpers/src/utils/toValue.ts
+++ b/packages/helpers/src/utils/toValue.ts
@@ -1,0 +1,52 @@
+import type { Primitive } from '../types';
+import type { Variant } from '@aws-sdk/client-iotsitewise';
+
+/**
+ * Extracts the value out of a SiteWise Model Variant
+ *
+ * SiteWise Model values can either be a string, number or boolean.
+ *
+ * NOTE: Currently we treat booleans as strings.
+ */
+export const toValue = (variant: Variant | undefined): Primitive => {
+  if (variant == null) {
+    throw new Error('variant is undefined');
+  }
+
+  const { doubleValue, integerValue, stringValue, booleanValue } = variant;
+
+  if (doubleValue != null) {
+    return doubleValue;
+  }
+
+  if (integerValue != null) {
+    return integerValue;
+  }
+
+  if (stringValue != null) {
+    return stringValue;
+  }
+
+  if (booleanValue != null) {
+    return booleanValue.toString();
+  }
+
+  if ('nullValue' in variant && variant.nullValue != null) {
+    /**
+     * nullValue is not a nullish value
+     * it's an object with the string type of
+     * what the value should be.
+     */
+    return null;
+  }
+
+  /**
+   * A variant with no properties is treated
+   * as null data so that datastreams do not
+   * break when the sdk updates
+   */
+  return null;
+  // throw new Error(
+  //   'Expected value to have at least one property value, but instead it has none!'
+  // );
+};

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -58,7 +58,6 @@
   "devDependencies": {
     "@iot-app-kit/core": "*",
     "@iot-app-kit/eslint-config": "*",
-    "@iot-app-kit/helpers": "*",
     "@iot-app-kit/testing-util": "*",
     "@iot-app-kit/ts-config": "*",
     "@iot-app-kit/vite-config": "*",
@@ -120,6 +119,7 @@
     "@iot-app-kit/charts-core": "^2.1.2",
     "@iot-app-kit/core": "*",
     "@iot-app-kit/core-util": "*",
+    "@iot-app-kit/helpers": "*",
     "@iot-app-kit/source-iotsitewise": "*",
     "@iot-app-kit/source-iottwinmaker": "*",
     "@popperjs/core": "^2.11.8",

--- a/packages/react-components/src/components/bar-chart/hooks/useBarChartAlarms.ts
+++ b/packages/react-components/src/components/bar-chart/hooks/useBarChartAlarms.ts
@@ -1,6 +1,6 @@
+import type { Primitive } from '@iot-app-kit/helpers';
 import {
   type DataStream,
-  type Primitive,
   type ResolutionConfig,
   type Threshold,
   type ThresholdValue,

--- a/packages/react-components/src/components/chart/chartOptions/tooltip/value.tsx
+++ b/packages/react-components/src/components/chart/chartOptions/tooltip/value.tsx
@@ -1,10 +1,10 @@
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 import { isNumeric, round } from '@iot-app-kit/core-util';
 
 export const formatValue =
   (significantDigits = 4) =>
   (value: Primitive) =>
-    isNumeric(value) ? `${round(value, significantDigits)}` : value.toString();
+    isNumeric(value) ? `${round(value, significantDigits)}` : value?.toString();
 
 export type XYPlotTooltipValueOptions = {
   value?: Primitive;

--- a/packages/react-components/src/components/chart/hooks/useChartAlarms.ts
+++ b/packages/react-components/src/components/chart/hooks/useChartAlarms.ts
@@ -1,6 +1,6 @@
+import type { Primitive } from '@iot-app-kit/helpers';
 import {
   type DataStream,
-  type Primitive,
   type Threshold,
   type ThresholdValue,
 } from '@iot-app-kit/core';

--- a/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
+++ b/packages/react-components/src/components/chart/legend/table/legendTableAdapter.tsx
@@ -1,4 +1,5 @@
-import { type DataStream, type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
+import { type DataStream } from '@iot-app-kit/core';
 import { type ChartLegend, type ChartOptions } from '../../types';
 import { ChartLegendTable } from './table';
 import { type DataStreamInformation, type TrendCursor } from './types';

--- a/packages/react-components/src/components/chart/legend/table/types.ts
+++ b/packages/react-components/src/components/chart/legend/table/types.ts
@@ -1,4 +1,5 @@
-import { type DataStream, type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
+import { type DataStream } from '@iot-app-kit/core';
 import type { AlarmAssistantContext } from '../../../../common/assistantProps';
 
 export type TrendCursorValues = { [id in string]?: number };

--- a/packages/react-components/src/components/chart/multiYAxis/yAxisMenu.tsx
+++ b/packages/react-components/src/components/chart/multiYAxis/yAxisMenu.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useMeasure } from 'react-use';
 import { isNumeric, round } from '@iot-app-kit/core-util';
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 
 import Icon from '@cloudscape-design/components/icon';
 import {
@@ -24,7 +24,7 @@ import { useHighlightedDataStreams } from '../hooks/useHighlightedDataStreams';
 import './yAxisMenu.css';
 
 const getValue = (value: Primitive, significantDigits = 4) =>
-  isNumeric(value) ? `${round(value, significantDigits)}` : value.toString();
+  isNumeric(value) ? `${round(value, significantDigits)}` : value?.toString();
 
 const MENU_OFFSET = 5;
 const MENU_FONT_SIZE = 14;

--- a/packages/react-components/src/components/chart/types.ts
+++ b/packages/react-components/src/components/chart/types.ts
@@ -1,6 +1,6 @@
+import type { Primitive } from '@iot-app-kit/helpers';
 import {
   type DataStream,
-  type Primitive,
   type StyledThreshold,
   type ThresholdSettings,
   type Viewport,

--- a/packages/react-components/src/components/gauge/converters/convertDataset.ts
+++ b/packages/react-components/src/components/gauge/converters/convertDataset.ts
@@ -1,4 +1,4 @@
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 
 export const convertDataset = (gaugeValue?: Primitive) => {
   return {

--- a/packages/react-components/src/components/gauge/gaugeText.tsx
+++ b/packages/react-components/src/components/gauge/gaugeText.tsx
@@ -9,7 +9,7 @@ import {
 import { AlarmStateTextWithAssistant } from '../alarm-components/alarm-state/alarmStateTextWithAssistant';
 import { AlarmStateText } from '../alarm-components/alarm-state/alarmStateText';
 import { getPreciseValue } from '../../utils/getPreciseValue';
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 import { GaugeErrorText } from './gaugeErrorText';
 import { type AlarmContent } from '../alarm-components/alarm-content/types';
 import { type AssistantProperty } from '../../common/assistantProps';

--- a/packages/react-components/src/components/gauge/hooks/useGaugeConfiguration.ts
+++ b/packages/react-components/src/components/gauge/hooks/useGaugeConfiguration.ts
@@ -1,4 +1,4 @@
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 import isEqual from 'lodash-es/isEqual';
 import merge from 'lodash-es/merge';
 import { useEffect, useReducer } from 'react';

--- a/packages/react-components/src/components/gauge/types.ts
+++ b/packages/react-components/src/components/gauge/types.ts
@@ -1,8 +1,8 @@
+import type { Primitive } from '@iot-app-kit/helpers';
 import {
   type StyleSettingsMap,
   type Threshold,
   type Viewport,
-  type Primitive,
 } from '@iot-app-kit/core';
 import type { WidgetSettings } from '../../common/dataTypes';
 import { type AssistantProperty } from '../../common/assistantProps';

--- a/packages/react-components/src/components/gauge/utils/thresholdsToColor.ts
+++ b/packages/react-components/src/components/gauge/utils/thresholdsToColor.ts
@@ -1,4 +1,5 @@
-import { type Primitive, type Threshold } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
+import { type Threshold } from '@iot-app-kit/core';
 
 export const thresholdsToColor = ({
   gaugeValue,

--- a/packages/react-components/src/components/resource-explorers/requests/use-latest-values/create-data-streams-with-latest-value.ts
+++ b/packages/react-components/src/components/resource-explorers/requests/use-latest-values/create-data-streams-with-latest-value.ts
@@ -1,6 +1,7 @@
 import type { BatchGetAssetPropertyValueSuccessEntry } from '@aws-sdk/client-iotsitewise';
 import type { DataStreamRequestEntry, DataStreamResource } from './types';
 import type { DataStreamResourceWithLatestValue } from '../../types/resources';
+import { toValue } from '@iot-app-kit/helpers';
 
 type SuccessEntry = BatchGetAssetPropertyValueSuccessEntry;
 
@@ -41,11 +42,10 @@ function createDataStreamWithLatestValue<DataStream extends DataStreamResource>(
   requestEntry: DataStreamRequestEntry<DataStream>,
   successEntry?: SuccessEntry
 ): DataStreamResourceWithLatestValue<DataStream> {
+  const variant = successEntry?.assetPropertyValue?.value;
   const dataStreamWithLatestValue = {
     ...requestEntry.dataStream,
-    latestValue: Object.values(
-      successEntry?.assetPropertyValue?.value ?? {}
-    ).at(0),
+    latestValue: variant && toValue(variant),
     latestValueTimestamp:
       successEntry?.assetPropertyValue?.timestamp?.timeInSeconds,
   };

--- a/packages/react-components/src/components/resource-explorers/types/resources.ts
+++ b/packages/react-components/src/components/resource-explorers/types/resources.ts
@@ -1,4 +1,5 @@
 import type { AssetSummary } from '@aws-sdk/client-iotsitewise';
+import { type Primitive } from '@iot-app-kit/helpers';
 
 export interface AssetModelResource {
   assetModelId: string;
@@ -59,6 +60,6 @@ export type TimeSeriesResourceWithLatestValue =
 
 export type DataStreamResourceWithLatestValue<DataStreamResource> =
   DataStreamResource & {
-    latestValue?: number | string | boolean;
+    latestValue?: Primitive;
     latestValueTimestamp?: number;
   };

--- a/packages/react-components/src/components/shared-components/Value/Value.tsx
+++ b/packages/react-components/src/components/shared-components/Value/Value.tsx
@@ -1,4 +1,4 @@
-import type { Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 import { round } from '@iot-app-kit/core-util';
 
 export const Value: React.FC<{

--- a/packages/react-components/src/components/table/createTableItems.ts
+++ b/packages/react-components/src/components/table/createTableItems.ts
@@ -1,9 +1,5 @@
-import type {
-  DataStream,
-  Primitive,
-  Threshold,
-  Viewport,
-} from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
+import type { DataStream, Threshold, Viewport } from '@iot-app-kit/core';
 import { getDataBeforeDate } from '@iot-app-kit/core';
 import { breachedThreshold } from '../../utils/breachedThreshold';
 import { createCellItem } from './createCellItem';
@@ -40,7 +36,7 @@ export const createTableItems: (
   const alarmItemsWithData = alarms.map((alarm) => {
     const isLoading = alarm.isLoading;
     return {
-      id: alarm.id as Primitive,
+      id: alarm.id as string,
       assetId: createCellItem(
         {
           value: alarm.assetId,
@@ -189,7 +185,7 @@ export const createTableItems: (
 
     const [first] = keyDataPairs;
     return {
-      id: first.data.value as Primitive,
+      id: first.data.value as string | number | boolean,
       ...keyDataPairs.reduce(
         (previous, { key, data }) => ({
           ...previous,

--- a/packages/react-components/src/components/table/types.ts
+++ b/packages/react-components/src/components/table/types.ts
@@ -1,10 +1,6 @@
 import { type TableProps as CloudscapeTableProps } from '@cloudscape-design/components';
-import type {
-  DataPoint,
-  ErrorDetails,
-  Primitive,
-  Threshold,
-} from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
+import type { DataPoint, ErrorDetails, Threshold } from '@iot-app-kit/core';
 import type { UseCollectionOptions } from '@cloudscape-design/collection-hooks';
 import type { TableMessages } from './messages';
 import type { AssistantProperty } from '../../common/assistantProps';

--- a/packages/react-components/src/hooks/useSingleQueryAlarm/useSingleQueryAlarm.ts
+++ b/packages/react-components/src/hooks/useSingleQueryAlarm/useSingleQueryAlarm.ts
@@ -1,6 +1,6 @@
+import type { Primitive } from '@iot-app-kit/helpers';
 import {
   type DataStream,
-  type Primitive,
   type Threshold,
   type ThresholdValue,
   type Viewport,

--- a/packages/react-components/src/queries/useAssetPropertyValues/utils/toDataPoint.ts
+++ b/packages/react-components/src/queries/useAssetPropertyValues/utils/toDataPoint.ts
@@ -1,5 +1,6 @@
 import { NANO_SECOND_IN_MS, SECOND_IN_MS } from './timeConstants';
-import type { DataPoint, Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
+import type { DataPoint } from '@iot-app-kit/core';
 import type {
   AssetPropertyValue,
   TimeInNanos,

--- a/packages/react-components/src/utils/breachedThreshold.ts
+++ b/packages/react-components/src/utils/breachedThreshold.ts
@@ -1,3 +1,4 @@
+import type { Primitive } from '@iot-app-kit/helpers';
 import { getBreachedThreshold } from './thresholdUtils';
 import { isDefined } from './predicates';
 import { closestPoint } from './closestPoint';
@@ -6,7 +7,6 @@ import type {
   Threshold,
   DataStream,
   DataStreamId,
-  Primitive,
   StyledThreshold,
 } from '@iot-app-kit/core';
 

--- a/packages/react-components/src/utils/closestPoint.ts
+++ b/packages/react-components/src/utils/closestPoint.ts
@@ -1,6 +1,7 @@
+import type { Primitive } from '@iot-app-kit/helpers';
 import { pointBisector } from '@iot-app-kit/core';
 import { DATA_ALIGNMENT } from '../common/constants';
-import type { DataPoint, Primitive } from '@iot-app-kit/core';
+import type { DataPoint } from '@iot-app-kit/core';
 
 /**
  * Closest Points

--- a/packages/react-components/src/utils/getPreciseValue.ts
+++ b/packages/react-components/src/utils/getPreciseValue.ts
@@ -1,5 +1,5 @@
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 import { isNumeric, round } from '@iot-app-kit/core-util';
 
 export const getPreciseValue = (value: Primitive, significantDigits = 4) =>
-  isNumeric(value) ? `${round(value, significantDigits)}` : value.toString();
+  isNumeric(value) ? `${round(value, significantDigits)}` : value?.toString();

--- a/packages/react-components/src/utils/sort.ts
+++ b/packages/react-components/src/utils/sort.ts
@@ -1,4 +1,5 @@
-import type { DataPoint, Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
+import type { DataPoint } from '@iot-app-kit/core';
 
 /**
  * Sorts points in order of their points values.

--- a/packages/react-components/src/utils/thresholdUtils.ts
+++ b/packages/react-components/src/utils/thresholdUtils.ts
@@ -1,10 +1,7 @@
 import { bisector } from 'd3-array';
+import type { Primitive } from '@iot-app-kit/helpers';
 import { isNumeric } from '@iot-app-kit/core-util';
-import {
-  COMPARISON_OPERATOR,
-  type Threshold,
-  type Primitive,
-} from '@iot-app-kit/core';
+import { COMPARISON_OPERATOR, type Threshold } from '@iot-app-kit/core';
 
 import { isValid } from './predicates';
 
@@ -226,7 +223,11 @@ export const getBreachedThreshold = (
     return undefined;
   }
 
-  if (typeof value === 'string' || typeof value === 'boolean') {
+  if (
+    typeof value === 'string' ||
+    typeof value === 'boolean' ||
+    value === null
+  ) {
     return (
       thresholds.find((threshold) => isThresholdBreached(value, threshold)) ||
       undefined

--- a/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayDataRow.tsx
+++ b/packages/scene-composer/src/components/three-fiber/DataOverlayComponent/DataOverlayDataRow.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 
 import { useSceneComposerId } from '../../../common/sceneComposerIdContext';
 import { type ITwinMakerEntityDataBindingContext } from '../../../interfaces';

--- a/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/MotionIndicatorComponent.tsx
+++ b/packages/scene-composer/src/components/three-fiber/MotionIndicatorComponent/MotionIndicatorComponent.tsx
@@ -1,4 +1,4 @@
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 import { useMemo } from 'react';
 import { Color } from 'three';
 

--- a/packages/scene-composer/src/hooks/useBindingData.ts
+++ b/packages/scene-composer/src/hooks/useBindingData.ts
@@ -1,4 +1,5 @@
-import { type DataBase, type DurationViewport, type Primitive, type TimeSeriesData } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
+import { type DataBase, type DurationViewport, type TimeSeriesData } from '@iot-app-kit/core';
 import { type ITwinMakerEntityDataBindingContext } from '@iot-app-kit/source-iottwinmaker';
 import isEmpty from 'lodash-es/isEmpty';
 import { useEffect, useMemo, useRef, useState } from 'react';

--- a/packages/scene-composer/src/hooks/useRuleResult.ts
+++ b/packages/scene-composer/src/hooks/useRuleResult.ts
@@ -1,4 +1,4 @@
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 import { useMemo } from 'react';
 
 import { useSceneComposerId } from '../common/sceneComposerIdContext';

--- a/packages/scene-composer/src/utils/dataBindingUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingUtils.ts
@@ -1,4 +1,4 @@
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 import jexl from 'jexl';
 import isEqual from 'lodash-es/isEqual';
 import pick from 'lodash-es/pick';

--- a/packages/scene-composer/src/utils/dataBindingVariableUtils.ts
+++ b/packages/scene-composer/src/utils/dataBindingVariableUtils.ts
@@ -1,4 +1,4 @@
-import { type Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
 
 // Match ${xyz} where xyz can be anything except new line, and as few as possible
 const bindingVariableRegex = /\$\{.+?\}/gi;

--- a/packages/source-iotsitewise/src/alarms/iotevents/siteWiseAlarmModule.ts
+++ b/packages/source-iotsitewise/src/alarms/iotevents/siteWiseAlarmModule.ts
@@ -5,13 +5,13 @@ import { getAlarmModelName } from './util/getAlarmModelName';
 import { parseAlarmData } from './util/parseAlarmData';
 import { getPropertyId } from './util/getPropertyId';
 import { COMPARISON_SYMBOL } from './constants';
-import { toValue } from '../../time-series-data/util/toDataPoint';
 import {
   type SiteWiseAssetModule,
   type SiteWiseAssetSession,
 } from '../../asset-modules';
 import { getAlarmSourceProperty } from './util/getAlarmSourceProperty';
 import type { Alarm, AlarmModel } from './types';
+import { toValue } from '@iot-app-kit/helpers';
 
 export class SiteWiseAlarmModule {
   private readonly client: EventsClient;
@@ -110,7 +110,8 @@ export class SiteWiseAlarmModule {
         inputPropertyId,
         thresholdPropertyId,
         comparisonOperator,
-        threshold,
+        // old synchro charts type does not support null
+        threshold: threshold === null ? '' : threshold,
         severity,
         rule,
         state,

--- a/packages/source-iotsitewise/src/alarms/iotevents/util/completeAlarmStream.ts
+++ b/packages/source-iotsitewise/src/alarms/iotevents/util/completeAlarmStream.ts
@@ -35,7 +35,7 @@ export const completeAlarmStream = ({
   if (!assetModel) {
     if (
       isIoTEventsAlarmStateProperty(
-        dataStream.data[dataStream.data?.length - 1]?.y
+        dataStream.data[dataStream.data?.length - 1]?.y ?? undefined
       )
     ) {
       return {

--- a/packages/source-iotsitewise/src/time-series-data/util/toDataPoint.spec.ts
+++ b/packages/source-iotsitewise/src/time-series-data/util/toDataPoint.spec.ts
@@ -70,13 +70,16 @@ describe('toDataPoint', () => {
     });
   });
 
-  it('throws error when no property values passed in', () => {
+  it('does not throw error when no property values passed in', () => {
+    /**
+     * changing this functionality to patch support null / nan data
+     */
     expect(() =>
       toDataPoint({
         timestamp: { timeInSeconds: SECONDS },
         value: {},
       })
-    ).toThrowError();
+    ).not.toThrowError();
   });
 
   it('converts correctly for a string value', () => {

--- a/packages/source-iotsitewise/src/time-series-data/util/toDataPoint.ts
+++ b/packages/source-iotsitewise/src/time-series-data/util/toDataPoint.ts
@@ -1,12 +1,12 @@
 import { NANO_SECOND_IN_MS, SECOND_IN_MS } from './timeConstants';
-import type { DataPoint, Primitive } from '@iot-app-kit/core';
+import type { DataPoint } from '@iot-app-kit/core';
 import type {
   AssetPropertyValue,
   TimeInNanos,
-  Variant,
   Aggregates,
   AggregatedValue,
 } from '@aws-sdk/client-iotsitewise';
+import { toValue } from '@iot-app-kit/helpers';
 
 /** converts the TimeInNanos to milliseconds */
 const toTimestamp = (time: TimeInNanos | undefined): number =>
@@ -16,41 +16,6 @@ const toTimestamp = (time: TimeInNanos | undefined): number =>
         (time.offsetInNanos || 0) * NANO_SECOND_IN_MS
     )) ||
   0;
-
-/**
- * Extracts the value out of a SiteWise Model Variant
- *
- * SiteWise Model values can either be a string, number or boolean.
- *
- * NOTE: Currently we treat booleans as strings.
- */
-export const toValue = (variant: Variant | undefined): Primitive => {
-  if (variant == null) {
-    throw new Error('variant is undefined');
-  }
-
-  const { doubleValue, integerValue, stringValue, booleanValue } = variant;
-
-  if (doubleValue != null) {
-    return doubleValue;
-  }
-
-  if (integerValue != null) {
-    return integerValue;
-  }
-
-  if (stringValue != null) {
-    return stringValue;
-  }
-
-  if (booleanValue != null) {
-    return booleanValue.toString();
-  }
-
-  throw new Error(
-    'Expected value to have at least one property value, but instead it has none!'
-  );
-};
 
 /**
  * Converts a SiteWise response for data into a data point understood by IoT App Kit.

--- a/packages/source-iottwinmaker/src/common/types.ts
+++ b/packages/source-iottwinmaker/src/common/types.ts
@@ -1,1 +1,1 @@
-export type { Primitive } from '@iot-app-kit/core';
+export type { Primitive } from '@iot-app-kit/helpers';

--- a/packages/source-iottwinmaker/src/utils/propertyValueUtils.ts
+++ b/packages/source-iottwinmaker/src/utils/propertyValueUtils.ts
@@ -3,7 +3,8 @@ import type {
   DataType as TMDataType,
 } from '@aws-sdk/client-iottwinmaker';
 import { Type } from '@aws-sdk/client-iottwinmaker';
-import type { DataType, Primitive } from '@iot-app-kit/core';
+import type { Primitive } from '@iot-app-kit/helpers';
+import type { DataType } from '@iot-app-kit/core';
 import { DATA_TYPE } from '@iot-app-kit/core';
 import isEmpty from 'lodash-es/isEmpty';
 import isNil from 'lodash-es/isNil';


### PR DESCRIPTION
## Overview
Update for null / nan support. The main change is to the utility function `toValue`. This function is responsible for mapping the value of the `Variant` type object. 

The new type will look like:
```
interface Variant {
    /**
     * <p>Asset property data of type string (sequence of characters).</p>
     * @public
     */
    stringValue?: string | undefined;
    /**
     * <p>Asset property data of type integer (whole number).</p>
     * @public
     */
    integerValue?: number | undefined;
    /**
     * <p>Asset property data of type double (floating point number).</p>
     * @public
     */
    doubleValue?: number | undefined;
    /**
     * <p>Asset property data of type Boolean (true or false).</p>
     * @public
     */
    booleanValue?: boolean | undefined;
    nullValue?: PropertyValueNullValue | undefined;
}
```

This change also moves the `toValue` utility function to the protected helpers package so that it can be used in source-iotsitewise and react-components since the resource-explorer does not use the same datasource as the widgets.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
