### PR TITLE
fix: client side errors from unexpected null/undefined values

### DIFF
--- a/packages/react-components/src/echarts/extensions/trendCursors/echartsActions/extension.ts
+++ b/packages/react-components/src/echarts/extensions/trendCursors/echartsActions/extension.ts
@@ -31,6 +31,7 @@ export const actionExtension: any = (
       if (
         !event ||
         !trendCursor ||
+        !api ||
         ecmodel.getOption().appKitChartId !== chartId ||
         getTrendCursors(ecmodel).length > 4
       )
@@ -47,7 +48,8 @@ export const actionExtension: any = (
   registers.registerAction(
     RemoveNearestTrendCursorActionType,
     ({ event, chartId }: RemoveTrendCursorAction, ecmodel, api) => {
-      if (!event || ecmodel.getOption().appKitChartId !== chartId) return;
+      if (!event || !api || ecmodel.getOption().appKitChartId !== chartId)
+        return;
 
       const date = getXAxisDataValue(event.offsetX, api);
 
@@ -67,7 +69,12 @@ export const actionExtension: any = (
   registers.registerAction(
     CopyTrendCursorActionType,
     ({ event, chartId }: CopyTrendCursorAction, ecmodel, api) => {
-      if (!event || !chartId || ecmodel.getOption().appKitChartId !== chartId)
+      if (
+        !event ||
+        !chartId ||
+        !api ||
+        ecmodel.getOption().appKitChartId !== chartId
+      )
         return;
 
       const date = getXAxisDataValue(event.offsetX, api);

--- a/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.ts
+++ b/packages/source-iotsitewise/src/time-series-data/client/batchGetHistoricalPropertyDataPoints.ts
@@ -4,6 +4,10 @@ import {
   TimeOrdering,
   type BatchGetAssetPropertyValueHistoryErrorEntry,
   type BatchGetAssetPropertyValueHistorySuccessEntry,
+  type IoTSiteWiseServiceException,
+  AccessDeniedException,
+  InvalidRequestException,
+  ResourceNotFoundException,
 } from '@aws-sdk/client-iotsitewise';
 import { toDataPoint } from '../util/toDataPoint';
 import { dataStreamFromSiteWise } from '../dataStreamFromSiteWise';
@@ -159,14 +163,20 @@ const sendRequest = ({
         });
       }
     })
-    .catch((e) => {
-      Object.entries(callbackCache).forEach(([entryId, { onError }]) => {
-        onError({
-          entryId,
-          errorCode: e.$metadata?.httpStatusCode,
-          errorMessage: e.message,
+    .catch((e: IoTSiteWiseServiceException) => {
+      if (
+        e instanceof AccessDeniedException ||
+        e instanceof InvalidRequestException ||
+        e instanceof ResourceNotFoundException
+      ) {
+        Object.entries(callbackCache).forEach(([entryId, { onError }]) => {
+          onError({
+            entryId,
+            errorCode: e.name,
+            errorMessage: e.message,
+          });
         });
-      });
+      }
     });
 };
 


### PR DESCRIPTION
## Overview
This PR contains possible fixes for two types of client side errors.

(1) We received type errors that could not be reproduced that look like this:
`error: Cannot read properties of null (reading 'getCoordinateSystems') stackTrace: TypeError: Cannot read properties of null (reading 'getCoordinateSystems')`

This means that the ExtensionAPI was null somewhere in the code. Adding these null checks (`!api`) are harmless and will hopefully prevent these errors from occurring again.

(2) We received another type error when trying to read `$metadata`:
`error: Cannot read properties of undefined (reading 'httpStatusCode') stackTrace: TypeError: Cannot read properties of undefined (reading 'httpStatusCode')`

Changes for this include explicitly typing errors as `IoTSiteWiseServiceExceptions` and setting the `errorCode` to the error name (it was never supposed to be the http status code in the first place)

## Verifying Changes
- Nothing broke from manual testing in storybooks
- Can successfully add, copy, and delete trend cursors in charts
- `npm run test` in source-iotsitewise package was successful

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
