### PR TITLE
fix(ci): update release-please action inputs for v4 compatibility

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,9 +10,8 @@ jobs:
       - uses: google-github-actions/release-please-action@v4.1.1
         id: release
         with:
-          command: manifest
           token: ${{secrets.GITHUB_TOKEN}}
-          default-branch: main
+          target-branch: main
 
   update-pull-request:
     name: Update pull request


### PR DESCRIPTION
Fix the release-please GitHub Action which is failing with Unexpected input(s) 'command', 'default-branch'. These inputs were removed in v4 of the action. Replaces command: manifest (no longer needed, auto-detected from config files) and default-branch with target-branch.