### PR TITLE
fix: widget types

### DIFF
--- a/packages/dashboard/src/components/actions/index.tsx
+++ b/packages/dashboard/src/components/actions/index.tsx
@@ -12,7 +12,7 @@ import {
   spaceScaledXxxs,
 } from '@cloudscape-design/design-tokens';
 import { onSelectWidgetsAction, onToggleReadOnly } from '~/store/actions';
-import { type DashboardSave } from '~/types';
+import type { DashboardSave } from '~/types/saving';
 import CustomOrangeButton from '../customOrangeButton';
 import { RefreshRateDropDown } from '../refreshRate/refreshRateDropdown';
 import DashboardSettings from './settings';

--- a/packages/dashboard/src/components/actions/settings.tsx
+++ b/packages/dashboard/src/components/actions/settings.tsx
@@ -16,10 +16,10 @@ import { useDefaultViewport } from '../defaultViewport/useDefaultViewport';
 import LabeledInput from '../util/labeledInput';
 import { useGridSettings } from './useGridSettings';
 
-export type DashboardSettingsProps = {
+export interface DashboardSettingsProps {
   onClose: () => void;
   isVisible: boolean;
-};
+}
 
 const DashboardSettings: React.FC<DashboardSettingsProps> = ({
   onClose,

--- a/packages/dashboard/src/components/dashboard/clientContext.ts
+++ b/packages/dashboard/src/components/dashboard/clientContext.ts
@@ -1,10 +1,7 @@
-import { type IoTSiteWise } from '@aws-sdk/client-iotsitewise';
 import { createContext, useContext } from 'react';
-import { type DashboardIotSiteWiseClients } from '~/types';
+import type { DashboardIotSiteWiseClients } from '~/types/sdk-clients';
 
-export interface DashboardClientContext extends DashboardIotSiteWiseClients {
-  iotSiteWise: IoTSiteWise;
-}
+export type DashboardClientContext = DashboardIotSiteWiseClients;
 
 export const ClientContext = createContext<Partial<DashboardClientContext>>({});
 

--- a/packages/dashboard/src/components/dashboard/getClients.ts
+++ b/packages/dashboard/src/components/dashboard/getClients.ts
@@ -1,7 +1,7 @@
 import { IoTEventsClient } from '@aws-sdk/client-iot-events';
 import { IoTSiteWiseClient, IoTSiteWise } from '@aws-sdk/client-iotsitewise';
 import { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
-import { type DashboardClientConfiguration } from '~/types';
+import type { DashboardClientConfiguration } from '~/types/sdk-clients';
 import { type DashboardClientContext } from './clientContext';
 import { isCredentials } from '~/hooks/useAWSRegion';
 

--- a/packages/dashboard/src/components/dashboard/getQueries.ts
+++ b/packages/dashboard/src/components/dashboard/getQueries.ts
@@ -1,7 +1,5 @@
-import {
-  type DashboardClientConfiguration,
-  type DashboardIotSiteWiseQueries,
-} from '~/types';
+import type { DashboardClientConfiguration } from '~/types/sdk-clients';
+import type { DashboardIotSiteWiseQueries } from '~/types/queries';
 import { initialize } from '@iot-app-kit/source-iotsitewise';
 import { getClients } from './getClients';
 import { type EdgeMode } from '@iot-app-kit/core';

--- a/packages/dashboard/src/components/dashboard/index.tsx
+++ b/packages/dashboard/src/components/dashboard/index.tsx
@@ -13,15 +13,14 @@ import { useDashboardPlugins } from '~/customization/api';
 import { PropertiesPanel } from '~/customization/propertiesSections';
 import { queryClient } from '~/data/query-client';
 import { configureDashboardStore, toDashboardState } from '~/store';
+import type { DashboardClientConfiguration } from '~/types/sdk-clients';
+import type { DashboardConfiguration } from '~/types/dashboard-configuration';
 import type {
-  AssistantConfiguration,
-  DashboardClientConfiguration,
-  DashboardConfiguration,
   DashboardConfigurationChange,
-  DashboardSave,
-  DashboardToolbar,
   ViewportChange,
-} from '~/types';
+} from '~/types/dashboard-props';
+import type { DashboardSave } from '~/types/saving';
+import type { AssistantConfiguration, DashboardToolbar } from '~/types';
 import '../../styles/variables.css';
 import InternalDashboard from '../internalDashboard';
 import { ClientContext } from './clientContext';

--- a/packages/dashboard/src/components/dashboard/queryContext.ts
+++ b/packages/dashboard/src/components/dashboard/queryContext.ts
@@ -17,7 +17,7 @@ import type {
 import type {
   DashboardIotSiteWiseQueries,
   IoTSiteWiseDataStreamQuery,
-} from '~/types';
+} from '~/types/queries';
 
 const createTimeSeriesDataQuery = (
   iotSiteWiseQuery: SiteWiseQuery,

--- a/packages/dashboard/src/components/dashboard/view.tsx
+++ b/packages/dashboard/src/components/dashboard/view.tsx
@@ -9,13 +9,10 @@ import { TouchBackend } from 'react-dnd-touch-backend';
 import { Provider } from 'react-redux';
 import { useDashboardPlugins } from '~/customization/api';
 import { configureDashboardStore, toDashboardState } from '~/store';
-import type {
-  AssistantConfiguration,
-  DashboardClientConfiguration,
-  DashboardConfiguration,
-  DashboardToolbar,
-  ViewportChange,
-} from '~/types';
+import type { AssistantConfiguration, DashboardToolbar } from '~/types';
+import type { DashboardClientConfiguration } from '~/types/sdk-clients';
+import type { DashboardConfiguration } from '~/types/dashboard-configuration';
+import type { ViewportChange } from '~/types/dashboard-props';
 import '../../styles/variables.css';
 import InternalDashboard from '../internalDashboard';
 import { ClientContext } from './clientContext';

--- a/packages/dashboard/src/components/internalDashboard/dashboardHeader.tsx
+++ b/packages/dashboard/src/components/internalDashboard/dashboardHeader.tsx
@@ -6,7 +6,8 @@ import { TimeSelection, useViewport } from '@iot-app-kit/react-components';
 import isEqual from 'lodash-es/isEqual';
 import { useSelector } from 'react-redux';
 import { type DashboardState } from '~/store/state';
-import type { DashboardSave, DashboardToolbar } from '~/types';
+import type { DashboardSave } from '~/types/saving';
+import type { DashboardToolbar } from '~/types';
 import { convertToDashboardConfiguration } from '~/util/convertToDashbaoardConfiguration';
 import Actions from '../actions';
 

--- a/packages/dashboard/src/components/internalDashboard/gestures/index.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/index.ts
@@ -4,13 +4,13 @@ import { useMoveGestures } from './useMove';
 import { useResizeGestures } from './useResize';
 import { useSelectionGestures } from './useSelection';
 import type { DashboardState } from '~/store/state';
-import type { DashboardWidget } from '~/types';
+import type { RegisteredWidget } from '~/types/widgets';
 import type { DragEvent, PointClickEvent } from '../../grid';
 import type { Gesture } from './types';
 
 type GestureHooksProps = {
-  dashboardWidgets: DashboardWidget[];
-  selectedWidgets: DashboardWidget[];
+  dashboardWidgets: RegisteredWidget[];
+  selectedWidgets: RegisteredWidget[];
   cellSize: DashboardState['grid']['cellSize'];
 };
 

--- a/packages/dashboard/src/components/internalDashboard/gestures/useMove.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useMove.ts
@@ -4,13 +4,14 @@ import { useDispatch } from 'react-redux';
 import { onMoveWidgetsAction } from '~/store/actions';
 import { toGridPosition } from '~/util/position';
 import type { DashboardState } from '~/store/state';
-import type { Position, DashboardWidget } from '~/types';
+import type { Position } from '~/types';
+import type { RegisteredWidget } from '~/types/widgets';
 import type { DragEvent } from '../../grid';
 import type { Gesture } from './types';
 
 type MoveHooksProps = {
   setActiveGesture: React.Dispatch<React.SetStateAction<Gesture>>;
-  selectedWidgets: DashboardWidget[];
+  selectedWidgets: RegisteredWidget[];
   cellSize: DashboardState['grid']['cellSize'];
 };
 

--- a/packages/dashboard/src/components/internalDashboard/gestures/useResize.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useResize.ts
@@ -5,13 +5,14 @@ import { onResizeWidgetsAction } from '~/store/actions';
 import { toGridPosition } from '~/util/position';
 import type { Anchor } from '~/store/actions';
 import type { DashboardState } from '~/store/state';
-import type { Position, DashboardWidget } from '~/types';
+import type { Position } from '~/types';
+import type { RegisteredWidget } from '~/types/widgets';
 import type { DragEvent } from '../../grid';
 import type { Gesture } from './types';
 
 type ResizeHooksProps = {
   setActiveGesture: React.Dispatch<React.SetStateAction<Gesture>>;
-  selectedWidgets: DashboardWidget[];
+  selectedWidgets: RegisteredWidget[];
   cellSize: DashboardState['grid']['cellSize'];
 };
 

--- a/packages/dashboard/src/components/internalDashboard/gestures/useSelection.ts
+++ b/packages/dashboard/src/components/internalDashboard/gestures/useSelection.ts
@@ -2,15 +2,21 @@ import { useCallback, useState } from 'react';
 import type * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { onSelectWidgetsAction } from '~/store/actions';
-import { getSelectedWidgets, pointSelect, selectedRect } from '~/util/select';
+import {
+  getSelectedWidgets,
+  pointSelect,
+  selectedRect,
+  type Selection,
+} from '~/util/select';
 import type { DashboardState } from '~/store/state';
-import type { Position, Selection, DashboardWidget } from '~/types';
+import type { Position } from '~/types';
+import type { RegisteredWidget } from '~/types/widgets';
 import type { DragEvent } from '../../grid';
 import type { Gesture } from './types';
 
 type SelectionHooksProps = {
   setActiveGesture: React.Dispatch<React.SetStateAction<Gesture>>;
-  dashboardWidgets: DashboardWidget[];
+  dashboardWidgets: RegisteredWidget[];
   cellSize: DashboardState['grid']['cellSize'];
 };
 
@@ -21,7 +27,7 @@ export const useSelectionGestures = ({
 }: SelectionHooksProps) => {
   const dispatch = useDispatch();
   const selectWidgets = useCallback(
-    (widgets: DashboardWidget[], union: boolean) => {
+    (widgets: RegisteredWidget[], union: boolean) => {
       dispatch(
         onSelectWidgetsAction({
           widgets,

--- a/packages/dashboard/src/components/internalDashboard/index.test.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.test.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 
 import { configureDashboardStore } from '~/store';
 import { initialState } from '~/store/state';
-import { type DashboardWidgetsConfiguration } from '~/types';
+import { type DashboardConfiguration } from '~/types/dashboard-configuration';
 import { useDashboardPlugins } from '../../customization/api';
 import InternalDashboard from './index';
 
@@ -14,7 +14,8 @@ import { AppKitConfig } from '@iot-app-kit/react-components';
 // eslint-disable-next-line no-restricted-imports
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
-const EMPTY_DASHBOARD: DashboardWidgetsConfiguration = {
+const EMPTY_DASHBOARD: DashboardConfiguration = {
+  displaySettings: { numColumns: 100, numRows: 100 },
   widgets: [],
   viewport: { duration: '10m' },
 };

--- a/packages/dashboard/src/components/internalDashboard/index.tsx
+++ b/packages/dashboard/src/components/internalDashboard/index.tsx
@@ -51,13 +51,10 @@ import { useKeyboardShortcuts } from './keyboardShortcuts';
 import { useSelectedWidgets } from '~/hooks/useSelectedWidgets';
 import { DefaultDashboardMessages } from '~/messages';
 import type { DashboardState } from '~/store/state';
-import type {
-  DashboardConfigurationChange,
-  DashboardSave,
-  DashboardToolbar,
-  DashboardWidget,
-  Position,
-} from '~/types';
+import type { DashboardConfigurationChange } from '~/types/dashboard-props';
+import type { DashboardSave } from '~/types/saving';
+import type { RegisteredWidget } from '~/types/widgets';
+import type { DashboardToolbar, Position } from '~/types';
 import { AssetModelSelection } from '../assetModelSelection/assetModelSelection';
 import ConfirmDeleteModal from '../confirmDeleteModal';
 import type { ContextMenuProps } from '../contextMenu';
@@ -147,7 +144,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
 
   const metricsRecorder = getPlugin('metricsRecorder');
 
-  const createWidgets = (widgets: DashboardWidget[]) => {
+  const createWidgets = (widgets: RegisteredWidget[]) => {
     dispatch(
       onCreateWidgetsAction({
         widgets,
@@ -226,7 +223,7 @@ const InternalDashboard: React.FC<InternalDashboardProperties> = ({
 
     const { x, y } = toGridPosition(position, cellSize);
 
-    const widget: DashboardWidget = {
+    const widget: RegisteredWidget = {
       ...widgetPresets,
       x: Math.floor(x),
       y: Math.floor(y),

--- a/packages/dashboard/src/components/queryEditor/helpers/alarmSelectionLabel.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/alarmSelectionLabel.ts
@@ -1,6 +1,6 @@
-import {
-  type AlarmExplorerProps,
-  type AlarmResource,
+import type {
+  AlarmExplorerProps,
+  AlarmResource,
 } from '@iot-app-kit/react-components';
 
 export function alarmSelectionLabel(

--- a/packages/dashboard/src/components/queryEditor/helpers/getCorrectSelectionMode.spec.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/getCorrectSelectionMode.spec.ts
@@ -1,7 +1,9 @@
-import { type DashboardWidget } from '~/types';
+import type { RegisteredWidget, RegisteredWidgetType } from '~/types/widgets';
 import { getCorrectSelectionMode } from './getCorrectSelectionMode';
 
-const createMockWidget = (widgetType: string): DashboardWidget => {
+const createMockWidget = (
+  widgetType: RegisteredWidgetType
+): RegisteredWidget => {
   return {
     type: widgetType,
     id: 'test-id',
@@ -10,6 +12,7 @@ const createMockWidget = (widgetType: string): DashboardWidget => {
     z: 0,
     height: 20,
     width: 20,
+    // @ts-expect-error not handling properties
     properties: {},
   };
 };
@@ -30,8 +33,6 @@ describe('Get correct selection mode', () => {
   });
 
   it('returns multi if bar', () => {
-    expect(getCorrectSelectionMode([createMockWidget('bar-chart')])).toBe(
-      'multi'
-    );
+    expect(getCorrectSelectionMode([createMockWidget('bar')])).toBe('multi');
   });
 });

--- a/packages/dashboard/src/components/queryEditor/helpers/getCorrectSelectionMode.ts
+++ b/packages/dashboard/src/components/queryEditor/helpers/getCorrectSelectionMode.ts
@@ -1,6 +1,8 @@
-import { type DashboardWidget } from '~/types';
+import type { RegisteredWidget } from '~/types/widgets';
 
-export const getCorrectSelectionMode = (selectedWidgets: DashboardWidget[]) => {
+export const getCorrectSelectionMode = (
+  selectedWidgets: RegisteredWidget[]
+) => {
   return selectedWidgets.at(0)?.type === 'kpi' ||
     selectedWidgets.at(0)?.type === 'gauge'
     ? 'single'

--- a/packages/dashboard/src/customization/api.ts
+++ b/packages/dashboard/src/customization/api.ts
@@ -1,34 +1,38 @@
 import type * as React from 'react';
 import plugins from '~/customization/pluginsConfiguration';
-import type { DashboardWidget } from '~/types';
 import {
   ComponentLibraryComponentMap,
   ComponentLibraryComponentOrdering,
 } from './componentLibraryComponentMap';
 import { WidgetComponentMap } from './widgetComponentMap';
 import { WidgetPropertiesGeneratorMap } from './widgetPropertiesGeneratorMap';
+import type {
+  Widget,
+  DashboardWidgetRegistry,
+  RegisteredWidgetType,
+} from '~/types/widgets';
 
-type RenderFunc<T extends DashboardWidget> = (widget: T) => React.ReactElement;
+type RenderFunc<W extends Widget> = (widget: W) => React.ReactElement;
 
-type WidgetRegistrationOptions<T extends DashboardWidget> = {
-  render: RenderFunc<T>;
+type WidgetRegistrationOptions<T extends RegisteredWidgetType> = {
+  render: RenderFunc<Widget<T>>;
   componentLibrary?: {
     name: string;
     icon: React.FC;
   };
-  properties?: () => T['properties'];
-  initialSize?: Pick<DashboardWidget, 'height' | 'width'>;
+  properties?: () => DashboardWidgetRegistry[T];
+  initialSize?: Pick<Widget, 'height' | 'width'>;
 };
-type RegisterWidget = <T extends DashboardWidget>(
-  type: string,
+type RegisterWidget<T extends RegisteredWidgetType> = (
+  type: T,
   options: WidgetRegistrationOptions<T>
 ) => void;
 
 /**
  * function to register a new widget type in the dashboard
  */
-export const registerWidget: RegisterWidget = <T extends DashboardWidget>(
-  type: string,
+export const registerWidget = <T extends RegisteredWidgetType>(
+  type: T,
   options: WidgetRegistrationOptions<T>
 ) => {
   const { render, componentLibrary, properties, initialSize } = options;
@@ -48,8 +52,8 @@ export const registerWidget: RegisterWidget = <T extends DashboardWidget>(
   }
 };
 
-export type DashboardPlugin = {
-  install: (options: { registerWidget: RegisterWidget }) => void;
+export type DashboardPlugin<T extends RegisteredWidgetType> = {
+  install: (options: { registerWidget: RegisterWidget<T> }) => void;
 };
 
 const resetMaps = () => {

--- a/packages/dashboard/src/customization/widgets/barChart/constants.ts
+++ b/packages/dashboard/src/customization/widgets/barChart/constants.ts
@@ -1,0 +1,1 @@
+export const BarChartWidgetType = 'bar-chart';

--- a/packages/dashboard/src/customization/widgets/barChart/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/barChart/plugin.tsx
@@ -1,10 +1,9 @@
 import BarChartWidgetComponent from './component';
 import BarIcon from './icon';
 import type { DashboardPlugin } from '~/customization/api';
-import type { BarChartWidget } from '../types';
 import { WIDGET_INITIAL_HEIGHT, WIDGET_INITIAL_WIDTH } from '../constants';
 
-export const barChartPlugin: DashboardPlugin = {
+export const barChartPlugin = {
   install: ({ registerWidget }) => {
     registerWidget<BarChartWidget>('bar-chart', {
       render: (widget) => <BarChartWidgetComponent {...widget} />,
@@ -30,4 +29,4 @@ export const barChartPlugin: DashboardPlugin = {
       },
     });
   },
-};
+} satisfies DashboardPlugin;

--- a/packages/dashboard/src/customization/widgets/barChart/types.ts
+++ b/packages/dashboard/src/customization/widgets/barChart/types.ts
@@ -1,0 +1,21 @@
+import type { AggregateType } from '@aws-sdk/client-iotsitewise';
+import type { ThresholdSettings } from '@iot-app-kit/core';
+import type { QueryProperties } from '~/types/queries';
+import type { AxisSettings, ThresholdWithId } from '../../settings';
+import type { BarChartWidgetType } from './constants';
+
+declare module '~/types/widgets' {
+  interface DashboardWidgetRegistry {
+    [BarChartWidgetType]: BarChartProperties;
+  }
+}
+
+export interface BarChartProperties extends QueryProperties {
+  title?: string;
+  thresholds?: ThresholdWithId[];
+  thresholdSettings?: ThresholdSettings;
+  axis?: AxisSettings;
+  significantDigits?: number;
+  resolution?: string;
+  aggregationType?: AggregateType;
+}

--- a/packages/dashboard/src/customization/widgets/gauge/component.tsx
+++ b/packages/dashboard/src/customization/widgets/gauge/component.tsx
@@ -7,11 +7,13 @@ import WidgetTile from '~/components/widgets/tile';
 import { useChartSize } from '~/hooks/useChartSize';
 import type { DashboardState } from '~/store/state';
 import { isDefined } from '~/util/isDefined';
-import type { GaugeWidget } from '../types';
 import { createWidgetRenderKey } from '../utils/createWidgetRenderKey';
 import './component.css';
+import type { DashboardWidgetInstance } from '~/widgets/configuration';
 
-const GaugeWidgetComponent: React.FC<GaugeWidget> = (widget) => {
+const GaugeWidgetComponent = (
+  widget: Extract<DashboardWidgetInstance, { type: 'gauge' }>
+) => {
   const { viewport } = useViewport();
   const dashboardSignificantDigits = useSelector(
     (state: DashboardState) => state.significantDigits

--- a/packages/dashboard/src/customization/widgets/gauge/constants.ts
+++ b/packages/dashboard/src/customization/widgets/gauge/constants.ts
@@ -1,0 +1,1 @@
+export const GaugeWidgetType = 'gauge';

--- a/packages/dashboard/src/customization/widgets/gauge/plugin.tsx
+++ b/packages/dashboard/src/customization/widgets/gauge/plugin.tsx
@@ -1,39 +1,36 @@
 import GaugeWidgetComponent from './component';
-import GaugeIcon from './icon';
-import type { DashboardPlugin } from '~/customization/api';
-import type { GaugeWidget } from '../types';
+import { default as GaugeSvg } from './gauge.svg';
+import { default as GaugeSvgDark } from './gauge-dark.svg';
 import {
   GAUGE_WIDGET_INITIAL_HEIGHT,
   GAUGE_WIDGET_INITIAL_WIDTH,
 } from '../constants';
+import { registerWidget } from '~/widgets/widget-registry';
+import WidgetIcon from '../components/widgetIcon';
 
-export const gaugePlugin: DashboardPlugin = {
-  install: ({ registerWidget }) => {
-    registerWidget<GaugeWidget>('gauge', {
-      render: (widget) => <GaugeWidgetComponent {...widget} />,
-      componentLibrary: {
-        name: 'Gauge',
-        icon: GaugeIcon,
-      },
-      properties: () => ({
-        queryConfig: {
-          source: 'iotsitewise',
-          query: undefined,
-        },
-        resolution: '0',
-        showName: true,
-        showUnit: true,
-        fontSize: 40,
-        unitFontSize: 16,
-        labelFontSize: 16,
-        yMin: 0,
-        yMax: 100,
-        thresholds: [],
-      }),
-      initialSize: {
-        height: GAUGE_WIDGET_INITIAL_HEIGHT,
-        width: GAUGE_WIDGET_INITIAL_WIDTH,
-      },
-    });
+registerWidget({
+  type: 'gauge',
+  render: (widget) => <GaugeWidgetComponent {...widget} />,
+  name: 'Gauge',
+  icon: (
+    <WidgetIcon widget='gauge' defaultIcon={GaugeSvg} darkIcon={GaugeSvgDark} />
+  ),
+  initialProperties: {
+    queryConfig: {
+      source: 'iotsitewise',
+      query: undefined,
+    },
+    showName: true,
+    showUnit: true,
+    fontSize: 40,
+    unitFontSize: 16,
+    labelFontSize: 16,
+    yMin: 0,
+    yMax: 100,
+    thresholds: [],
   },
-};
+  initialSize: {
+    height: GAUGE_WIDGET_INITIAL_HEIGHT,
+    width: GAUGE_WIDGET_INITIAL_WIDTH,
+  },
+});

--- a/packages/dashboard/src/customization/widgets/gauge/types.ts
+++ b/packages/dashboard/src/customization/widgets/gauge/types.ts
@@ -1,0 +1,25 @@
+import type { StyledThreshold } from '@iot-app-kit/core';
+import type { AssistantProperty } from '@iot-app-kit/react-components';
+import type { QueryProperties } from '~/types/queries';
+import type { GaugeWidgetType } from './constants';
+
+declare module '~/widgets/types' {
+  export interface DashboardWidgetMap {
+    [GaugeWidgetType]: GaugeProperties;
+  }
+}
+
+export interface GaugeProperties extends QueryProperties {
+  title?: string;
+  gaugeThickness?: number;
+  showName?: boolean;
+  showUnit?: boolean;
+  fontSize?: number;
+  labelFontSize?: number;
+  unitFontSize?: number;
+  yMin?: number;
+  yMax?: number;
+  thresholds?: StyledThreshold[];
+  significantDigits?: number;
+  assistant?: AssistantProperty;
+}

--- a/packages/dashboard/src/customization/widgets/kpi/constants.ts
+++ b/packages/dashboard/src/customization/widgets/kpi/constants.ts
@@ -1,0 +1,1 @@
+export const KPIWidgetType = 'kpi';

--- a/packages/dashboard/src/customization/widgets/kpi/types.ts
+++ b/packages/dashboard/src/customization/widgets/kpi/types.ts
@@ -1,0 +1,28 @@
+import type { StyledThreshold } from '@iot-app-kit/core';
+import type { AssistantProperty } from '@iot-app-kit/react-components';
+import type { SimpleFontSettings } from '~/customization/settings';
+import type { QueryProperties } from '~/types/queries';
+import type { KPIWidgetType } from './constants';
+
+declare module '~/types/widgets' {
+  interface DashboardWidgetRegistry {
+    [KPIWidgetType]: KPIProperties;
+  }
+}
+
+export interface KPIProperties extends QueryProperties {
+  title?: string;
+  primaryFont: SimpleFontSettings;
+  secondaryFont: SimpleFontSettings;
+  showAggregationAndResolution?: boolean;
+  showValue?: boolean;
+  showUnit?: boolean;
+  showIcon?: boolean;
+  showName?: boolean;
+  showTimestamp?: boolean;
+  showDataQuality?: boolean;
+  thresholds?: StyledThreshold[];
+  backgroundColor?: string;
+  significantDigits?: number;
+  assistant?: AssistantProperty;
+}

--- a/packages/dashboard/src/customization/widgets/types.ts
+++ b/packages/dashboard/src/customization/widgets/types.ts
@@ -11,7 +11,7 @@ import type {
   SiteWiseAlarmQuery,
   SiteWiseAlarmAssetModelQuery,
 } from '@iot-app-kit/source-iotsitewise';
-import type { DashboardWidget } from '~/types';
+import type { RegisteredWidget } from '~/types/widgets';
 import type {
   AxisSettings,
   ComplexFontSettings,
@@ -24,45 +24,6 @@ import type {
   TableItem,
 } from '@iot-app-kit/react-components';
 import { type AggregateType } from '@aws-sdk/client-iotsitewise';
-
-export type QueryConfig<S, T> = {
-  source: S;
-  query: T;
-};
-
-export type SiteWiseQueryConfig = QueryConfig<
-  'iotsitewise',
-  | ((Partial<SiteWiseAssetQuery> &
-      Partial<SiteWisePropertyAliasQuery> &
-      Partial<SiteWiseAssetModelQuery>) &
-      Partial<SiteWiseAlarmQuery> &
-      Partial<SiteWiseAlarmAssetModelQuery>)
-  | undefined
->;
-
-export type QueryProperties = {
-  styleSettings?: StyleSettingsMap;
-  queryConfig: SiteWiseQueryConfig;
-};
-
-export type KPIProperties = QueryProperties & {
-  title?: string;
-  primaryFont: SimpleFontSettings;
-  secondaryFont: SimpleFontSettings;
-  showAggregationAndResolution?: boolean;
-  showValue?: boolean;
-  showUnit?: boolean;
-  showIcon?: boolean;
-  showName?: boolean;
-  showTimestamp?: boolean;
-  showDataQuality?: boolean;
-  thresholds?: StyledThreshold[];
-  backgroundColor?: string;
-  significantDigits?: number;
-  assistant?: AssistantProperty;
-};
-
-export type KPIPropertiesKeys = keyof KPIProperties;
 
 export type StatusProperties = QueryProperties & {
   title?: string;
@@ -206,18 +167,6 @@ export type LineScatterChartProperties = LineAndScatterStyles & {
 
 export type LineScatterChartPropertiesKeys = keyof LineScatterChartProperties;
 
-export type BarChartProperties = QueryProperties & {
-  title?: string;
-  thresholds?: ThresholdWithId[];
-  thresholdSettings?: ThresholdSettings;
-  axis?: AxisSettings;
-  significantDigits?: number;
-  resolution?: string;
-  aggregationType?: AggregateType;
-};
-
-export type BarChartPropertiesKeys = keyof BarChartProperties;
-
 export type TableProperties = QueryProperties & {
   title?: string;
   thresholds?: ThresholdWithId[];
@@ -258,21 +207,6 @@ export type LineProperties = {
   thickness?: number;
 };
 
-export type GaugeProperties = QueryProperties & {
-  title?: string;
-  gaugeThickness?: number;
-  showName?: boolean;
-  showUnit?: boolean;
-  fontSize?: number;
-  labelFontSize?: number;
-  unitFontSize?: number;
-  yMin?: number;
-  yMax?: number;
-  thresholds?: StyledThreshold[];
-  significantDigits?: number;
-  assistant?: AssistantProperty;
-};
-
 type ChartPropertiesUnion =
   | KPIProperties
   | StatusProperties
@@ -289,16 +223,15 @@ export type CommonChartProperties = Pick<
   ChartPropertiesKeysIntersection
 >;
 
-export type QueryWidget = DashboardWidget<QueryProperties>;
+export type QueryWidget = RegisteredWidget<QueryProperties>;
 
-export type GaugeWidget = DashboardWidget<GaugeProperties>;
-export type KPIWidget = DashboardWidget<KPIProperties>;
-export type StatusWidget = DashboardWidget<StatusProperties>;
+export type GaugeWidget = RegisteredWidget<GaugeProperties>;
+export type KPIWidget = RegisteredWidget<KPIProperties>;
+export type StatusWidget = RegisteredWidget<StatusProperties>;
 export type LineScatterChartWidget =
-  DashboardWidget<LineScatterChartProperties>;
-export type BarChartWidget = DashboardWidget<BarChartProperties>;
-export type TableWidget = DashboardWidget<TableProperties>;
-export type TextWidget = DashboardWidget<TextProperties>;
-export type StatusTimelineWidget = DashboardWidget<StatusTimelineProperties>;
-export type RectangleWidget = DashboardWidget<RectangleProperties>;
-export type LineWidget = DashboardWidget<LineProperties>;
+  RegisteredWidget<LineScatterChartProperties>;
+export type TableWidget = RegisteredWidget<TableProperties>;
+export type TextWidget = RegisteredWidget<TextProperties>;
+export type StatusTimelineWidget = RegisteredWidget<StatusTimelineProperties>;
+export type RectangleWidget = RegisteredWidget<RectangleProperties>;
+export type LineWidget = RegisteredWidget<LineProperties>;

--- a/packages/dashboard/src/hooks/useAWSRegion.ts
+++ b/packages/dashboard/src/hooks/useAWSRegion.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import {
   type DashboardClientConfiguration,
   type DashboardClientCredentials,
-} from '~/types';
+} from '~/types/sdk-clients';
 
 export const isCredentials = (
   dashboardClientConfiguration: DashboardClientConfiguration

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -17,9 +17,9 @@ import type {
   SiteWiseQuery,
 } from '@iot-app-kit/source-iotsitewise';
 import type { ReactElement } from 'react';
-import type { PartialDeep } from 'type-fest';
 import type { RefreshRate } from './components/refreshRate/types';
 
+/*
 export type DashboardClientCredentials = {
   awsCredentials: AwsCredentialIdentity | Provider<AwsCredentialIdentity>;
   awsRegion: string | Provider<string>;
@@ -31,7 +31,9 @@ export type DashboardIotSiteWiseClients = {
   iotTwinMakerClient: IoTTwinMakerClient;
   iotSiteWise: IoTSiteWise;
 };
+*/
 
+/*
 export type DashboardIotSiteWiseQueries = {
   iotSiteWiseQuery: SiteWiseQuery;
 };
@@ -47,8 +49,10 @@ export type IoTSiteWiseDataStreamQuery = Partial<
 export type DashboardClientConfiguration =
   | DashboardIotSiteWiseClients
   | DashboardClientCredentials;
+  */
 
 // OnSave has an optional viewMode value which can be used to persist the dashboard's viewMode after the save action
+/*
 export type DashboardSave = (
   dashboardConfiguration: DashboardConfiguration,
   viewModeOnSave?: 'preview' | 'edit'
@@ -59,6 +63,7 @@ export type ViewportChange = (viewport: Viewport) => void;
 export type DashboardConfigurationChange = (
   dashboardConfiguration: DashboardConfiguration
 ) => void;
+ */
 
 export type AssistantStateTypes = 'DISABLED' | 'PASSIVE';
 
@@ -66,6 +71,7 @@ export type AssistantConfiguration = {
   state?: AssistantStateTypes;
 };
 
+/*
 export type DashboardWidget<
   Properties extends Record<string, unknown> = Record<string, unknown>
 > = {
@@ -78,7 +84,9 @@ export type DashboardWidget<
   width: number;
   properties: Properties;
 };
+*/
 
+/*
 export type DashboardDisplaySettings = {
   numRows: number;
   numColumns: number;
@@ -89,7 +97,9 @@ export type DashboardDisplaySettings = {
 export type DashboardTimeSeriesSettings = {
   refreshRate?: RefreshRate;
 };
+*/
 
+/*
 export type DashboardConfiguration<
   Properties extends Record<string, unknown> = Record<string, unknown>
 > = {
@@ -97,34 +107,17 @@ export type DashboardConfiguration<
   querySettings?: DashboardTimeSeriesSettings;
   widgets: DashboardWidget<Properties>[];
   defaultViewport?: Viewport;
-  /** @deprecated */
   viewport?: Viewport;
 };
-
-export type DashboardWidgetsConfiguration<
-  Properties extends Record<string, unknown> = Record<string, unknown>
-> = {
-  widgets: DashboardWidget<Properties>[];
-  viewport: Viewport;
-};
+*/
 
 export type Position = { x: number; y: number };
 export type Rect = { x: number; y: number; width: number; height: number };
-export type Selection = {
-  start: Position;
-  end: Position;
-};
 
 export enum MouseClick {
   Left = 0,
   Right = 2,
 }
-
-export type PickRequiredOptional<
-  T,
-  TRequired extends keyof T,
-  TOptional extends keyof T
-> = Pick<T, TRequired> & PartialDeep<Pick<T, TOptional>>;
 
 export type RequestTimeout = number;
 

--- a/packages/dashboard/src/types/dashboard-configuration.ts
+++ b/packages/dashboard/src/types/dashboard-configuration.ts
@@ -1,0 +1,23 @@
+import type { Viewport } from '@iot-app-kit/core';
+import type { RefreshRate } from '../components/refreshRate/types';
+import type { RegisteredWidget } from './widgets';
+
+export interface DashboardDisplaySettings {
+  numRows: number;
+  numColumns: number;
+  cellSize?: number;
+  significantDigits?: number;
+}
+
+export interface DashboardTimeSeriesSettings {
+  refreshRate?: RefreshRate;
+}
+
+export interface DashboardConfiguration {
+  displaySettings: DashboardDisplaySettings;
+  querySettings?: DashboardTimeSeriesSettings;
+  widgets: RegisteredWidget[];
+  defaultViewport?: Viewport;
+  /** @deprecated */
+  viewport?: Viewport;
+}

--- a/packages/dashboard/src/types/dashboard-props.ts
+++ b/packages/dashboard/src/types/dashboard-props.ts
@@ -1,0 +1,8 @@
+import type { Viewport } from '@iot-app-kit/core';
+import type { DashboardConfiguration } from './dashboard-configuration';
+
+export type DashboardConfigurationChange = (
+  dashboardConfiguration: DashboardConfiguration
+) => void;
+
+export type ViewportChange = (viewport: Viewport) => void;

--- a/packages/dashboard/src/types/queries.ts
+++ b/packages/dashboard/src/types/queries.ts
@@ -1,0 +1,41 @@
+import type { StyleSettingsMap } from '@iot-app-kit/core';
+import type {
+  SiteWiseAlarmAssetModelQuery,
+  SiteWiseAlarmQuery,
+  SiteWiseAssetModelQuery,
+  SiteWiseAssetQuery,
+  SiteWisePropertyAliasQuery,
+  SiteWiseQuery,
+} from '@iot-app-kit/source-iotsitewise';
+
+export interface DashboardIotSiteWiseQueries {
+  iotSiteWiseQuery: SiteWiseQuery;
+}
+
+export type IoTSiteWiseDataStreamQuery = Partial<
+  SiteWiseAssetQuery &
+    SiteWisePropertyAliasQuery &
+    SiteWiseAssetModelQuery &
+    SiteWiseAlarmQuery &
+    SiteWiseAlarmAssetModelQuery
+>;
+
+export type QueryConfig<S, T> = {
+  source: S;
+  query: T;
+};
+
+export type SiteWiseQueryConfig = QueryConfig<
+  'iotsitewise',
+  | ((Partial<SiteWiseAssetQuery> &
+      Partial<SiteWisePropertyAliasQuery> &
+      Partial<SiteWiseAssetModelQuery>) &
+      Partial<SiteWiseAlarmQuery> &
+      Partial<SiteWiseAlarmAssetModelQuery>)
+  | undefined
+>;
+
+export type QueryProperties = {
+  styleSettings?: StyleSettingsMap;
+  queryConfig: SiteWiseQueryConfig;
+};

--- a/packages/dashboard/src/types/saving.ts
+++ b/packages/dashboard/src/types/saving.ts
@@ -1,0 +1,6 @@
+import type { DashboardConfiguration } from './dashboard-configuration';
+
+export type DashboardSave = (
+  dashboardConfiguration: DashboardConfiguration,
+  viewModeOnSave?: 'preview' | 'edit'
+) => Promise<void>;

--- a/packages/dashboard/src/types/sdk-clients.ts
+++ b/packages/dashboard/src/types/sdk-clients.ts
@@ -1,0 +1,23 @@
+import type { IoTEventsClient } from '@aws-sdk/client-iot-events';
+import type {
+  IoTSiteWise,
+  IoTSiteWiseClient,
+} from '@aws-sdk/client-iotsitewise';
+import type { IoTTwinMakerClient } from '@aws-sdk/client-iottwinmaker';
+import type { AwsCredentialIdentity, Provider } from '@aws-sdk/types';
+
+export interface DashboardIotSiteWiseClients {
+  iotSiteWiseClient: IoTSiteWiseClient;
+  iotEventsClient: IoTEventsClient;
+  iotTwinMakerClient: IoTTwinMakerClient;
+  iotSiteWise: IoTSiteWise;
+}
+
+export interface DashboardClientCredentials {
+  awsCredentials: AwsCredentialIdentity | Provider<AwsCredentialIdentity>;
+  awsRegion: string | Provider<string>;
+}
+
+export type DashboardClientConfiguration =
+  | DashboardIotSiteWiseClients
+  | DashboardClientCredentials;

--- a/packages/dashboard/src/types/widgets.ts
+++ b/packages/dashboard/src/types/widgets.ts
@@ -1,0 +1,28 @@
+export type WidgetType = string;
+
+export interface Widget<
+  T extends WidgetType = WidgetType,
+  P = Record<string, unknown>
+> {
+  id: string;
+  x: number;
+  y: number;
+  z: number;
+  height: number;
+  width: number;
+  type: T;
+  properties: P;
+}
+
+export interface RegisterWidget<T extends string, P> {
+  (type: T, properties: P): void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DashboardWidgetRegistry {}
+
+export type RegisteredWidgetType = keyof DashboardWidgetRegistry;
+
+export type RegisteredWidget = {
+  [K in RegisteredWidgetType]: Widget<K, DashboardWidgetRegistry[K]>;
+}[RegisteredWidgetType];

--- a/packages/dashboard/src/util/select.ts
+++ b/packages/dashboard/src/util/select.ts
@@ -1,7 +1,12 @@
 import last from 'lodash-es/last';
 import sortBy from 'lodash-es/sortBy';
-import type { DashboardWidget, Position, Rect, Selection } from '~/types';
+import type { DashboardWidget, Position, Rect } from '~/types';
 import { overlaps } from './overlaps';
+
+export interface Selection {
+  start: Position;
+  end: Position;
+}
 
 export const getSelectedWidgets = ({
   selectedRect,

--- a/packages/dashboard/src/widgets/configuration.ts
+++ b/packages/dashboard/src/widgets/configuration.ts
@@ -1,0 +1,23 @@
+import type { DashboardWidgetMap } from './types';
+
+export interface WidgetInstance<
+  WidgetType extends string = string,
+  Properties = unknown
+> {
+  type: WidgetType;
+  properties: Properties;
+  id: string;
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+  z: number;
+}
+
+export type DashboardWidgetInstance = {
+  [K in keyof DashboardWidgetMap]: WidgetInstance<K, DashboardWidgetMap[K]>;
+}[keyof DashboardWidgetMap];
+
+export interface DashboardConfiguration {
+  widgets: DashboardWidgetInstance[];
+}

--- a/packages/dashboard/src/widgets/types.ts
+++ b/packages/dashboard/src/widgets/types.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DashboardWidgetMap {}

--- a/packages/dashboard/src/widgets/widget-definition.ts
+++ b/packages/dashboard/src/widgets/widget-definition.ts
@@ -1,0 +1,15 @@
+import type { ComponentType, ReactNode } from 'react';
+import type { DashboardWidgetMap } from './types';
+import type { DashboardWidgetInstance } from './configuration';
+
+export interface WidgetDefinition<T extends keyof DashboardWidgetMap> {
+  type: T;
+  name: string;
+  icon: ReactNode;
+  render: ComponentType<Extract<DashboardWidgetInstance, { type: T }>>;
+  initialProperties: DashboardWidgetMap[T];
+  initialSize: {
+    height: number;
+    width: number;
+  };
+}

--- a/packages/dashboard/src/widgets/widget-registry.ts
+++ b/packages/dashboard/src/widgets/widget-registry.ts
@@ -1,0 +1,17 @@
+import type { DashboardWidgetMap } from './types';
+import type { WidgetDefinition } from './widget-definition';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const widgetRegistry: Record<string, WidgetDefinition<any>> = {};
+
+export function registerWidget<T extends keyof DashboardWidgetMap>(
+  registration: WidgetDefinition<T>
+): void {
+  widgetRegistry[registration.type] = registration;
+}
+
+export function getWidgetRegistration<T extends keyof DashboardWidgetMap>(
+  type: T
+): WidgetDefinition<T> {
+  return widgetRegistry[type];
+}


### PR DESCRIPTION
## Overview
Provide an explanation of what the change is

## Verifying Changes

### Scene Composer
For `scene-composer` package changes specifically, you can preview the component in the published storybook artifact. To do this, wait for the `Publish Storybook` action to complete below.

- Click on the workflow details
- Select the Summary item on the left
- Download the zip file

To run the storybook build locally, you need a local static web server:

```
npm install -g httpserver
cd <Extracted Zip Directory>
httpserver
```

Then open the website http://localhost:8080 to run the doc site.

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
