### PR TITLE
fix: smoke test playwright installation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -225,30 +225,5 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
-      - name: Get installed Playwright version
-        id: playwright-version
-        run: echo "::set-output name=version::$(npm info @playwright/test version)"
-        working-directory: ./testing/smoke-test
-
-      - name: Playwright cache (smoke test)
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: '${{ runner.os }}-playwright-smoke-test-${{ steps.playwright-version.outputs.version }}'
-          restore-keys: |
-            ${{ runner.os }}-playwright-smoke-test-
-
-      - name: Install Playwright with dependencies
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
-        working-directory: ./testing/smoke-test
-
-      - name: Install Playwright's dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps
-        working-directory: ./testing/smoke-test
-
       - name: Run smoke test
-        run: ./smoke-test.sh -n
+        run: ./smoke-test.sh -dn

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -260,7 +260,6 @@ check_for_dependencies() {
   check_for_package git
   check_for_package curl
   check_for_package pgrep
-  check_for_playwright
 }
 
 ###############################################################################
@@ -373,6 +372,8 @@ log_info "Validating bundling"
 if ! smoke_test_run_cmd npm run validate:bundling; then
   log_error "Bundling validation failed."
 fi
+
+check_for_playwright
 
 log_info "Validating runtime"
 if ! smoke_test_run_cmd npm run validate:runtime; then


### PR DESCRIPTION
## Overview
This change fixes the playwright installation in the smoke test by moving its installation, which happens in check_for_playwright, to after npm install is run. Running npm install after installing playwright seems to be uninstalling playwright.

Also changed:
- Removed redundant playwright installation in the GH action outside of the script
- Turned on debug mode in the GH action, because, why not? More info is good? :D

## Legal
This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
