### PR TITLE
fix(ci): use RELEASE_PLEASE_TOKEN for release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,9 @@ on:
     branches:
       - main
 name: Create release PR
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -10,7 +13,7 @@ jobs:
       - uses: google-github-actions/release-please-action@v4.1.1
         id: release
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{secrets.RELEASE_PLEASE_TOKEN}}
           target-branch: main
 
   update-pull-request:


### PR DESCRIPTION
Fix release-please workflow to use RELEASE_PLEASE_TOKEN secret instead of GITHUB_TOKEN. The awslabs org restricts the default token to read-only, which prevents the action from creating PRs (Resource not accessible by integration error). Also adds explicit permissions block and documents the token requirement in the release process guide.