### PR TITLE
fix(react-components): mark cytoscape as an optional peer dependency

### DIFF
--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -18,5 +18,12 @@ For an example of a real world use case using the IoT App Kit, [visit this tutor
 
 <img width="1170" alt="IoT App Kit Demo" src="https://user-images.githubusercontent.com/6397726/159107236-ea95e7ba-a89c-43e6-a34c-c5ea1dd37e8b.png">
 
+## Optional peer dependencies
+
+`cytoscape` is only required by the knowledge graph component (`KnowledgeGraphPanel`). It
+is declared as an optional peer dependency, so applications that do not use the knowledge
+graph component do not need to install it and will not see an unmet peer dependency warning.
+If you do use the knowledge graph component, install `cytoscape` alongside this package.
+
 ## License
 This project is licensed under the Apache-2.0 License.

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -156,6 +156,11 @@
     "react": "^18",
     "react-dom": "^18"
   },
+  "peerDependenciesMeta": {
+    "cytoscape": {
+      "optional": true
+    }
+  },
   "bugs": {
     "url": "https://github.com/awslabs/iot-app-kit/issues"
   },


### PR DESCRIPTION
## Overview

`cytoscape` is only imported by the knowledge graph component (`KnowledgeGraphPanel`) — every `cytoscape` / `react-cytoscapejs` import in `react-components` lives under `src/components/knowledge-graph/`. However, it is declared as a **required** `peerDependency`, which forces every consumer of `@iot-app-kit/react-components` to install `cytoscape` (or accept an unmet peer dependency warning), even when they never use the knowledge graph.

This change declares `cytoscape` optional via `peerDependenciesMeta`, so only consumers of the knowledge graph component need it. `cytoscape` is kept in `peerDependencies`, so its version range is still validated when the dependency is present.

```jsonc
"peerDependenciesMeta": {
  "cytoscape": {
    "optional": true
  }
}
```

A short note in the package README documents that `cytoscape` is only required for the knowledge graph component.

Relates to #1810 (reducing friction when consuming `react-components` as a dependency). This addresses the `cytoscape` portion specifically; other dependencies mentioned in that issue are out of scope here.

## Verifying Changes

- Package-metadata + docs change only; no runtime/source code is modified.
- `packages/react-components/package.json` remains valid JSON and `cytoscape` stays listed under `peerDependencies` (range retained), now flagged optional via `peerDependenciesMeta`.
- `cytoscape` remains a `devDependency`, so the knowledge graph component and its tests continue to build within this repo.

## Legal

This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).